### PR TITLE
fix(pos): fix checkout crash and rebuild POS UI

### DIFF
--- a/components/retail/portal/pos-checkout-view.tsx
+++ b/components/retail/portal/pos-checkout-view.tsx
@@ -130,8 +130,8 @@ function NumField({
       className={cn(
         "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left transition-all duration-100",
         active
-          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,var(--surface-base))] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
-          : "border-[var(--border-default)] bg-[var(--surface-base)] hover:border-[var(--action-primary-bg)] hover:bg-[var(--surface-muted)]",
+          ? "border-[var(--border-default)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,var(--surface-base))] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
+          : "border-[var(--border-default)] bg-[var(--surface-base)] hover:bg-[var(--surface-muted)]",
         className,
       )}
     >
@@ -263,17 +263,26 @@ export function PosCheckoutView() {
       setPayments([{ ...base }]);
       return;
     }
-    if (cart.length > 0 && !payments[0].amount.trim()) {
+    // Auto-fill only when the user has NOT manually edited the field.
+    // This lets backspace reach "" without immediately bouncing back to the total.
+    if (cart.length > 0 && !payments[0].amount.trim() && !paymentUserEditedRef.current) {
       setPayments((current) =>
         current.map((p, i) => (i === 0 ? { ...p, amount: total.toFixed(2) } : p)),
       );
     }
     if (cart.length === 0 && payments[0].amount.trim()) {
+      // Cart cleared — reset dirty flag so the next sale gets auto-filled again.
+      paymentUserEditedRef.current = false;
       setPayments((current) =>
         current.map((p, i) => (i === 0 ? { ...p, amount: "" } : p)),
       );
     }
   }, [cart.length, payments, setPayments, splitTenderMode, total]);
+
+  // Tracks whether the user has manually touched the payment amount via the
+  // keypad. When true we stop auto-filling empty amounts so backspacing to ""
+  // doesn't immediately reset back to the sale total.
+  const paymentUserEditedRef = useRef(false);
 
   const prevCartLengthRef = useRef(cart.length);
   useEffect(() => {
@@ -313,6 +322,7 @@ export function PosCheckoutView() {
       return;
     }
     if (target.type === "tender_amount") {
+      paymentUserEditedRef.current = true;
       const nextValue = applyPosKeypadAction(payments[target.index]?.amount ?? "", action);
       updatePayment(target.index, { amount: nextValue });
       return;
@@ -491,7 +501,7 @@ export function PosCheckoutView() {
       {/* ── Top bar ─────────────────────────────────────── */}
       <div className="flex shrink-0 items-center gap-2 border-b border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2">
         {/* Search */}
-        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-2.5 py-1.5 transition-all duration-100 focus-within:border-[var(--action-primary-bg)] focus-within:bg-[var(--surface-base)] focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
+        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-2.5 py-1.5 transition-all duration-100 focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
           <Search className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
           <input
             ref={searchInputRef}
@@ -759,7 +769,7 @@ export function PosCheckoutView() {
             {cart.length > 0 ? (
               <button
                 type="button"
-                onClick={clearCart}
+                onClick={() => { paymentUserEditedRef.current = false; clearCart(); }}
                 className="rounded-md px-2 py-0.5 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-600"
               >
                 Clear
@@ -1065,8 +1075,8 @@ export function PosCheckoutView() {
                       className={cn(
                         "flex h-12 w-full items-center justify-between rounded-xl border px-4 font-mono text-xl font-black transition-all duration-100",
                         isActiveTender
-                          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,white)] text-[var(--action-primary-bg)] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
-                          : "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
+                          ? "border-[var(--border-default)] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,white)] text-[var(--action-primary-bg)] ring-2 ring-[var(--action-primary-bg)] ring-offset-1"
+                          : "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-strong)]",
                       )}
                     >
                       <span className="text-[13px] font-semibold text-[var(--text-muted)] opacity-70">
@@ -1183,7 +1193,7 @@ export function PosCheckoutView() {
 
             <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4 pr-1">
               {/* Search */}
-              <div className="flex items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2 transition-all focus-within:border-[var(--action-primary-bg)] focus-within:bg-[var(--surface-base)] focus-within:ring-1 focus-within:ring-[var(--action-primary-bg)]">
+              <div className="flex items-center gap-2 rounded-lg border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2 transition-all focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
                 <Search className="h-4 w-4 text-[var(--text-muted)]" />
                 <Input
                   value={customerName}


### PR DESCRIPTION
## Summary

- **Fixes checkout crash** — resolved the \"current transaction is aborted\" error that blocked all sales
- **Fixes backspace-to-zero** — payment amount no longer snaps back to total when cleared via keypad
- **Rebuilds POS checkout UI** — deliberate, fast layout optimised for cashier workflow

## Bug fixes

### \"Current transaction is aborted\" on checkout
Two places in the codebase caught `P2002` (unique constraint violation) inside a PostgreSQL transaction callback and silently continued. In PostgreSQL, once any statement in a transaction fails the connection enters an aborted state — all subsequent statements on that connection fail with the error above until a `ROLLBACK` is issued. Prisma's interactive transactions don't add implicit savepoints, so the catch-and-continue pattern was fundamentally broken.

- **`lib/id-generator.ts`** — replaced `idSequence.create` + P2002 catch with `createMany({ skipDuplicates: true })`, which maps to `INSERT ... ON CONFLICT DO NOTHING` and is safe inside any transaction
- **`app/api/v2/retail/_helpers.ts`** — removed the retry loop inside `writeMovement` that caught P2002 and continued; since `reserveIdentifier` now generates IDs atomically the loop was both unnecessary and dangerous

### Backspace resets to total
The payment sync `useEffect` refilled an empty amount string immediately, so backspacing to `""` snapped back to the sale total. Added `paymentUserEditedRef` — set when the user first touches a tender field via the keypad, gates the auto-fill so it only runs before the field has been touched. Resets on cart clear so the next transaction auto-fills normally.

## UI changes

- **Tender type** — visual tab buttons (icon + label) replace the `<Select>` dropdown; one tap instead of three
- **Cart rows** — inline `−` / qty / `+` controls on every item, no editor step needed
- **Catalog items** — live in-cart quantity badge, low-stock amber highlight, compare-at price when available
- **Payment panel** — large scalable amount-due display, change shown as a green pill, context-aware charge button (shows blocker count, spinner during submission)
- **Success screen** — dominant change-amount number in emerald, secondary details below
- **Keypad** — refined key depth and contrast, distinct backspace/clear keys
- **Sidebar** — active nav icon tinted with primary colour
- **Styling** — removed all `border` + `ring` doubles from focus/active states; each now uses ring-only

## Test plan

- [ ] Open a shift and add items to cart — payment auto-fills with total
- [ ] Backspace the payment amount all the way to zero — should stay at `""` / `0`, not reset
- [ ] Tap a preset (exact / round) — amount updates correctly
- [ ] Complete a sale — no \"current transaction is aborted\" error, success screen shows change due
- [ ] Switch tender types via the tab buttons
- [ ] Use split tender — add/remove rows, each row independently editable
- [ ] Hold a cart and recall it
- [ ] Clear cart — next sale auto-fills payment again

🤖 Generated with [Claude Code](https://claude.com/claude-code)