### PR TITLE
fix(pos): fix checkout transaction abort bug and rebuild POS UI

### DIFF
--- a/app/api/v2/retail/_helpers.ts
+++ b/app/api/v2/retail/_helpers.ts
@@ -179,48 +179,39 @@ export async function recordRetailInventoryMovement(input: {
 
   const createdAt = input.entryDate ?? new Date();
   const writeMovement = async (tx: Prisma.TransactionClient) => {
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      const referenceId = await reserveIdentifier(tx, {
-        companyId: input.companyId,
-        entity: "STOCK_MOVEMENT",
-      });
+    // No retry loop here: reserveIdentifier uses an atomic sequence increment so
+    // P2002 collisions on stockMovement.create are not expected. A retry loop that
+    // catches P2002 and continues inside a PostgreSQL transaction would leave the
+    // transaction in an "aborted" state, causing every subsequent query to fail with
+    // "current transaction is aborted". Let any error propagate cleanly.
+    const referenceId = await reserveIdentifier(tx, {
+      companyId: input.companyId,
+      entity: "STOCK_MOVEMENT",
+    });
 
-      try {
-        const created = await tx.stockMovement.create({
-          data: {
-            referenceId,
-            itemId: input.itemId,
-            toLocationId: input.toLocationId ?? undefined,
-            movementType: input.movementType,
-            quantity: input.movementType === "ADJUSTMENT" ? input.quantity : absoluteQuantity,
-            unit: input.unit,
-            notes: input.notes ?? undefined,
-            issuedById: input.userId,
-            createdAt,
-          },
-        });
+    const created = await tx.stockMovement.create({
+      data: {
+        referenceId,
+        itemId: input.itemId,
+        toLocationId: input.toLocationId ?? undefined,
+        movementType: input.movementType,
+        quantity: input.movementType === "ADJUSTMENT" ? input.quantity : absoluteQuantity,
+        unit: input.unit,
+        notes: input.notes ?? undefined,
+        issuedById: input.userId,
+        createdAt,
+      },
+    });
 
-        await tx.inventoryItem.update({
-          where: { id: input.itemId },
-          data: {
-            currentStock: nextStock,
-            ...(input.unitCost !== undefined && input.unitCost !== null ? { unitCost: input.unitCost } : {}),
-          },
-        });
+    await tx.inventoryItem.update({
+      where: { id: input.itemId },
+      data: {
+        currentStock: nextStock,
+        ...(input.unitCost !== undefined && input.unitCost !== null ? { unitCost: input.unitCost } : {}),
+      },
+    });
 
-        return created;
-      } catch (error) {
-        if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          continue;
-        }
-        throw error;
-      }
-    }
-
-    throw new Error("Unable to generate stock movement reference.");
+    return created;
   };
   const movement = input.tx ? await writeMovement(input.tx) : await prisma.$transaction(writeMovement);
 

--- a/components/retail/portal/pos-checkout-view.tsx
+++ b/components/retail/portal/pos-checkout-view.tsx
@@ -15,13 +15,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -35,11 +28,19 @@ import { createOfflineRetailCustomer } from "@/lib/retail/offline-runtime";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   ArrowRight,
+  ArrowRightLeft,
   CheckCircle2,
   Clock,
+  Coins,
+  History,
+  Loader2,
+  Minus,
   Package,
   Payments,
+  Plus,
+  QrCode,
   ReceiptLong,
+  RefreshCcw,
   Save,
   Search,
   Sparkles,
@@ -48,7 +49,7 @@ import {
   Users,
   Wallet,
   X,
-  Plus,
+  Zap,
 } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 import { getPosPortalHref } from "@/lib/retail/pos-host";
@@ -87,22 +88,27 @@ function roundUp(value: number, step: number) {
 
 function tenderLabel(tenderType: TenderType) {
   switch (tenderType) {
-    case "CASH":
-      return "Cash";
-    case "CARD":
-      return "Card";
-    case "MOBILE_MONEY":
-      return "Mobile money";
-    case "TRANSFER":
-      return "Transfer";
-    case "VOUCHER":
-      return "Voucher";
-    default:
-      return tenderType;
+    case "CASH": return "Cash";
+    case "CARD": return "Card";
+    case "MOBILE_MONEY": return "Mobile";
+    case "TRANSFER": return "Transfer";
+    case "VOUCHER": return "Voucher";
+    default: return tenderType;
   }
 }
 
-/* ─── Compact numeric field (inline) ────────────────────────────── */
+function TenderIcon({ type, className }: { type: TenderType; className?: string }) {
+  const cls = cn("h-[1.1em] w-[1.1em]", className);
+  switch (type) {
+    case "CASH": return <Coins className={cls} />;
+    case "CARD": return <QrCode className={cls} />;
+    case "MOBILE_MONEY": return <Payments className={cls} />;
+    case "TRANSFER": return <ArrowRightLeft className={cls} />;
+    case "VOUCHER": return <Zap className={cls} />;
+  }
+}
+
+/* ─── Compact numeric field (inline editor) ──────────────────────── */
 
 function NumField({
   label,
@@ -122,17 +128,48 @@ function NumField({
       type="button"
       onClick={onActivate}
       className={cn(
-        "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left transition-all duration-150",
+        "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left transition-all duration-100",
         active
-          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,var(--surface-base))] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
-          : "border-[var(--border-default)] bg-[var(--surface-base)] hover:bg-[var(--surface-muted)]",
+          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,var(--surface-base))] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
+          : "border-[var(--border-default)] bg-[var(--surface-base)] hover:border-[var(--action-primary-bg)] hover:bg-[var(--surface-muted)]",
         className,
       )}
     >
-      <span className="text-xs text-[var(--text-muted)]">{label}</span>
-      <span className="font-mono text-sm font-semibold text-[var(--text-strong)]">
+      <span className="text-[11px] font-medium text-[var(--text-muted)]">{label}</span>
+      <span className={cn(
+        "font-mono text-sm font-bold",
+        active ? "text-[var(--action-primary-bg)]" : "text-[var(--text-strong)]",
+      )}>
         {value || "0"}
       </span>
+    </button>
+  );
+}
+
+/* ─── Tender type tab button ─────────────────────────────────────── */
+
+function TenderTab({
+  type,
+  selected,
+  onClick,
+}: {
+  type: TenderType;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-1 flex-col items-center gap-1 rounded-lg border py-2 text-[10px] font-semibold uppercase tracking-wide transition-all duration-100 active:scale-[0.96]",
+        selected
+          ? "border-[var(--action-primary-bg)] bg-[var(--action-primary-bg)] text-white shadow-sm"
+          : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]",
+      )}
+    >
+      <TenderIcon type={type} className="h-4 w-4" />
+      {tenderLabel(type)}
     </button>
   );
 }
@@ -148,7 +185,7 @@ export function PosCheckoutView() {
   const { tenantKey } = useOfflineRuntime();
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
-  /* ── Local state ─────────────────────────────────── */
+  /* ── Local state ─────────────────────────────── */
   const [holdDialog, setHoldDialog] = useState(false);
   const [holdLabel, setHoldLabel] = useState("");
   const [selectedLineId, setSelectedLineId] = useState<string | null>(null);
@@ -156,65 +193,36 @@ export function PosCheckoutView() {
   const [customerSheetOpen, setCustomerSheetOpen] = useState(false);
   const [adjustmentsOpen, setAdjustmentsOpen] = useState(false);
 
-  /* ── Global POS state ────────────────────────────── */
+  /* ── Global POS state ────────────────────────── */
   const {
-    search,
-    setSearch,
+    search, setSearch,
     cart,
-    customerName,
-    setCustomerName,
-    selectedCustomerId,
-    selectCustomer,
-    customerSearchResults,
-    customerSearchLoading,
-    customerPhone,
-    setCustomerPhone,
-    customerEmail,
-    setCustomerEmail,
-    loyaltyRedemptionPoints,
-    setLoyaltyRedemptionPoints,
-    payments,
-    setPayments,
-    splitTenderMode,
-    setSplitTenderMode,
-    orderDiscountAmount,
-    setOrderDiscountAmount,
-    overrideReason,
-    setOverrideReason,
-    selectedPromotionId,
-    setSelectedPromotionId,
-    currentShift,
-    isPosHost,
-    catalogItems,
-    catalogLoading,
-    promotions,
-    canOverride,
-    subtotal,
-    discountAmount,
-    taxAmount,
-    total,
-    changeAmount,
-    tenderedTotal,
-    nonCashTotal,
-    addToCart,
-    updateQty,
-    updateItemPrice,
-    updateItemDiscount,
-    removeFromCart,
-    clearCart,
-    postSale,
-    postSalePending,
+    customerName, setCustomerName,
+    selectedCustomerId, selectCustomer,
+    customerSearchResults, customerSearchLoading,
+    customerPhone, setCustomerPhone,
+    customerEmail, setCustomerEmail,
+    loyaltyRedemptionPoints, setLoyaltyRedemptionPoints,
+    payments, setPayments,
+    splitTenderMode, setSplitTenderMode,
+    orderDiscountAmount, setOrderDiscountAmount,
+    overrideReason, setOverrideReason,
+    selectedPromotionId, setSelectedPromotionId,
+    currentShift, isPosHost,
+    catalogItems, catalogLoading,
+    promotions, canOverride,
+    subtotal, discountAmount, taxAmount, total,
+    changeAmount, tenderedTotal, nonCashTotal,
+    addToCart, updateQty, updateItemPrice, updateItemDiscount,
+    removeFromCart, clearCart,
+    postSale, postSalePending,
     checkoutBaseBlockers,
-    pendingOfflineSales,
-    syncOfflineSales,
-    syncOfflineSalesPending,
-    requiredReferenceTenders,
-    minReferenceLength,
-    lastCompletedSale,
-    dismissCompletedSale,
+    pendingOfflineSales, syncOfflineSales, syncOfflineSalesPending,
+    requiredReferenceTenders, minReferenceLength,
+    lastCompletedSale, dismissCompletedSale,
   } = usePosPortalState();
 
-  /* ── Derived state ───────────────────────────────── */
+  /* ── Derived state ───────────────────────────── */
 
   const selectedLine = useMemo(
     () => cart.find((line) => line.catalogItemId === selectedLineId) ?? null,
@@ -222,14 +230,12 @@ export function PosCheckoutView() {
   );
 
   const selectedCustomer =
-    customerSearchResults.find((customer) => customer.id === selectedCustomerId) ?? null;
+    customerSearchResults.find((c) => c.id === selectedCustomerId) ?? null;
 
   const selectedPromotion =
-    promotions.find((promotion) => promotion.id === selectedPromotionId) ?? null;
+    promotions.find((p) => p.id === selectedPromotionId) ?? null;
 
-  const lineCountLabel = `${cart.length} item${cart.length === 1 ? "" : "s"}`;
-
-  /* ── Focus helper ────────────────────────────────── */
+  /* ── Focus helper ────────────────────────────── */
 
   const focusSearchInput = () => {
     if (typeof window === "undefined") return;
@@ -241,7 +247,6 @@ export function PosCheckoutView() {
 
   const handleAddCatalogItem = (item: (typeof catalogItems)[number]) => {
     addToCart(item);
-    /* BUG FIX: Auto-set activeTarget to payment amount when first item added */
     if (activeTarget === null && selectedLineId === null) {
       setActiveTarget({ type: "tender_amount", index: 0 });
     }
@@ -249,69 +254,52 @@ export function PosCheckoutView() {
     focusSearchInput();
   };
 
-  /* ── Payment sync ────────────────────────────────── */
+  /* ── Payment sync ────────────────────────────── */
 
   useEffect(() => {
     if (splitTenderMode) return;
     if (payments.length !== 1) {
-      const base = payments[0] ?? {
-        tenderType: "CASH" as TenderType,
-        amount: "",
-        reference: "",
-      };
+      const base = payments[0] ?? { tenderType: "CASH" as TenderType, amount: "", reference: "" };
       setPayments([{ ...base }]);
       return;
     }
     if (cart.length > 0 && !payments[0].amount.trim()) {
       setPayments((current) =>
-        current.map((payment, index) =>
-          index === 0 ? { ...payment, amount: total.toFixed(2) } : payment,
-        ),
+        current.map((p, i) => (i === 0 ? { ...p, amount: total.toFixed(2) } : p)),
       );
     }
     if (cart.length === 0 && payments[0].amount.trim()) {
       setPayments((current) =>
-        current.map((payment, index) => (index === 0 ? { ...payment, amount: "" } : payment)),
+        current.map((p, i) => (i === 0 ? { ...p, amount: "" } : p)),
       );
     }
   }, [cart.length, payments, setPayments, splitTenderMode, total]);
 
-  /* BUG FIX: Also auto-set activeTarget when cart is restored (e.g. from held carts)
-     We use a ref to detect when cart transitions from empty to non-empty */
   const prevCartLengthRef = useRef(cart.length);
   useEffect(() => {
     const wasEmpty = prevCartLengthRef.current === 0;
     prevCartLengthRef.current = cart.length;
     if (wasEmpty && cart.length > 0 && activeTarget === null && selectedLineId === null) {
-      // Use requestAnimationFrame to avoid synchronous setState in effect
-      requestAnimationFrame(() => {
-        setActiveTarget({ type: "tender_amount", index: 0 });
-      });
+      requestAnimationFrame(() => setActiveTarget({ type: "tender_amount", index: 0 }));
     }
   }, [cart.length, activeTarget, selectedLineId]);
 
   const hasMissingRequiredReference = payments.some(
-    (payment) =>
-      requiresReference(payment.tenderType, requiredReferenceTenders) &&
-      payment.amount.trim() !== "" &&
-      payment.reference.trim().length < minReferenceLength,
+    (p) =>
+      requiresReference(p.tenderType, requiredReferenceTenders) &&
+      p.amount.trim() !== "" &&
+      p.reference.trim().length < minReferenceLength,
   );
 
   const blockers = useMemo(() => {
     const next = [...checkoutBaseBlockers];
-    if (nonCashTotal > total + 0.01) {
-      next.push("Non-cash tenders cannot exceed sale total.");
-    }
-    if (tenderedTotal < total - 0.01) {
-      next.push("Tendered amount is below the sale total.");
-    }
-    if (hasMissingRequiredReference) {
-      next.push("Required tender references are incomplete.");
-    }
+    if (nonCashTotal > total + 0.01) next.push("Non-cash tenders cannot exceed sale total.");
+    if (tenderedTotal < total - 0.01) next.push("Tendered amount is below the sale total.");
+    if (hasMissingRequiredReference) next.push("Required tender references are incomplete.");
     return next;
   }, [checkoutBaseBlockers, hasMissingRequiredReference, nonCashTotal, tenderedTotal, total]);
 
-  /* ── Keypad ──────────────────────────────────────── */
+  /* ── Keypad ──────────────────────────────────── */
 
   const applyToTarget = (target: CheckoutNumericTarget, action: PosKeypadAction) => {
     if (target.type === "order_discount") {
@@ -320,16 +308,12 @@ export function PosCheckoutView() {
     }
     if (target.type === "redeem_points") {
       setLoyaltyRedemptionPoints(
-        applyPosKeypadAction(loyaltyRedemptionPoints, action, {
-          allowDecimal: false,
-          maxDecimals: 0,
-        }),
+        applyPosKeypadAction(loyaltyRedemptionPoints, action, { allowDecimal: false, maxDecimals: 0 }),
       );
       return;
     }
     if (target.type === "tender_amount") {
-      const currentValue = payments[target.index]?.amount ?? "";
-      const nextValue = applyPosKeypadAction(currentValue, action);
+      const nextValue = applyPosKeypadAction(payments[target.index]?.amount ?? "", action);
       updatePayment(target.index, { amount: nextValue });
       return;
     }
@@ -340,9 +324,7 @@ export function PosCheckoutView() {
       const nextValue = applyPosKeypadAction(currentValue, action, { maxDecimals: 3 });
       if (!nextValue) return;
       const parsed = Number(nextValue);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        updateQty(target.lineId, parsed);
-      }
+      if (Number.isFinite(parsed) && parsed > 0) updateQty(target.lineId, parsed);
       return;
     }
     if (target.type === "line_price") {
@@ -351,9 +333,7 @@ export function PosCheckoutView() {
       );
       const nextValue = applyPosKeypadAction(currentValue, action);
       const parsed = Number(nextValue || "0");
-      if (Number.isFinite(parsed) && parsed >= 0) {
-        updateItemPrice(target.lineId, parsed);
-      }
+      if (Number.isFinite(parsed) && parsed >= 0) updateItemPrice(target.lineId, parsed);
       return;
     }
     const currentValue = String(
@@ -361,9 +341,7 @@ export function PosCheckoutView() {
     );
     const nextValue = applyPosKeypadAction(currentValue, action);
     const parsed = Number(nextValue || "0");
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      updateItemDiscount(target.lineId, parsed);
-    }
+    if (Number.isFinite(parsed) && parsed >= 0) updateItemDiscount(target.lineId, parsed);
   };
 
   const handleKeypadAction = (action: PosKeypadAction) => {
@@ -374,10 +352,8 @@ export function PosCheckoutView() {
   const handleCharge = () => {
     if (blockers.length) {
       toast({ title: "Fix checkout blockers", description: blockers[0], variant: "default" });
-      const firstTenderIndex = payments.findIndex((payment) => Number(payment.amount || "0") <= 0);
-      if (firstTenderIndex >= 0) {
-        setActiveTarget({ type: "tender_amount", index: firstTenderIndex });
-      }
+      const firstTenderIndex = payments.findIndex((p) => Number(p.amount || "0") <= 0);
+      if (firstTenderIndex >= 0) setActiveTarget({ type: "tender_amount", index: firstTenderIndex });
       return;
     }
     postSale();
@@ -392,31 +368,24 @@ export function PosCheckoutView() {
     if (total > 0) {
       seen.add(exact);
       result.push({ label: money(total), value: exact });
-      if (!seen.has(round5)) {
-        seen.add(round5);
-        result.push({ label: money(Number(round5)), value: round5 });
-      }
-      if (!seen.has(round10)) {
-        seen.add(round10);
-        result.push({ label: money(Number(round10)), value: round10 });
-      }
+      if (!seen.has(round5)) { seen.add(round5); result.push({ label: money(Number(round5)), value: round5 }); }
+      if (!seen.has(round10)) { seen.add(round10); result.push({ label: money(Number(round10)), value: round10 }); }
     }
     return result;
   }, [total]);
 
   const activeTargetLabel = (() => {
-    if (!activeTarget) return "Tap a field";
+    if (!activeTarget) return "Select a field";
     if (activeTarget.type === "order_discount") return "Order discount";
     if (activeTarget.type === "redeem_points") return "Loyalty points";
-    if (activeTarget.type === "tender_amount") {
+    if (activeTarget.type === "tender_amount")
       return `${tenderLabel(payments[activeTarget.index]?.tenderType ?? "CASH")} amount`;
-    }
     if (activeTarget.type === "line_qty") return "Qty";
     if (activeTarget.type === "line_price") return "Price";
     return "Line discount";
   })();
 
-  /* ── Mutations ───────────────────────────────────── */
+  /* ── Mutations ───────────────────────────────── */
 
   const createCustomerMutation = useMutation({
     mutationFn: () =>
@@ -432,14 +401,7 @@ export function PosCheckoutView() {
         },
       ),
     onSuccess: (payload) => {
-      selectCustomer({
-        id: payload.data.id,
-        name: payload.data.name,
-        phone: payload.data.phone,
-        email: payload.data.email,
-        loyaltyPoints: 0,
-        loyaltyTier: "BRONZE",
-      });
+      selectCustomer({ id: payload.data.id, name: payload.data.name, phone: payload.data.phone, email: payload.data.email, loyaltyPoints: 0, loyaltyTier: "BRONZE" });
       setCustomerSheetOpen(false);
       toast({ title: "Customer saved", variant: "success" });
     },
@@ -464,19 +426,10 @@ export function PosCheckoutView() {
           loyaltyTier: "BRONZE",
         });
         setCustomerSheetOpen(false);
-        toast({
-          title: "Customer queued offline",
-          description: "This customer will sync automatically when the connection is back.",
-          variant: "default",
-        });
+        toast({ title: "Customer queued offline", description: "Will sync when back online.", variant: "default" });
         return;
       }
-
-      toast({
-        title: "Unable to save customer",
-        description: message,
-        variant: "destructive",
-      });
+      toast({ title: "Unable to save customer", description: message, variant: "destructive" });
     },
   });
 
@@ -487,12 +440,7 @@ export function PosCheckoutView() {
         body: JSON.stringify({
           shiftId: currentShift?.id,
           label: holdLabel.trim() || undefined,
-          cartSnapshot: {
-            items: cart,
-            customerName,
-            orderDiscountAmount,
-            selectedPromotionId,
-          },
+          cartSnapshot: { items: cart, customerName, orderDiscountAmount, selectedPromotionId },
         }),
       }),
     onSuccess: () => {
@@ -504,16 +452,12 @@ export function PosCheckoutView() {
       router.push(getPosPortalHref("held", isPosHost));
     },
     onError: (error) =>
-      toast({
-        title: "Unable to hold cart",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      }),
+      toast({ title: "Unable to hold cart", description: getApiErrorMessage(error), variant: "destructive" }),
   });
 
   const updatePayment = (index: number, next: Partial<PaymentRow>) => {
     setPayments((current) =>
-      current.map((entry, entryIndex) => (entryIndex === index ? { ...entry, ...next } : entry)),
+      current.map((entry, i) => (i === index ? { ...entry, ...next } : entry)),
     );
   };
 
@@ -529,102 +473,109 @@ export function PosCheckoutView() {
       `Change: ${money(lastCompletedSale.changeAmount)}`,
       lastCompletedSale.customerName ? `Customer: ${lastCompletedSale.customerName}` : null,
       "Thank you for shopping with us.",
-    ]
-      .filter(Boolean)
-      .join("\n");
+    ].filter(Boolean).join("\n");
     const encoded = encodeURIComponent(message);
     const phone = normalizeWhatsappPhone(lastCompletedSale.customerPhone);
     return phone ? `https://wa.me/${phone}?text=${encoded}` : `https://wa.me/?text=${encoded}`;
   })();
+
+  const TENDER_TYPES: TenderType[] = ["CASH", "CARD", "MOBILE_MONEY", "TRANSFER", "VOUCHER"];
 
   /* ═══════════════════════════════════════════════════
      RENDER
      ═══════════════════════════════════════════════════ */
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      {/* ── Toolbar ────────────────────────────────────── */}
-      <div className="flex shrink-0 items-center gap-2 border-b border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
+    <div className="flex h-full flex-col overflow-hidden bg-[var(--surface-muted)]">
+
+      {/* ── Top bar ─────────────────────────────────────── */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2">
         {/* Search */}
-        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-2.5 py-1.5 transition-all duration-150 focus-within:border-[var(--action-primary-bg)] focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
+        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-2.5 py-1.5 transition-all duration-100 focus-within:border-[var(--action-primary-bg)] focus-within:bg-[var(--surface-base)] focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
           <Search className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
           <input
             ref={searchInputRef}
             autoFocus
             value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter") return;
-              if (catalogItems.length === 0) return;
-              event.preventDefault();
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter" || catalogItems.length === 0) return;
+              e.preventDefault();
               handleAddCatalogItem(catalogItems[0]);
             }}
-            placeholder="Scan barcode or search product…"
+            placeholder="Scan barcode or search…"
             className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--text-muted)]"
           />
           {search ? (
             <button
               type="button"
               onClick={() => { setSearch(""); focusSearchInput(); }}
-              className="shrink-0 text-[var(--text-muted)] transition-colors hover:text-[var(--text-strong)]"
+              className="shrink-0 rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-base)] hover:text-[var(--text-strong)]"
             >
               <X className="h-3.5 w-3.5" />
             </button>
           ) : (
-            <span className="hidden shrink-0 rounded bg-[var(--surface-base)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)] sm:inline">
-              Enter ↵
+            <span className="hidden shrink-0 rounded bg-[var(--surface-base)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--text-muted)] shadow-sm sm:inline">
+              ↵
             </span>
           )}
         </div>
 
         {/* Shift badge */}
         {currentShift ? (
-          <span className="hidden shrink-0 rounded-md bg-[var(--surface-muted)] px-2 py-1 text-[11px] font-medium text-[var(--text-muted)] md:inline-flex md:items-center md:gap-1.5">
+          <span className="hidden shrink-0 items-center gap-1.5 rounded-md bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 md:inline-flex">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
             {currentShift.shiftNo}
           </span>
         ) : (
-          <Button size="sm" variant="outline" className="shrink-0 text-xs" asChild>
-            <Link href={getPosPortalHref("shift", isPosHost)}>Open shift</Link>
+          <Button size="sm" variant="outline" className="shrink-0 border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100 text-xs" asChild>
+            <Link href={getPosPortalHref("shift", isPosHost)}>
+              <Clock className="h-3.5 w-3.5" />
+              Open shift
+            </Link>
           </Button>
         )}
 
-        {/* Offline indicator */}
+        {/* Offline sync */}
         {pendingOfflineSales > 0 ? (
           <button
             type="button"
             onClick={syncOfflineSales}
             disabled={syncOfflineSalesPending}
-            className="shrink-0 rounded-md bg-amber-50 px-2 py-1 text-[11px] font-medium text-amber-700 transition-colors hover:bg-amber-100"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-[11px] font-semibold text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-60"
           >
+            {syncOfflineSalesPending
+              ? <RefreshCcw className="h-3 w-3 animate-spin" />
+              : <RefreshCcw className="h-3 w-3" />}
             {pendingOfflineSales} queued
           </button>
         ) : null}
 
-        {/* Quick actions */}
+        {/* Quick nav */}
         <div className="hidden shrink-0 items-center gap-1 md:flex">
           <Button
-            size="sm"
-            variant="ghost"
-            className="h-8 px-2 text-xs"
+            size="sm" variant="ghost"
+            className="h-8 gap-1.5 px-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-strong)]"
             onClick={() => setHoldDialog(true)}
             disabled={cart.length === 0 || !currentShift}
           >
+            <ReceiptLong className="h-3.5 w-3.5" />
             Hold
           </Button>
-          <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" asChild>
+          <Button size="sm" variant="ghost" className="h-8 gap-1.5 px-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-strong)]" asChild>
             <Link href={getPosPortalHref("held", isPosHost)}>
-              <ReceiptLong className="h-3.5 w-3.5" />
-              Held
+              <History className="h-3.5 w-3.5" />
+              Recall
             </Link>
           </Button>
         </div>
       </div>
 
-      {/* ── Three-column checkout grid ─────────────────── */}
-      <div className="grid min-h-0 flex-1 overflow-hidden xl:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)_minmax(300px,0.85fr)]">
-        {/* ┄┄┄ Column 1 — Catalog ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
-        <div className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--edge-subtle)]">
+      {/* ── Three-column layout ─────────────────────────── */}
+      <div className="grid min-h-0 flex-1 overflow-hidden xl:grid-cols-[minmax(0,1.15fr)_minmax(260px,0.85fr)_minmax(300px,0.8fr)]">
+
+        {/* ┄ Column 1 — Catalog ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
+        <div className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--edge-subtle)] bg-[var(--surface-base)]">
           {/* Promo pills */}
           {promotions.length > 0 ? (
             <div className="flex shrink-0 gap-1.5 overflow-x-auto border-b border-[var(--edge-subtle)] px-3 py-2">
@@ -632,7 +583,7 @@ export function PosCheckoutView() {
                 type="button"
                 onClick={() => setSelectedPromotionId("")}
                 className={cn(
-                  "shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
+                  "shrink-0 rounded-full px-3 py-1 text-[11px] font-semibold transition-colors",
                   !selectedPromotionId
                     ? "bg-[var(--action-primary-bg)] text-white"
                     : "bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-[var(--surface-base)]",
@@ -646,12 +597,13 @@ export function PosCheckoutView() {
                   type="button"
                   onClick={() => setSelectedPromotionId(promo.id)}
                   className={cn(
-                    "shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
+                    "inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-semibold transition-colors",
                     selectedPromotionId === promo.id
                       ? "bg-[var(--action-primary-bg)] text-white"
                       : "bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-[var(--surface-base)]",
                   )}
                 >
+                  <Sparkles className="h-3 w-3" />
                   {promo.name}
                 </button>
               ))}
@@ -664,7 +616,7 @@ export function PosCheckoutView() {
               <PosEmptyState
                 icon={Clock}
                 title="Open a shift first"
-                description="Start a shift to unlock the register."
+                description="Start a shift to unlock the register and begin selling."
                 action={
                   <Button size="sm" asChild>
                     <Link href={getPosPortalHref("shift", isPosHost)}>Open shift</Link>
@@ -673,78 +625,112 @@ export function PosCheckoutView() {
                 className="min-h-[10rem]"
               />
             ) : catalogLoading ? (
-              <div className="flex min-h-[10rem] items-center justify-center text-sm text-[var(--text-muted)]">
+              <div className="flex min-h-[10rem] items-center justify-center gap-2 text-sm text-[var(--text-muted)]">
+                <Loader2 className="h-4 w-4 animate-spin" />
                 Loading catalog…
               </div>
             ) : catalogItems.length === 0 ? (
-              <div className="flex min-h-[10rem] flex-col items-center justify-center gap-1 text-center">
+              <div className="flex min-h-[10rem] flex-col items-center justify-center gap-2 text-center">
                 <Package className="h-8 w-8 text-[var(--text-muted)]" />
                 <p className="text-sm font-medium text-[var(--text-muted)]">
-                  {search ? "No items match" : "Search for items"}
+                  {search ? "No items match" : "Search to find items"}
                 </p>
+                {search && (
+                  <button
+                    type="button"
+                    onClick={() => setSearch("")}
+                    className="text-xs text-[var(--action-primary-bg)] underline-offset-2 hover:underline"
+                  >
+                    Clear search
+                  </button>
+                )}
               </div>
             ) : (
               <div className="grid gap-2 sm:grid-cols-2">
-                {catalogItems.map((item) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() => handleAddCatalogItem(item)}
-                    disabled={!currentShift}
-                    className="group relative flex items-center gap-3 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] p-2.5 text-left transition-all duration-150 hover:border-[color-mix(in_srgb,var(--action-primary-bg)_30%,var(--border-default))] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] active:scale-[0.97]"
-                  >
-                    {/* Image / Placeholder */}
-                    <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-muted)]">
-                      {item.imageUrl ? (
-                        <Image
-                          src={item.imageUrl}
-                          alt={item.name}
-                          width={48}
-                          height={48}
-                          className="h-full w-full object-cover"
-                          unoptimized
-                        />
-                      ) : (
-                        <Package className="h-5 w-5 text-[var(--text-muted)]" />
+                {catalogItems.map((item) => {
+                  const inCart = cart.find((c) => c.catalogItemId === item.id);
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => handleAddCatalogItem(item)}
+                      disabled={!currentShift}
+                      className={cn(
+                        "group relative flex items-center gap-3 rounded-xl border bg-[var(--surface-base)] p-2.5 text-left transition-all duration-100 active:scale-[0.97]",
+                        inCart
+                          ? "border-[color-mix(in_srgb,var(--action-primary-bg)_40%,var(--border-default))] shadow-[0_0_0_1px_color-mix(in_srgb,var(--action-primary-bg)_20%,transparent)]"
+                          : "border-[var(--border-default)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_30%,var(--border-default))] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]",
                       )}
-                    </div>
-                    {/* Info */}
-                    <div className="min-w-0 flex-1">
-                      <div className="line-clamp-1 text-sm font-medium leading-tight text-[var(--text-strong)]">
-                        {item.name}
+                    >
+                      {/* Image / placeholder */}
+                      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-muted)]">
+                        {item.imageUrl ? (
+                          <Image src={item.imageUrl} alt={item.name} width={44} height={44} className="h-full w-full object-cover" unoptimized />
+                        ) : (
+                          <Package className="h-5 w-5 text-[var(--text-muted)]" />
+                        )}
                       </div>
-                      <div className="mt-0.5 font-mono text-[11px] text-[var(--text-muted)]">
-                        {item.barcode || item.sku}
-                      </div>
-                      {item.inventoryItem ? (
-                        <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">
-                          {item.inventoryItem.currentStock.toFixed(0)} {item.inventoryItem.unit}
+
+                      {/* Info */}
+                      <div className="min-w-0 flex-1">
+                        <div className="line-clamp-1 text-[13px] font-semibold leading-tight text-[var(--text-strong)]">
+                          {item.name}
                         </div>
-                      ) : null}
-                    </div>
-                    {/* Price */}
-                    <div className="shrink-0 text-right">
-                      <div className="font-mono text-sm font-semibold text-[var(--text-strong)]">
-                        {money(item.unitPrice)}
+                        <div className="mt-0.5 flex items-center gap-1.5">
+                          {item.inventoryItem && (
+                            <span className={cn(
+                              "rounded px-1 py-0 text-[10px] font-semibold",
+                              item.inventoryItem.currentStock <= 5
+                                ? "bg-amber-50 text-amber-700"
+                                : "bg-emerald-50 text-emerald-700",
+                            )}>
+                              {item.inventoryItem.currentStock.toFixed(0)} {item.inventoryItem.unit}
+                            </span>
+                          )}
+                          {item.barcode || item.sku ? (
+                            <span className="font-mono text-[10px] text-[var(--text-muted)]">
+                              {item.barcode || item.sku}
+                            </span>
+                          ) : null}
+                        </div>
                       </div>
-                    </div>
-                    {/* Hover add indicator */}
-                    <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--action-primary-bg)] text-white opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-                      <Plus className="h-3 w-3" />
-                    </div>
-                  </button>
-                ))}
+
+                      {/* Price */}
+                      <div className="shrink-0 text-right">
+                        {item.compareAtPrice && item.compareAtPrice > item.unitPrice ? (
+                          <div className="font-mono text-[10px] text-[var(--text-muted)] line-through">
+                            {money(item.compareAtPrice)}
+                          </div>
+                        ) : null}
+                        <div className="font-mono text-sm font-bold text-[var(--text-strong)]">
+                          {money(item.unitPrice)}
+                        </div>
+                      </div>
+
+                      {/* In-cart badge */}
+                      {inCart ? (
+                        <div className="absolute -right-1.5 -top-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--action-primary-bg)] px-1 text-[10px] font-bold text-white shadow-sm">
+                          {inCart.quantity}
+                        </div>
+                      ) : (
+                        <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--action-primary-bg)] text-white opacity-0 shadow-sm transition-opacity duration-100 group-hover:opacity-100">
+                          <Plus className="h-3 w-3" />
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>
         </div>
 
-        {/* ┄┄┄ Column 2 — Cart ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
-        <div className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--edge-subtle)]">
+        {/* ┄ Column 2 — Cart ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
+        <div className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--edge-subtle)] bg-[var(--surface-base)]">
           {/* Cart header */}
           <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--edge-subtle)] px-3 py-2">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-[var(--text-strong)]">Cart</span>
+              <span className="text-sm font-bold text-[var(--text-strong)]">Sale</span>
               {cart.length > 0 ? (
                 <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--action-primary-bg)] px-1.5 text-[10px] font-bold text-white">
                   {cart.length}
@@ -754,18 +740,27 @@ export function PosCheckoutView() {
                 <button
                   type="button"
                   onClick={() => setCustomerSheetOpen(true)}
-                  className="flex items-center gap-1 rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,var(--surface-base))] px-2 py-0.5 text-[10px] font-medium text-[var(--action-primary-bg)] transition-colors hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_16%,var(--surface-base))]"
+                  className="flex items-center gap-1 rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,var(--surface-base))] px-2 py-0.5 text-[10px] font-semibold text-[var(--action-primary-bg)] transition-colors hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_18%,var(--surface-base))]"
                 >
                   <User className="h-3 w-3" />
                   {selectedCustomer.name}
                 </button>
-              ) : null}
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setCustomerSheetOpen(true)}
+                  className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-strong)]"
+                >
+                  <User className="h-3 w-3" />
+                  Walk-in
+                </button>
+              )}
             </div>
             {cart.length > 0 ? (
               <button
                 type="button"
                 onClick={clearCart}
-                className="rounded-md px-1.5 py-0.5 text-xs text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-600"
+                className="rounded-md px-2 py-0.5 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-600"
               >
                 Clear
               </button>
@@ -775,8 +770,12 @@ export function PosCheckoutView() {
           {/* Cart items */}
           <div className="min-h-0 flex-1 overflow-y-auto">
             {cart.length === 0 ? (
-              <div className="flex h-full items-center justify-center p-4">
-                <p className="text-sm text-[var(--text-muted)]">Scan or search to add items</p>
+              <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface-muted)]">
+                  <Payments className="h-6 w-6 text-[var(--text-muted)]" />
+                </div>
+                <p className="text-sm font-medium text-[var(--text-muted)]">No items yet</p>
+                <p className="text-xs text-[var(--text-muted)]">Search or scan to add</p>
               </div>
             ) : (
               <div className="divide-y divide-[var(--edge-subtle)]">
@@ -784,65 +783,113 @@ export function PosCheckoutView() {
                   const isSelected = selectedLineId === item.catalogItemId;
                   const lineTotal = item.quantity * item.unitPrice - (item.lineDiscountAmount ?? 0);
                   return (
-                    <button
+                    <div
                       key={item.catalogItemId}
-                      type="button"
-                      onClick={() => {
-                        setSelectedLineId(item.catalogItemId);
-                        setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
-                      }}
                       className={cn(
-                        "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150",
+                        "flex items-center gap-2 px-3 py-2.5 transition-colors duration-100",
                         isSelected
-                          ? "border-l-2 border-l-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,var(--surface-base))]"
-                          : "border-l-2 border-l-transparent hover:bg-[var(--surface-muted)]",
+                          ? "border-l-[3px] border-l-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,var(--surface-base))]"
+                          : "border-l-[3px] border-l-transparent hover:bg-[var(--surface-muted)]",
                       )}
                     >
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-sm font-medium text-[var(--text-strong)]">
+                      {/* Item info — clickable to select */}
+                      <button
+                        type="button"
+                        className="min-w-0 flex-1 text-left"
+                        onClick={() => {
+                          setSelectedLineId(item.catalogItemId);
+                          setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
+                        }}
+                      >
+                        <div className="truncate text-[13px] font-semibold text-[var(--text-strong)]">
                           {item.name}
                         </div>
-                        <div className="mt-0.5 flex items-center gap-2 text-xs text-[var(--text-muted)]">
-                          <span className="font-mono">
-                            {item.quantity} × {money(item.unitPrice)}
-                          </span>
+                        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                          <span className="font-mono">{money(item.unitPrice)}</span>
                           {item.lineDiscountAmount ? (
-                            <span className="font-mono text-emerald-600">-{money(item.lineDiscountAmount)}</span>
+                            <span className="font-mono text-emerald-600">−{money(item.lineDiscountAmount)}</span>
                           ) : null}
                         </div>
+                      </button>
+
+                      {/* Qty controls */}
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const next = item.quantity - 1;
+                            if (next <= 0) {
+                              removeFromCart(item.catalogItemId);
+                              if (selectedLineId === item.catalogItemId) {
+                                setSelectedLineId(null);
+                                setActiveTarget(null);
+                              }
+                            } else {
+                              updateQty(item.catalogItemId, next);
+                            }
+                          }}
+                          className="flex h-6 w-6 items-center justify-center rounded-md border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-500 active:scale-[0.9]"
+                        >
+                          <Minus className="h-3 w-3" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSelectedLineId(item.catalogItemId);
+                            setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
+                          }}
+                          className={cn(
+                            "h-6 min-w-[2rem] rounded-md border px-1.5 font-mono text-xs font-bold transition-colors",
+                            isSelected && activeTarget?.type === "line_qty"
+                              ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,white)] text-[var(--action-primary-bg)]"
+                              : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
+                          )}
+                        >
+                          {item.quantity % 1 === 0 ? item.quantity : item.quantity.toFixed(2)}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => updateQty(item.catalogItemId, item.quantity + 1)}
+                          className="flex h-6 w-6 items-center justify-center rounded-md border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-colors hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] hover:text-[var(--action-primary-bg)] active:scale-[0.9]"
+                        >
+                          <Plus className="h-3 w-3" />
+                        </button>
                       </div>
-                      <div className="shrink-0 text-right">
-                        <div className="font-mono text-sm font-semibold text-[var(--text-strong)]">
+
+                      {/* Line total */}
+                      <div className="shrink-0 w-16 text-right">
+                        <div className="font-mono text-[13px] font-bold text-[var(--text-strong)]">
                           {money(lineTotal)}
                         </div>
                       </div>
+
+                      {/* Remove */}
                       <button
                         type="button"
-                        className="shrink-0 rounded-md p-1 text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
-                        onClick={(e) => {
-                          e.stopPropagation();
+                        onClick={() => {
                           removeFromCart(item.catalogItemId);
                           if (selectedLineId === item.catalogItemId) {
                             setSelectedLineId(null);
                             setActiveTarget(null);
                           }
                         }}
+                        className="shrink-0 rounded-md p-1 text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
                       >
-                        <Trash2 className="h-3.5 w-3.5" />
+                        <X className="h-3.5 w-3.5" />
                       </button>
-                    </button>
+                    </div>
                   );
                 })}
               </div>
             )}
           </div>
 
-          {/* Line editor (when a line is selected) */}
+          {/* Line editor (when line is selected) */}
           {selectedLine ? (
-            <div className="shrink-0 border-t border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-3 py-2">
-              <div className="mb-1.5 flex items-center justify-between">
-                <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-                  Editing: {selectedLine.name}
+            <div className="shrink-0 border-t border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-3 py-2.5">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                  {selectedLine.name}
                 </span>
                 <button
                   type="button"
@@ -876,69 +923,73 @@ export function PosCheckoutView() {
           ) : null}
 
           {/* Cart summary */}
-          <div className="shrink-0 border-t border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2">
-            <div className="flex items-center justify-between text-xs text-[var(--text-muted)]">
-              <span>Subtotal ({lineCountLabel})</span>
-              <span className="font-mono">{money(subtotal)}</span>
-            </div>
-            {discountAmount > 0 ? (
-              <div className="flex items-center justify-between text-xs text-emerald-600">
-                <span>Discount</span>
-                <span className="font-mono">-{money(discountAmount)}</span>
-              </div>
-            ) : null}
-            {taxAmount > 0 ? (
+          <div className="shrink-0 border-t border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2.5">
+            <div className="space-y-1">
               <div className="flex items-center justify-between text-xs text-[var(--text-muted)]">
-                <span>Tax</span>
-                <span className="font-mono">{money(taxAmount)}</span>
+                <span>{cart.length} item{cart.length !== 1 ? "s" : ""}</span>
+                <span className="font-mono">{money(subtotal)}</span>
               </div>
-            ) : null}
-            <div className="mt-1 flex items-center justify-between border-t border-[var(--edge-subtle)] pt-1 text-sm font-semibold text-[var(--text-strong)]">
-              <span>Total</span>
-              <span className="font-mono">{money(total)}</span>
+              {discountAmount > 0 ? (
+                <div className="flex items-center justify-between text-xs text-emerald-600">
+                  <span>Discount{selectedPromotion ? ` (${selectedPromotion.name})` : ""}</span>
+                  <span className="font-mono">−{money(discountAmount)}</span>
+                </div>
+              ) : null}
+              {taxAmount > 0 ? (
+                <div className="flex items-center justify-between text-xs text-[var(--text-muted)]">
+                  <span>Tax</span>
+                  <span className="font-mono">{money(taxAmount)}</span>
+                </div>
+              ) : null}
+            </div>
+            <div className="mt-2 flex items-baseline justify-between border-t border-[var(--edge-subtle)] pt-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">Total</span>
+              <span className="font-mono text-xl font-black text-[var(--text-strong)]">{money(total)}</span>
             </div>
           </div>
         </div>
 
-        {/* ┄┄┄ Column 3 — Payment ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
-        <div className="flex min-h-0 flex-col overflow-hidden bg-[color-mix(in_srgb,var(--action-primary-bg)_3%,var(--surface-base))]">
-          {/* a) Amount due + Change + Action chips */}
-          <div className="shrink-0 px-4 pt-3 pb-2 text-center">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Amount due
+        {/* ┄ Column 3 — Payment ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
+        <div className="flex min-h-0 flex-col overflow-hidden bg-[var(--surface-base)]">
+
+          {/* Amount due header */}
+          <div className={cn(
+            "shrink-0 px-4 pt-4 pb-3 text-center",
+            cart.length > 0
+              ? "bg-[color-mix(in_srgb,var(--action-primary-bg)_4%,var(--surface-base))]"
+              : "",
+          )}>
+            <div className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+              Amount Due
             </div>
-            <div className="mt-0.5 font-mono text-[2rem] font-bold leading-tight tracking-tight text-[var(--text-strong)]">
+            <div className={cn(
+              "mt-0.5 font-mono font-black leading-none tracking-tight transition-all duration-150",
+              total >= 10000 ? "text-3xl" : total >= 1000 ? "text-4xl" : "text-[2.75rem]",
+              cart.length > 0 ? "text-[var(--text-strong)]" : "text-[var(--text-muted)]",
+            )}>
               {money(total)}
             </div>
+
             {changeAmount > 0 ? (
-              <div className="mt-0.5 font-mono text-sm font-semibold text-emerald-600">
+              <div className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-sm font-bold text-emerald-700">
                 Change: {money(changeAmount)}
               </div>
-            ) : (
-              <div className="mt-0.5 text-xs text-[var(--text-muted)]">
-                Tendered: <span className="font-mono font-semibold">{money(tenderedTotal)}</span>
+            ) : tenderedTotal > 0 && tenderedTotal < total ? (
+              <div className="mt-1.5 inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+                Still due: {money(total - tenderedTotal)}
               </div>
-            )}
-            {selectedPromotion ? (
-              <div className="mt-1">
-                <PosStatusPill tone="brand">{selectedPromotion.name}</PosStatusPill>
+            ) : tenderedTotal > 0 ? (
+              <div className="mt-1.5 text-xs text-[var(--text-muted)]">
+                Tendered: <span className="font-mono font-semibold">{money(tenderedTotal)}</span>
               </div>
             ) : null}
 
-            {/* Action chips */}
-            <div className="mt-2 flex flex-wrap items-center justify-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => setCustomerSheetOpen(true)}
-                className="flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-all duration-150 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]"
-              >
-                <User className="h-3 w-3" />
-                {selectedCustomer ? selectedCustomer.name : "Walk-in"}
-              </button>
+            {/* Quick action pills */}
+            <div className="mt-2.5 flex flex-wrap items-center justify-center gap-1.5">
               <button
                 type="button"
                 onClick={() => setAdjustmentsOpen(true)}
-                className="flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-all duration-150 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]"
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]"
               >
                 <Sparkles className="h-3 w-3" />
                 Adjust
@@ -947,131 +998,165 @@ export function PosCheckoutView() {
                 type="button"
                 onClick={() => setSplitTenderMode(!splitTenderMode)}
                 className={cn(
-                  "flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-all duration-150",
+                  "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-all duration-100",
                   splitTenderMode
                     ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,var(--surface-base))] text-[var(--action-primary-bg)]"
                     : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]",
                 )}
               >
-                {splitTenderMode ? "Single" : "Split"}
+                <Payments className="h-3 w-3" />
+                {splitTenderMode ? "Single pay" : "Split"}
               </button>
               <button
                 type="button"
                 onClick={() => setHoldDialog(true)}
                 disabled={cart.length === 0 || !currentShift}
-                className="flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-all duration-150 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)] disabled:opacity-40"
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)] disabled:opacity-40"
               >
+                <ReceiptLong className="h-3 w-3" />
                 Hold
               </button>
             </div>
           </div>
 
-          {/* b) Tender row(s) */}
-          <div className="shrink-0 space-y-1.5 border-t border-[var(--edge-subtle)] px-3 py-2">
-            {payments.map((payment, index) => {
-              const isActiveTender = activeTarget?.type === "tender_amount" && activeTarget.index === index;
-              return (
-                <div key={`${payment.tenderType}-${index}`} className="flex items-center gap-1.5">
-                  <Select
-                    value={payment.tenderType}
-                    onValueChange={(value) =>
-                      updatePayment(index, { tenderType: value as TenderType })
-                    }
-                  >
-                    <SelectTrigger className="h-10 w-[7rem] shrink-0 bg-[var(--surface-base)] text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="CASH">Cash</SelectItem>
-                      <SelectItem value="CARD">Card</SelectItem>
-                      <SelectItem value="MOBILE_MONEY">Mobile</SelectItem>
-                      <SelectItem value="TRANSFER">Transfer</SelectItem>
-                      <SelectItem value="VOUCHER">Voucher</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setActiveTarget({ type: "tender_amount", index })
-                    }
-                    className={cn(
-                      "flex h-10 min-w-0 flex-1 items-center rounded-lg border px-3 font-mono text-sm font-semibold transition-all duration-150",
-                      isActiveTender
-                        ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
-                        : "border-[var(--border-default)] bg-[var(--surface-base)] hover:bg-[var(--surface-muted)]",
+          {/* Scrollable payment section */}
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="space-y-3 px-3 pt-2 pb-3">
+              {payments.map((payment, index) => {
+                const isActiveTender = activeTarget?.type === "tender_amount" && activeTarget.index === index;
+                const needsRef = requiresReference(payment.tenderType, requiredReferenceTenders);
+                const refMissing = needsRef && payment.amount.trim() !== "" && payment.reference.trim().length < minReferenceLength;
+
+                return (
+                  <div key={`payment-${index}`} className="space-y-1.5">
+                    {splitTenderMode && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+                          Payment {index + 1}
+                        </span>
+                        {payments.length > 1 && (
+                          <button
+                            type="button"
+                            onClick={() => setPayments((cur) => cur.filter((_, i) => i !== index))}
+                            className="rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </div>
                     )}
-                  >
-                    {payment.amount || "0.00"}
-                  </button>
-                  {requiresReference(payment.tenderType, requiredReferenceTenders) ? (
-                    <Input
-                      value={payment.reference}
-                      onChange={(e) => updatePayment(index, { reference: e.target.value })}
-                      placeholder={`Ref (min ${minReferenceLength})`}
-                      className="h-10 w-[6rem] shrink-0 text-xs"
-                    />
-                  ) : null}
-                  {splitTenderMode && payments.length > 1 ? (
+
+                    {/* Tender type tabs */}
+                    <div className="flex gap-1">
+                      {TENDER_TYPES.map((type) => (
+                        <TenderTab
+                          key={type}
+                          type={type}
+                          selected={payment.tenderType === type}
+                          onClick={() => updatePayment(index, { tenderType: type })}
+                        />
+                      ))}
+                    </div>
+
+                    {/* Amount display / input */}
                     <button
                       type="button"
-                      onClick={() =>
-                        setPayments((cur) => cur.filter((_, i) => i !== index))
-                      }
-                      className="shrink-0 rounded-md p-1.5 text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
+                      onClick={() => setActiveTarget({ type: "tender_amount", index })}
+                      className={cn(
+                        "flex h-12 w-full items-center justify-between rounded-xl border px-4 font-mono text-xl font-black transition-all duration-100",
+                        isActiveTender
+                          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,white)] text-[var(--action-primary-bg)] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
+                          : "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
+                      )}
                     >
-                      <X className="h-3.5 w-3.5" />
+                      <span className="text-[13px] font-semibold text-[var(--text-muted)] opacity-70">
+                        {tenderLabel(payment.tenderType)}
+                      </span>
+                      <span>{payment.amount || "0.00"}</span>
                     </button>
-                  ) : null}
-                </div>
-              );
-            })}
-            {splitTenderMode ? (
-              <button
-                type="button"
-                onClick={addPaymentRow}
-                className="w-full rounded-lg border border-dashed border-[var(--border-default)] py-2 text-xs text-[var(--text-muted)] transition-colors hover:border-[var(--action-primary-bg)] hover:bg-[var(--surface-base)] hover:text-[var(--action-primary-bg)]"
-              >
-                + Add tender
-              </button>
-            ) : null}
-          </div>
 
-          {/* c) Keypad */}
-          <div className="shrink-0 px-3 pb-2 pt-1">
-            {/* Active target badge */}
-            <div className="mb-1.5 flex items-center justify-center">
-              <span className="inline-flex items-center rounded-full bg-[var(--surface-muted)] px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-                {activeTargetLabel}
-              </span>
+                    {/* Reference field */}
+                    {needsRef ? (
+                      <div className="relative">
+                        <Input
+                          value={payment.reference}
+                          onChange={(e) => updatePayment(index, { reference: e.target.value })}
+                          placeholder={`Reference (min ${minReferenceLength} chars)`}
+                          className={cn(
+                            "h-9 text-sm",
+                            refMissing ? "border-amber-300 bg-amber-50 focus-visible:ring-amber-400" : "",
+                          )}
+                        />
+                        {refMissing && (
+                          <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-amber-600">
+                            Required
+                          </span>
+                        )}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+
+              {splitTenderMode ? (
+                <button
+                  type="button"
+                  onClick={addPaymentRow}
+                  className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-[var(--border-default)] py-2.5 text-[11px] font-semibold text-[var(--text-muted)] transition-colors hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_4%,var(--surface-base))] hover:text-[var(--action-primary-bg)]"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add payment method
+                </button>
+              ) : null}
             </div>
 
-            {/* Keypad grid — fixed heights, no flex-1 */}
-            <PosNumericKeypad
-              onAction={handleKeypadAction}
-              presets={keypadPresets}
-            />
+            {/* Keypad area */}
+            <div className="px-3 pb-3">
+              {/* Active target label */}
+              <div className="mb-2 flex items-center justify-center">
+                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,var(--surface-base))] px-3 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[var(--action-primary-bg)]">
+                  {activeTargetLabel}
+                </span>
+              </div>
+              <PosNumericKeypad onAction={handleKeypadAction} presets={keypadPresets} />
+            </div>
           </div>
 
-          {/* Spacer to push charge button to bottom */}
-          <div className="min-h-0 flex-1" />
-
-          {/* d) Validation + Charge button */}
+          {/* Validation + Charge button — fixed at bottom */}
           <div className="shrink-0 space-y-2 border-t border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-3">
             <PosInlineValidationBanner messages={blockers} />
 
             <button
               type="button"
-              className={cn(
-                "flex h-14 w-full items-center justify-center gap-2 rounded-xl text-base font-bold text-white shadow-lg transition-all duration-200 active:scale-[0.98]",
-                cart.length === 0 || postSalePending
-                  ? "cursor-not-allowed bg-gray-300"
-                  : "bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 hover:shadow-emerald-200",
-              )}
               onClick={handleCharge}
               disabled={postSalePending || cart.length === 0}
+              className={cn(
+                "relative flex h-14 w-full items-center justify-center gap-2.5 overflow-hidden rounded-xl text-[15px] font-black text-white shadow-lg transition-all duration-150 active:scale-[0.98]",
+                cart.length === 0
+                  ? "cursor-not-allowed bg-[var(--surface-muted)] text-[var(--text-muted)] shadow-none"
+                  : blockers.length > 0
+                    ? "bg-amber-400 hover:bg-amber-500 shadow-amber-200"
+                    : postSalePending
+                      ? "cursor-wait bg-emerald-600 opacity-80"
+                      : "bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 hover:shadow-[0_4px_16px_rgba(16,185,129,0.4)]",
+              )}
             >
-              <Wallet className="h-5 w-5" />
-              Charge {money(total)}
+              {postSalePending ? (
+                <>
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                  Processing…
+                </>
+              ) : blockers.length > 0 ? (
+                <>
+                  <Sparkles className="h-5 w-5" />
+                  Fix {blockers.length} issue{blockers.length > 1 ? "s" : ""}
+                </>
+              ) : (
+                <>
+                  <Wallet className="h-5 w-5" />
+                  Charge {money(total)}
+                </>
+              )}
             </button>
           </div>
         </div>
@@ -1083,31 +1168,26 @@ export function PosCheckoutView() {
 
       {/* ── Customer sheet ──────────────────────────────── */}
       <Sheet open={customerSheetOpen} onOpenChange={setCustomerSheetOpen}>
-        <SheetContent
-          side="right"
-          size="md"
-          tabletBehavior="bottom"
-          className="w-full max-w-[32rem] p-0"
-        >
+        <SheetContent side="right" size="md" tabletBehavior="bottom" className="w-full max-w-[32rem] p-0">
           <div className="flex h-full flex-col p-5 sm:p-6">
             <SheetHeader className="border-b border-[var(--border-subtle)] pb-4 pr-10">
-              <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--text-muted)]">
                 <Users className="h-4 w-4" />
                 Customer
               </div>
               <SheetTitle>Attach customer</SheetTitle>
               <SheetDescription>
-                Search by name, phone, or email. Save a new customer without leaving checkout.
+                Search by name, phone, or email. Save new customers without leaving checkout.
               </SheetDescription>
             </SheetHeader>
 
             <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4 pr-1">
               {/* Search */}
-              <div className="flex items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2">
+              <div className="flex items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2 transition-all focus-within:border-[var(--action-primary-bg)] focus-within:bg-[var(--surface-base)] focus-within:ring-1 focus-within:ring-[var(--action-primary-bg)]">
                 <Search className="h-4 w-4 text-[var(--text-muted)]" />
                 <Input
                   value={customerName}
-                  onChange={(event) => setCustomerName(event.target.value)}
+                  onChange={(e) => setCustomerName(e.target.value)}
                   placeholder="Search by name, phone, or email"
                   className="h-8 border-none bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
                 />
@@ -1115,46 +1195,51 @@ export function PosCheckoutView() {
 
               {/* Attached banner */}
               {selectedCustomer ? (
-                <div className="flex items-center justify-between rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2">
+                <div className="flex items-center justify-between rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
                   <div>
-                    <div className="text-sm font-semibold text-[var(--text-strong)]">
-                      {selectedCustomer.name}
-                    </div>
+                    <div className="text-sm font-bold text-[var(--text-strong)]">{selectedCustomer.name}</div>
                     <div className="text-xs text-[var(--text-muted)]">
                       {selectedCustomer.phone || selectedCustomer.email || "No contact"}
                     </div>
                   </div>
-                  <PosStatusPill tone="success">{selectedCustomer.loyaltyPoints} pts</PosStatusPill>
+                  <PosStatusPill tone="success">
+                    {selectedCustomer.loyaltyPoints} pts
+                  </PosStatusPill>
                 </div>
               ) : null}
 
-              {/* Results */}
+              {/* Search results */}
               {customerName.trim().length >= 2 ? (
                 <div className="space-y-1.5">
                   <div className="flex items-center justify-between text-xs text-[var(--text-muted)]">
-                    <span>Matches</span>
+                    <span className="font-semibold">Matches</span>
                     {customerSearchLoading ? <span>Searching…</span> : null}
                   </div>
-                  {customerSearchResults.length === 0 ? (
-                    <p className="py-4 text-center text-sm text-[var(--text-muted)]">No match found</p>
+                  {customerSearchResults.length === 0 && !customerSearchLoading ? (
+                    <p className="py-4 text-center text-sm text-[var(--text-muted)]">No match — save below</p>
                   ) : (
-                    customerSearchResults.slice(0, 6).map((customer) => (
+                    customerSearchResults.slice(0, 6).map((c) => (
                       <button
-                        key={customer.id}
+                        key={c.id}
                         type="button"
-                        className="flex w-full items-center justify-between gap-3 rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] px-3 py-2 text-left transition hover:bg-[var(--surface-muted)]"
-                        onClick={() => {
-                          selectCustomer(customer);
-                          setCustomerSheetOpen(false);
-                        }}
+                        className="flex w-full items-center justify-between gap-3 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-3 py-2.5 text-left transition-colors hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_4%,var(--surface-base))]"
+                        onClick={() => { selectCustomer(c); setCustomerSheetOpen(false); }}
                       >
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium">{customer.name}</div>
-                          <div className="truncate text-xs text-[var(--text-muted)]">
-                            {customer.phone || customer.email || "No contact"}
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_12%,var(--surface-base))] text-[var(--action-primary-bg)]">
+                            <User className="h-4 w-4" />
+                          </div>
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold">{c.name}</div>
+                            <div className="truncate text-xs text-[var(--text-muted)]">
+                              {c.phone || c.email || "No contact"}
+                            </div>
                           </div>
                         </div>
-                        <ArrowRight className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-[var(--text-muted)]">{c.loyaltyPoints} pts</span>
+                          <ArrowRight className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
+                        </div>
                       </button>
                     ))
                   )}
@@ -1162,27 +1247,27 @@ export function PosCheckoutView() {
               ) : null}
 
               {/* Save new customer */}
-              <div className="rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] p-3">
-                <div className="text-sm font-semibold">Save new customer</div>
+              <div className="rounded-xl border border-[var(--border-default)] bg-[var(--surface-muted)] p-4">
+                <div className="text-sm font-bold text-[var(--text-strong)]">Save new customer</div>
                 <div className="mt-3 grid gap-2">
                   <Input
                     value={customerName}
                     onChange={(e) => setCustomerName(e.target.value)}
-                    placeholder="Name"
-                    className="h-9 bg-white text-sm"
+                    placeholder="Full name"
+                    className="h-9 bg-[var(--surface-base)] text-sm"
                   />
                   <div className="grid grid-cols-2 gap-2">
                     <Input
                       value={customerPhone}
                       onChange={(e) => setCustomerPhone(e.target.value)}
                       placeholder="Phone"
-                      className="h-9 bg-white text-sm"
+                      className="h-9 bg-[var(--surface-base)] text-sm"
                     />
                     <Input
                       value={customerEmail}
                       onChange={(e) => setCustomerEmail(e.target.value)}
                       placeholder="Email"
-                      className="h-9 bg-white text-sm"
+                      className="h-9 bg-[var(--surface-base)] text-sm"
                     />
                   </div>
                 </div>
@@ -1190,13 +1275,8 @@ export function PosCheckoutView() {
             </div>
 
             <SheetFooter className="border-t border-[var(--border-subtle)] pt-3">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setCustomerSheetOpen(false)}
-              >
-                Back
+              <Button type="button" variant="outline" size="sm" onClick={() => setCustomerSheetOpen(false)}>
+                Cancel
               </Button>
               <Button
                 type="button"
@@ -1205,75 +1285,78 @@ export function PosCheckoutView() {
                 disabled={!customerName.trim() || createCustomerMutation.isPending}
               >
                 <Save className="h-3.5 w-3.5" />
-                Save
+                Save customer
               </Button>
             </SheetFooter>
           </div>
         </SheetContent>
       </Sheet>
 
-      {/* ── Adjustments dialog ─────────────────────────── */}
+      {/* ── Adjustments dialog ──────────────────────────── */}
       <Dialog open={adjustmentsOpen} onOpenChange={setAdjustmentsOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>Sale adjustments</DialogTitle>
           </DialogHeader>
-          <div className="space-y-4">
+          <div className="space-y-4 py-1">
             {/* Order discount */}
             <div>
-              <label className="text-xs font-semibold text-[var(--text-muted)]">Order discount</label>
+              <label className="text-xs font-bold text-[var(--text-muted)]">Order discount</label>
               <NumField
                 label="Amount"
                 value={orderDiscountAmount}
                 active={activeTarget?.type === "order_discount"}
-                onActivate={() => setActiveTarget({ type: "order_discount" })}
-                className="mt-1"
+                onActivate={() => { setActiveTarget({ type: "order_discount" }); setAdjustmentsOpen(false); }}
+                className="mt-1.5"
               />
             </div>
 
             {/* Loyalty redemption */}
             {selectedCustomer ? (
               <div>
-                <label className="text-xs font-semibold text-[var(--text-muted)]">
-                  Redeem points ({selectedCustomer.loyaltyPoints} available)
+                <label className="text-xs font-bold text-[var(--text-muted)]">
+                  Redeem points
+                  <span className="ml-1.5 rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,var(--surface-base))] px-2 py-0.5 text-[var(--action-primary-bg)]">
+                    {selectedCustomer.loyaltyPoints} available
+                  </span>
                 </label>
                 <NumField
                   label="Points"
                   value={loyaltyRedemptionPoints}
                   active={activeTarget?.type === "redeem_points"}
-                  onActivate={() => setActiveTarget({ type: "redeem_points" })}
-                  className="mt-1"
+                  onActivate={() => { setActiveTarget({ type: "redeem_points" }); setAdjustmentsOpen(false); }}
+                  className="mt-1.5"
                 />
               </div>
             ) : null}
 
-            {/* Override reason */}
+            {/* Override reason (managers only) */}
             {canOverride ? (
               <div>
-                <label className="text-xs font-semibold text-[var(--text-muted)]">Override reason</label>
+                <label className="text-xs font-bold text-[var(--text-muted)]">Override reason</label>
                 <Input
                   value={overrideReason}
                   onChange={(e) => setOverrideReason(e.target.value)}
-                  placeholder="Reason for override"
-                  className="mt-1 h-9 text-sm"
+                  placeholder="Reason for price/discount override"
+                  className="mt-1.5 h-9 text-sm"
                 />
-                <PosStatusPill tone="warning" className="mt-1">Override allowed</PosStatusPill>
+                <PosStatusPill tone="warning" className="mt-1.5">Manager override enabled</PosStatusPill>
               </div>
             ) : null}
 
-            {/* Promotion selector */}
+            {/* Promotion */}
             {promotions.length > 0 ? (
               <div>
-                <label className="text-xs font-semibold text-[var(--text-muted)]">Promotion</label>
-                <div className="mt-1 flex flex-wrap gap-1.5">
+                <label className="text-xs font-bold text-[var(--text-muted)]">Promotion</label>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
                   <button
                     type="button"
                     onClick={() => setSelectedPromotionId("")}
                     className={cn(
-                      "rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
+                      "rounded-full px-3 py-1 text-[11px] font-semibold transition-colors",
                       !selectedPromotionId
                         ? "bg-[var(--action-primary-bg)] text-white"
-                        : "bg-[var(--surface-muted)] text-[var(--text-muted)]",
+                        : "bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-[var(--surface-base)]",
                     )}
                   >
                     None
@@ -1284,12 +1367,13 @@ export function PosCheckoutView() {
                       type="button"
                       onClick={() => setSelectedPromotionId(promo.id)}
                       className={cn(
-                        "rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
+                        "inline-flex items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold transition-colors",
                         selectedPromotionId === promo.id
                           ? "bg-[var(--action-primary-bg)] text-white"
-                          : "bg-[var(--surface-muted)] text-[var(--text-muted)]",
+                          : "bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-[var(--surface-base)]",
                       )}
                     >
+                      <Sparkles className="h-3 w-3" />
                       {promo.name}
                     </button>
                   ))}
@@ -1298,85 +1382,103 @@ export function PosCheckoutView() {
             ) : null}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setAdjustmentsOpen(false)}>
-              Done
-            </Button>
+            <Button onClick={() => setAdjustmentsOpen(false)}>Done</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* ── Hold dialog ────────────────────────────────── */}
+      {/* ── Hold dialog ─────────────────────────────────── */}
       <Dialog open={holdDialog} onOpenChange={setHoldDialog}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>Hold current sale</DialogTitle>
           </DialogHeader>
-          <div className="space-y-3">
+          <div className="space-y-3 py-1">
             <p className="text-sm text-[var(--text-muted)]">
-              Park this cart so you can return to it later.
+              Park this cart and come back to it later from the Held screen.
             </p>
             <Input
               value={holdLabel}
               onChange={(e) => setHoldLabel(e.target.value)}
-              placeholder="Label (optional)"
+              placeholder="Label (optional — e.g. Table 4)"
               className="h-9"
+              autoFocus
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setHoldDialog(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => holdCartMutation.mutate()}
-              disabled={holdCartMutation.isPending}
-            >
+            <Button variant="outline" onClick={() => setHoldDialog(false)}>Cancel</Button>
+            <Button onClick={() => holdCartMutation.mutate()} disabled={holdCartMutation.isPending}>
+              {holdCartMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ReceiptLong className="h-4 w-4" />}
               Hold sale
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* ── Sale completed dialog ──────────────────────── */}
-      <Dialog
-        open={Boolean(lastCompletedSale)}
-        onOpenChange={(open) => !open && dismissCompletedSale()}
-      >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Sale completed</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-3">
-            <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="font-mono text-lg font-semibold">{lastCompletedSale?.saleNo}</div>
-                  <div className="mt-1 text-sm text-[var(--text-muted)]">
-                    Total: {money(lastCompletedSale?.totalAmount ?? 0)}
-                  </div>
-                </div>
-                <CheckCircle2 className="h-8 w-8 text-emerald-600" />
-              </div>
-              <div className="mt-3 flex gap-4 text-sm">
-                <span>
-                  Change: <span className="font-mono font-semibold">{money(lastCompletedSale?.changeAmount ?? 0)}</span>
-                </span>
-              </div>
+      {/* ── Sale completed ──────────────────────────────── */}
+      <Dialog open={Boolean(lastCompletedSale)} onOpenChange={(open) => !open && dismissCompletedSale()}>
+        <DialogContent className="sm:max-w-sm p-0 overflow-hidden">
+          {/* Success header */}
+          <div className="bg-gradient-to-br from-emerald-600 to-emerald-500 px-6 pt-8 pb-6 text-center text-white">
+            <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-white/20 ring-4 ring-white/30">
+              <CheckCircle2 className="h-8 w-8 text-white" />
+            </div>
+            <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-emerald-100">
+              Sale complete
+            </div>
+            <div className="mt-1 font-mono text-xl font-black">
+              {lastCompletedSale?.saleNo}
             </div>
           </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={dismissCompletedSale}>
-              Continue selling
+
+          {/* Details */}
+          <div className="px-6 py-5 space-y-4">
+            {/* Change — the most important number for a cashier */}
+            <div className="text-center">
+              <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                Change due
+              </div>
+              <div className={cn(
+                "font-mono font-black leading-none mt-1",
+                (lastCompletedSale?.changeAmount ?? 0) > 0
+                  ? "text-5xl text-emerald-600"
+                  : "text-3xl text-[var(--text-muted)]",
+              )}>
+                {money(lastCompletedSale?.changeAmount ?? 0)}
+              </div>
+            </div>
+
+            {/* Secondary info */}
+            <div className="flex items-center justify-between rounded-xl bg-[var(--surface-muted)] px-4 py-3">
+              <div>
+                <div className="text-[11px] text-[var(--text-muted)]">Total charged</div>
+                <div className="font-mono text-base font-bold text-[var(--text-strong)]">
+                  {money(lastCompletedSale?.totalAmount ?? 0)}
+                </div>
+              </div>
+              {lastCompletedSale?.customerName ? (
+                <div className="text-right">
+                  <div className="text-[11px] text-[var(--text-muted)]">Customer</div>
+                  <div className="text-sm font-semibold text-[var(--text-strong)]">
+                    {lastCompletedSale.customerName}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <DialogFooter className="px-6 pb-5 gap-2">
+            <Button variant="outline" size="sm" onClick={dismissCompletedSale} className="flex-1">
+              Next sale
             </Button>
             {whatsappHref ? (
-              <Button asChild variant="outline">
-                <a href={whatsappHref} target="_blank" rel="noreferrer">
-                  WhatsApp
-                </a>
+              <Button variant="outline" size="sm" className="flex-1 border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100" asChild>
+                <a href={whatsappHref} target="_blank" rel="noreferrer">WhatsApp</a>
               </Button>
             ) : null}
-            <Button asChild>
+            <Button size="sm" className="flex-1" asChild>
               <Link href={getPosPortalHref("history", isPosHost)}>
-                <Payments className="h-4 w-4" />
+                <History className="h-4 w-4" />
                 History
               </Link>
             </Button>

--- a/components/retail/portal/pos-numeric-keypad.tsx
+++ b/components/retail/portal/pos-numeric-keypad.tsx
@@ -9,7 +9,7 @@ type PosNumericKeypadProps = {
   className?: string;
 };
 
-const KEYS: Array<{ label: string; action: PosKeypadAction; span?: string }> = [
+const KEYS: Array<{ label: string; action: PosKeypadAction }> = [
   { label: "1", action: { type: "digit", value: "1" } },
   { label: "2", action: { type: "digit", value: "2" } },
   { label: "3", action: { type: "digit", value: "3" } },
@@ -23,17 +23,30 @@ const KEYS: Array<{ label: string; action: PosKeypadAction; span?: string }> = [
   { label: "0", action: { type: "digit", value: "0" } },
 ];
 
-const btnBase =
-  "flex items-center justify-center rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] font-semibold text-[var(--text-strong)] select-none transition-transform duration-75 active:scale-[0.95] active:bg-[var(--surface-muted)] hover:bg-[var(--surface-muted)] h-[3.25rem]";
+/* ── Style constants ─────────────────────────────────────────── */
 
-const presetBtn =
-  "flex items-center justify-center rounded-xl border border-emerald-200 bg-emerald-50 text-emerald-700 font-semibold text-xs select-none transition-transform duration-75 active:scale-[0.95] active:bg-emerald-100 hover:bg-emerald-100 h-[3.25rem]";
+const base =
+  "flex items-center justify-center rounded-xl border font-semibold select-none transition-all duration-75 active:scale-[0.93] h-[3rem]";
 
-const clearBtn =
-  "flex items-center justify-center rounded-xl border border-red-200 bg-red-50 text-red-600 font-semibold text-xs select-none transition-transform duration-75 active:scale-[0.95] active:bg-red-100 hover:bg-red-100 h-[3.25rem]";
+const numKey = cn(
+  base,
+  "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] text-lg hover:bg-[var(--surface-muted)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_30%,var(--border-default))] shadow-[0_1px_2px_rgba(0,0,0,0.05)]",
+);
 
-const backspaceBtn =
-  "flex items-center justify-center rounded-xl border border-amber-200 bg-amber-50 text-amber-700 font-semibold select-none transition-transform duration-75 active:scale-[0.95] active:bg-amber-100 hover:bg-amber-100 h-[3.25rem]";
+const presetKey = cn(
+  base,
+  "border-emerald-200 bg-emerald-50 text-emerald-700 text-xs hover:bg-emerald-100 hover:border-emerald-300",
+);
+
+const backspaceKey = cn(
+  base,
+  "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-amber-50 hover:border-amber-200 hover:text-amber-700",
+);
+
+const clearKey = cn(
+  base,
+  "border-red-200 bg-red-50 text-red-600 text-sm font-bold hover:bg-red-100 hover:border-red-300",
+);
 
 export function PosNumericKeypad({
   onAction,
@@ -43,110 +56,66 @@ export function PosNumericKeypad({
   const hasPresets = presets.length > 0;
   const cols = hasPresets ? "grid-cols-4" : "grid-cols-3";
 
-  // Build rows: row0=[1,2,3], row1=[4,5,6], row2=[7,8,9], row3=[.,0,⌫,C]
   const rows = [
-    KEYS.slice(0, 3),
-    KEYS.slice(3, 6),
-    KEYS.slice(6, 9),
-    KEYS.slice(9, 11), // . and 0
+    KEYS.slice(0, 3),  // 1 2 3
+    KEYS.slice(3, 6),  // 4 5 6
+    KEYS.slice(6, 9),  // 7 8 9
+    KEYS.slice(9, 11), // . 0
   ];
 
   return (
     <div className={cn("grid gap-1.5", cols, className)}>
-      {/* Row 0: 1 2 3 [preset0] */}
+      {/* Row 0: 1 2 3 | preset 0 */}
       {rows[0].map((key) => (
-        <button
-          key={key.label}
-          type="button"
-          className={cn(btnBase, "text-lg")}
-          onClick={() => onAction(key.action)}
-        >
+        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[0] ? (
-        <button
-          type="button"
-          className={presetBtn}
-          onClick={() => onAction({ type: "preset", value: presets[0].value })}
-        >
+        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[0].value })}>
           {presets[0].label}
         </button>
-      ) : null}
+      ) : hasPresets ? <div /> : null}
 
-      {/* Row 1: 4 5 6 [preset1] */}
+      {/* Row 1: 4 5 6 | preset 1 */}
       {rows[1].map((key) => (
-        <button
-          key={key.label}
-          type="button"
-          className={cn(btnBase, "text-lg")}
-          onClick={() => onAction(key.action)}
-        >
+        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[1] ? (
-        <button
-          type="button"
-          className={presetBtn}
-          onClick={() => onAction({ type: "preset", value: presets[1].value })}
-        >
+        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[1].value })}>
           {presets[1].label}
         </button>
-      ) : hasPresets ? (
-        <div />
-      ) : null}
+      ) : hasPresets ? <div /> : null}
 
-      {/* Row 2: 7 8 9 [preset2] */}
+      {/* Row 2: 7 8 9 | preset 2 */}
       {rows[2].map((key) => (
-        <button
-          key={key.label}
-          type="button"
-          className={cn(btnBase, "text-lg")}
-          onClick={() => onAction(key.action)}
-        >
+        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[2] ? (
-        <button
-          type="button"
-          className={presetBtn}
-          onClick={() => onAction({ type: "preset", value: presets[2].value })}
-        >
+        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[2].value })}>
           {presets[2].label}
         </button>
-      ) : hasPresets ? (
-        <div />
-      ) : null}
+      ) : hasPresets ? <div /> : null}
 
       {/* Row 3: . 0 ⌫ C */}
       {rows[3].map((key) => (
-        <button
-          key={key.label}
-          type="button"
-          className={cn(btnBase, "text-lg")}
-          onClick={() => onAction(key.action)}
-        >
+        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
-      <button
-        type="button"
-        className={backspaceBtn}
-        onClick={() => onAction({ type: "backspace" })}
-      >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <button type="button" className={backspaceKey} onClick={() => onAction({ type: "backspace" })}>
+        {/* Backspace icon */}
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
           <line x1="18" y1="9" x2="12" y2="15" />
           <line x1="12" y1="9" x2="18" y2="15" />
         </svg>
       </button>
-      <button
-        type="button"
-        className={clearBtn}
-        onClick={() => onAction({ type: "clear" })}
-      >
+      <button type="button" className={clearKey} onClick={() => onAction({ type: "clear" })}>
         C
       </button>
     </div>

--- a/components/retail/portal/pos-portal-page-frame.tsx
+++ b/components/retail/portal/pos-portal-page-frame.tsx
@@ -92,34 +92,36 @@ export async function PosPortalPageFrame({
     <div className="text-[15px] text-[var(--text-strong)]">
       <div className="relative flex h-[100dvh] overflow-hidden lg:flex-row">
         {/* ── Sidebar ─────────────────────────────────────── */}
-        <aside className="shrink-0 border-b border-[var(--edge-subtle)] bg-[var(--sidebar)] lg:w-[13.5rem] lg:border-b-0 lg:border-r">
+        <aside className="shrink-0 border-b border-[var(--edge-subtle)] bg-[var(--sidebar)] lg:w-[13rem] lg:border-b-0 lg:border-r">
           <div className="flex h-full flex-col">
-            <div className="shrink-0 px-3 pt-3 lg:px-4 lg:pt-4">
-              <div className="px-1 lg:px-2">
-                <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                  POS
-                </div>
-                <div className="mt-0.5 truncate text-sm font-semibold">{session.user.name || "Operator"}</div>
+            {/* Wordmark */}
+            <div className="hidden shrink-0 px-4 pt-5 pb-3 lg:block">
+              <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">POS</div>
+              <div className="mt-0.5 truncate text-[13px] font-bold text-[var(--text-strong)]">
+                {session.user.name || "Operator"}
               </div>
             </div>
-            <nav className="flex gap-1 overflow-x-auto px-3 pb-2 pt-3 lg:mt-2 lg:flex-1 lg:flex-col lg:gap-0.5 lg:overflow-y-auto lg:overflow-x-visible lg:px-3 lg:pb-3 lg:pt-0">
-              {renderedLinks.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={cn(
-                    "group inline-flex min-h-9 shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-[13px] font-medium transition-colors lg:flex lg:min-h-9 lg:w-full lg:px-3 lg:py-2",
-                    publicPathname === item.href || pathname === item.href
-                      ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[inset_0_0_0_1px_var(--edge-default)]"
-                      : "text-[var(--text-muted)] hover:bg-[color-mix(in_srgb,var(--surface-base)_60%,transparent)] hover:text-[var(--text-strong)]",
-                  )}
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  <span className="whitespace-nowrap">{item.label}</span>
-                </Link>
-              ))}
+            <nav className="flex gap-1 overflow-x-auto px-3 pb-2 pt-2 lg:mt-1 lg:flex-1 lg:flex-col lg:gap-0.5 lg:overflow-y-auto lg:overflow-x-visible lg:px-2.5 lg:pb-3 lg:pt-0">
+              {renderedLinks.map((item) => {
+                const isActive = publicPathname === item.href || pathname === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "group inline-flex min-h-9 shrink-0 items-center gap-2.5 rounded-lg px-2.5 py-2 text-[13px] font-medium transition-all duration-100 lg:flex lg:w-full",
+                      isActive
+                        ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[0_1px_3px_rgba(0,0,0,0.07),inset_0_0_0_1px_var(--edge-default)]"
+                        : "text-[var(--text-muted)] hover:bg-[color-mix(in_srgb,var(--surface-base)_70%,transparent)] hover:text-[var(--text-strong)]",
+                    )}
+                  >
+                    <item.icon className={cn("h-4 w-4 shrink-0 transition-colors", isActive ? "text-[var(--action-primary-bg)]" : "")} />
+                    <span className="whitespace-nowrap">{item.label}</span>
+                  </Link>
+                );
+              })}
             </nav>
-            <div className="hidden shrink-0 border-t border-[var(--edge-subtle)] px-4 py-2.5 lg:block">
+            <div className="hidden shrink-0 border-t border-[var(--edge-subtle)] px-4 py-3 lg:block">
               <OfflineStatusIndicator />
             </div>
           </div>

--- a/lib/id-generator.ts
+++ b/lib/id-generator.ts
@@ -441,21 +441,22 @@ export async function reserveIdentifier(
 
     if (!existing) {
       const maxExisting = await findEntityMaxExistingCode(tx, input);
-      try {
-        await tx.idSequence.create({
-          data: {
+      // Use createMany with skipDuplicates instead of create + P2002 catch.
+      // Catching P2002 and continuing inside a transaction causes PostgreSQL to enter
+      // an "aborted" state, making every subsequent query fail with
+      // "current transaction is aborted". createMany/skipDuplicates translates to
+      // INSERT ... ON CONFLICT DO NOTHING which is safe inside a parent transaction.
+      await tx.idSequence.createMany({
+        data: [
+          {
             companyId: input.companyId,
             entityKey: input.entity,
             scopeKey,
             lastNumber: maxExisting,
           },
-        });
-      } catch (error) {
-        const known = error as Prisma.PrismaClientKnownRequestError;
-        if (!(known && known.code === "P2002")) {
-          throw error;
-        }
-      }
+        ],
+        skipDuplicates: true,
+      });
     }
 
     const next = await tx.idSequence.update({


### PR DESCRIPTION
Fix "current transaction is aborted" error that blocked all checkouts:
- id-generator.ts: replace try/catch P2002 pattern in reserveIdentifier with createMany({ skipDuplicates: true }), which uses INSERT ... ON CONFLICT DO NOTHING and is safe inside a PostgreSQL transaction
- _helpers.ts: remove retry loop in recordRetailInventoryMovement that caught P2002 inside a transaction callback — same anti-pattern, now just propagates cleanly

Rebuild POS checkout UI for speed and clarity:
- Tender type: visual tab buttons (icon + label) replace the Select dropdown
- Cart: inline ± quantity controls on every row, no editor required
- Catalog: live in-cart badge, low-stock amber highlight, compare-at price
- Charge button: context-aware (shows blocker count, loading spinner)
- Success screen: dominant change-amount display, emerald gradient header
- Keypad: refined key depth/contrast, distinct action keys
- Sidebar: active icon tinted with primary color