### PR TITLE
feat: finalize backend branded exports and serverless pdf runtime

### DIFF
--- a/lib/documents/pdf-renderer.ts
+++ b/lib/documents/pdf-renderer.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import type { Browser } from "puppeteer-core";
 import type { DocumentTemplateSchema } from "@/lib/documents/template-schema";
 
@@ -35,9 +36,38 @@ function findLocalChromiumExecutable(): string | null {
   return null;
 }
 
+function findSparticuzBinDirectories(): string[] {
+  const candidates: string[] = [];
+  const direct = join(process.cwd(), "node_modules", "@sparticuz", "chromium", "bin");
+  if (existsSync(direct)) {
+    candidates.push(direct);
+  }
+
+  const pnpmRoot = join(process.cwd(), "node_modules", ".pnpm");
+  if (existsSync(pnpmRoot)) {
+    for (const entry of readdirSync(pnpmRoot)) {
+      if (!entry.startsWith("@sparticuz+chromium@")) continue;
+      const candidate = join(
+        pnpmRoot,
+        entry,
+        "node_modules",
+        "@sparticuz",
+        "chromium",
+        "bin",
+      );
+      if (existsSync(candidate)) {
+        candidates.push(candidate);
+      }
+    }
+  }
+
+  return Array.from(new Set(candidates));
+}
+
 async function launchBrowser(): Promise<Browser> {
   const chromium = (await import("@sparticuz/chromium")).default;
   const puppeteer = await import("puppeteer-core");
+  const errors: string[] = [];
 
   const launch = async (executablePath: string) =>
     puppeteer.launch({
@@ -49,25 +79,52 @@ async function launchBrowser(): Promise<Browser> {
 
   const explicitExecutable = process.env.CHROME_EXECUTABLE_PATH?.trim();
   if (explicitExecutable) {
-    return launch(explicitExecutable);
+    try {
+      return await launch(explicitExecutable);
+    } catch (error) {
+      errors.push(
+        `CHROME_EXECUTABLE_PATH launch failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   try {
     const serverlessExecutable = await chromium.executablePath();
     if (serverlessExecutable) {
-      return launch(serverlessExecutable);
+      return await launch(serverlessExecutable);
     }
-  } catch {
-    // Fall through to local executable detection.
+  } catch (error) {
+    errors.push(
+      `@sparticuz/chromium default executablePath failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  for (const binDir of findSparticuzBinDirectories()) {
+    try {
+      const serverlessExecutable = await chromium.executablePath(binDir);
+      if (serverlessExecutable) {
+        return await launch(serverlessExecutable);
+      }
+    } catch (error) {
+      errors.push(
+        `@sparticuz/chromium executablePath('${binDir}') failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   const localExecutable = findLocalChromiumExecutable();
   if (localExecutable) {
-    return launch(localExecutable);
+    try {
+      return await launch(localExecutable);
+    } catch (error) {
+      errors.push(
+        `Local Chromium launch failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   throw new Error(
-    "No Chromium executable found. Configure CHROME_EXECUTABLE_PATH for local runtime, or deploy with @sparticuz/chromium support.",
+    `No Chromium executable found. ${errors.join(" | ")}`,
   );
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  outputFileTracingIncludes: {
+    "/api/documents/render": [
+      "./node_modules/@sparticuz/chromium/bin/**",
+      "./node_modules/.pnpm/@sparticuz+chromium@*/node_modules/@sparticuz/chromium/bin/**",
+    ],
+    "/api/documents/render-jobs/process": [
+      "./node_modules/@sparticuz/chromium/bin/**",
+      "./node_modules/.pnpm/@sparticuz+chromium@*/node_modules/@sparticuz/chromium/bin/**",
+    ],
+    "/api/documents/render-jobs/[id]": [
+      "./node_modules/@sparticuz/chromium/bin/**",
+      "./node_modules/.pnpm/@sparticuz+chromium@*/node_modules/@sparticuz/chromium/bin/**",
+    ],
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary\n- finalizes backend-branded export flow across templates and frontend integration updates\n- refactors template settings UX to platform standards (DataTable + Dialog + actions dropdown + autocomplete options)\n- switches PDF rendering from Playwright to serverless-safe Puppeteer + @sparticuz/chromium\n- hardens production packaging by tracing chromium assets into Next.js serverless output\n\n## Key Changes\n- templates settings page refactor and dialog-driven create/edit flows\n- backend PDF renderer runtime updates for Vercel/Next.js serverless\n- Next.js output tracing includes for chromium binaries\n\n## Validation\n- pnpm lint (passes; existing unrelated warnings remain)\n- pnpm build (passes)\n\n## Notes\n- branch includes prior export/branding/template work and this final production fix for PDF runtime\n