### PR TITLE
feat: optimize tablet responsiveness for tables, dialogs, sheets, and dashboards

### DIFF
--- a/app/cctv/views/access-logs.tsx
+++ b/app/cctv/views/access-logs.tsx
@@ -159,7 +159,7 @@ export function AccessLogsView({ sites, cameras }: AccessLogsViewProps) {
             <CardDescription>{logs.length} access event(s) in this view.</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/cctv/views/playback.tsx
+++ b/app/cctv/views/playback.tsx
@@ -227,7 +227,7 @@ export function PlaybackView({ sites, cameras }: PlaybackViewProps) {
                 description="Expand the time range or verify that the camera was recording."
               />
             ) : (
-              <div className="overflow-x-auto">
+              <div className="table-rail">
                 <Table className="w-full text-sm">
                   <TableHeader className="bg-muted">
                     <TableRow>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -211,7 +211,7 @@ export default function DashboardPage() {
         </Alert>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-sm font-semibold text-muted-foreground">Tonnes Processed</CardTitle>

--- a/app/globals.css
+++ b/app/globals.css
@@ -500,6 +500,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
     .table-rail {
         width: 100%;
         overflow: auto;
+        overscroll-behavior-x: contain;
         border-radius: 0;
     }
     .table-edge-to-edge {
@@ -511,5 +512,45 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
     }
     .section-shell {
         padding-inline: var(--section-gutter-x);
+    }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+    .table-rail:not([data-tablet-scrollable="false"]) {
+        overflow-x: auto;
+        overflow-y: hidden;
+        touch-action: pan-x;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-gutter: stable both-edges;
+    }
+
+    .table-rail:not([data-tablet-scrollable="false"]) > [data-slot="table"] {
+        min-width: var(--table-tablet-min-width, max-content);
+    }
+
+    .table-rail:not([data-tablet-sticky-first-column="false"]) [data-slot="table-head"]:first-child,
+    .table-rail:not([data-tablet-sticky-first-column="false"]) [data-slot="table-cell"]:first-child {
+        position: sticky;
+        left: 0;
+        z-index: 10;
+        background: var(--surface-base);
+        background-clip: padding-box;
+        box-shadow: inset -1px 0 0 var(--border);
+    }
+
+    .table-rail:not([data-tablet-sticky-first-column="false"])
+        [data-slot="table-header"]
+        [data-slot="table-head"]:first-child {
+        z-index: 30;
+        background: var(--surface-subtle);
+    }
+
+    .table-rail:not([data-tablet-scrollable="false"])::-webkit-scrollbar {
+        height: 8px;
+    }
+
+    .table-rail:not([data-tablet-scrollable="false"])::-webkit-scrollbar-thumb {
+        background: color-mix(in srgb, var(--text-muted) 35%, transparent);
+        border-radius: 9999px;
     }
 }

--- a/app/reports/fuel-ledger/page.tsx
+++ b/app/reports/fuel-ledger/page.tsx
@@ -144,7 +144,7 @@ export default function FuelLedgerReportPage() {
           ) : filteredMovements.length === 0 ? (
             <div className="text-sm text-muted-foreground">No fuel movements for the selected filters.</div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/reports/gold-receipts/page.tsx
+++ b/app/reports/gold-receipts/page.tsx
@@ -81,7 +81,7 @@ export default function GoldReceiptsReportPage() {
           ) : rows.length === 0 ? (
             <div className="text-sm text-muted-foreground">No receipt records found.</div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/reports/maintenance-equipment/page.tsx
+++ b/app/reports/maintenance-equipment/page.tsx
@@ -83,7 +83,7 @@ export default function MaintenanceEquipmentReportPage() {
           ) : rows.length === 0 ? (
             <div className="text-sm text-muted-foreground">No equipment records found.</div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/reports/maintenance-work-orders/page.tsx
+++ b/app/reports/maintenance-work-orders/page.tsx
@@ -123,7 +123,7 @@ export default function MaintenanceWorkOrdersReportPage() {
           ) : filteredRows.length === 0 ? (
             <div className="text-sm text-muted-foreground">No work orders for the selected filters.</div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/reports/stores-movements/page.tsx
+++ b/app/reports/stores-movements/page.tsx
@@ -211,7 +211,7 @@ export default function StoresMovementsReportPage() {
               No movement records found for the current filters.
             </div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="table-rail">
               <Table className="w-full text-sm">
                 <TableHeader className="bg-muted">
                   <TableRow>

--- a/app/stores/fuel/page.tsx
+++ b/app/stores/fuel/page.tsx
@@ -204,7 +204,7 @@ export default function StoresFuelPage() {
             )}
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="table-rail">
             <Table className="w-full" aria-label="Fuel ledger table">
               <TableHeader className="bg-muted">
                 <TableRow>

--- a/app/stores/inventory/page.tsx
+++ b/app/stores/inventory/page.tsx
@@ -823,7 +823,7 @@ export default function StoresInventoryPage() {
             </Select>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="table-rail">
             <Table className="w-full">
               <TableHeader className="bg-muted">
                 <TableRow>
@@ -1345,7 +1345,7 @@ export default function StoresInventoryPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
+          <div className="table-rail">
             <Table className="w-full">
               <TableHeader className="bg-muted">
                 <TableRow>

--- a/app/stores/movements/page.tsx
+++ b/app/stores/movements/page.tsx
@@ -222,7 +222,7 @@ export default function StoresMovementsPage() {
           </div>
         }
       >
-        <div className="overflow-x-auto">
+        <div className="table-rail">
           <Table className="w-full">
             <TableHeader className="sticky top-0 z-10 bg-muted">
               <TableRow>

--- a/components/maintenance/maintenance-content.tsx
+++ b/components/maintenance/maintenance-content.tsx
@@ -1284,7 +1284,7 @@ export function MaintenanceContent({
                 )}
               </div>
 
-              <div className="overflow-x-auto">
+              <div className="table-rail">
                 <Table className="w-full">
                   <TableHeader className="bg-muted">
                     <TableRow>
@@ -1692,7 +1692,7 @@ export function MaintenanceContent({
               </div>
             </CardHeader>
             <CardContent>
-              <div className="overflow-x-auto">
+              <div className="table-rail">
                 <Table className="w-full">
                   <TableHeader className="bg-muted">
                     <TableRow>
@@ -1978,7 +1978,7 @@ export function MaintenanceContent({
               </div>
             </CardHeader>
             <CardContent>
-              <div className="overflow-x-auto">
+              <div className="table-rail">
                 <Table className="w-full">
                   <TableHeader className="bg-muted">
                     <TableRow>

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -133,6 +133,9 @@ export type DataTableProps<TData, TValue> = {
   toolbar?: React.ReactNode;
   stickyHeader?: boolean;
   stickyHeaderOffset?: number;
+  tabletScrollable?: boolean;
+  tabletStickyFirstColumn?: boolean;
+  tabletMinTableWidth?: string;
   maxBodyHeight?: string;
   searchPlaceholder?: string;
   searchBehavior?: DataTableSearchBehavior;
@@ -175,6 +178,9 @@ export function DataTable<TData, TValue>({
   toolbar,
   stickyHeader = true,
   stickyHeaderOffset = 0,
+  tabletScrollable = true,
+  tabletStickyFirstColumn = true,
+  tabletMinTableWidth = "max-content",
   maxBodyHeight,
   searchPlaceholder = "Search records",
   searchBehavior = "submit",
@@ -383,10 +389,10 @@ export function DataTable<TData, TValue>({
   return (
     <div className={cn("space-y-3", className)}>
       {showTopToolbar ? (
-        <div className="section-shell flex flex-wrap items-center gap-2 py-1">
+        <div className="section-shell flex flex-wrap items-center gap-2 py-1 md:max-lg:flex-nowrap md:max-lg:overflow-x-auto md:max-lg:[&>*]:shrink-0">
           {globalFilterEnabled ? (
             <form
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 md:max-lg:shrink-0"
               onSubmit={(event) => {
                 event.preventDefault();
                 applySearch(searchDraft);
@@ -416,10 +422,10 @@ export function DataTable<TData, TValue>({
             </form>
           ) : null}
 
-          {toolbar ? <div className="flex flex-wrap items-center gap-2">{toolbar}</div> : null}
+          {toolbar ? <div className="flex flex-wrap items-center gap-2 md:max-lg:shrink-0">{toolbar}</div> : null}
 
           {showToolbarPagination ? (
-            <div className="ml-auto flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <div className="ml-auto flex flex-wrap items-center gap-2 text-xs text-muted-foreground md:max-lg:flex-nowrap md:max-lg:[&>*]:shrink-0">
               <span>Rows per page</span>
               <Select
                 value={String(pageSize)}
@@ -470,6 +476,9 @@ export function DataTable<TData, TValue>({
           enablePagination={false}
           stickyHeader={stickyHeader}
           stickyHeaderOffset={stickyHeaderOffset}
+          tabletScrollable={tabletScrollable}
+          tabletStickyFirstColumn={tabletStickyFirstColumn}
+          tabletMinTableWidth={tabletMinTableWidth}
           edgeToEdge
         >
           <TableHeader>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -37,9 +37,9 @@ const sheetVariants = cva(
         bottom:
           "inset-x-0 bottom-0 max-h-[92dvh] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left:
-          "inset-y-0 left-0 h-dvh w-[var(--sheet-size-mobile)] sm:w-[var(--sheet-size-sm)] md:w-[var(--sheet-size-md)] lg:w-[var(--sheet-size-lg)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+          "inset-y-0 left-0 h-dvh w-[var(--sheet-size-mobile)] sm:w-[var(--sheet-size-sm)] md:w-[var(--sheet-size-md)] lg:w-[var(--sheet-size-lg)] md:max-lg:left-2 md:max-lg:h-[calc(100dvh-1rem)] md:max-lg:max-h-[calc(100dvh-1rem)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
         right:
-          "inset-y-0 right-0 h-dvh w-[var(--sheet-size-mobile)] sm:w-[var(--sheet-size-sm)] md:w-[var(--sheet-size-md)] lg:w-[var(--sheet-size-lg)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+          "inset-y-0 right-0 h-dvh w-[var(--sheet-size-mobile)] sm:w-[var(--sheet-size-sm)] md:w-[var(--sheet-size-md)] lg:w-[var(--sheet-size-lg)] md:max-lg:right-2 md:max-lg:h-[calc(100dvh-1rem)] md:max-lg:max-h-[calc(100dvh-1rem)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
       },
       size: SHEET_SIZE_CLASSNAMES,
       tabletBehavior: {

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -53,6 +53,9 @@ export type TableProps = React.ComponentProps<"table"> & {
   controlsClassName?: string;
   hideControlsWhenSinglePage?: boolean;
   edgeToEdge?: boolean;
+  tabletScrollable?: boolean;
+  tabletStickyFirstColumn?: boolean;
+  tabletMinTableWidth?: string;
 };
 
 const defaultPageSizeOptions = [10, 25, 50, 100] as const;
@@ -96,7 +99,7 @@ function TablePaginationControls({
       )}
     >
       {mode === "paginated" ? (
-        <div className="ml-auto flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <div className="ml-auto flex flex-wrap items-center gap-2 text-xs text-muted-foreground md:max-lg:flex-nowrap md:max-lg:overflow-x-auto md:max-lg:[&>*]:shrink-0">
           <span>Rows per page</span>
           <Select
             value={String(pageSize)}
@@ -170,6 +173,10 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
       controlsClassName,
       hideControlsWhenSinglePage = false,
       edgeToEdge = true,
+      tabletScrollable = true,
+      tabletStickyFirstColumn = true,
+      tabletMinTableWidth = "max-content",
+      style: tableStyle,
       ...props
     },
     ref,
@@ -317,11 +324,23 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
             />
           ) : null}
 
-          <div className={cn("table-rail", edgeToEdge && "table-edge-to-edge")}>
+          <div
+            className={cn("table-rail", edgeToEdge && "table-edge-to-edge")}
+            data-tablet-scrollable={tabletScrollable ? "true" : "false"}
+            data-tablet-sticky-first-column={tabletStickyFirstColumn ? "true" : "false"}
+            style={
+              tabletScrollable
+                ? ({
+                    "--table-tablet-min-width": tabletMinTableWidth,
+                  } as React.CSSProperties)
+                : undefined
+            }
+          >
             <table
               ref={ref}
               data-slot="table"
               className={cn("w-full caption-bottom text-sm", className)}
+              style={tableStyle}
               {...props}
             />
           </div>

--- a/lib/ui/responsive-surface.ts
+++ b/lib/ui/responsive-surface.ts
@@ -30,8 +30,10 @@ export const DIALOG_TABLET_VIEWPORT_CLASSNAMES: Record<DialogTabletBehavior, str
 }
 
 export const DIALOG_TABLET_CONTENT_CLASSNAMES: Record<DialogTabletBehavior, string> = {
-  adaptive: "rounded-t-2xl sm:rounded-2xl md:max-lg:max-h-[min(90dvh,56rem)]",
-  centered: "rounded-2xl md:max-lg:max-h-[min(92dvh,58rem)]",
+  adaptive:
+    "rounded-t-2xl sm:rounded-2xl md:max-lg:w-[min(100%,calc(100vw-2rem))] md:max-lg:max-h-[min(90dvh,56rem)]",
+  centered:
+    "rounded-2xl md:max-lg:w-[min(100%,calc(100vw-2rem))] md:max-lg:max-h-[min(92dvh,58rem)]",
   fullscreen:
     "rounded-none md:max-lg:!h-[calc(100dvh-1rem)] md:max-lg:!max-h-[calc(100dvh-1rem)] md:max-lg:!w-[calc(100vw-1rem)] md:max-lg:!max-w-none lg:rounded-2xl",
 }
@@ -40,4 +42,3 @@ export const DIALOG_INSET_VIEWPORT_CLASSNAMES = {
   true: "p-0 sm:p-6 md:max-lg:p-4",
   false: "p-0",
 } as const
-


### PR DESCRIPTION
## Summary\n- add shared tablet table behavior with horizontal row scrolling and sticky first column\n- wire tablet table options through DataTable so existing screens inherit behavior\n- normalize manual table wrappers to shared 	able-rail across stores/reports/maintenance/cctv views\n- tune tablet dialog/sheet surfaces for balanced inset sizing\n- reduce dashboard KPI grid density on tablet for readability\n\n## Validation\n- pnpm lint passes (existing non-blocking warnings remain)\n\n## Notes\n- excluded untracked local paths (-Context, .worktrees/) from the commit