### PR TITLE
feat: schools core backend models and workflow APIs

### DIFF
--- a/app/api/v2/schools/_helpers.ts
+++ b/app/api/v2/schools/_helpers.ts
@@ -1,0 +1,67 @@
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+
+export const schoolStudentStatusSchema = z.enum([
+  "APPLICANT",
+  "ACTIVE",
+  "SUSPENDED",
+  "GRADUATED",
+  "WITHDRAWN",
+]);
+
+export const schoolEnrollmentStatusSchema = z.enum([
+  "ACTIVE",
+  "TRANSFERRED",
+  "WITHDRAWN",
+  "COMPLETED",
+]);
+
+export const schoolBoardingAllocationStatusSchema = z.enum([
+  "ACTIVE",
+  "TRANSFERRED",
+  "ENDED",
+]);
+
+export const schoolResultSheetStatusSchema = z.enum([
+  "DRAFT",
+  "SUBMITTED",
+  "HOD_APPROVED",
+  "HOD_REJECTED",
+  "PUBLISHED",
+]);
+
+export const dateInputSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !Number.isNaN(new Date(value).getTime()), {
+    message: "Invalid date value",
+  });
+
+export const optionalDateInputSchema = dateInputSchema.optional();
+export const nullableDateInputSchema = dateInputSchema.nullable().optional();
+
+export function toOptionalDate(value?: string | null) {
+  if (!value) return undefined;
+  return new Date(value);
+}
+
+export function toNullableDate(value?: string | null) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return new Date(value);
+}
+
+export function normalizeOptionalNullableString(value?: string | null) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+export function isUniqueConstraintError(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002"
+  );
+}
+

--- a/app/api/v2/schools/boarding/allocations/route.ts
+++ b/app/api/v2/schools/boarding/allocations/route.ts
@@ -1,0 +1,296 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import {
+  isUniqueConstraintError,
+  normalizeOptionalNullableString,
+  nullableDateInputSchema,
+  optionalDateInputSchema,
+  schoolBoardingAllocationStatusSchema,
+  toNullableDate,
+  toOptionalDate,
+} from "../../_helpers";
+
+const allocationQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  studentId: z.string().uuid().optional(),
+  termId: z.string().uuid().optional(),
+  hostelId: z.string().uuid().optional(),
+  roomId: z.string().uuid().optional(),
+  bedId: z.string().uuid().optional(),
+  status: schoolBoardingAllocationStatusSchema.optional(),
+});
+
+const createAllocationSchema = z.object({
+  studentId: z.string().uuid(),
+  termId: z.string().uuid(),
+  hostelId: z.string().uuid(),
+  roomId: z.string().uuid().nullable().optional(),
+  bedId: z.string().uuid().nullable().optional(),
+  status: schoolBoardingAllocationStatusSchema.optional(),
+  startDate: optionalDateInputSchema,
+  endDate: nullableDateInputSchema,
+  reason: z.string().trim().min(1).max(1000).nullable().optional(),
+});
+
+const allocationInclude = {
+  student: {
+    select: {
+      id: true,
+      studentNo: true,
+      firstName: true,
+      lastName: true,
+      status: true,
+      isBoarding: true,
+    },
+  },
+  term: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  hostel: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  room: {
+    select: {
+      id: true,
+      code: true,
+      floor: true,
+    },
+  },
+  bed: {
+    select: {
+      id: true,
+      code: true,
+      status: true,
+      isActive: true,
+    },
+  },
+} satisfies Prisma.SchoolBoardingAllocationInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = allocationQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      studentId: searchParams.get("studentId") ?? undefined,
+      termId: searchParams.get("termId") ?? undefined,
+      hostelId: searchParams.get("hostelId") ?? undefined,
+      roomId: searchParams.get("roomId") ?? undefined,
+      bedId: searchParams.get("bedId") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+    });
+
+    const where: Prisma.SchoolBoardingAllocationWhereInput = {
+      companyId: session.user.companyId,
+    };
+
+    if (query.search) {
+      where.student = {
+        OR: [
+          { studentNo: { contains: query.search, mode: "insensitive" } },
+          { firstName: { contains: query.search, mode: "insensitive" } },
+          { lastName: { contains: query.search, mode: "insensitive" } },
+        ],
+      };
+    }
+    if (query.studentId) where.studentId = query.studentId;
+    if (query.termId) where.termId = query.termId;
+    if (query.hostelId) where.hostelId = query.hostelId;
+    if (query.roomId) where.roomId = query.roomId;
+    if (query.bedId) where.bedId = query.bedId;
+    if (query.status) where.status = query.status;
+
+    const [records, total] = await Promise.all([
+      prisma.schoolBoardingAllocation.findMany({
+        where,
+        include: allocationInclude,
+        orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolBoardingAllocation.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/boarding/allocations error:", error);
+    return errorResponse("Failed to fetch boarding allocations");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createAllocationSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    const [student, term, hostel, room, bed] = await Promise.all([
+      prisma.schoolStudent.findFirst({
+        where: { id: validated.studentId, companyId },
+        select: { id: true },
+      }),
+      prisma.schoolTerm.findFirst({
+        where: { id: validated.termId, companyId },
+        select: { id: true },
+      }),
+      prisma.schoolHostel.findFirst({
+        where: { id: validated.hostelId, companyId },
+        select: { id: true },
+      }),
+      validated.roomId
+        ? prisma.schoolHostelRoom.findFirst({
+            where: { id: validated.roomId, companyId },
+            select: { id: true, hostelId: true, isActive: true },
+          })
+        : Promise.resolve(null),
+      validated.bedId
+        ? prisma.schoolHostelBed.findFirst({
+            where: { id: validated.bedId, companyId },
+            select: { id: true, hostelId: true, roomId: true, status: true, isActive: true },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    if (!student) return errorResponse("Invalid student for this company", 400);
+    if (!term) return errorResponse("Invalid term for this company", 400);
+    if (!hostel) return errorResponse("Invalid hostel for this company", 400);
+    if (validated.roomId && !room) {
+      return errorResponse("Invalid room for this company", 400);
+    }
+    if (validated.bedId && !bed) {
+      return errorResponse("Invalid bed for this company", 400);
+    }
+    if (room && room.hostelId !== validated.hostelId) {
+      return errorResponse("Room does not belong to the selected hostel", 400);
+    }
+    if (bed && bed.hostelId !== validated.hostelId) {
+      return errorResponse("Bed does not belong to the selected hostel", 400);
+    }
+    if (validated.roomId && bed && bed.roomId !== validated.roomId) {
+      return errorResponse("Bed does not belong to the selected room", 400);
+    }
+    if (room && !room.isActive) {
+      return errorResponse("Selected room is inactive", 400);
+    }
+    if (bed && !bed.isActive) {
+      return errorResponse("Selected bed is inactive", 400);
+    }
+
+    const startDate = toOptionalDate(validated.startDate) ?? new Date();
+    const endDate = toNullableDate(validated.endDate);
+    if (endDate && endDate < startDate) {
+      return errorResponse("endDate cannot be before startDate", 400);
+    }
+
+    const status = validated.status ?? "ACTIVE";
+    if (status === "ACTIVE") {
+      const [existingStudentAllocation, existingBedAllocation] = await Promise.all([
+        prisma.schoolBoardingAllocation.findFirst({
+          where: {
+            companyId,
+            studentId: validated.studentId,
+            termId: validated.termId,
+            status: "ACTIVE",
+            OR: [{ endDate: null }, { endDate: { gte: startDate } }],
+          },
+          select: { id: true },
+        }),
+        validated.bedId
+          ? prisma.schoolBoardingAllocation.findFirst({
+              where: {
+                companyId,
+                bedId: validated.bedId,
+                status: "ACTIVE",
+                OR: [{ endDate: null }, { endDate: { gte: startDate } }],
+              },
+              select: { id: true },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      if (existingStudentAllocation) {
+        return errorResponse(
+          "Student already has an active boarding allocation for this term",
+          409,
+        );
+      }
+      if (existingBedAllocation) {
+        return errorResponse("Selected bed is already allocated", 409);
+      }
+    }
+
+    const roomId = validated.roomId ?? bed?.roomId ?? null;
+    const allocation = await prisma.$transaction(async (tx) => {
+      const created = await tx.schoolBoardingAllocation.create({
+        data: {
+          companyId,
+          studentId: validated.studentId,
+          termId: validated.termId,
+          hostelId: validated.hostelId,
+          roomId,
+          bedId: validated.bedId ?? null,
+          status,
+          startDate,
+          endDate,
+          reason: normalizeOptionalNullableString(validated.reason) ?? null,
+        },
+        include: allocationInclude,
+      });
+
+      if (status === "ACTIVE" && !endDate) {
+        await tx.schoolStudent.update({
+          where: { id: validated.studentId },
+          data: { isBoarding: true },
+        });
+        if (validated.bedId) {
+          await tx.schoolHostelBed.update({
+            where: { id: validated.bedId },
+            data: { status: "OCCUPIED" },
+          });
+        }
+      }
+
+      return created;
+    });
+
+    return successResponse(allocation, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse("Boarding allocation conflict", 409);
+    }
+    console.error("[API] POST /api/v2/schools/boarding/allocations error:", error);
+    return errorResponse("Failed to create boarding allocation");
+  }
+}
+

--- a/app/api/v2/schools/boarding/hostels/route.ts
+++ b/app/api/v2/schools/boarding/hostels/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { isUniqueConstraintError, normalizeOptionalNullableString } from "../../_helpers";
+
+const hostelQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  isActive: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .optional(),
+  genderPolicy: z.string().trim().min(1).optional(),
+});
+
+const hostelRoomSchema = z.object({
+  code: z.string().trim().min(1).max(40),
+  floor: z.string().trim().min(1).max(50).nullable().optional(),
+  capacity: z.number().int().min(0).nullable().optional(),
+  isActive: z.boolean().optional(),
+  bedCodes: z.array(z.string().trim().min(1).max(40)).optional(),
+});
+
+const createHostelSchema = z.object({
+  code: z.string().trim().min(1).max(40),
+  name: z.string().trim().min(1).max(160),
+  genderPolicy: z.string().trim().min(1).max(30).optional(),
+  capacity: z.number().int().min(0).nullable().optional(),
+  isActive: z.boolean().optional(),
+  rooms: z.array(hostelRoomSchema).optional(),
+});
+
+const hostelInclude = {
+  rooms: {
+    select: {
+      id: true,
+      code: true,
+      floor: true,
+      capacity: true,
+      isActive: true,
+    },
+    orderBy: { code: "asc" },
+  },
+  beds: {
+    select: {
+      id: true,
+      code: true,
+      roomId: true,
+      status: true,
+      isActive: true,
+    },
+    orderBy: [{ roomId: "asc" }, { code: "asc" }],
+  },
+  _count: {
+    select: {
+      rooms: true,
+      beds: true,
+      allocations: true,
+    },
+  },
+} satisfies Prisma.SchoolHostelInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = hostelQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      isActive: searchParams.get("isActive") ?? undefined,
+      genderPolicy: searchParams.get("genderPolicy") ?? undefined,
+    });
+
+    const where: Prisma.SchoolHostelWhereInput = {
+      companyId: session.user.companyId,
+    };
+
+    if (query.search) {
+      where.OR = [
+        { code: { contains: query.search, mode: "insensitive" } },
+        { name: { contains: query.search, mode: "insensitive" } },
+      ];
+    }
+    if (query.isActive !== undefined) where.isActive = query.isActive;
+    if (query.genderPolicy) where.genderPolicy = query.genderPolicy;
+
+    const [records, total] = await Promise.all([
+      prisma.schoolHostel.findMany({
+        where,
+        include: hostelInclude,
+        orderBy: [{ isActive: "desc" }, { name: "asc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolHostel.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/boarding/hostels error:", error);
+    return errorResponse("Failed to fetch hostels");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createHostelSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    const rooms = validated.rooms ?? [];
+    const normalizedRoomCodes = rooms.map((room) => room.code.trim().toUpperCase());
+    if (new Set(normalizedRoomCodes).size !== normalizedRoomCodes.length) {
+      return errorResponse("Duplicate room codes are not allowed in one request", 400);
+    }
+
+    for (const room of rooms) {
+      const bedCodes = (room.bedCodes ?? []).map((bedCode) =>
+        bedCode.trim().toUpperCase(),
+      );
+      if (new Set(bedCodes).size !== bedCodes.length) {
+        return errorResponse(`Duplicate bed codes found in room ${room.code}`, 400);
+      }
+    }
+
+    const hostel = await prisma.$transaction(async (tx) => {
+      const createdHostel = await tx.schoolHostel.create({
+        data: {
+          companyId,
+          code: validated.code,
+          name: validated.name,
+          genderPolicy: validated.genderPolicy ?? "MIXED",
+          capacity: validated.capacity ?? null,
+          isActive: validated.isActive ?? true,
+        },
+      });
+
+      for (const room of rooms) {
+        const createdRoom = await tx.schoolHostelRoom.create({
+          data: {
+            companyId,
+            hostelId: createdHostel.id,
+            code: room.code,
+            floor: normalizeOptionalNullableString(room.floor) ?? null,
+            capacity: room.capacity ?? null,
+            isActive: room.isActive ?? true,
+          },
+        });
+
+        const bedCodes = room.bedCodes ?? [];
+        if (bedCodes.length > 0) {
+          await tx.schoolHostelBed.createMany({
+            data: bedCodes.map((bedCode) => ({
+              companyId,
+              hostelId: createdHostel.id,
+              roomId: createdRoom.id,
+              code: bedCode,
+              status: "AVAILABLE",
+              isActive: true,
+            })),
+          });
+        }
+      }
+
+      return tx.schoolHostel.findUnique({
+        where: { id: createdHostel.id },
+        include: hostelInclude,
+      });
+    });
+
+    if (!hostel) {
+      return errorResponse("Failed to create hostel", 500);
+    }
+    return successResponse(hostel, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse("Hostel/room/bed code already exists", 409);
+    }
+    console.error("[API] POST /api/v2/schools/boarding/hostels error:", error);
+    return errorResponse("Failed to create hostel");
+  }
+}
+

--- a/app/api/v2/schools/enrollments/route.ts
+++ b/app/api/v2/schools/enrollments/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import {
+  isUniqueConstraintError,
+  normalizeOptionalNullableString,
+  nullableDateInputSchema,
+  optionalDateInputSchema,
+  schoolEnrollmentStatusSchema,
+  toNullableDate,
+  toOptionalDate,
+} from "../_helpers";
+
+const enrollmentQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  studentId: z.string().uuid().optional(),
+  termId: z.string().uuid().optional(),
+  classId: z.string().uuid().optional(),
+  streamId: z.string().uuid().optional(),
+  status: schoolEnrollmentStatusSchema.optional(),
+});
+
+const createEnrollmentSchema = z.object({
+  studentId: z.string().uuid(),
+  termId: z.string().uuid(),
+  classId: z.string().uuid(),
+  streamId: z.string().uuid().nullable().optional(),
+  status: schoolEnrollmentStatusSchema.optional(),
+  enrolledAt: optionalDateInputSchema,
+  endedAt: nullableDateInputSchema,
+  notes: z.string().trim().min(1).max(1000).nullable().optional(),
+});
+
+const enrollmentInclude = {
+  student: {
+    select: {
+      id: true,
+      studentNo: true,
+      firstName: true,
+      lastName: true,
+      status: true,
+      currentClassId: true,
+      currentStreamId: true,
+    },
+  },
+  term: { select: { id: true, code: true, name: true } },
+  class: { select: { id: true, code: true, name: true } },
+  stream: { select: { id: true, code: true, name: true } },
+} satisfies Prisma.SchoolEnrollmentInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = enrollmentQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      studentId: searchParams.get("studentId") ?? undefined,
+      termId: searchParams.get("termId") ?? undefined,
+      classId: searchParams.get("classId") ?? undefined,
+      streamId: searchParams.get("streamId") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+    });
+
+    const where: Prisma.SchoolEnrollmentWhereInput = {
+      companyId: session.user.companyId,
+    };
+
+    if (query.search) {
+      where.student = {
+        OR: [
+          { studentNo: { contains: query.search, mode: "insensitive" } },
+          { firstName: { contains: query.search, mode: "insensitive" } },
+          { lastName: { contains: query.search, mode: "insensitive" } },
+        ],
+      };
+    }
+    if (query.studentId) where.studentId = query.studentId;
+    if (query.termId) where.termId = query.termId;
+    if (query.classId) where.classId = query.classId;
+    if (query.streamId) where.streamId = query.streamId;
+    if (query.status) where.status = query.status;
+
+    const [records, total] = await Promise.all([
+      prisma.schoolEnrollment.findMany({
+        where,
+        include: enrollmentInclude,
+        orderBy: [{ enrolledAt: "desc" }, { createdAt: "desc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolEnrollment.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/enrollments error:", error);
+    return errorResponse("Failed to fetch enrollments");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createEnrollmentSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    const [student, term, schoolClass, stream] = await Promise.all([
+      prisma.schoolStudent.findFirst({
+        where: { id: validated.studentId, companyId },
+        select: { id: true },
+      }),
+      prisma.schoolTerm.findFirst({
+        where: { id: validated.termId, companyId },
+        select: { id: true },
+      }),
+      prisma.schoolClass.findFirst({
+        where: { id: validated.classId, companyId },
+        select: { id: true },
+      }),
+      validated.streamId
+        ? prisma.schoolStream.findFirst({
+            where: { id: validated.streamId, companyId },
+            select: { id: true, classId: true },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    if (!student) return errorResponse("Invalid student for this company", 400);
+    if (!term) return errorResponse("Invalid term for this company", 400);
+    if (!schoolClass) return errorResponse("Invalid class for this company", 400);
+    if (validated.streamId && !stream) {
+      return errorResponse("Invalid stream for this company", 400);
+    }
+    if (stream && stream.classId !== validated.classId) {
+      return errorResponse("Stream does not belong to the selected class", 400);
+    }
+
+    const enrolledAt = toOptionalDate(validated.enrolledAt) ?? new Date();
+    const endedAt = toNullableDate(validated.endedAt);
+    if (endedAt && endedAt < enrolledAt) {
+      return errorResponse("endedAt cannot be before enrolledAt", 400);
+    }
+
+    const enrollment = await prisma.$transaction(async (tx) => {
+      const created = await tx.schoolEnrollment.create({
+        data: {
+          companyId,
+          studentId: validated.studentId,
+          termId: validated.termId,
+          classId: validated.classId,
+          streamId: validated.streamId ?? null,
+          status: validated.status ?? "ACTIVE",
+          enrolledAt,
+          endedAt,
+          notes: normalizeOptionalNullableString(validated.notes) ?? null,
+        },
+        include: enrollmentInclude,
+      });
+
+      if ((validated.status ?? "ACTIVE") === "ACTIVE") {
+        await tx.schoolStudent.update({
+          where: { id: validated.studentId },
+          data: {
+            status: "ACTIVE",
+            currentClassId: validated.classId,
+            currentStreamId: validated.streamId ?? null,
+          },
+        });
+      }
+
+      return created;
+    });
+
+    return successResponse(enrollment, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse(
+        "Enrollment already exists for this student and term",
+        409,
+      );
+    }
+    console.error("[API] POST /api/v2/schools/enrollments error:", error);
+    return errorResponse("Failed to create enrollment");
+  }
+}
+

--- a/app/api/v2/schools/guardians/route.ts
+++ b/app/api/v2/schools/guardians/route.ts
@@ -1,0 +1,199 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
+import { prisma } from "@/lib/prisma";
+import { isUniqueConstraintError, normalizeOptionalNullableString } from "../_helpers";
+
+const guardianQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  studentId: z.string().uuid().optional(),
+});
+
+const guardianStudentLinkSchema = z.object({
+  studentId: z.string().uuid(),
+  relationship: z.string().trim().min(1).max(120),
+  isPrimary: z.boolean().optional(),
+  canReceiveFinancials: z.boolean().optional(),
+  canReceiveAcademicResults: z.boolean().optional(),
+});
+
+const createGuardianSchema = z.object({
+  guardianNo: z.string().trim().min(1).max(40).optional(),
+  firstName: z.string().trim().min(1).max(120),
+  lastName: z.string().trim().min(1).max(120),
+  phone: z.string().trim().min(3).max(50),
+  email: z.string().trim().email().nullable().optional(),
+  address: z.string().trim().min(1).max(500).nullable().optional(),
+  nationalId: z.string().trim().min(1).max(80).nullable().optional(),
+  studentLinks: z.array(guardianStudentLinkSchema).optional(),
+});
+
+const guardianInclude = {
+  studentLinks: {
+    include: {
+      student: {
+        select: {
+          id: true,
+          studentNo: true,
+          firstName: true,
+          lastName: true,
+          status: true,
+        },
+      },
+    },
+  },
+  _count: {
+    select: {
+      studentLinks: true,
+    },
+  },
+} satisfies Prisma.SchoolGuardianInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = guardianQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      studentId: searchParams.get("studentId") ?? undefined,
+    });
+
+    const where: Prisma.SchoolGuardianWhereInput = {
+      companyId: session.user.companyId,
+    };
+
+    if (query.search) {
+      where.OR = [
+        { guardianNo: { contains: query.search, mode: "insensitive" } },
+        { firstName: { contains: query.search, mode: "insensitive" } },
+        { lastName: { contains: query.search, mode: "insensitive" } },
+        { phone: { contains: query.search, mode: "insensitive" } },
+        { email: { contains: query.search, mode: "insensitive" } },
+        { nationalId: { contains: query.search, mode: "insensitive" } },
+      ];
+    }
+    if (query.studentId) {
+      where.studentLinks = {
+        some: {
+          studentId: query.studentId,
+        },
+      };
+    }
+
+    const [records, total] = await Promise.all([
+      prisma.schoolGuardian.findMany({
+        where,
+        include: guardianInclude,
+        orderBy: [{ lastName: "asc" }, { firstName: "asc" }, { createdAt: "desc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolGuardian.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/guardians error:", error);
+    return errorResponse("Failed to fetch guardians");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createGuardianSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    let guardianNo: string;
+    try {
+      guardianNo = validated.guardianNo
+        ? normalizeProvidedId(validated.guardianNo, "SCHOOL_GUARDIAN")
+        : await reserveIdentifier(prisma, {
+            companyId,
+            entity: "SCHOOL_GUARDIAN",
+          });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Invalid guardian number format";
+      return errorResponse(message, 400);
+    }
+
+    const studentLinks = validated.studentLinks ?? [];
+    const studentIds = studentLinks.map((link) => link.studentId);
+    const uniqueStudentIds = new Set(studentIds);
+    if (uniqueStudentIds.size !== studentIds.length) {
+      return errorResponse("Duplicate student links are not allowed in one request", 400);
+    }
+
+    if (studentIds.length > 0) {
+      const students = await prisma.schoolStudent.findMany({
+        where: {
+          companyId,
+          id: { in: studentIds },
+        },
+        select: { id: true },
+      });
+      if (students.length !== studentIds.length) {
+        return errorResponse("One or more students are invalid for this company", 400);
+      }
+    }
+
+    const guardian = await prisma.schoolGuardian.create({
+      data: {
+        companyId,
+        guardianNo,
+        firstName: validated.firstName,
+        lastName: validated.lastName,
+        phone: validated.phone,
+        email: normalizeOptionalNullableString(validated.email) ?? null,
+        address: normalizeOptionalNullableString(validated.address) ?? null,
+        nationalId: normalizeOptionalNullableString(validated.nationalId) ?? null,
+        studentLinks:
+          studentLinks.length > 0
+            ? {
+                create: studentLinks.map((link) => ({
+                  companyId,
+                  studentId: link.studentId,
+                  relationship: link.relationship,
+                  isPrimary: link.isPrimary ?? false,
+                  canReceiveFinancials: link.canReceiveFinancials ?? true,
+                  canReceiveAcademicResults: link.canReceiveAcademicResults ?? true,
+                })),
+              }
+            : undefined,
+      },
+      include: guardianInclude,
+    });
+
+    return successResponse(guardian, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse("Guardian number or student link already exists", 409);
+    }
+    console.error("[API] POST /api/v2/schools/guardians error:", error);
+    return errorResponse("Failed to create guardian");
+  }
+}
+

--- a/app/api/v2/schools/results/sheets/[id]/hod-approve/route.ts
+++ b/app/api/v2/schools/results/sheets/[id]/hod-approve/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const existing = await prisma.schoolResultSheet.findUnique({
+      where: { id },
+      select: { id: true, companyId: true, status: true, submittedById: true },
+    });
+    if (!existing || existing.companyId !== session.user.companyId) {
+      return errorResponse("Result sheet not found", 404);
+    }
+    if (existing.status !== "SUBMITTED") {
+      return errorResponse("Only submitted result sheets can be HOD approved", 400);
+    }
+
+    const updated = await prisma.schoolResultSheet.update({
+      where: { id },
+      data: {
+        status: "HOD_APPROVED",
+        hodApprovedById: session.user.id,
+        hodApprovedAt: new Date(),
+      },
+      include: {
+        term: { select: { id: true, code: true, name: true } },
+        class: { select: { id: true, code: true, name: true } },
+        stream: { select: { id: true, code: true, name: true } },
+        _count: { select: { lines: true } },
+      },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    console.error(
+      "[API] POST /api/v2/schools/results/sheets/[id]/hod-approve error:",
+      error,
+    );
+    return errorResponse("Failed to approve result sheet");
+  }
+}
+

--- a/app/api/v2/schools/results/sheets/[id]/hod-request-changes/route.ts
+++ b/app/api/v2/schools/results/sheets/[id]/hod-request-changes/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+const requestChangesSchema = z.object({
+  note: z.string().trim().min(1).max(1000),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+    const body = await request.json();
+    const validated = requestChangesSchema.parse(body);
+
+    const existing = await prisma.schoolResultSheet.findUnique({
+      where: { id },
+      select: { id: true, companyId: true, status: true },
+    });
+    if (!existing || existing.companyId !== session.user.companyId) {
+      return errorResponse("Result sheet not found", 404);
+    }
+    if (existing.status !== "SUBMITTED") {
+      return errorResponse(
+        "Only submitted result sheets can be sent back for changes",
+        400,
+      );
+    }
+
+    const updated = await prisma.schoolResultSheet.update({
+      where: { id },
+      data: {
+        status: "HOD_REJECTED",
+        hodApprovedById: null,
+        hodApprovedAt: null,
+        publishedById: null,
+        publishedAt: null,
+      },
+      include: {
+        term: { select: { id: true, code: true, name: true } },
+        class: { select: { id: true, code: true, name: true } },
+        stream: { select: { id: true, code: true, name: true } },
+        _count: { select: { lines: true } },
+      },
+    });
+
+    return successResponse({
+      sheet: updated,
+      note: validated.note,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error(
+      "[API] POST /api/v2/schools/results/sheets/[id]/hod-request-changes error:",
+      error,
+    );
+    return errorResponse("Failed to request result sheet changes");
+  }
+}
+

--- a/app/api/v2/schools/results/sheets/[id]/publish/route.ts
+++ b/app/api/v2/schools/results/sheets/[id]/publish/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const existing = await prisma.schoolResultSheet.findUnique({
+      where: { id },
+      select: { id: true, companyId: true, status: true },
+    });
+    if (!existing || existing.companyId !== session.user.companyId) {
+      return errorResponse("Result sheet not found", 404);
+    }
+    if (existing.status !== "HOD_APPROVED") {
+      return errorResponse("Only HOD-approved result sheets can be published", 400);
+    }
+
+    const updated = await prisma.schoolResultSheet.update({
+      where: { id },
+      data: {
+        status: "PUBLISHED",
+        publishedById: session.user.id,
+        publishedAt: new Date(),
+      },
+      include: {
+        term: { select: { id: true, code: true, name: true } },
+        class: { select: { id: true, code: true, name: true } },
+        stream: { select: { id: true, code: true, name: true } },
+        _count: { select: { lines: true } },
+      },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    console.error(
+      "[API] POST /api/v2/schools/results/sheets/[id]/publish error:",
+      error,
+    );
+    return errorResponse("Failed to publish result sheet");
+  }
+}
+

--- a/app/api/v2/schools/results/sheets/[id]/submit/route.ts
+++ b/app/api/v2/schools/results/sheets/[id]/submit/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const existing = await prisma.schoolResultSheet.findUnique({
+      where: { id },
+      select: { id: true, companyId: true, status: true },
+    });
+    if (!existing || existing.companyId !== session.user.companyId) {
+      return errorResponse("Result sheet not found", 404);
+    }
+    if (existing.status !== "DRAFT" && existing.status !== "HOD_REJECTED") {
+      return errorResponse(
+        "Only draft or HOD-rejected result sheets can be submitted",
+        400,
+      );
+    }
+
+    const updated = await prisma.schoolResultSheet.update({
+      where: { id },
+      data: {
+        status: "SUBMITTED",
+        submittedById: session.user.id,
+        submittedAt: new Date(),
+      },
+      include: {
+        term: { select: { id: true, code: true, name: true } },
+        class: { select: { id: true, code: true, name: true } },
+        stream: { select: { id: true, code: true, name: true } },
+        _count: { select: { lines: true } },
+      },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    console.error("[API] POST /api/v2/schools/results/sheets/[id]/submit error:", error);
+    return errorResponse("Failed to submit result sheet");
+  }
+}

--- a/app/api/v2/schools/results/sheets/route.ts
+++ b/app/api/v2/schools/results/sheets/route.ts
@@ -1,0 +1,237 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { isUniqueConstraintError, schoolResultSheetStatusSchema } from "../../_helpers";
+
+const resultSheetQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  termId: z.string().uuid().optional(),
+  classId: z.string().uuid().optional(),
+  streamId: z.string().uuid().optional(),
+  status: schoolResultSheetStatusSchema.optional(),
+  includeLines: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .optional(),
+});
+
+const resultLineSchema = z.object({
+  studentId: z.string().uuid(),
+  subjectCode: z.string().trim().min(1).max(40),
+  score: z.number().finite().min(0).max(100),
+  grade: z.string().trim().min(1).max(10).nullable().optional(),
+  remarks: z.string().trim().min(1).max(500).nullable().optional(),
+});
+
+const createResultSheetSchema = z.object({
+  termId: z.string().uuid(),
+  classId: z.string().uuid(),
+  streamId: z.string().uuid().nullable().optional(),
+  title: z.string().trim().min(1).max(200),
+  lines: z.array(resultLineSchema).optional(),
+});
+
+const baseSheetInclude = {
+  term: { select: { id: true, code: true, name: true } },
+  class: { select: { id: true, code: true, name: true } },
+  stream: { select: { id: true, code: true, name: true } },
+  _count: { select: { lines: true } },
+} satisfies Prisma.SchoolResultSheetInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = resultSheetQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      termId: searchParams.get("termId") ?? undefined,
+      classId: searchParams.get("classId") ?? undefined,
+      streamId: searchParams.get("streamId") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+      includeLines: searchParams.get("includeLines") ?? undefined,
+    });
+
+    const where: Prisma.SchoolResultSheetWhereInput = {
+      companyId: session.user.companyId,
+    };
+    if (query.search) {
+      where.title = { contains: query.search, mode: "insensitive" };
+    }
+    if (query.termId) where.termId = query.termId;
+    if (query.classId) where.classId = query.classId;
+    if (query.streamId) where.streamId = query.streamId;
+    if (query.status) where.status = query.status;
+
+    const include = query.includeLines
+      ? ({
+          ...baseSheetInclude,
+          lines: {
+            include: {
+              student: {
+                select: {
+                  id: true,
+                  studentNo: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
+            orderBy: [{ studentId: "asc" }, { subjectCode: "asc" }],
+          },
+        } satisfies Prisma.SchoolResultSheetInclude)
+      : baseSheetInclude;
+
+    const [records, total] = await Promise.all([
+      prisma.schoolResultSheet.findMany({
+        where,
+        include,
+        orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolResultSheet.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/results/sheets error:", error);
+    return errorResponse("Failed to fetch result sheets");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createResultSheetSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    const [term, schoolClass, stream] = await Promise.all([
+      prisma.schoolTerm.findFirst({
+        where: { id: validated.termId, companyId },
+        select: { id: true },
+      }),
+      prisma.schoolClass.findFirst({
+        where: { id: validated.classId, companyId },
+        select: { id: true },
+      }),
+      validated.streamId
+        ? prisma.schoolStream.findFirst({
+            where: { id: validated.streamId, companyId },
+            select: { id: true, classId: true },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    if (!term) return errorResponse("Invalid term for this company", 400);
+    if (!schoolClass) return errorResponse("Invalid class for this company", 400);
+    if (validated.streamId && !stream) {
+      return errorResponse("Invalid stream for this company", 400);
+    }
+    if (stream && stream.classId !== validated.classId) {
+      return errorResponse("Stream does not belong to the selected class", 400);
+    }
+
+    const lines = validated.lines ?? [];
+    if (lines.length > 0) {
+      const dedupeSet = new Set<string>();
+      for (const line of lines) {
+        const key = `${line.studentId}|${line.subjectCode.trim().toUpperCase()}`;
+        if (dedupeSet.has(key)) {
+          return errorResponse("Duplicate student+subject lines are not allowed", 400);
+        }
+        dedupeSet.add(key);
+      }
+
+      const studentIds = [...new Set(lines.map((line) => line.studentId))];
+      const studentCount = await prisma.schoolStudent.count({
+        where: {
+          companyId,
+          id: { in: studentIds },
+        },
+      });
+      if (studentCount !== studentIds.length) {
+        return errorResponse("One or more line students are invalid for this company", 400);
+      }
+    }
+
+    const sheet = await prisma.$transaction(async (tx) => {
+      const created = await tx.schoolResultSheet.create({
+        data: {
+          companyId,
+          termId: validated.termId,
+          classId: validated.classId,
+          streamId: validated.streamId ?? null,
+          title: validated.title,
+          status: "DRAFT",
+        },
+      });
+
+      if (lines.length > 0) {
+        await tx.schoolResultLine.createMany({
+          data: lines.map((line) => ({
+            companyId,
+            sheetId: created.id,
+            studentId: line.studentId,
+            subjectCode: line.subjectCode.trim().toUpperCase(),
+            score: line.score,
+            grade: line.grade ?? null,
+            remarks: line.remarks ?? null,
+          })),
+        });
+      }
+
+      return tx.schoolResultSheet.findUnique({
+        where: { id: created.id },
+        include: {
+          ...baseSheetInclude,
+          lines: {
+            include: {
+              student: {
+                select: {
+                  id: true,
+                  studentNo: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
+            orderBy: [{ studentId: "asc" }, { subjectCode: "asc" }],
+          },
+        },
+      });
+    });
+
+    if (!sheet) {
+      return errorResponse("Failed to create result sheet", 500);
+    }
+    return successResponse(sheet, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse("Duplicate result line detected", 409);
+    }
+    console.error("[API] POST /api/v2/schools/results/sheets error:", error);
+    return errorResponse("Failed to create result sheet");
+  }
+}

--- a/app/api/v2/schools/route.ts
+++ b/app/api/v2/schools/route.ts
@@ -1,10 +1,47 @@
-import { NextRequest } from "next/server";
-import { errorResponse } from "@/lib/api-utils";
-import { buildV2CollectionResponse } from "../_shared";
+import { NextRequest, NextResponse } from "next/server";
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
 
 export async function GET(request: NextRequest) {
   try {
-    return await buildV2CollectionResponse(request, "schools");
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const companyId = session.user.companyId;
+    const [students, guardians, enrollments, boardingAllocations, resultSheets] =
+      await Promise.all([
+        prisma.schoolStudent.count({ where: { companyId } }),
+        prisma.schoolGuardian.count({ where: { companyId } }),
+        prisma.schoolEnrollment.count({ where: { companyId } }),
+        prisma.schoolBoardingAllocation.count({ where: { companyId } }),
+        prisma.schoolResultSheet.count({ where: { companyId } }),
+      ]);
+
+    const counts = {
+      students,
+      guardians,
+      enrollments,
+      boardingAllocations,
+      resultSheets,
+    };
+
+    return successResponse({
+      success: true,
+      data: {
+        resource: "schools",
+        companyId,
+        counts,
+        count: Object.keys(counts).length,
+        records: [
+          { id: "students", name: String(students) },
+          { id: "guardians", name: String(guardians) },
+          { id: "enrollments", name: String(enrollments) },
+          { id: "boarding-allocations", name: String(boardingAllocations) },
+          { id: "result-sheets", name: String(resultSheets) },
+        ],
+      },
+    });
   } catch (error) {
     console.error("[API] GET /api/v2/schools error:", error);
     return errorResponse("Failed to fetch schools v2 data");

--- a/app/api/v2/schools/students/route.ts
+++ b/app/api/v2/schools/students/route.ts
@@ -1,0 +1,250 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import {
+  errorResponse,
+  getPaginationParams,
+  paginationResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
+import { prisma } from "@/lib/prisma";
+import {
+  isUniqueConstraintError,
+  normalizeOptionalNullableString,
+  nullableDateInputSchema,
+  schoolStudentStatusSchema,
+  toNullableDate,
+} from "../_helpers";
+
+const studentQuerySchema = z.object({
+  search: z.string().trim().min(1).optional(),
+  status: schoolStudentStatusSchema.optional(),
+  classId: z.string().uuid().optional(),
+  streamId: z.string().uuid().optional(),
+  isBoarding: z
+    .enum(["true", "false"])
+    .transform((value) => value === "true")
+    .optional(),
+});
+
+const studentGuardianLinkSchema = z.object({
+  guardianId: z.string().uuid(),
+  relationship: z.string().trim().min(1).max(120),
+  isPrimary: z.boolean().optional(),
+  canReceiveFinancials: z.boolean().optional(),
+  canReceiveAcademicResults: z.boolean().optional(),
+});
+
+const createStudentSchema = z.object({
+  studentNo: z.string().trim().min(1).max(40).optional(),
+  admissionNo: z.string().trim().min(1).max(80).nullable().optional(),
+  firstName: z.string().trim().min(1).max(120),
+  lastName: z.string().trim().min(1).max(120),
+  dateOfBirth: nullableDateInputSchema,
+  gender: z.string().trim().min(1).max(30).nullable().optional(),
+  status: schoolStudentStatusSchema.optional(),
+  currentClassId: z.string().uuid().nullable().optional(),
+  currentStreamId: z.string().uuid().nullable().optional(),
+  isBoarding: z.boolean().optional(),
+  admissionDate: nullableDateInputSchema,
+  guardianLinks: z.array(studentGuardianLinkSchema).optional(),
+});
+
+const studentInclude = {
+  currentClass: { select: { id: true, code: true, name: true } },
+  currentStream: { select: { id: true, code: true, name: true, classId: true } },
+  guardianLinks: {
+    include: {
+      guardian: {
+        select: {
+          id: true,
+          guardianNo: true,
+          firstName: true,
+          lastName: true,
+          phone: true,
+          email: true,
+        },
+      },
+    },
+  },
+  _count: {
+    select: {
+      guardianLinks: true,
+      enrollments: true,
+      boardingAllocations: true,
+      resultLines: true,
+    },
+  },
+} satisfies Prisma.SchoolStudentInclude;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { searchParams } = new URL(request.url);
+    const { page, limit, skip } = getPaginationParams(request);
+
+    const query = studentQuerySchema.parse({
+      search: searchParams.get("search") ?? undefined,
+      status: searchParams.get("status") ?? undefined,
+      classId: searchParams.get("classId") ?? undefined,
+      streamId: searchParams.get("streamId") ?? undefined,
+      isBoarding: searchParams.get("isBoarding") ?? undefined,
+    });
+
+    const where: Prisma.SchoolStudentWhereInput = {
+      companyId: session.user.companyId,
+    };
+
+    if (query.search) {
+      where.OR = [
+        { studentNo: { contains: query.search, mode: "insensitive" } },
+        { admissionNo: { contains: query.search, mode: "insensitive" } },
+        { firstName: { contains: query.search, mode: "insensitive" } },
+        { lastName: { contains: query.search, mode: "insensitive" } },
+      ];
+    }
+    if (query.status) where.status = query.status;
+    if (query.classId) where.currentClassId = query.classId;
+    if (query.streamId) where.currentStreamId = query.streamId;
+    if (query.isBoarding !== undefined) where.isBoarding = query.isBoarding;
+
+    const [records, total] = await Promise.all([
+      prisma.schoolStudent.findMany({
+        where,
+        include: studentInclude,
+        orderBy: [{ lastName: "asc" }, { firstName: "asc" }, { createdAt: "desc" }],
+        skip,
+        take: limit,
+      }),
+      prisma.schoolStudent.count({ where }),
+    ]);
+
+    return successResponse(paginationResponse(records, total, page, limit));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    console.error("[API] GET /api/v2/schools/students error:", error);
+    return errorResponse("Failed to fetch students");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = await request.json();
+    const validated = createStudentSchema.parse(body);
+    const companyId = session.user.companyId;
+
+    let studentNo: string;
+    try {
+      studentNo = validated.studentNo
+        ? normalizeProvidedId(validated.studentNo, "SCHOOL_STUDENT")
+        : await reserveIdentifier(prisma, {
+            companyId,
+            entity: "SCHOOL_STUDENT",
+          });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Invalid student number format";
+      return errorResponse(message, 400);
+    }
+
+    let classId = validated.currentClassId ?? null;
+    const streamId = validated.currentStreamId ?? null;
+    if (classId) {
+      const schoolClass = await prisma.schoolClass.findFirst({
+        where: { id: classId, companyId },
+        select: { id: true },
+      });
+      if (!schoolClass) {
+        return errorResponse("Invalid class for this company", 400);
+      }
+    }
+
+    if (streamId) {
+      const stream = await prisma.schoolStream.findFirst({
+        where: { id: streamId, companyId },
+        select: { id: true, classId: true },
+      });
+      if (!stream) {
+        return errorResponse("Invalid stream for this company", 400);
+      }
+      if (classId && stream.classId !== classId) {
+        return errorResponse("Stream does not belong to the selected class", 400);
+      }
+      if (!classId) classId = stream.classId;
+    }
+
+    const guardianLinks = validated.guardianLinks ?? [];
+    const guardianIds = guardianLinks.map((link) => link.guardianId);
+    const uniqueGuardianIds = new Set(guardianIds);
+    if (uniqueGuardianIds.size !== guardianIds.length) {
+      return errorResponse("Duplicate guardians are not allowed in one request", 400);
+    }
+
+    const primaryCount = guardianLinks.filter((link) => link.isPrimary).length;
+    if (primaryCount > 1) {
+      return errorResponse("Only one primary guardian can be assigned per student", 400);
+    }
+
+    if (guardianIds.length > 0) {
+      const guardians = await prisma.schoolGuardian.findMany({
+        where: { companyId, id: { in: guardianIds } },
+        select: { id: true },
+      });
+      if (guardians.length !== guardianIds.length) {
+        return errorResponse("One or more guardians are invalid for this company", 400);
+      }
+    }
+
+    const student = await prisma.schoolStudent.create({
+      data: {
+        companyId,
+        studentNo,
+        admissionNo: normalizeOptionalNullableString(validated.admissionNo) ?? null,
+        firstName: validated.firstName,
+        lastName: validated.lastName,
+        dateOfBirth: toNullableDate(validated.dateOfBirth),
+        gender: normalizeOptionalNullableString(validated.gender) ?? null,
+        status: validated.status ?? "APPLICANT",
+        currentClassId: classId,
+        currentStreamId: streamId,
+        isBoarding: validated.isBoarding ?? false,
+        admissionDate: toNullableDate(validated.admissionDate),
+        guardianLinks:
+          guardianLinks.length > 0
+            ? {
+                create: guardianLinks.map((link) => ({
+                  companyId,
+                  guardianId: link.guardianId,
+                  relationship: link.relationship,
+                  isPrimary: link.isPrimary ?? false,
+                  canReceiveFinancials: link.canReceiveFinancials ?? true,
+                  canReceiveAcademicResults: link.canReceiveAcademicResults ?? true,
+                })),
+              }
+            : undefined,
+      },
+      include: studentInclude,
+    });
+
+    return successResponse(student, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    if (isUniqueConstraintError(error)) {
+      return errorResponse("Student number or admission number already exists", 409);
+    }
+    console.error("[API] POST /api/v2/schools/students error:", error);
+    return errorResponse("Failed to create student");
+  }
+}

--- a/docs/expansion-plan/erp-expansion-master-plan.md
+++ b/docs/expansion-plan/erp-expansion-master-plan.md
@@ -244,3 +244,9 @@ Required QA evidence per pack:
 2. Any new finance-impacting source event requires accounting-map update in same PR.
 3. Deferred scope requires dependency ID, owner role, target wave, and interim control.
 4. Stop-ship conditions from risk register override timeline commitments.
+
+## 13. Implementation Progress Log
+| Date | Branch | Slice | Status | Notes |
+| --- | --- | --- | --- | --- |
+| 2026-02-27 | `feat/platform-expansion-foundation-v1` | Wave 0 base scaffolding | Completed | Feature catalog/bundles, route gating, templates, portal/module route scaffolds, expansion spec docs. |
+| 2026-02-27 | `feat/schools-core-phase1-v1` | Wave 1 Schools core backend (increment 1) | In Progress | Prisma models for schools core + boarding/results state + `/api/v2/schools/*` CRUD/workflow endpoints. |

--- a/lib/id-generator.ts
+++ b/lib/id-generator.ts
@@ -15,6 +15,8 @@ export type ReservableIdEntity =
   | "INVENTORY_ITEM"
   | "STOCK_LOCATION"
   | "STOCK_MOVEMENT"
+  | "SCHOOL_STUDENT"
+  | "SCHOOL_GUARDIAN"
   | "GOLD_POUR"
   | "GOLD_RECEIPT"
   | "GOLD_PURCHASE";
@@ -42,6 +44,8 @@ export const ID_ENTITY_CONFIG: Record<ReservableIdEntity, EntityConfig> = {
   INVENTORY_ITEM: { prefix: "INV", requiresSiteId: true },
   STOCK_LOCATION: { prefix: "LOC", requiresSiteId: true },
   STOCK_MOVEMENT: { prefix: "MOV", requiresSiteId: false },
+  SCHOOL_STUDENT: { prefix: "STU", requiresSiteId: false },
+  SCHOOL_GUARDIAN: { prefix: "GDN", requiresSiteId: false },
   GOLD_POUR: { prefix: "BAR", requiresSiteId: false },
   GOLD_RECEIPT: { prefix: "RCP", requiresSiteId: false },
   GOLD_PURCHASE: { prefix: "GPUR", requiresSiteId: false },
@@ -193,6 +197,20 @@ async function findEntityMaxExistingCode(
         select: { referenceId: true },
       });
       return extractMaxFromCodes(records.map((record) => record.referenceId), prefix);
+    }
+    case "SCHOOL_STUDENT": {
+      const records = await db.schoolStudent.findMany({
+        where: { companyId },
+        select: { studentNo: true },
+      });
+      return extractMaxFromCodes(records.map((record) => record.studentNo), prefix);
+    }
+    case "SCHOOL_GUARDIAN": {
+      const records = await db.schoolGuardian.findMany({
+        where: { companyId },
+        select: { guardianNo: true },
+      });
+      return extractMaxFromCodes(records.map((record) => record.guardianNo), prefix);
     }
     case "GOLD_POUR": {
       const records = await db.goldPour.findMany({

--- a/lib/platform/gating/route-registry.ts
+++ b/lib/platform/gating/route-registry.ts
@@ -235,6 +235,8 @@ export const API_FEATURE_ROUTES: FeatureRouteEntry[] = [
 
   { scope: "api", prefix: "/api/schools/admissions", featureKey: "schools.admissions" },
   { scope: "api", prefix: "/api/schools/students", featureKey: "schools.students" },
+  { scope: "api", prefix: "/api/schools/guardians", featureKey: "schools.students" },
+  { scope: "api", prefix: "/api/schools/enrollments", featureKey: "schools.admissions" },
   { scope: "api", prefix: "/api/schools/attendance", featureKey: "schools.attendance" },
   { scope: "api", prefix: "/api/schools/fees", featureKey: "schools.fees" },
   { scope: "api", prefix: "/api/schools/boarding", featureKey: "schools.boarding" },
@@ -245,6 +247,8 @@ export const API_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "api", prefix: "/api/schools", featureKey: "schools.core" },
   { scope: "api", prefix: "/api/v2/schools/admissions", featureKey: "schools.admissions" },
   { scope: "api", prefix: "/api/v2/schools/students", featureKey: "schools.students" },
+  { scope: "api", prefix: "/api/v2/schools/guardians", featureKey: "schools.students" },
+  { scope: "api", prefix: "/api/v2/schools/enrollments", featureKey: "schools.admissions" },
   { scope: "api", prefix: "/api/v2/schools/attendance", featureKey: "schools.attendance" },
   { scope: "api", prefix: "/api/v2/schools/fees", featureKey: "schools.fees" },
   { scope: "api", prefix: "/api/v2/schools/boarding", featureKey: "schools.boarding" },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,20 @@ model Company {
   documentRenderJobs   DocumentRenderJob[]
   documentArtifacts    DocumentArtifact[]
   idSequences          IdSequence[]
+  schoolAcademicYears  SchoolAcademicYear[]
+  schoolTerms          SchoolTerm[]
+  schoolClasses        SchoolClass[]
+  schoolStreams        SchoolStream[]
+  schoolStudents       SchoolStudent[]
+  schoolGuardians      SchoolGuardian[]
+  schoolStudentGuardians SchoolStudentGuardian[]
+  schoolEnrollments    SchoolEnrollment[]
+  schoolHostels        SchoolHostel[]
+  schoolHostelRooms    SchoolHostelRoom[]
+  schoolHostelBeds     SchoolHostelBed[]
+  schoolBoardingAllocations SchoolBoardingAllocation[]
+  schoolResultSheets   SchoolResultSheet[]
+  schoolResultLines    SchoolResultLine[]
   goldPurchases        GoldPurchase[]
   goldPrices          GoldPrice[]
 
@@ -3621,6 +3635,357 @@ model TrainingRecord {
 
   @@index([userId])
   @@index([expiryDate])
+}
+
+// ============================================
+// SCHOOLS PACK MODELS
+// ============================================
+
+enum SchoolStudentStatus {
+  APPLICANT
+  ACTIVE
+  SUSPENDED
+  GRADUATED
+  WITHDRAWN
+}
+
+enum SchoolEnrollmentStatus {
+  ACTIVE
+  TRANSFERRED
+  WITHDRAWN
+  COMPLETED
+}
+
+enum SchoolResultSheetStatus {
+  DRAFT
+  SUBMITTED
+  HOD_APPROVED
+  HOD_REJECTED
+  PUBLISHED
+}
+
+enum SchoolBoardingAllocationStatus {
+  ACTIVE
+  TRANSFERRED
+  ENDED
+}
+
+model SchoolAcademicYear {
+  id        String   @id @default(uuid())
+  companyId String
+  code      String
+  name      String
+  startDate DateTime
+  endDate   DateTime
+  isActive  Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  terms   SchoolTerm[]
+  classes SchoolClass[]
+
+  @@unique([companyId, code])
+  @@index([companyId, isActive])
+}
+
+model SchoolTerm {
+  id             String   @id @default(uuid())
+  companyId      String
+  academicYearId String
+  code           String
+  name           String
+  startDate      DateTime
+  endDate        DateTime
+  isActive       Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  company      Company            @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  academicYear SchoolAcademicYear @relation(fields: [academicYearId], references: [id], onDelete: Cascade)
+  classes      SchoolClass[]
+  streams      SchoolStream[]
+  enrollments  SchoolEnrollment[]
+  boardingAllocations SchoolBoardingAllocation[]
+  resultSheets SchoolResultSheet[]
+
+  @@unique([companyId, academicYearId, code])
+  @@index([companyId, isActive])
+}
+
+model SchoolClass {
+  id             String   @id @default(uuid())
+  companyId      String
+  code           String
+  name           String
+  level          Int?
+  capacity       Int?
+  academicYearId String?
+  termId         String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  company      Company            @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  academicYear SchoolAcademicYear? @relation(fields: [academicYearId], references: [id], onDelete: SetNull)
+  term         SchoolTerm?         @relation(fields: [termId], references: [id], onDelete: SetNull)
+  streams      SchoolStream[]
+  students     SchoolStudent[]
+  enrollments  SchoolEnrollment[]
+  resultSheets SchoolResultSheet[]
+
+  @@unique([companyId, code])
+  @@index([companyId])
+  @@index([termId])
+}
+
+model SchoolStream {
+  id        String   @id @default(uuid())
+  companyId String
+  classId   String
+  termId    String?
+  code      String
+  name      String
+  capacity  Int?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  company     Company      @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  class       SchoolClass  @relation(fields: [classId], references: [id], onDelete: Cascade)
+  term        SchoolTerm?  @relation(fields: [termId], references: [id], onDelete: SetNull)
+  students    SchoolStudent[]
+  enrollments SchoolEnrollment[]
+  resultSheets SchoolResultSheet[]
+
+  @@unique([companyId, classId, code])
+  @@index([companyId])
+}
+
+model SchoolStudent {
+  id             String            @id @default(uuid())
+  companyId      String
+  studentNo      String
+  admissionNo    String?
+  firstName      String
+  lastName       String
+  dateOfBirth    DateTime?
+  gender         String?
+  status         SchoolStudentStatus @default(APPLICANT)
+  currentClassId String?
+  currentStreamId String?
+  isBoarding     Boolean           @default(false)
+  admissionDate  DateTime?
+  createdAt      DateTime          @default(now())
+  updatedAt      DateTime          @updatedAt
+
+  company        Company        @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  currentClass   SchoolClass?   @relation(fields: [currentClassId], references: [id], onDelete: SetNull)
+  currentStream  SchoolStream?  @relation(fields: [currentStreamId], references: [id], onDelete: SetNull)
+  guardianLinks  SchoolStudentGuardian[]
+  enrollments    SchoolEnrollment[]
+  boardingAllocations SchoolBoardingAllocation[]
+  resultLines    SchoolResultLine[]
+
+  @@unique([companyId, studentNo])
+  @@unique([companyId, admissionNo])
+  @@index([companyId, status])
+  @@index([currentClassId])
+}
+
+model SchoolGuardian {
+  id         String   @id @default(uuid())
+  companyId  String
+  guardianNo String
+  firstName  String
+  lastName   String
+  phone      String
+  email      String?
+  address    String?
+  nationalId String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  company      Company               @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  studentLinks SchoolStudentGuardian[]
+
+  @@unique([companyId, guardianNo])
+  @@index([companyId, phone])
+}
+
+model SchoolStudentGuardian {
+  id                      String   @id @default(uuid())
+  companyId               String
+  studentId               String
+  guardianId              String
+  relationship            String
+  isPrimary               Boolean  @default(false)
+  canReceiveFinancials    Boolean  @default(true)
+  canReceiveAcademicResults Boolean @default(true)
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  company  Company       @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  student  SchoolStudent @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  guardian SchoolGuardian @relation(fields: [guardianId], references: [id], onDelete: Cascade)
+
+  @@unique([companyId, studentId, guardianId])
+  @@index([companyId, guardianId])
+}
+
+model SchoolEnrollment {
+  id         String               @id @default(uuid())
+  companyId  String
+  studentId  String
+  termId     String
+  classId    String
+  streamId   String?
+  status     SchoolEnrollmentStatus @default(ACTIVE)
+  enrolledAt DateTime             @default(now())
+  endedAt    DateTime?
+  notes      String?
+  createdAt  DateTime             @default(now())
+  updatedAt  DateTime             @updatedAt
+
+  company Company      @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  student SchoolStudent @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  term    SchoolTerm   @relation(fields: [termId], references: [id], onDelete: Cascade)
+  class   SchoolClass  @relation(fields: [classId], references: [id], onDelete: Cascade)
+  stream  SchoolStream? @relation(fields: [streamId], references: [id], onDelete: SetNull)
+
+  @@unique([companyId, studentId, termId])
+  @@index([companyId, status])
+}
+
+model SchoolHostel {
+  id           String   @id @default(uuid())
+  companyId    String
+  code         String
+  name         String
+  genderPolicy String   @default("MIXED")
+  capacity     Int?
+  isActive     Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  company     Company        @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  rooms       SchoolHostelRoom[]
+  beds        SchoolHostelBed[]
+  allocations SchoolBoardingAllocation[]
+
+  @@unique([companyId, code])
+  @@index([companyId, isActive])
+}
+
+model SchoolHostelRoom {
+  id        String   @id @default(uuid())
+  companyId String
+  hostelId  String
+  code      String
+  floor     String?
+  capacity  Int?
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  company     Company        @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  hostel      SchoolHostel   @relation(fields: [hostelId], references: [id], onDelete: Cascade)
+  beds        SchoolHostelBed[]
+  allocations SchoolBoardingAllocation[]
+
+  @@unique([companyId, hostelId, code])
+  @@index([companyId, isActive])
+}
+
+model SchoolHostelBed {
+  id        String   @id @default(uuid())
+  companyId String
+  hostelId  String
+  roomId    String
+  code      String
+  status    String   @default("AVAILABLE")
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  company     Company      @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  hostel      SchoolHostel @relation(fields: [hostelId], references: [id], onDelete: Cascade)
+  room        SchoolHostelRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  allocations SchoolBoardingAllocation[]
+
+  @@unique([companyId, roomId, code])
+  @@index([companyId, isActive])
+}
+
+model SchoolBoardingAllocation {
+  id        String   @id @default(uuid())
+  companyId String
+  studentId String
+  termId    String
+  hostelId  String
+  roomId    String?
+  bedId     String?
+  status    SchoolBoardingAllocationStatus @default(ACTIVE)
+  startDate DateTime @default(now())
+  endDate   DateTime?
+  reason    String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  student SchoolStudent @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  term    SchoolTerm    @relation(fields: [termId], references: [id], onDelete: Cascade)
+  hostel  SchoolHostel  @relation(fields: [hostelId], references: [id], onDelete: Cascade)
+  room    SchoolHostelRoom? @relation(fields: [roomId], references: [id], onDelete: SetNull)
+  bed     SchoolHostelBed?  @relation(fields: [bedId], references: [id], onDelete: SetNull)
+
+  @@index([companyId, status])
+  @@index([studentId, termId])
+}
+
+model SchoolResultSheet {
+  id              String   @id @default(uuid())
+  companyId       String
+  termId          String
+  classId         String
+  streamId        String?
+  title           String
+  status          SchoolResultSheetStatus @default(DRAFT)
+  submittedById   String?
+  hodApprovedById String?
+  publishedById   String?
+  submittedAt     DateTime?
+  hodApprovedAt   DateTime?
+  publishedAt     DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  term    SchoolTerm @relation(fields: [termId], references: [id], onDelete: Cascade)
+  class   SchoolClass @relation(fields: [classId], references: [id], onDelete: Cascade)
+  stream  SchoolStream? @relation(fields: [streamId], references: [id], onDelete: SetNull)
+  lines   SchoolResultLine[]
+
+  @@index([companyId, status])
+  @@index([termId, classId])
+}
+
+model SchoolResultLine {
+  id         String   @id @default(uuid())
+  companyId  String
+  sheetId    String
+  studentId  String
+  subjectCode String
+  score      Float
+  grade      String?
+  remarks    String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  company Company @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  sheet   SchoolResultSheet @relation(fields: [sheetId], references: [id], onDelete: Cascade)
+  student SchoolStudent @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([companyId, sheetId, studentId, subjectCode])
+  @@index([companyId, studentId])
 }
 
 // ============================================


### PR DESCRIPTION
## Summary\n- add Schools core data model to Prisma (students, guardians, enrollments, boarding, result sheets/lines)\n- extend ID reservation for student and guardian document numbers\n- add v2 Schools APIs for students, guardians, enrollments, hostels/allocations, and result moderation workflow\n- extend route registry gating for newly added schools API routes\n- update expansion master plan implementation log\n\n## Validation\n- pnpm lint (passes; existing unrelated warnings remain)\n- pnpm build (passes)\n\n## Notes\n- PR is stacked on eat/platform-expansion-foundation-v1 as the next delivery wave increment.\n- Untracked local file export-calls.txt intentionally excluded.