### PR TITLE
feat(pos): full POS surface redesign with cashier-focused UI

### DIFF
--- a/components/retail/portal/pos-checkout-view.tsx
+++ b/components/retail/portal/pos-checkout-view.tsx
@@ -143,6 +143,29 @@ function NumField({
 
 /* ─── Tender type grid button ─────────────────────────────────────── */
 
+const TENDER_TYPE_STYLES: Record<TenderType, { selected: string; idle: string }> = {
+  CASH: {
+    selected: "border-emerald-500 bg-emerald-500 text-white shadow-[0_4px_14px_rgba(16,185,129,0.35)]",
+    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-700",
+  },
+  CARD: {
+    selected: "border-blue-500 bg-blue-500 text-white shadow-[0_4px_14px_rgba(59,130,246,0.35)]",
+    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700",
+  },
+  MOBILE_MONEY: {
+    selected: "border-orange-500 bg-orange-500 text-white shadow-[0_4px_14px_rgba(249,115,22,0.35)]",
+    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-orange-400 hover:bg-orange-50 hover:text-orange-700",
+  },
+  TRANSFER: {
+    selected: "border-violet-500 bg-violet-500 text-white shadow-[0_4px_14px_rgba(139,92,246,0.35)]",
+    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-violet-400 hover:bg-violet-50 hover:text-violet-700",
+  },
+  VOUCHER: {
+    selected: "border-amber-500 bg-amber-500 text-white shadow-[0_4px_14px_rgba(245,158,11,0.35)]",
+    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-amber-400 hover:bg-amber-50 hover:text-amber-700",
+  },
+};
+
 function TenderButton({
   type,
   selected,
@@ -152,15 +175,14 @@ function TenderButton({
   selected: boolean;
   onClick: () => void;
 }) {
+  const styles = TENDER_TYPE_STYLES[type];
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        "flex flex-col items-center justify-center gap-1.5 rounded-xl border py-3 text-[11px] font-bold uppercase tracking-wide transition-all duration-100 active:scale-[0.96]",
-        selected
-          ? "border-[var(--action-primary-bg)] bg-[var(--action-primary-bg)] text-white shadow-[0_4px_12px_rgba(0,0,0,0.15)]"
-          : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]",
+        "flex flex-col items-center justify-center gap-1.5 rounded-xl border py-3 text-[11px] font-bold uppercase tracking-wide transition-all duration-100 active:scale-[0.95]",
+        selected ? styles.selected : styles.idle,
       )}
     >
       <TenderIcon type={type} className="h-5 w-5" />
@@ -683,64 +705,67 @@ export function PosCheckoutView() {
                       onClick={() => handleAddCatalogItem(item)}
                       disabled={!currentShift}
                       className={cn(
-                        "group relative flex items-center gap-3.5 rounded-xl border bg-[var(--surface-base)] p-3 text-left transition-all duration-100 active:scale-[0.97]",
+                        "group relative flex items-start gap-3 rounded-2xl border bg-[var(--surface-base)] p-3.5 text-left transition-all duration-100 active:scale-[0.97]",
                         inCart
-                          ? "border-[color-mix(in_srgb,var(--action-primary-bg)_50%,var(--border-default))] shadow-[0_0_0_1px_color-mix(in_srgb,var(--action-primary-bg)_25%,transparent),0_4px_12px_rgba(0,0,0,0.05)]"
-                          : "border-[var(--border-default)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:shadow-[0_4px_14px_rgba(0,0,0,0.08)]",
+                          ? "border-[color-mix(in_srgb,var(--action-primary-bg)_50%,var(--border-default))] bg-[color-mix(in_srgb,var(--action-primary-bg)_3%,var(--surface-base))] shadow-[0_0_0_1.5px_color-mix(in_srgb,var(--action-primary-bg)_30%,transparent),0_4px_16px_rgba(0,0,0,0.06)]"
+                          : "border-[var(--border-default)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_40%,var(--border-default))] hover:shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
                       )}
                     >
                       {/* Image / placeholder */}
-                      <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-muted)]">
+                      <div className={cn(
+                        "flex h-[3.75rem] w-[3.75rem] shrink-0 items-center justify-center overflow-hidden rounded-xl transition-colors",
+                        inCart
+                          ? "bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,var(--surface-muted))]"
+                          : "bg-[var(--surface-muted)]",
+                      )}>
                         {item.imageUrl ? (
-                          <Image src={item.imageUrl} alt={item.name} width={56} height={56} className="h-full w-full object-cover" unoptimized />
+                          <Image src={item.imageUrl} alt={item.name} width={60} height={60} className="h-full w-full object-cover" unoptimized />
                         ) : (
-                          <Package className="h-6 w-6 text-[var(--text-muted)]" />
+                          <Package className={cn("h-6 w-6", inCart ? "text-[var(--action-primary-bg)]" : "text-[var(--text-muted)]")} />
                         )}
                       </div>
 
-                      {/* Info */}
-                      <div className="min-w-0 flex-1">
-                        <div className="line-clamp-1 text-sm font-semibold leading-tight text-[var(--text-strong)]">
+                      {/* Info + price stacked */}
+                      <div className="min-w-0 flex-1 pt-0.5">
+                        <div className="line-clamp-2 text-[13px] font-semibold leading-[1.3] text-[var(--text-strong)]">
                           {item.name}
                         </div>
-                        <div className="mt-1 flex items-center gap-2">
-                          {item.inventoryItem && (
-                            <span className={cn(
-                              "rounded-md px-1.5 py-0.5 text-[10px] font-semibold",
-                              item.inventoryItem.currentStock <= 5
-                                ? "bg-amber-50 text-amber-700"
-                                : "bg-emerald-50 text-emerald-700",
-                            )}>
-                              {item.inventoryItem.currentStock.toFixed(0)} {item.inventoryItem.unit}
-                            </span>
-                          )}
-                          {item.barcode || item.sku ? (
-                            <span className="font-mono text-[10px] text-[var(--text-muted)]">
-                              {item.barcode || item.sku}
-                            </span>
-                          ) : null}
-                        </div>
-                      </div>
-
-                      {/* Price */}
-                      <div className="shrink-0 text-right">
-                        {item.compareAtPrice && item.compareAtPrice > item.unitPrice ? (
-                          <div className="font-mono text-[10px] text-[var(--text-muted)] line-through">
-                            {money(item.compareAtPrice)}
+                        <div className="mt-2 flex items-end justify-between gap-1">
+                          <div className="flex flex-wrap items-center gap-1.5">
+                            {item.inventoryItem && (
+                              <span className={cn(
+                                "rounded-md px-1.5 py-0.5 text-[10px] font-semibold",
+                                item.inventoryItem.currentStock <= 5
+                                  ? "bg-amber-50 text-amber-700"
+                                  : "bg-emerald-50 text-emerald-700",
+                              )}>
+                                {item.inventoryItem.currentStock.toFixed(0)} {item.inventoryItem.unit}
+                              </span>
+                            )}
                           </div>
-                        ) : null}
-                        <div className="font-mono text-[15px] font-bold text-[var(--text-strong)]">
-                          {money(item.unitPrice)}
+                          <div className="shrink-0 text-right">
+                            {item.compareAtPrice && item.compareAtPrice > item.unitPrice ? (
+                              <div className="font-mono text-[10px] text-[var(--text-muted)] line-through">
+                                {money(item.compareAtPrice)}
+                              </div>
+                            ) : null}
+                            <div className={cn(
+                              "font-mono text-[15px] font-black leading-none",
+                              inCart ? "text-[var(--action-primary-bg)]" : "text-[var(--text-strong)]",
+                            )}>
+                              {money(item.unitPrice)}
+                            </div>
+                          </div>
                         </div>
                       </div>
 
                       {/* In-cart badge */}
                       {inCart ? (
-                        <div className="absolute -right-2 -top-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-[var(--action-primary-bg)] px-1.5 text-[11px] font-bold text-white shadow-md">
-                          {inCart.quantity % 1 === 0 ? inCart.quantity : inCart.quantity.toFixed(2)}
+                        <div className="absolute -right-2 -top-2 flex h-6 min-w-6 items-center justify-center rounded-full bg-[var(--action-primary-bg)] px-1.5 text-[11px] font-black text-white shadow-[0_2px_8px_rgba(0,0,0,0.2)]">
+                          ×{inCart.quantity % 1 === 0 ? inCart.quantity : inCart.quantity.toFixed(2)}
                         </div>
                       ) : (
-                        <div className="absolute right-2.5 top-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--action-primary-bg)] text-white opacity-0 shadow-md transition-opacity duration-100 group-hover:opacity-100">
+                        <div className="absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--action-primary-bg)] text-white opacity-0 shadow-md transition-opacity duration-100 group-hover:opacity-100">
                           <Plus className="h-3.5 w-3.5" />
                         </div>
                       )}
@@ -817,10 +842,10 @@ export function PosCheckoutView() {
                     <div
                       key={item.catalogItemId}
                       className={cn(
-                        "flex items-center gap-2 px-3 py-3 transition-colors duration-100",
+                        "flex items-center gap-2 px-3 py-3.5 transition-colors duration-100",
                         isSelected
-                          ? "border-l-4 border-l-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,var(--surface-base))]"
-                          : "border-l-4 border-l-transparent hover:bg-[var(--surface-muted)]",
+                          ? "border-l-[3px] border-l-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,var(--surface-base))]"
+                          : "border-l-[3px] border-l-transparent hover:bg-[var(--surface-muted)]",
                       )}
                     >
                       {/* Item info — clickable to select */}
@@ -832,13 +857,13 @@ export function PosCheckoutView() {
                           setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
                         }}
                       >
-                        <div className="truncate text-[13px] font-semibold text-[var(--text-strong)]">
+                        <div className="truncate text-[13px] font-semibold leading-tight text-[var(--text-strong)]">
                           {item.name}
                         </div>
-                        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                        <div className="mt-1 flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
                           <span className="font-mono">{money(item.unitPrice)}</span>
                           {item.lineDiscountAmount ? (
-                            <span className="font-mono text-emerald-600">−{money(item.lineDiscountAmount)}</span>
+                            <span className="rounded bg-emerald-50 px-1 font-mono text-emerald-600">−{money(item.lineDiscountAmount)}</span>
                           ) : null}
                         </div>
                       </button>
@@ -859,7 +884,7 @@ export function PosCheckoutView() {
                               updateQty(item.catalogItemId, next);
                             }
                           }}
-                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-500 active:scale-[0.92]"
+                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-red-200 hover:bg-red-50 hover:text-red-500 active:scale-[0.90]"
                         >
                           <Minus className="h-3.5 w-3.5" />
                         </button>
@@ -870,10 +895,10 @@ export function PosCheckoutView() {
                             setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
                           }}
                           className={cn(
-                            "h-8 min-w-[2.25rem] rounded-lg border px-2 font-mono text-sm font-bold transition-colors",
+                            "h-8 min-w-[2.5rem] rounded-lg border px-2 font-mono text-sm font-bold transition-all",
                             isSelected && activeTarget?.type === "line_qty"
                               ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,white)] text-[var(--action-primary-bg)]"
-                              : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
+                              : "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
                           )}
                         >
                           {item.quantity % 1 === 0 ? item.quantity : item.quantity.toFixed(2)}
@@ -881,15 +906,18 @@ export function PosCheckoutView() {
                         <button
                           type="button"
                           onClick={() => updateQty(item.catalogItemId, item.quantity + 1)}
-                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-colors hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] hover:text-[var(--action-primary-bg)] active:scale-[0.92]"
+                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] hover:text-[var(--action-primary-bg)] active:scale-[0.90]"
                         >
                           <Plus className="h-3.5 w-3.5" />
                         </button>
                       </div>
 
                       {/* Line total */}
-                      <div className="shrink-0 w-[4.5rem] text-right">
-                        <div className="font-mono text-sm font-bold text-[var(--text-strong)]">
+                      <div className="shrink-0 w-[4.75rem] text-right">
+                        <div className={cn(
+                          "font-mono text-sm font-black",
+                          isSelected ? "text-[var(--action-primary-bg)]" : "text-[var(--text-strong)]",
+                        )}>
                           {money(lineTotal)}
                         </div>
                       </div>
@@ -947,66 +975,69 @@ export function PosCheckoutView() {
 
           {/* Amount due header */}
           <div className={cn(
-            "shrink-0 px-4 pt-5 pb-3 text-center",
+            "shrink-0 border-b border-[var(--edge-subtle)] px-4 pt-5 pb-4 text-center",
             cart.length > 0
-              ? "bg-gradient-to-b from-[color-mix(in_srgb,var(--action-primary-bg)_6%,var(--surface-base))] to-[color-mix(in_srgb,var(--action-primary-bg)_2%,var(--surface-base))]"
-              : "",
+              ? "bg-gradient-to-b from-[color-mix(in_srgb,var(--action-primary-bg)_7%,var(--surface-base))] via-[color-mix(in_srgb,var(--action-primary-bg)_3%,var(--surface-base))] to-[var(--surface-base)]"
+              : "bg-[var(--surface-base)]",
           )}>
-            <div className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+            <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
               Amount Due
             </div>
             <div className={cn(
               "mt-1 font-mono font-black leading-none tracking-tight transition-all duration-150",
-              total >= 10000 ? "text-4xl" : total >= 1000 ? "text-5xl" : "text-[3.25rem]",
+              total >= 10000 ? "text-[2.6rem]" : total >= 1000 ? "text-[3rem]" : "text-[3.5rem]",
               cart.length > 0 ? "text-[var(--text-strong)]" : "text-[var(--text-muted)]",
             )}>
               {money(total)}
             </div>
 
+            {/* Change / balance indicators */}
             {changeAmount > 0 ? (
-              <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-sm font-bold text-emerald-700">
-                Change: {money(changeAmount)}
+              <div className="mt-2.5 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-4 py-1.5 text-sm font-black text-emerald-700 shadow-sm">
+                <span className="text-emerald-500">↩</span>
+                Change {money(changeAmount)}
               </div>
             ) : tenderedTotal > 0 && tenderedTotal < total ? (
-              <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
-                Still due: {money(total - tenderedTotal)}
+              <div className="mt-2.5 inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1.5 text-xs font-bold text-amber-700 shadow-sm">
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                Still due {money(total - tenderedTotal)}
               </div>
-            ) : tenderedTotal > 0 ? (
-              <div className="mt-2 text-xs text-[var(--text-muted)]">
-                Tendered: <span className="font-mono font-semibold">{money(tenderedTotal)}</span>
+            ) : tenderedTotal > 0 && cart.length > 0 ? (
+              <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-3 py-1 text-xs font-medium text-[var(--text-muted)]">
+                Tendered <span className="font-mono font-semibold">{money(tenderedTotal)}</span>
               </div>
             ) : null}
 
             {/* Quick action pills */}
-            <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+            <div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">
               <button
                 type="button"
                 onClick={() => setAdjustmentsOpen(true)}
-                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-3 py-1.5 text-[11px] font-semibold text-[var(--text-muted)] shadow-sm transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]"
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-semibold text-[var(--text-muted)] shadow-sm transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]"
               >
-                <Sparkles className="h-3.5 w-3.5" />
+                <Sparkles className="h-3 w-3" />
                 Adjust
               </button>
               <button
                 type="button"
                 onClick={() => setSplitTenderMode(!splitTenderMode)}
                 className={cn(
-                  "inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-[11px] font-semibold shadow-sm transition-all duration-100",
+                  "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-semibold shadow-sm transition-all duration-100",
                   splitTenderMode
                     ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,var(--surface-base))] text-[var(--action-primary-bg)]"
                     : "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)]",
                 )}
               >
-                <Payments className="h-3.5 w-3.5" />
-                {splitTenderMode ? "Single pay" : "Split"}
+                <Payments className="h-3 w-3" />
+                {splitTenderMode ? "Single" : "Split"}
               </button>
               <button
                 type="button"
                 onClick={() => setHoldDialog(true)}
                 disabled={cart.length === 0 || !currentShift}
-                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-3 py-1.5 text-[11px] font-semibold text-[var(--text-muted)] shadow-sm transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)] disabled:opacity-40"
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--border-default)] bg-[var(--surface-base)] px-2.5 py-1 text-[11px] font-semibold text-[var(--text-muted)] shadow-sm transition-all duration-100 hover:border-[var(--action-primary-bg)] hover:text-[var(--action-primary-bg)] disabled:opacity-40"
               >
-                <ReceiptLong className="h-3.5 w-3.5" />
+                <ReceiptLong className="h-3 w-3" />
                 Hold
               </button>
             </div>
@@ -1141,16 +1172,20 @@ export function PosCheckoutView() {
               onClick={handleCharge}
               disabled={postSalePending || cart.length === 0}
               className={cn(
-                "relative flex h-14 w-full items-center justify-center gap-2.5 overflow-hidden rounded-xl text-[15px] font-black text-white shadow-lg transition-all duration-150 active:scale-[0.98]",
+                "relative flex h-[3.75rem] w-full items-center justify-center gap-2.5 overflow-hidden rounded-2xl text-[15px] font-black text-white transition-all duration-150 active:scale-[0.98]",
                 cart.length === 0
-                  ? "cursor-not-allowed bg-[var(--surface-muted)] text-[var(--text-muted)] shadow-none"
+                  ? "cursor-not-allowed bg-[var(--surface-muted)] text-[var(--text-muted)]"
                   : blockers.length > 0
-                    ? "bg-amber-400 hover:bg-amber-500 shadow-amber-200"
+                    ? "bg-amber-400 shadow-[0_6px_20px_rgba(245,158,11,0.4)] hover:bg-amber-500"
                     : postSalePending
                       ? "cursor-wait bg-emerald-600 opacity-80"
-                      : "bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 hover:shadow-[0_4px_16px_rgba(16,185,129,0.4)]",
+                      : "bg-gradient-to-br from-emerald-500 to-emerald-600 shadow-[0_6px_24px_rgba(16,185,129,0.45)] hover:shadow-[0_8px_28px_rgba(16,185,129,0.5)]",
               )}
             >
+              {/* Subtle shine overlay */}
+              {cart.length > 0 && !postSalePending && blockers.length === 0 && (
+                <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-t from-transparent to-white/[0.08]" />
+              )}
               {postSalePending ? (
                 <>
                   <Loader2 className="h-5 w-5 animate-spin" />
@@ -1470,42 +1505,44 @@ export function PosCheckoutView() {
 
       {/* ── Sale completed ──────────────────────────────── */}
       <Dialog open={Boolean(lastCompletedSale)} onOpenChange={(open) => !open && dismissCompletedSale()}>
-        <DialogContent className="sm:max-w-sm p-0 overflow-hidden">
-          {/* Success header */}
-          <div className="bg-gradient-to-br from-emerald-600 to-emerald-500 px-6 pt-8 pb-6 text-center text-white">
-            <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-white/20 ring-4 ring-white/30">
-              <CheckCircle2 className="h-8 w-8 text-white" />
-            </div>
-            <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-emerald-100">
-              Sale complete
-            </div>
-            <div className="mt-1 font-mono text-xl font-black">
-              {lastCompletedSale?.saleNo}
-            </div>
-          </div>
-
-          {/* Details */}
-          <div className="px-6 py-6 space-y-5">
-            {/* Change — the most important number for a cashier */}
-            <div className="text-center">
-              <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+        <DialogContent className="sm:max-w-[22rem] p-0 overflow-hidden">
+          {/* Change amount — the MOST important thing a cashier needs */}
+          {(lastCompletedSale?.changeAmount ?? 0) > 0 ? (
+            <div className="bg-gradient-to-br from-emerald-600 via-emerald-500 to-emerald-600 px-6 pt-8 pb-7 text-center text-white">
+              <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-emerald-200">
                 Change due
               </div>
-              <div className={cn(
-                "font-mono font-black leading-none mt-1",
-                (lastCompletedSale?.changeAmount ?? 0) > 0
-                  ? "text-6xl text-emerald-600"
-                  : "text-4xl text-[var(--text-muted)]",
-              )}>
+              <div className="mt-1 font-mono text-[4.5rem] font-black leading-none tracking-tight">
                 {money(lastCompletedSale?.changeAmount ?? 0)}
               </div>
+              <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-[11px] font-semibold text-emerald-100">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                {lastCompletedSale?.saleNo}
+              </div>
             </div>
+          ) : (
+            <div className="bg-gradient-to-br from-emerald-600 to-emerald-500 px-6 pt-7 pb-6 text-center text-white">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-white/20 ring-4 ring-white/25">
+                <CheckCircle2 className="h-6 w-6 text-white" />
+              </div>
+              <div className="text-[11px] font-bold uppercase tracking-[0.15em] text-emerald-100">
+                Sale complete
+              </div>
+              <div className="mt-0.5 font-mono text-lg font-black">
+                {lastCompletedSale?.saleNo}
+              </div>
+              <div className="mt-1 font-mono text-2xl font-black text-white/90">
+                {money(lastCompletedSale?.totalAmount ?? 0)}
+              </div>
+            </div>
+          )}
 
-            {/* Secondary info */}
+          {/* Secondary info */}
+          <div className="px-5 py-4 space-y-3">
             <div className="flex items-center justify-between rounded-xl bg-[var(--surface-muted)] px-4 py-3">
               <div>
                 <div className="text-[11px] text-[var(--text-muted)]">Total charged</div>
-                <div className="font-mono text-base font-bold text-[var(--text-strong)]">
+                <div className="font-mono text-base font-black text-[var(--text-strong)]">
                   {money(lastCompletedSale?.totalAmount ?? 0)}
                 </div>
               </div>
@@ -1520,11 +1557,11 @@ export function PosCheckoutView() {
             </div>
           </div>
 
-          <DialogFooter className="px-6 pb-6 gap-2">
-            <Button variant="outline" size="sm" onClick={dismissCompletedSale} className="flex-1">
+          <DialogFooter className="px-5 pb-5 gap-2">
+            <Button variant="outline" size="sm" onClick={dismissCompletedSale} className="flex-1 h-11 text-sm font-semibold">
               Next sale
             </Button>
-            <Button size="sm" className="flex-1" asChild>
+            <Button size="sm" className="flex-1 h-11 text-sm font-semibold" asChild>
               <Link href={getPosPortalHref("history", isPosHost)}>
                 <History className="h-4 w-4" />
                 History

--- a/components/retail/portal/pos-held-view.tsx
+++ b/components/retail/portal/pos-held-view.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { Clock, Package, ReceiptLong, RefreshCcw, Wallet } from "@/lib/icons";
+import { ArrowRight, Clock, Package, ReceiptLong, RefreshCcw, User, Wallet } from "@/lib/icons";
 import { getPosPortalHref } from "@/lib/retail/pos-host";
 import {
   PosEmptyState,
@@ -17,6 +17,19 @@ import {
 import { usePosPortalState } from "./pos-portal-state";
 import type { HeldCart } from "./pos-types";
 import { money } from "./pos-utils";
+import { cn } from "@/lib/utils";
+
+/* ─── Elapsed time helper ─────────────────────────────────────────── */
+function elapsedLabel(createdAt: string): { label: string; urgent: boolean } {
+  const ms = Date.now() - new Date(createdAt).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return { label: "Just held", urgent: false };
+  if (mins < 5) return { label: `${mins}m ago`, urgent: false };
+  if (mins < 15) return { label: `${mins}m ago`, urgent: true };
+  const hours = Math.floor(mins / 60);
+  if (hours < 1) return { label: `${mins}m ago`, urgent: true };
+  return { label: `${hours}h ${mins % 60}m ago`, urgent: true };
+}
 
 export function PosHeldView() {
   const router = useRouter();
@@ -58,72 +71,60 @@ export function PosHeldView() {
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4">
+
+      {/* ── Header metrics ────────────────────────────────── */}
       <PosPanel>
         <PosPanelHeader
-          eyebrow="Held queue"
-          title="Resume parked sales quickly"
-          description="Held carts should feel like a short pause in checkout, not a separate workflow."
+          eyebrow="Parked sales"
+          title="Held carts"
+          description="Recall any cart to instantly resume it at checkout."
           actions={
             <Button
               size="sm"
               variant="outline"
-              onClick={() =>
-                queryClient.invalidateQueries({ queryKey: ["retail-held-carts"] })
-              }
+              onClick={() => queryClient.invalidateQueries({ queryKey: ["retail-held-carts"] })}
             >
               <RefreshCcw className="h-4 w-4" />
               Refresh
             </Button>
           }
         />
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2">
           <PosMetricCard
             icon={ReceiptLong}
             label="Held carts"
             value={String(heldCarts.length)}
-            meta="Waiting to be recalled"
+            meta={heldCarts.length === 0 ? "Queue is clear" : "Waiting to be recalled"}
             tone={heldCarts.length > 0 ? "warning" : "neutral"}
           />
           <PosMetricCard
             icon={Clock}
-            label="Shift"
+            label="Active shift"
             value={currentShift?.shiftNo ?? "Not open"}
             meta={currentShift?.registerName ?? "Open a shift to park carts"}
             tone={currentShift ? "brand" : "warning"}
           />
-          <PosMetricCard
-            icon={Package}
-            label="Checkout"
-            value="Return fast"
-            meta="Recalling a cart should put the cashier back in the active sale lane."
-            tone="success"
-          />
         </div>
       </PosPanel>
 
+      {/* ── Cart grid ─────────────────────────────────────── */}
       <PosPanel className="min-h-0">
-        <PosPanelHeader
-          eyebrow="Queue"
-          title="Held carts"
-          description="Strong labels, timestamps, totals, and one obvious recall action."
-        />
-
-        <div className="h-full min-h-0 overflow-y-auto pr-1">
+        <div className="h-full min-h-0 overflow-y-auto pr-0.5">
           {!currentShift ? (
             <PosEmptyState
               icon={Clock}
-              title="Open a shift to use held carts"
-              description="Held carts are tied to the active register shift, so this queue stays closed until the drawer is open."
+              title="Open a shift first"
+              description="Held carts are tied to the active register shift. Open a shift to see and recall parked sales."
             />
+          ) : heldCartsQuery.isLoading ? (
+            <div className="flex min-h-[10rem] items-center justify-center text-sm text-[var(--text-muted)]">
+              Loading held carts…
+            </div>
           ) : heldCarts.length === 0 ? (
             <PosEmptyState
               icon={ReceiptLong}
-              title="No held carts for this shift"
-              description={
-                heldCartsQuery.isLoading
-                  ? "Loading the queue now."
-                  : "Once a cashier parks a sale, it will appear here for quick recall."
-              }
+              title="No held carts"
+              description="Use the Hold button at checkout to park a sale. It will appear here for quick recall."
             />
           ) : (
             <div className="grid gap-3 xl:grid-cols-2">
@@ -132,80 +133,83 @@ export function PosHeldView() {
                 const total =
                   heldCart.cartSnapshot.items?.reduce(
                     (sum, item) =>
-                      sum +
-                      item.quantity * item.unitPrice -
-                      (item.lineDiscountAmount ?? 0),
+                      sum + item.quantity * item.unitPrice - (item.lineDiscountAmount ?? 0),
                     0,
                   ) ?? 0;
+                const { label: timeLabel, urgent } = elapsedLabel(heldCart.createdAt);
+                const isRecalling = recallMutation.isPending &&
+                  recallMutation.variables?.id === heldCart.id;
 
                 return (
                   <div
                     key={heldCart.id}
-                    className="rounded-[1.35rem] border border-[var(--border-default)] bg-[var(--surface-muted)] p-4"
+                    className="flex flex-col rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] overflow-hidden"
                   >
-                    <div className="flex items-start justify-between gap-3">
+                    {/* Card header */}
+                    <div className="flex items-start justify-between gap-3 bg-[var(--surface-base)] px-4 py-3.5 border-b border-[var(--border-subtle)]">
                       <div className="min-w-0">
                         <div className="flex items-center gap-2">
-                          <div className="truncate text-base font-semibold text-[var(--text-strong)]">
+                          <span className="truncate text-[15px] font-bold text-[var(--text-strong)]">
                             {heldCart.label || heldCart.holdNo}
-                          </div>
-                          <PosStatusPill tone="warning">Held</PosStatusPill>
+                          </span>
+                          {heldCart.label && (
+                            <span className="font-mono text-[10px] text-[var(--text-muted)]">
+                              {heldCart.holdNo}
+                            </span>
+                          )}
                         </div>
-                        <div className="mt-1 font-mono text-xs text-[var(--text-muted)]">
-                          {heldCart.holdNo}
+                        <div className={cn(
+                          "mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold",
+                          urgent ? "text-amber-600" : "text-[var(--text-muted)]",
+                        )}>
+                          <Clock className="h-3 w-3" />
+                          {timeLabel}
                         </div>
                       </div>
-                      <div className="text-right">
-                        <div className="font-mono text-lg font-semibold text-[var(--text-strong)]">
+                      <div className="text-right shrink-0">
+                        <div className="font-mono text-xl font-black text-[var(--text-strong)]">
                           {money(total)}
                         </div>
-                        <div className="mt-1 text-xs text-[var(--text-muted)]">
-                          {itemCount} line{itemCount === 1 ? "" : "s"}
+                        <div className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                          {itemCount} line{itemCount !== 1 ? "s" : ""}
                         </div>
                       </div>
                     </div>
 
-                    <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                      <div className="rounded-[1rem] border border-[var(--border-subtle)] bg-white/80 px-3 py-3">
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                          Customer
-                        </div>
-                        <div className="mt-2 truncate text-sm font-medium text-[var(--text-strong)]">
+                    {/* Cart details */}
+                    <div className="flex items-center gap-4 px-4 py-3">
+                      <div className="flex items-center gap-1.5 text-[12px] text-[var(--text-muted)]">
+                        <User className="h-3.5 w-3.5 shrink-0" />
+                        <span className="font-medium">
                           {heldCart.cartSnapshot.customerName || "Walk-in"}
-                        </div>
+                        </span>
                       </div>
-                      <div className="rounded-[1rem] border border-[var(--border-subtle)] bg-white/80 px-3 py-3">
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                          Held at
+                      {itemCount > 0 && (
+                        <div className="flex items-center gap-1.5 text-[12px] text-[var(--text-muted)]">
+                          <Package className="h-3.5 w-3.5 shrink-0" />
+                          <span>
+                            {heldCart.cartSnapshot.items?.slice(0, 2).map(i => i.name).join(", ")}
+                            {(heldCart.cartSnapshot.items?.length ?? 0) > 2 && " …"}
+                          </span>
                         </div>
-                        <div className="mt-2 text-sm font-medium text-[var(--text-strong)]">
-                          {new Date(heldCart.createdAt).toLocaleTimeString([], {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
-                        </div>
-                      </div>
-                      <div className="rounded-[1rem] border border-[var(--border-subtle)] bg-white/80 px-3 py-3">
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                          Value
-                        </div>
-                        <div className="mt-2 font-mono text-sm font-semibold text-[var(--text-strong)]">
-                          {money(total)}
-                        </div>
-                      </div>
+                      )}
                     </div>
 
-                    <div className="mt-4 flex items-center justify-between gap-3">
-                      <div className="inline-flex items-center gap-2 text-xs text-[var(--text-muted)]">
-                        <Wallet className="h-4 w-4" />
-                        Recalling drops this cart back into checkout immediately.
-                      </div>
+                    {/* CTA */}
+                    <div className="px-4 pb-4 pt-1">
                       <Button
-                        className="min-h-11"
+                        className="w-full h-11 gap-2 rounded-xl text-[14px] font-bold"
                         onClick={() => recallMutation.mutate(heldCart)}
                         disabled={recallMutation.isPending}
                       >
-                        Recall cart
+                        {isRecalling ? (
+                          "Loading…"
+                        ) : (
+                          <>
+                            Recall to checkout
+                            <ArrowRight className="h-4 w-4" />
+                          </>
+                        )}
                       </Button>
                     </div>
                   </div>

--- a/components/retail/portal/pos-history-view.tsx
+++ b/components/retail/portal/pos-history-view.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { History, Plus, RefreshCcw, Trash2, XCircle } from "@/lib/icons";
+import { History, Plus, RefreshCcw, Search, Trash2, XCircle } from "@/lib/icons";
 import { PosNumericField } from "./pos-numeric-field";
 import { PosNumericKeypad } from "./pos-numeric-keypad";
 import { applyPosKeypadAction, type PosKeypadAction } from "./pos-numeric-input";
@@ -204,54 +204,64 @@ export function PosHistoryView() {
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4">
       <PosPanel>
-        <PosPanelHeader
-          eyebrow="Transaction workspace"
-          title="Receipts and reversals"
-          description="Find a sale, inspect it, refund or void if allowed, and get back to selling."
-          actions={
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => queryClient.invalidateQueries({ queryKey: ["retail-pos-sales"] })}
-            >
-              <RefreshCcw className="h-4 w-4" />
-              Refresh
-            </Button>
-          }
-        />
-        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px_180px]">
-          <div className="rounded-[1.15rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-3">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+              Transaction workspace
+            </p>
+            <h2 className="mt-1 text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+              Sales history
+            </h2>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => queryClient.invalidateQueries({ queryKey: ["retail-pos-sales"] })}
+          >
+            <RefreshCcw className="h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Search + stats row */}
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_160px_160px]">
+          {/* Search bar */}
+          <div className="flex items-center gap-2.5 rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-3.5 py-2 transition-all focus-within:border-[var(--action-primary-bg)] focus-within:bg-[var(--surface-base)] focus-within:ring-2 focus-within:ring-[var(--action-primary-bg)] focus-within:ring-offset-1">
+            <Search className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
             <Input
               value={search}
               onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search receipt, customer, cashier, or item"
-              className="h-11 border-none bg-transparent px-0 text-base shadow-none focus-visible:ring-0"
+              placeholder="Search receipt, customer, item…"
+              className="h-10 border-none bg-transparent px-0 text-[14px] shadow-none focus-visible:ring-0"
             />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                className="shrink-0 rounded-md p-0.5 text-[var(--text-muted)] hover:text-[var(--text-strong)]"
+              >
+                <XCircle className="h-4 w-4" />
+              </button>
+            )}
           </div>
           <PosMetricCard
             icon={History}
             label="Results"
             value={String(saleRows.length)}
-            meta="Receipts matching this view"
+            meta="Matching receipts"
             tone="neutral"
           />
           <PosMetricCard
             icon={RefreshCcw}
             label="Posted"
             value={String(postedSaleCount)}
-            meta="Posted sales available for follow-up"
+            meta="Ready for follow-up"
             tone="success"
           />
         </div>
       </PosPanel>
 
       <PosPanel className="min-h-0">
-        <PosPanelHeader
-          eyebrow="Receipt list"
-          title="Transaction history"
-          description="Use one full-width operational table so cashiers and managers can scan receipts quickly."
-        />
-
         <div className="h-full min-h-0 overflow-auto">
           {saleRows.length === 0 ? (
             <PosEmptyState
@@ -259,58 +269,77 @@ export function PosHistoryView() {
               title="No transactions found"
               description={
                 salesQuery.isLoading
-                  ? "Loading receipt history now."
-                  : "Try a different receipt number, customer, cashier, or item."
+                  ? "Loading receipt history…"
+                  : "Try a different receipt number, customer, or item name."
               }
             />
           ) : (
-            <table className="w-full min-w-[940px] text-sm">
-              <thead className="border-b border-[var(--border-subtle)] text-left text-[11px] uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            <table className="w-full min-w-[860px] text-sm">
+              <thead className="sticky top-0 z-10 border-b border-[var(--border-subtle)] bg-[var(--surface-base)] text-left text-[10px] uppercase tracking-[0.13em] text-[var(--text-muted)]">
                 <tr>
-                  <th className="px-3 py-3">Receipt</th>
-                  <th className="px-3 py-3">Type</th>
-                  <th className="px-3 py-3">Customer</th>
-                  <th className="px-3 py-3">Items</th>
-                  <th className="px-3 py-3">Status</th>
-                  <th className="px-3 py-3 text-right">Total</th>
-                  <th className="px-3 py-3">Posted</th>
+                  <th className="px-4 py-3">Receipt</th>
+                  <th className="px-4 py-3">Type</th>
+                  <th className="px-4 py-3">Customer</th>
+                  <th className="px-4 py-3 text-center">Items</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3 text-right">Total</th>
+                  <th className="px-4 py-3">Posted</th>
                 </tr>
               </thead>
-              <tbody>
-                {saleRows.map((sale) => (
-                  <tr
-                    key={sale.id}
-                    className="cursor-pointer border-b border-[var(--border-subtle)] bg-[var(--surface-base)] transition hover:bg-[var(--surface-muted)]"
-                    onClick={() => setSelectedSaleId(sale.id)}
-                  >
-                    <td className="px-3 py-4 font-mono font-semibold text-[var(--text-strong)]">
-                      {sale.saleNo}
-                    </td>
-                    <td className="px-3 py-4 text-[var(--text-strong)]">{sale.saleType}</td>
-                    <td className="px-3 py-4 text-[var(--text-muted)]">
-                      {sale.customerName ?? "Walk-in"}
-                    </td>
-                    <td className="px-3 py-4 text-[var(--text-muted)]">{sale.itemCount}</td>
-                    <td className="px-3 py-4">
-                      <PosStatusPill
-                        tone={sale.status === "POSTED" ? "success" : "warning"}
-                      >
-                        {sale.status}
-                      </PosStatusPill>
-                    </td>
-                    <td className="px-3 py-4 text-right font-mono font-semibold text-[var(--text-strong)]">
-                      {money(sale.totalAmount)}
-                    </td>
-                    <td className="px-3 py-4 text-[var(--text-muted)]">
-                      {new Date(sale.postedAt).toLocaleString([], {
-                        month: "short",
-                        day: "numeric",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </td>
-                  </tr>
-                ))}
+              <tbody className="divide-y divide-[var(--border-subtle)]">
+                {saleRows.map((sale) => {
+                  const isRefund = sale.saleType === "REFUND";
+                  const isVoid = sale.saleType === "VOID";
+                  return (
+                    <tr
+                      key={sale.id}
+                      className="group cursor-pointer transition-colors hover:bg-[var(--surface-muted)]"
+                      onClick={() => setSelectedSaleId(sale.id)}
+                    >
+                      <td className="px-4 py-4">
+                        <span className="font-mono text-[13px] font-bold text-[var(--text-strong)]">
+                          {sale.saleNo}
+                        </span>
+                      </td>
+                      <td className="px-4 py-4">
+                        <span className={
+                          isRefund
+                            ? "inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-bold text-red-600"
+                            : isVoid
+                              ? "inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-bold text-amber-700"
+                              : "inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-bold text-emerald-700"
+                        }>
+                          {sale.saleType}
+                        </span>
+                      </td>
+                      <td className="px-4 py-4 text-[var(--text-muted)]">
+                        {sale.customerName ?? "Walk-in"}
+                      </td>
+                      <td className="px-4 py-4 text-center text-[var(--text-muted)]">
+                        {sale.itemCount}
+                      </td>
+                      <td className="px-4 py-4">
+                        <PosStatusPill
+                          tone={sale.status === "POSTED" ? "success" : "warning"}
+                        >
+                          {sale.status}
+                        </PosStatusPill>
+                      </td>
+                      <td className={`px-4 py-4 text-right font-mono text-[13px] font-black ${isRefund ? "text-red-600" : "text-[var(--text-strong)]"}`}>
+                        {isRefund && sale.totalAmount < 0 ? "−" : ""}
+                        {money(Math.abs(sale.totalAmount))}
+                      </td>
+                      <td className="px-4 py-4 text-xs text-[var(--text-muted)]">
+                        {new Date(sale.postedAt).toLocaleString([], {
+                          month: "short",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           )}
@@ -318,195 +347,212 @@ export function PosHistoryView() {
       </PosPanel>
 
       <Dialog open={Boolean(selectedSaleId)} onOpenChange={(open) => !open && setSelectedSaleId(null)}>
-        <DialogContent className="sm:max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>{selectedSale?.saleNo ?? "Transaction detail"}</DialogTitle>
-          </DialogHeader>
+        <DialogContent className="sm:max-w-3xl p-0 overflow-hidden">
           {selectedSale ? (
-            <div className="space-y-4">
-              <div className="rounded-[1.35rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
+            <>
+              {/* Receipt header — colored by type */}
+              <div className={`px-6 pt-6 pb-5 ${
+                selectedSale.saleType === "REFUND"
+                  ? "bg-gradient-to-r from-red-50 to-red-50/50 border-b border-red-100"
+                  : selectedSale.saleType === "VOID"
+                    ? "bg-gradient-to-r from-amber-50 to-amber-50/50 border-b border-amber-100"
+                    : "bg-gradient-to-r from-emerald-50 to-emerald-50/50 border-b border-emerald-100"
+              }`}>
+                <div className="flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                      Receipt summary
-                    </p>
-                    <h3 className="mt-2 text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
-                      {selectedSale.customerName ?? "Walk-in"} / {selectedSale.saleNo}
-                    </h3>
-                    <p className="mt-1 text-sm text-[var(--text-muted)]">
-                      Posted{" "}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-mono text-xl font-black text-[var(--text-strong)]">
+                        {selectedSale.saleNo}
+                      </span>
+                      <PosStatusPill tone={selectedSale.status === "POSTED" ? "success" : "warning"}>
+                        {selectedSale.status}
+                      </PosStatusPill>
+                      <span className={`rounded-full px-2.5 py-0.5 text-[11px] font-bold ${
+                        selectedSale.saleType === "REFUND"
+                          ? "bg-red-100 text-red-700"
+                          : selectedSale.saleType === "VOID"
+                            ? "bg-amber-100 text-amber-700"
+                            : "bg-emerald-100 text-emerald-700"
+                      }`}>
+                        {selectedSale.saleType}
+                      </span>
+                    </div>
+                    <p className="mt-1.5 text-sm text-[var(--text-muted)]">
+                      {selectedSale.customerName ?? "Walk-in"} ·{" "}
                       {selectedSale.postedAt
                         ? new Date(selectedSale.postedAt).toLocaleString([], {
-                            month: "short",
-                            day: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
+                            month: "short", day: "numeric",
+                            hour: "2-digit", minute: "2-digit",
                           })
-                        : "not yet posted"}
+                        : "Not yet posted"}
                     </p>
                   </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <PosStatusPill
-                      tone={selectedSale.status === "POSTED" ? "success" : "warning"}
-                    >
-                      {selectedSale.status}
-                    </PosStatusPill>
-                    <PosStatusPill tone="brand">{selectedSale.saleType}</PosStatusPill>
+                  <div className="text-right shrink-0">
+                    <div className={`font-mono text-2xl font-black ${
+                      selectedSale.saleType === "REFUND" ? "text-red-600" : "text-[var(--text-strong)]"
+                    }`}>
+                      {money(Math.abs(selectedSale.totalAmount))}
+                    </div>
+                    <div className="text-xs text-[var(--text-muted)]">
+                      {selectedSale.lines.length} line{selectedSale.lines.length !== 1 ? "s" : ""}
+                    </div>
                   </div>
-                </div>
-
-                <div className="mt-4 grid gap-3 md:grid-cols-4">
-                  <PosMetricCard
-                    icon={History}
-                    label="Total"
-                    value={money(selectedSale.totalAmount)}
-                    meta={`${selectedSale.lines.length} line${selectedSale.lines.length === 1 ? "" : "s"}`}
-                    tone="brand"
-                  />
-                  <PosMetricCard
-                    icon={RefreshCcw}
-                    label="Promotion"
-                    value={selectedSale.promotionCode ?? "-"}
-                    meta="Promo code on this receipt"
-                    tone="neutral"
-                  />
-                  <PosMetricCard
-                    icon={RefreshCcw}
-                    label="Source"
-                    value={selectedSale.sourceSaleNo ?? "-"}
-                    meta="Original source reference"
-                    tone="neutral"
-                  />
-                  <PosMetricCard
-                    icon={XCircle}
-                    label="Reversals"
-                    value={String(selectedSale.reversals?.length ?? 0)}
-                    meta="Refunds or voids linked to this sale"
-                    tone={(selectedSale.reversals?.length ?? 0) > 0 ? "warning" : "success"}
-                  />
                 </div>
               </div>
 
-              <div className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(300px,0.9fr)]">
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="text-sm font-semibold text-[var(--text-strong)]">
-                      Sold items
+              <div className="max-h-[70vh] overflow-y-auto">
+                <div className="grid gap-4 p-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.9fr)]">
+                  {/* Line items */}
+                  <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] overflow-hidden">
+                    <div className="border-b border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-3">
+                      <span className="text-[12px] font-bold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                        Items sold
+                      </span>
                     </div>
-                    <div className="text-xs text-[var(--text-muted)]">
-                      Review line items before refunding or voiding.
-                    </div>
-                  </div>
-                  <div className="mt-3 space-y-2">
-                    {selectedSale.lines.map((line) => (
-                      <div
-                        key={line.id}
-                        className="flex items-center justify-between gap-3 rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3 text-sm"
-                      >
-                        <div className="min-w-0">
-                          <div className="truncate font-medium text-[var(--text-strong)]">
-                            {line.itemName}
-                          </div>
-                          <div className="text-xs text-[var(--text-muted)]">
-                            {line.quantity.toFixed(2)} x {money(line.unitPrice)}
-                          </div>
-                        </div>
-                        <NumericCell>{money(line.lineTotal)}</NumericCell>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                    <div className="text-sm font-semibold text-[var(--text-strong)]">
-                      Tenders collected
-                    </div>
-                    <div className="mt-3 space-y-2">
-                      {selectedSale.payments.map((payment) => (
+                    <div className="divide-y divide-[var(--border-subtle)]">
+                      {selectedSale.lines.map((line) => (
                         <div
-                          key={payment.id}
-                          className="flex items-center justify-between gap-3 rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3 text-sm"
+                          key={line.id}
+                          className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
                         >
                           <div className="min-w-0">
-                            <div className="font-medium text-[var(--text-strong)]">
-                              {payment.tenderType.replaceAll("_", " ")}
+                            <div className="truncate font-semibold text-[var(--text-strong)]">
+                              {line.itemName}
                             </div>
-                            <div className="truncate text-xs text-[var(--text-muted)]">
-                              {payment.reference ?? "No reference"}
+                            <div className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                              {line.quantity % 1 === 0 ? line.quantity : line.quantity.toFixed(2)} × {money(line.unitPrice)}
                             </div>
                           </div>
-                          <NumericCell>{money(payment.amount)}</NumericCell>
+                          <span className="shrink-0 font-mono text-[13px] font-bold text-[var(--text-strong)]">
+                            {money(line.lineTotal)}
+                          </span>
                         </div>
                       ))}
                     </div>
                   </div>
 
-                  <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="text-sm font-semibold text-[var(--text-strong)]">
-                        Follow-up actions
+                  <div className="space-y-3">
+                    {/* Payments */}
+                    <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] overflow-hidden">
+                      <div className="border-b border-[var(--border-subtle)] bg-[var(--surface-base)] px-4 py-3">
+                        <span className="text-[12px] font-bold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                          Tenders
+                        </span>
                       </div>
-                      {canOverride && currentShift ? (
-                        <PosStatusPill tone="success">Shift ready</PosStatusPill>
-                      ) : (
-                        <PosStatusPill tone="warning">Manager action only</PosStatusPill>
-                      )}
-                    </div>
-                    {(selectedSale.reversals ?? []).length ? (
-                      <div className="mt-3 space-y-2">
-                        {selectedSale.reversals.map((reversal) => (
+                      <div className="divide-y divide-[var(--border-subtle)]">
+                        {selectedSale.payments.map((payment) => (
                           <div
-                            key={reversal.id}
-                            className="flex items-center justify-between gap-3 rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3 text-sm"
+                            key={payment.id}
+                            className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
                           >
-                            <div>
-                              <div className="font-medium text-[var(--text-strong)]">
-                                {reversal.saleNo}
+                            <div className="min-w-0">
+                              <div className="font-semibold text-[var(--text-strong)]">
+                                {payment.tenderType.replaceAll("_", " ")}
                               </div>
-                              <div className="text-xs text-[var(--text-muted)]">
-                                {reversal.saleType}
-                              </div>
+                              {payment.reference && (
+                                <div className="truncate text-[11px] text-[var(--text-muted)]">
+                                  Ref: {payment.reference}
+                                </div>
+                              )}
                             </div>
-                            <NumericCell>{money(reversal.totalAmount)}</NumericCell>
+                            <span className="shrink-0 font-mono text-[13px] font-bold text-[var(--text-strong)]">
+                              {money(payment.amount)}
+                            </span>
                           </div>
                         ))}
                       </div>
-                    ) : (
-                      <p className="mt-3 text-sm leading-6 text-[var(--text-muted)]">
-                        No refunds or voids have been linked to this receipt yet.
-                      </p>
+                    </div>
+
+                    {/* Promo / source info if relevant */}
+                    {(selectedSale.promotionCode || selectedSale.sourceSaleNo) && (
+                      <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-3 space-y-1 text-sm">
+                        {selectedSale.promotionCode && (
+                          <div className="flex justify-between text-[var(--text-muted)]">
+                            <span>Promo</span>
+                            <span className="font-mono font-semibold text-[var(--text-strong)]">{selectedSale.promotionCode}</span>
+                          </div>
+                        )}
+                        {selectedSale.sourceSaleNo && (
+                          <div className="flex justify-between text-[var(--text-muted)]">
+                            <span>Source receipt</span>
+                            <span className="font-mono font-semibold text-[var(--text-strong)]">{selectedSale.sourceSaleNo}</span>
+                          </div>
+                        )}
+                      </div>
                     )}
 
-                    {canOverride &&
-                    currentShift &&
-                    selectedSale.saleType === "SALE" &&
-                    selectedSale.status === "POSTED" ? (
-                      <div className="mt-4 flex flex-wrap gap-2">
-                        <Button type="button" variant="outline" onClick={startRefund}>
-                          Refund
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => setVoidDialog(true)}
-                          disabled={(selectedSale.reversals ?? []).length > 0}
-                        >
-                          <XCircle className="h-4 w-4" />
-                          Void sale
-                        </Button>
+                    {/* Actions / reversals */}
+                    <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                      <div className="flex items-center justify-between gap-2 mb-3">
+                        <span className="text-[12px] font-bold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                          Follow-up
+                        </span>
+                        <PosStatusPill tone={canOverride && currentShift ? "success" : "warning"}>
+                          {canOverride && currentShift ? "Allowed" : "Restricted"}
+                        </PosStatusPill>
                       </div>
-                    ) : null}
+
+                      {(selectedSale.reversals ?? []).length > 0 && (
+                        <div className="mb-3 space-y-1.5">
+                          {selectedSale.reversals.map((reversal) => (
+                            <div
+                              key={reversal.id}
+                              className="flex items-center justify-between rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2.5 text-sm"
+                            >
+                              <div>
+                                <span className="font-mono font-semibold text-[var(--text-strong)]">{reversal.saleNo}</span>
+                                <span className="ml-2 text-xs text-[var(--text-muted)]">{reversal.saleType}</span>
+                              </div>
+                              <span className="font-mono text-sm font-bold text-red-600">
+                                {money(reversal.totalAmount)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {canOverride && currentShift && selectedSale.saleType === "SALE" && selectedSale.status === "POSTED" ? (
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="flex-1 h-10"
+                            onClick={startRefund}
+                          >
+                            Refund
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="flex-1 h-10 border-red-200 text-red-600 hover:bg-red-50"
+                            onClick={() => setVoidDialog(true)}
+                            disabled={(selectedSale.reversals ?? []).length > 0}
+                          >
+                            <XCircle className="h-4 w-4" />
+                            Void
+                          </Button>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {(selectedSale.reversals ?? []).length > 0
+                            ? "This sale has already been reversed."
+                            : "No reversals yet. Manager or cashier with override can refund or void."}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </>
           ) : (
-            <PosEmptyState
-              icon={History}
-              title="Loading receipt detail"
-              description="We are fetching the selected sale so you can review it without leaving the history workspace."
-            />
+            <div className="p-6">
+              <PosEmptyState
+                icon={History}
+                title="Loading receipt…"
+                description="Fetching the transaction details."
+              />
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/components/retail/portal/pos-numeric-keypad.tsx
+++ b/components/retail/portal/pos-numeric-keypad.tsx
@@ -26,26 +26,31 @@ const KEYS: Array<{ label: string; action: PosKeypadAction }> = [
 /* ── Style constants ─────────────────────────────────────────── */
 
 const base =
-  "flex items-center justify-center rounded-xl border font-semibold select-none transition-all duration-75 active:scale-[0.93] h-[3rem]";
+  "flex items-center justify-center rounded-2xl border font-semibold select-none transition-all duration-75 active:scale-[0.92] active:shadow-none h-[3.5rem]";
 
 const numKey = cn(
   base,
-  "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] text-lg hover:bg-[var(--surface-muted)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_30%,var(--border-default))] shadow-[0_1px_2px_rgba(0,0,0,0.05)]",
+  "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] text-xl font-bold",
+  "shadow-[0_2px_0_var(--border-default)] hover:bg-[var(--surface-muted)]",
+  "hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))]",
 );
 
 const presetKey = cn(
   base,
-  "border-emerald-200 bg-emerald-50 text-emerald-700 text-xs hover:bg-emerald-100 hover:border-emerald-300",
+  "border-emerald-200 bg-emerald-50 text-emerald-700 text-[12px] font-bold",
+  "shadow-[0_2px_0_rgba(16,185,129,0.2)] hover:bg-emerald-100 hover:border-emerald-300",
 );
 
 const backspaceKey = cn(
   base,
-  "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-muted)] hover:bg-amber-50 hover:border-amber-200 hover:text-amber-700",
+  "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-muted)]",
+  "shadow-[0_2px_0_var(--border-default)] hover:bg-amber-50 hover:border-amber-200 hover:text-amber-700",
 );
 
 const clearKey = cn(
   base,
-  "border-red-200 bg-red-50 text-red-600 text-sm font-bold hover:bg-red-100 hover:border-red-300",
+  "border-red-200 bg-red-50 text-red-600 text-sm font-black tracking-wide",
+  "shadow-[0_2px_0_rgba(239,68,68,0.2)] hover:bg-red-100 hover:border-red-300",
 );
 
 export function PosNumericKeypad({
@@ -64,7 +69,7 @@ export function PosNumericKeypad({
   ];
 
   return (
-    <div className={cn("grid gap-1.5", cols, className)}>
+    <div className={cn("grid gap-2", cols, className)}>
       {/* Row 0: 1 2 3 | preset 0 */}
       {rows[0].map((key) => (
         <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
@@ -108,15 +113,14 @@ export function PosNumericKeypad({
         </button>
       ))}
       <button type="button" className={backspaceKey} onClick={() => onAction({ type: "backspace" })}>
-        {/* Backspace icon */}
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z" />
           <line x1="18" y1="9" x2="12" y2="15" />
           <line x1="12" y1="9" x2="18" y2="15" />
         </svg>
       </button>
       <button type="button" className={clearKey} onClick={() => onAction({ type: "clear" })}>
-        C
+        CLR
       </button>
     </div>
   );

--- a/components/retail/portal/pos-overview-view.tsx
+++ b/components/retail/portal/pos-overview-view.tsx
@@ -4,20 +4,31 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { fetchJson } from "@/lib/api-client";
-import { Clock, History, Package, Payments, Wallet } from "@/lib/icons";
+import { BarChart3, Clock, History, Package, Payments, Wallet } from "@/lib/icons";
 import { getPosPortalHref } from "@/lib/retail/pos-host";
 import {
   PosEmptyState,
   PosMetricCard,
   PosPanel,
   PosPanelHeader,
+  PosStatusPill,
 } from "./pos-primitives";
 import { usePosPortalState } from "./pos-portal-state";
 import type { HeldCart, SaleRow } from "./pos-types";
 import { money } from "./pos-utils";
+import { cn } from "@/lib/utils";
+
+/* ── Sale type style helpers ──────────────────────────────────────── */
+function saleTypeTone(saleType: string): "success" | "danger" | "warning" | "neutral" {
+  if (saleType === "SALE") return "success";
+  if (saleType === "REFUND") return "danger";
+  if (saleType === "VOID") return "warning";
+  return "neutral";
+}
 
 export function PosOverviewView() {
   const { currentShift, isPosHost } = usePosPortalState();
+
   const heldCartsQuery = useQuery({
     queryKey: ["retail-held-carts", currentShift?.id],
     queryFn: () =>
@@ -26,6 +37,7 @@ export function PosOverviewView() {
       ),
     enabled: Boolean(currentShift?.id),
   });
+
   const salesQuery = useQuery({
     queryKey: ["retail-pos-sales-overview", currentShift?.id],
     queryFn: () =>
@@ -33,102 +45,149 @@ export function PosOverviewView() {
   });
 
   const recentSales = (salesQuery.data?.data ?? []).slice(0, 8);
+  const heldCount = heldCartsQuery.data?.data?.length ?? 0;
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-4">
+
+      {/* ── Shift & metrics ───────────────────────────────── */}
       <PosPanel>
-        <PosPanelHeader
-          eyebrow="Operational snapshot"
-          title="Overview"
-          description="This stays lightweight. The real center of the product is checkout, and this page should only help operators get back there fast."
-        />
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+              Operational snapshot
+            </p>
+            <h2 className="mt-1 text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+              {currentShift
+                ? `Shift ${currentShift.shiftNo} · ${currentShift.registerName}`
+                : "No active shift"}
+            </h2>
+            {currentShift?.site?.name && (
+              <p className="mt-0.5 text-sm text-[var(--text-muted)]">{currentShift.site.name}</p>
+            )}
+          </div>
+          <PosStatusPill tone={currentShift ? "success" : "warning"}>
+            {currentShift ? "Shift open" : "Shift closed"}
+          </PosStatusPill>
+        </div>
+
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <PosMetricCard
-            icon={Clock}
-            label="Shift"
-            value={currentShift?.shiftNo ?? "Not open"}
-            meta={currentShift?.registerName ?? "No active drawer"}
-            tone={currentShift ? "brand" : "warning"}
-          />
-          <PosMetricCard
-            icon={Package}
-            label="Held carts"
-            value={String(heldCartsQuery.data?.data?.length ?? 0)}
-            meta="Parked sales waiting for recall"
-            tone={(heldCartsQuery.data?.data?.length ?? 0) > 0 ? "warning" : "neutral"}
-          />
           <PosMetricCard
             icon={Wallet}
             label="Net sales"
             value={money(currentShift?.netSalesValue ?? 0)}
-            meta="Current shift performance"
-            tone="success"
+            meta={`${currentShift?.saleCount ?? 0} transaction${(currentShift?.saleCount ?? 0) !== 1 ? "s" : ""}`}
+            tone={currentShift ? "success" : "neutral"}
           />
           <PosMetricCard
             icon={Payments}
-            label="Recent receipts"
-            value={String(recentSales.length)}
-            meta="Latest transaction activity"
-            tone="neutral"
+            label="Cash sales"
+            value={money(currentShift?.cashSales ?? 0)}
+            meta="Cash tendered this shift"
+            tone="brand"
+          />
+          <PosMetricCard
+            icon={Package}
+            label="Held carts"
+            value={String(heldCount)}
+            meta={heldCount > 0 ? "Parked sales waiting" : "No carts on hold"}
+            tone={heldCount > 0 ? "warning" : "neutral"}
+          />
+          <PosMetricCard
+            icon={BarChart3}
+            label="Refunds"
+            value={money(currentShift?.refundValue ?? 0)}
+            meta={`${currentShift?.refundCount ?? 0} refund${(currentShift?.refundCount ?? 0) !== 1 ? "s" : ""}`}
+            tone={(currentShift?.refundCount ?? 0) > 0 ? "danger" : "neutral"}
           />
         </div>
       </PosPanel>
 
+      {/* ── Quick actions ──────────────────────────────────── */}
       <PosPanel>
         <PosPanelHeader
-          eyebrow="Launch points"
+          eyebrow="Navigate"
           title="Quick actions"
-          description="These are support routes. They should never compete with checkout."
+          className="mb-3"
         />
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <Button
-            asChild
-            variant="outline"
-            className="min-h-16 justify-start rounded-[1rem] bg-[var(--surface-muted)] text-[15px]"
+        <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
+          <Link
+            href={getPosPortalHref("checkout", isPosHost)}
+            className="group flex items-center gap-3.5 rounded-2xl border border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,var(--surface-base))] px-4 py-3.5 transition-all hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_9%,var(--surface-base))] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
           >
-            <Link href={getPosPortalHref("checkout", isPosHost)}>
-              <Payments className="h-5 w-5" />
-              Checkout
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="min-h-16 justify-start rounded-[1rem] bg-[var(--surface-muted)] text-[15px]"
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[var(--action-primary-bg)] text-white shadow-[0_4px_10px_rgba(0,0,0,0.15)]">
+              <Payments className="h-4.5 w-4.5" />
+            </div>
+            <div>
+              <div className="text-[13px] font-bold text-[var(--text-strong)]">Checkout</div>
+              <div className="text-[11px] text-[var(--text-muted)]">Start a new sale</div>
+            </div>
+          </Link>
+
+          <Link
+            href={getPosPortalHref("held", isPosHost)}
+            className={cn(
+              "group flex items-center gap-3.5 rounded-2xl border px-4 py-3.5 transition-all hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]",
+              heldCount > 0
+                ? "border-amber-300 bg-amber-50 hover:border-amber-400 hover:bg-amber-50"
+                : "border-[var(--border-default)] bg-[var(--surface-muted)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)]",
+            )}
           >
-            <Link href={getPosPortalHref("held", isPosHost)}>
-              <Package className="h-5 w-5" />
-              Held carts
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="min-h-16 justify-start rounded-[1rem] bg-[var(--surface-muted)] text-[15px]"
+            <div className={cn(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]",
+              heldCount > 0 ? "bg-amber-500" : "bg-[var(--text-muted)]",
+            )}>
+              <Package className="h-4.5 w-4.5" />
+            </div>
+            <div>
+              <div className="text-[13px] font-bold text-[var(--text-strong)]">
+                Held{heldCount > 0 ? ` (${heldCount})` : ""}
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)]">
+                {heldCount > 0 ? "Recall a parked sale" : "No carts on hold"}
+              </div>
+            </div>
+          </Link>
+
+          <Link
+            href={getPosPortalHref("history", isPosHost)}
+            className="group flex items-center gap-3.5 rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-3.5 transition-all hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
           >
-            <Link href={getPosPortalHref("history", isPosHost)}>
-              <History className="h-5 w-5" />
-              History
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="min-h-16 justify-start rounded-[1rem] bg-[var(--surface-muted)] text-[15px]"
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-500 text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]">
+              <History className="h-4.5 w-4.5" />
+            </div>
+            <div>
+              <div className="text-[13px] font-bold text-[var(--text-strong)]">History</div>
+              <div className="text-[11px] text-[var(--text-muted)]">Receipts & refunds</div>
+            </div>
+          </Link>
+
+          <Link
+            href={getPosPortalHref("shift", isPosHost)}
+            className="group flex items-center gap-3.5 rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-3.5 transition-all hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
           >
-            <Link href={getPosPortalHref("shift", isPosHost)}>
-              <Clock className="h-5 w-5" />
-              Shift
-            </Link>
-          </Button>
+            <div className={cn(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]",
+              currentShift ? "bg-emerald-500" : "bg-amber-500",
+            )}>
+              <Clock className="h-4.5 w-4.5" />
+            </div>
+            <div>
+              <div className="text-[13px] font-bold text-[var(--text-strong)]">Shift</div>
+              <div className="text-[11px] text-[var(--text-muted)]">
+                {currentShift ? "Open · manage drawer" : "Open the drawer"}
+              </div>
+            </div>
+          </Link>
         </div>
       </PosPanel>
 
+      {/* ── Recent sales ──────────────────────────────────── */}
       <PosPanel className="min-h-0">
         <PosPanelHeader
           eyebrow="Recent activity"
           title="Latest receipts"
-          description="A compact ops snapshot for leads and follow-up, not a full transaction workspace."
+          description="Most recent transactions for this session."
         />
 
         <div className="h-full min-h-0 overflow-auto">
@@ -136,36 +195,40 @@ export function PosOverviewView() {
             <PosEmptyState
               icon={History}
               title="No transactions yet"
-              description="Recent receipt activity will appear here once this cashier starts posting sales."
+              description="Receipt activity will appear here once you start posting sales."
             />
           ) : (
-            <table className="w-full min-w-[720px] text-sm">
-              <thead className="border-b border-[var(--border-subtle)] text-left text-[11px] uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            <table className="w-full min-w-[600px] text-sm">
+              <thead className="sticky top-0 z-10 border-b border-[var(--border-subtle)] bg-[var(--surface-base)] text-left text-[10px] uppercase tracking-[0.13em] text-[var(--text-muted)]">
                 <tr>
-                  <th className="px-3 py-3">Receipt</th>
-                  <th className="px-3 py-3">Type</th>
-                  <th className="px-3 py-3">Customer</th>
-                  <th className="px-3 py-3 text-right">Total</th>
-                  <th className="px-3 py-3">Posted</th>
+                  <th className="px-3 py-2.5">Receipt</th>
+                  <th className="px-3 py-2.5">Type</th>
+                  <th className="px-3 py-2.5">Customer</th>
+                  <th className="px-3 py-2.5 text-right">Total</th>
+                  <th className="px-3 py-2.5">Time</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="divide-y divide-[var(--border-subtle)]">
                 {recentSales.map((sale) => (
                   <tr
                     key={sale.id}
-                    className="border-b border-[var(--border-subtle)] bg-[var(--surface-base)]"
+                    className="group transition-colors hover:bg-[var(--surface-muted)]"
                   >
-                    <td className="px-3 py-4 font-mono font-semibold text-[var(--text-strong)]">
+                    <td className="px-3 py-3.5 font-mono text-[13px] font-bold text-[var(--text-strong)]">
                       {sale.saleNo}
                     </td>
-                    <td className="px-3 py-4 text-[var(--text-strong)]">{sale.saleType}</td>
-                    <td className="px-3 py-4 text-[var(--text-muted)]">
+                    <td className="px-3 py-3.5">
+                      <PosStatusPill tone={saleTypeTone(sale.saleType)}>
+                        {sale.saleType}
+                      </PosStatusPill>
+                    </td>
+                    <td className="px-3 py-3.5 text-[var(--text-muted)]">
                       {sale.customerName ?? "Walk-in"}
                     </td>
-                    <td className="px-3 py-4 text-right font-mono font-semibold text-[var(--text-strong)]">
+                    <td className="px-3 py-3.5 text-right font-mono text-[13px] font-black text-[var(--text-strong)]">
                       {money(sale.totalAmount)}
                     </td>
-                    <td className="px-3 py-4 text-[var(--text-muted)]">
+                    <td className="px-3 py-3.5 text-xs text-[var(--text-muted)]">
                       {new Date(sale.postedAt).toLocaleTimeString([], {
                         hour: "2-digit",
                         minute: "2-digit",

--- a/components/retail/portal/pos-portal-layout-frame.tsx
+++ b/components/retail/portal/pos-portal-layout-frame.tsx
@@ -95,16 +95,28 @@ export function PosPortalLayoutFrame({ children }: { children: ReactNode }) {
     <div className="text-[15px] text-[var(--text-strong)]">
       <div className="relative flex h-[100dvh] overflow-hidden lg:flex-row">
         {/* ── Sidebar ─────────────────────────────────────── */}
-        <aside className="shrink-0 border-b border-[var(--edge-subtle)] bg-[var(--sidebar)] lg:w-[13rem] lg:border-b-0 lg:border-r">
+        <aside className="shrink-0 border-b border-[var(--edge-subtle)] bg-[var(--sidebar)] lg:w-[13.5rem] lg:border-b-0 lg:border-r">
           <div className="flex h-full flex-col">
-            {/* Wordmark */}
-            <div className="hidden shrink-0 px-4 pt-5 pb-3 lg:block">
-              <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">POS</div>
-              <div className="mt-0.5 truncate text-[13px] font-bold text-[var(--text-strong)]">
-                {session?.user?.name || "Operator"}
+            {/* Operator identity */}
+            <div className="hidden shrink-0 px-4 pt-5 pb-4 lg:block">
+              <div className="flex items-center gap-2.5">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_12%,var(--surface-base))] text-[var(--action-primary-bg)]">
+                  <span className="text-[13px] font-black leading-none">
+                    {(session?.user?.name || "O")[0].toUpperCase()}
+                  </span>
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-[13px] font-bold leading-tight text-[var(--text-strong)]">
+                    {session?.user?.name || "Operator"}
+                  </div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                    Cashier
+                  </div>
+                </div>
               </div>
             </div>
-            <nav className="flex gap-1 overflow-x-auto px-3 pb-2 pt-2 lg:mt-1 lg:flex-1 lg:flex-col lg:gap-0.5 lg:overflow-y-auto lg:overflow-x-visible lg:px-2.5 lg:pb-3 lg:pt-0">
+
+            <nav className="flex gap-1 overflow-x-auto px-3 pb-2 pt-2 lg:mt-0 lg:flex-1 lg:flex-col lg:gap-0.5 lg:overflow-y-auto lg:overflow-x-visible lg:px-3 lg:pb-3 lg:pt-0">
               {renderedLinks.map((item) => {
                 const isActive = pathname === item.href;
                 return (
@@ -112,18 +124,25 @@ export function PosPortalLayoutFrame({ children }: { children: ReactNode }) {
                     key={item.href}
                     href={item.href}
                     className={cn(
-                      "group inline-flex min-h-9 shrink-0 items-center gap-2.5 rounded-lg px-2.5 py-2 text-[13px] font-medium transition-all duration-100 lg:flex lg:w-full",
+                      "group inline-flex min-h-10 shrink-0 items-center gap-2.5 rounded-xl px-2.5 py-2.5 text-[13px] font-medium transition-all duration-100 lg:flex lg:w-full",
                       isActive
-                        ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[0_1px_3px_rgba(0,0,0,0.07),inset_0_0_0_1px_var(--edge-default)]"
-                        : "text-[var(--text-muted)] hover:bg-[color-mix(in_srgb,var(--surface-base)_70%,transparent)] hover:text-[var(--text-strong)]",
+                        ? "bg-[var(--surface-base)] font-semibold text-[var(--text-strong)] shadow-[0_1px_4px_rgba(0,0,0,0.08),inset_0_0_0_1px_var(--edge-default)]"
+                        : "text-[var(--text-muted)] hover:bg-[color-mix(in_srgb,var(--surface-base)_60%,transparent)] hover:text-[var(--text-strong)]",
                     )}
                   >
-                    <item.icon className={cn("h-4 w-4 shrink-0 transition-colors", isActive ? "text-[var(--action-primary-bg)]" : "")} />
+                    <item.icon className={cn(
+                      "h-[1.05rem] w-[1.05rem] shrink-0 transition-colors",
+                      isActive ? "text-[var(--action-primary-bg)]" : "opacity-70",
+                    )} />
                     <span className="whitespace-nowrap">{item.label}</span>
+                    {isActive && (
+                      <span className="ml-auto h-1.5 w-1.5 rounded-full bg-[var(--action-primary-bg)]" />
+                    )}
                   </Link>
                 );
               })}
             </nav>
+
             <div className="hidden shrink-0 border-t border-[var(--edge-subtle)] px-4 py-3 lg:block">
               <OfflineStatusIndicator />
             </div>

--- a/components/retail/portal/pos-primitives.tsx
+++ b/components/retail/portal/pos-primitives.tsx
@@ -69,7 +69,7 @@ type PosMetricCardProps = {
   icon: LucideIcon;
   label: string;
   value: string;
-  meta?: string;
+  meta?: ReactNode;
   tone?: "brand" | "success" | "warning" | "danger" | "neutral";
   className?: string;
 };
@@ -117,7 +117,9 @@ export function PosMetricCard({
         {value}
       </div>
       {meta ? (
-        <div className="mt-1 text-xs leading-5 text-[var(--text-muted)]">{meta}</div>
+        <div className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
+          {meta}
+        </div>
       ) : null}
     </div>
   );

--- a/components/retail/portal/pos-reports-view.tsx
+++ b/components/retail/portal/pos-reports-view.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   AdminDistributionChart,
   AdminDonutChart,
   AdminTrendChart,
 } from "@/components/charts/admin-headless-charts";
-import { BarChart3, Calendar, RefreshCcw, TrendingUp, Wallet } from "@/lib/icons";
+import {
+  BarChart3,
+  Clock,
+  Package,
+  RefreshCcw,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from "@/lib/icons";
 import { fetchJson } from "@/lib/api-client";
 import {
   PosEmptyState,
@@ -15,8 +23,12 @@ import {
   PosPanel,
   PosPanelHeader,
 } from "./pos-primitives";
+import { usePosPortalState } from "./pos-portal-state";
 import { money, round } from "./pos-utils";
 import type { SaleRow } from "./pos-types";
+import { cn } from "@/lib/utils";
+
+/* ─── Helpers ─────────────────────────────────────────────────────── */
 
 function formatDateLabel(date: Date) {
   return date.toLocaleDateString(undefined, { weekday: "short", day: "numeric" });
@@ -34,7 +46,101 @@ function endOfDay(date: Date) {
   return d;
 }
 
+function formatHour(hour: number) {
+  if (hour === 0) return "12am";
+  if (hour < 12) return `${hour}am`;
+  if (hour === 12) return "12pm";
+  return `${hour - 12}pm`;
+}
+
+type Period = "today" | "week";
+
+type SaleWithDetail = SaleRow & {
+  payments: Array<{ id: string; tenderType: string; amount: number }>;
+  lines: Array<{ id: string; itemName: string; quantity: number; unitPrice: number; lineTotal: number }>;
+};
+
+/* ─── Shift Summary Banner ────────────────────────────────────────── */
+
+function ShiftBanner({ shift }: { shift: NonNullable<ReturnType<typeof usePosPortalState>["currentShift"]> }) {
+  const cashSalesFormatted = money(shift.cashSales);
+  const nonCashFormatted = money(shift.nonCashSales);
+  return (
+    <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-2xl border border-emerald-200 bg-gradient-to-r from-emerald-50 to-emerald-50/50 px-5 py-3.5">
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.2)]" />
+        <span className="text-[13px] font-bold text-emerald-800">Shift {shift.shiftNo}</span>
+        <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[11px] font-semibold text-emerald-700">
+          {shift.registerName}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-[12px] text-emerald-700">
+        <span>
+          <span className="font-bold">{shift.saleCount}</span> sale{shift.saleCount !== 1 ? "s" : ""}
+        </span>
+        <span>
+          Cash <span className="font-bold">{cashSalesFormatted}</span>
+        </span>
+        <span>
+          Non-cash <span className="font-bold">{nonCashFormatted}</span>
+        </span>
+        {shift.refundCount > 0 && (
+          <span className="text-amber-700">
+            <span className="font-bold">{shift.refundCount}</span> refund{shift.refundCount !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Period tab pill ──────────────────────────────────────────────── */
+
+function PeriodTab({
+  label,
+  active,
+  onClick,
+}: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex-1 rounded-lg px-4 py-1.5 text-[13px] font-semibold transition-all duration-100",
+        active
+          ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[0_1px_3px_rgba(0,0,0,0.08),inset_0_0_0_1px_var(--border-default)]"
+          : "text-[var(--text-muted)] hover:text-[var(--text-strong)]",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+/* ─── Trend indicator ─────────────────────────────────────────────── */
+
+function TrendChip({ value, label }: { value: number; label: string }) {
+  if (value === 0) return null;
+  const isUp = value > 0;
+  return (
+    <span className={cn(
+      "inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+      isUp ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-600",
+    )}>
+      {isUp ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+      {Math.abs(value).toFixed(0)}% {label}
+    </span>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   MAIN COMPONENT
+   ═══════════════════════════════════════════════════════════════════ */
+
 export function PosReportsView() {
+  const [period, setPeriod] = useState<Period>("today");
+  const { currentShift } = usePosPortalState();
+
   const today = useMemo(() => startOfDay(new Date()), []);
   const sevenDaysAgo = useMemo(() => {
     const d = new Date(today);
@@ -47,12 +153,7 @@ export function PosReportsView() {
     queryKey: ["retail-pos-sales", "reports", sevenDaysAgo.toISOString(), to.toISOString()],
     queryFn: () =>
       fetchJson<{
-        data: Array<
-          SaleRow & {
-            payments: Array<{ id: string; tenderType: string; amount: number }>;
-            lines: Array<{ id: string; itemName: string; quantity: number; unitPrice: number; lineTotal: number }>;
-          }
-        >;
+        data: SaleWithDetail[];
         summary?: {
           grossSales: number;
           refundValue: number;
@@ -67,16 +168,113 @@ export function PosReportsView() {
   });
 
   const summary = salesQuery.data?.summary;
-  const salesData = useMemo(() => salesQuery.data?.data ?? [], [salesQuery.data?.data]);
+  const allSales = useMemo(() => salesQuery.data?.data ?? [], [salesQuery.data?.data]);
 
-  const {
-    trendRows,
-    paymentRows,
-    topItemRows,
-    totalTransactions,
-    avgBasket,
-    refundTotal,
-  } = useMemo(() => {
+  /* ── Split sales into today vs rest of week ─────── */
+  const { todaySales, weekSales } = useMemo(() => {
+    const todayStr = today.toISOString().split("T")[0];
+    const todayData: SaleWithDetail[] = [];
+    const weekData: SaleWithDetail[] = [];
+    allSales.forEach((sale) => {
+      const dayStr = new Date(sale.postedAt).toISOString().split("T")[0];
+      if (dayStr === todayStr) {
+        todayData.push(sale);
+        weekData.push(sale);
+      } else {
+        weekData.push(sale);
+      }
+    });
+    return { todaySales: todayData, weekSales: weekData };
+  }, [allSales, today]);
+
+  /* ── Today metrics ──────────────────────────────── */
+  const todayMetrics = useMemo(() => {
+    // Hourly buckets (only show hours with data + surrounding context)
+    const hours: Record<number, number> = {};
+    for (let i = 0; i < 24; i++) hours[i] = 0;
+
+    const paymentsMap: Record<string, number> = {};
+    const itemsMap: Record<string, number> = {};
+    let txCount = 0;
+    let refundSum = 0;
+    let totalRevenue = 0;
+
+    todaySales.forEach((sale) => {
+      if (sale.status !== "POSTED") return;
+      const hour = new Date(sale.postedAt).getHours();
+      if (sale.saleType === "SALE") {
+        hours[hour] = (hours[hour] ?? 0) + sale.totalAmount;
+        txCount += 1;
+        totalRevenue += sale.totalAmount;
+      } else if (sale.saleType === "REFUND") {
+        refundSum += Math.abs(sale.totalAmount);
+      }
+
+      sale.payments?.forEach((p) => {
+        paymentsMap[p.tenderType] = (paymentsMap[p.tenderType] ?? 0) + p.amount;
+      });
+
+      sale.lines?.forEach((line) => {
+        if (sale.saleType === "SALE") {
+          itemsMap[line.itemName] = (itemsMap[line.itemName] ?? 0) + Math.abs(line.lineTotal);
+        }
+      });
+    });
+
+    // Find the active hour range (first sale to now + buffer)
+    const currentHour = new Date().getHours();
+    let firstSaleHour = currentHour;
+    for (let i = 0; i <= currentHour; i++) {
+      if (hours[i] > 0) { firstSaleHour = i; break; }
+    }
+    const startHour = Math.max(0, firstSaleHour - 1);
+    const endHour = Math.min(23, currentHour + 1);
+
+    const hourRows = [];
+    for (let i = startHour; i <= endHour; i++) {
+      hourRows.push({ label: formatHour(i), sales: round(hours[i]) });
+    }
+
+    const paymentPalette = ["var(--primary-500)", "var(--accent-500)", "var(--success-500)", "var(--warning-500)"];
+    const paymentRows = Object.entries(paymentsMap)
+      .sort((a, b) => b[1] - a[1])
+      .map(([label, value], i) => ({
+        id: label,
+        label: label.replace(/_/g, " "),
+        value: round(value),
+        color: paymentPalette[i % paymentPalette.length],
+      }));
+
+    const topItemRows = Object.entries(itemsMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 6)
+      .map(([label, value], i) => ({
+        id: label,
+        label,
+        value: round(value),
+        tone: (i === 0 ? "success" : "default") as "success" | "default",
+      }));
+
+    // Find peak hour
+    const peakHour = Object.entries(hours).reduce(
+      (best, [h, v]) => (v > best.value ? { hour: Number(h), value: v } : best),
+      { hour: -1, value: -1 },
+    );
+
+    return {
+      hourRows,
+      paymentRows,
+      topItemRows,
+      txCount,
+      refundSum,
+      totalRevenue,
+      avgBasket: txCount > 0 ? totalRevenue / txCount : 0,
+      peakHour: peakHour.value > 0 ? peakHour.hour : null,
+    };
+  }, [todaySales]);
+
+  /* ── Week metrics ───────────────────────────────── */
+  const weekMetrics = useMemo(() => {
     const days: Record<string, number> = {};
     for (let i = 0; i < 7; i += 1) {
       const d = new Date(sevenDaysAgo);
@@ -89,126 +287,91 @@ export function PosReportsView() {
     let txCount = 0;
     let refundSum = 0;
 
-    salesData.forEach((sale) => {
+    weekSales.forEach((sale) => {
       if (sale.status !== "POSTED") return;
       const dayKey = new Date(sale.postedAt).toISOString().split("T")[0];
       if (dayKey in days) {
-        days[dayKey] += sale.totalAmount;
+        if (sale.saleType === "SALE") days[dayKey] += sale.totalAmount;
       }
-
-      if (sale.saleType === "SALE") {
-        txCount += 1;
-      } else if (sale.saleType === "REFUND") {
-        refundSum += Math.abs(sale.totalAmount);
-      }
+      if (sale.saleType === "SALE") txCount += 1;
+      else if (sale.saleType === "REFUND") refundSum += Math.abs(sale.totalAmount);
 
       sale.payments?.forEach((p) => {
         paymentsMap[p.tenderType] = (paymentsMap[p.tenderType] ?? 0) + p.amount;
       });
-
       sale.lines?.forEach((line) => {
-        itemsMap[line.itemName] = (itemsMap[line.itemName] ?? 0) + Math.abs(line.lineTotal);
+        if (sale.saleType === "SALE") {
+          itemsMap[line.itemName] = (itemsMap[line.itemName] ?? 0) + Math.abs(line.lineTotal);
+        }
       });
     });
 
-    const trend = Object.entries(days)
+    const trendRows = Object.entries(days)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([date, value]) => ({
-        label: formatDateLabel(new Date(date)),
+        label: formatDateLabel(new Date(date + "T12:00:00")),
         sales: round(value),
       }));
 
-    const paymentPalette = [
-      "var(--primary-500)",
-      "var(--accent-500)",
-      "var(--success-500)",
-      "var(--warning-500)",
-      "var(--info-500)",
-    ];
-    const paymentEntries = Object.entries(paymentsMap).sort((a, b) => b[1] - a[1]);
-    const pRows = paymentEntries.map(([label, value], index) => ({
-      id: label,
-      label: label.replace(/_/g, " "),
-      value: round(value),
-      color: paymentPalette[index % paymentPalette.length],
-    }));
-
-    const itemEntries = Object.entries(itemsMap)
+    const paymentPalette = ["var(--primary-500)", "var(--accent-500)", "var(--success-500)", "var(--warning-500)", "var(--info-500)"];
+    const paymentRows = Object.entries(paymentsMap)
       .sort((a, b) => b[1] - a[1])
-      .slice(0, 8);
-    const iRows = itemEntries.map(([label, value], index) => ({
-      id: label,
-      label,
-      value: round(value),
-      tone: (index === 0 ? "success" : "default") as "success" | "default",
-    }));
+      .map(([label, value], i) => ({
+        id: label,
+        label: label.replace(/_/g, " "),
+        value: round(value),
+        color: paymentPalette[i % paymentPalette.length],
+      }));
+
+    const topItemRows = Object.entries(itemsMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8)
+      .map(([label, value], i) => ({
+        id: label,
+        label,
+        value: round(value),
+        tone: (i === 0 ? "success" : "default") as "success" | "default",
+      }));
 
     const netSales = summary?.netSales ?? Object.values(days).reduce((a, b) => a + b, 0);
-    const averageBasket = txCount > 0 ? netSales / txCount : 0;
+
+    // Compare first half of week vs second half
+    const dayValues = Object.values(days);
+    const firstHalf = dayValues.slice(0, 3).reduce((a, b) => a + b, 0);
+    const secondHalf = dayValues.slice(3).reduce((a, b) => a + b, 0);
+    const weekTrend = firstHalf > 0 ? Math.round(((secondHalf - firstHalf) / firstHalf) * 100) : 0;
 
     return {
-      trendRows: trend,
-      paymentRows: pRows,
-      topItemRows: iRows,
-      totalTransactions: txCount,
-      avgBasket: averageBasket,
-      refundTotal: refundSum,
+      trendRows,
+      paymentRows,
+      topItemRows,
+      txCount,
+      refundSum,
+      netSales,
+      avgBasket: txCount > 0 ? netSales / txCount : 0,
+      weekTrend,
     };
-  }, [salesData, summary, sevenDaysAgo]);
+  }, [weekSales, summary, sevenDaysAgo]);
 
-  const hasData = salesData.length > 0;
+  const hasData = allSales.length > 0;
+  const todayHasData = todaySales.length > 0;
+
+  /* ══ Render ══════════════════════════════════════════════════════ */
 
   return (
     <div className="h-full min-h-0 overflow-y-auto pr-1">
-      <div className="space-y-4 pb-1">
-        {/* Header */}
-        <PosPanel>
-          <PosPanelHeader
-            eyebrow="Performance"
-            title="This week at a glance"
-            description="Sales, payments, and top products for the last 7 days."
-            actions={
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-muted)]">
-                <Calendar className="h-3.5 w-3.5" />
-                Last 7 days
-              </span>
-            }
-          />
+      <div className="space-y-4 pb-4">
 
-          {/* Metrics */}
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            <PosMetricCard
-              icon={Wallet}
-              label="Total sales"
-              value={money(summary?.netSales ?? trendRows.reduce((a, b) => a + b.sales, 0))}
-              meta="Net sales this week"
-              tone="success"
-            />
-            <PosMetricCard
-              icon={TrendingUp}
-              label="Transactions"
-              value={String(totalTransactions)}
-              meta="Posted sales"
-              tone="brand"
-            />
-            <PosMetricCard
-              icon={BarChart3}
-              label="Avg. basket"
-              value={money(avgBasket)}
-              meta="Average sale value"
-              tone="neutral"
-            />
-            <PosMetricCard
-              icon={RefreshCcw}
-              label="Refunds"
-              value={money(refundTotal)}
-              meta="Total refund value"
-              tone="danger"
-            />
-          </div>
-        </PosPanel>
+        {/* ── Current shift banner ─────────────────────────── */}
+        {currentShift && <ShiftBanner shift={currentShift} />}
 
-        {/* Error state */}
+        {/* ── Period tabs ──────────────────────────────────── */}
+        <div className="flex gap-1 rounded-xl bg-[var(--surface-muted)] p-1">
+          <PeriodTab label="Today" active={period === "today"} onClick={() => setPeriod("today")} />
+          <PeriodTab label="This week" active={period === "week"} onClick={() => setPeriod("week")} />
+        </div>
+
+        {/* ══ ERROR / LOADING ════════════════════════════════ */}
         {salesQuery.isError ? (
           <PosPanel>
             <PosEmptyState
@@ -220,74 +383,235 @@ export function PosReportsView() {
         ) : salesQuery.isLoading ? (
           <>
             <PosPanel>
-              <div className="flex min-h-[12rem] items-center justify-center text-sm text-[var(--text-muted)]">
+              <div className="flex min-h-[8rem] items-center justify-center text-sm text-[var(--text-muted)]">
                 Loading reports…
               </div>
             </PosPanel>
-            <PosPanel>
-              <div className="flex min-h-[16rem] items-center justify-center text-sm text-[var(--text-muted)]">
-                Loading charts…
-              </div>
-            </PosPanel>
-          </>
-        ) : hasData ? (
-          <>
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(320px,1fr)]">
-              <PosPanel className="min-h-0">
-                <PosPanelHeader
-                  eyebrow="Trend"
-                  title="Daily sales"
-                  description="Sales value per day over the last 7 days."
-                />
-                <AdminTrendChart
-                  rows={trendRows}
-                  series={[{ key: "sales", label: "Sales", kind: "bar", tone: "success" }]}
-                  height={280}
-                  valueFormatter={(v) => money(v)}
-                  yTickFormatter={(v) => money(v)}
-                  xTickInterval={0}
-                />
-              </PosPanel>
-
-              <PosPanel className="min-h-0">
-                <PosPanelHeader
-                  eyebrow="Composition"
-                  title="Payment methods"
-                  description="How customers paid this week."
-                />
-                <AdminDonutChart
-                  rows={paymentRows}
-                  height={280}
-                  valueLabel="Total"
-                  valueFormatter={(v) => money(v)}
-                  emptyLabel="No payment data"
-                />
-              </PosPanel>
-            </div>
-
-            <PosPanel className="min-h-0">
-              <PosPanelHeader
-                eyebrow="Products"
-                title="Top selling items"
-                description="Highest revenue items this week."
-              />
-              <AdminDistributionChart
-                rows={topItemRows}
-                height={280}
-                valueLabel="Revenue"
-                valueFormatter={(v) => money(v)}
-                emptyLabel="No item data"
-              />
-            </PosPanel>
           </>
         ) : (
-          <PosPanel>
-            <PosEmptyState
-              icon={BarChart3}
-              title="No sales data"
-              description="There are no transactions in the last 7 days to report on."
-            />
-          </PosPanel>
+
+          /* ══ TODAY ═══════════════════════════════════════════════ */
+          period === "today" ? (
+            <>
+              {/* Metric cards */}
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <PosMetricCard
+                  icon={Wallet}
+                  label="Revenue today"
+                  value={money(todayMetrics.totalRevenue)}
+                  meta={currentShift ? `Shift ${currentShift.shiftNo}` : "Current day"}
+                  tone="success"
+                />
+                <PosMetricCard
+                  icon={Package}
+                  label="Transactions"
+                  value={String(todayMetrics.txCount)}
+                  meta="Completed sales"
+                  tone="brand"
+                />
+                <PosMetricCard
+                  icon={BarChart3}
+                  label="Avg. basket"
+                  value={money(todayMetrics.avgBasket)}
+                  meta="Per transaction"
+                  tone="neutral"
+                />
+                <PosMetricCard
+                  icon={RefreshCcw}
+                  label="Refunds"
+                  value={money(todayMetrics.refundSum)}
+                  meta="Returned today"
+                  tone={todayMetrics.refundSum > 0 ? "danger" : "neutral"}
+                />
+              </div>
+
+              {/* Peak hour callout */}
+              {todayMetrics.peakHour !== null && (
+                <div className="flex items-center gap-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-4 py-3">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--action-primary-bg)_12%,var(--surface-base))] text-[var(--action-primary-bg)]">
+                    <Clock className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <div className="text-[12px] font-bold text-[var(--text-strong)]">
+                      Peak hour: <span className="text-[var(--action-primary-bg)]">{formatHour(todayMetrics.peakHour)}</span>
+                    </div>
+                    <div className="text-[11px] text-[var(--text-muted)]">
+                      Busiest period so far today
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {!todayHasData ? (
+                <PosPanel>
+                  <PosEmptyState
+                    icon={BarChart3}
+                    title="No sales yet today"
+                    description="Complete a transaction to see today's performance metrics and hourly breakdown."
+                  />
+                </PosPanel>
+              ) : (
+                <>
+                  {/* Hourly trend */}
+                  <PosPanel className="min-h-0">
+                    <PosPanelHeader
+                      eyebrow="Hourly"
+                      title="Sales by hour"
+                      description="Transaction revenue broken down by hour of day."
+                    />
+                    <AdminTrendChart
+                      rows={todayMetrics.hourRows}
+                      series={[{ key: "sales", label: "Sales", kind: "bar", tone: "success" }]}
+                      height={220}
+                      valueFormatter={(v) => money(v)}
+                      yTickFormatter={(v) => money(v)}
+                      xTickInterval={0}
+                    />
+                  </PosPanel>
+
+                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.85fr)]">
+                    {/* Payment methods */}
+                    <PosPanel className="min-h-0">
+                      <PosPanelHeader
+                        eyebrow="Today"
+                        title="Payment methods"
+                        description="How customers paid today."
+                      />
+                      <AdminDonutChart
+                        rows={todayMetrics.paymentRows}
+                        height={240}
+                        valueLabel="Total"
+                        valueFormatter={(v) => money(v)}
+                        emptyLabel="No payment data"
+                      />
+                    </PosPanel>
+
+                    {/* Top items */}
+                    <PosPanel className="min-h-0">
+                      <PosPanelHeader
+                        eyebrow="Today"
+                        title="Top items"
+                        description="Best sellers today."
+                      />
+                      <AdminDistributionChart
+                        rows={todayMetrics.topItemRows}
+                        height={240}
+                        valueLabel="Revenue"
+                        valueFormatter={(v) => money(v)}
+                        emptyLabel="No item data"
+                      />
+                    </PosPanel>
+                  </div>
+                </>
+              )}
+            </>
+          ) : (
+
+          /* ══ THIS WEEK ════════════════════════════════════════════ */
+            <>
+              {/* Metric cards */}
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <PosMetricCard
+                  icon={Wallet}
+                  label="Net sales"
+                  value={money(weekMetrics.netSales)}
+                  meta={
+                    <span className="flex items-center gap-1">
+                      Last 7 days
+                      {weekMetrics.weekTrend !== 0 && (
+                        <TrendChip value={weekMetrics.weekTrend} label="vs prior" />
+                      )}
+                    </span>
+                  }
+                  tone="success"
+                />
+                <PosMetricCard
+                  icon={Package}
+                  label="Transactions"
+                  value={String(weekMetrics.txCount)}
+                  meta="Completed sales"
+                  tone="brand"
+                />
+                <PosMetricCard
+                  icon={BarChart3}
+                  label="Avg. basket"
+                  value={money(weekMetrics.avgBasket)}
+                  meta="Per transaction"
+                  tone="neutral"
+                />
+                <PosMetricCard
+                  icon={RefreshCcw}
+                  label="Refunds"
+                  value={money(weekMetrics.refundSum)}
+                  meta="Total refund value"
+                  tone={weekMetrics.refundSum > 0 ? "danger" : "neutral"}
+                />
+              </div>
+
+              {!hasData ? (
+                <PosPanel>
+                  <PosEmptyState
+                    icon={BarChart3}
+                    title="No sales data this week"
+                    description="There are no transactions in the last 7 days to report on."
+                  />
+                </PosPanel>
+              ) : (
+                <>
+                  {/* Daily trend */}
+                  <PosPanel className="min-h-0">
+                    <PosPanelHeader
+                      eyebrow="Trend"
+                      title="Daily sales"
+                      description="Sales value per day over the last 7 days."
+                    />
+                    <AdminTrendChart
+                      rows={weekMetrics.trendRows}
+                      series={[{ key: "sales", label: "Sales", kind: "bar", tone: "success" }]}
+                      height={260}
+                      valueFormatter={(v) => money(v)}
+                      yTickFormatter={(v) => money(v)}
+                      xTickInterval={0}
+                    />
+                  </PosPanel>
+
+                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,1fr)]">
+                    {/* Payment methods */}
+                    <PosPanel className="min-h-0">
+                      <PosPanelHeader
+                        eyebrow="Composition"
+                        title="Payment methods"
+                        description="How customers paid this week."
+                      />
+                      <AdminDonutChart
+                        rows={weekMetrics.paymentRows}
+                        height={260}
+                        valueLabel="Total"
+                        valueFormatter={(v) => money(v)}
+                        emptyLabel="No payment data"
+                      />
+                    </PosPanel>
+
+                    {/* Top items */}
+                    <PosPanel className="min-h-0">
+                      <PosPanelHeader
+                        eyebrow="Products"
+                        title="Top selling items"
+                        description="Highest revenue items this week."
+                      />
+                      <AdminDistributionChart
+                        rows={weekMetrics.topItemRows}
+                        height={260}
+                        valueLabel="Revenue"
+                        valueFormatter={(v) => money(v)}
+                        emptyLabel="No item data"
+                      />
+                    </PosPanel>
+                  </div>
+                </>
+              )}
+            </>
+          )
         )}
       </div>
     </div>

--- a/components/retail/portal/pos-shift-view.tsx
+++ b/components/retail/portal/pos-shift-view.tsx
@@ -12,13 +12,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { useReservedId } from "@/hooks/use-reserved-id";
-import { Clock, Payments, Wallet } from "@/lib/icons";
+import { CheckCircle2, Clock, Payments, TrendingDown, TrendingUp, Wallet } from "@/lib/icons";
 import { PosNumericField } from "./pos-numeric-field";
 import { PosNumericKeypad } from "./pos-numeric-keypad";
 import { applyPosKeypadAction, type PosKeypadAction } from "./pos-numeric-input";
 import { PosMetricCard, PosPanel, PosPanelHeader, PosStatusPill } from "./pos-primitives";
 import { usePosPortalState } from "./pos-portal-state";
 import { money, round } from "./pos-utils";
+import { cn } from "@/lib/utils";
 
 type CloseoutSummary = {
   shiftNo: string;
@@ -26,6 +27,54 @@ type CloseoutSummary = {
   countedCash: number;
   variance: number;
 };
+
+/* ─── Variance bar ────────────────────────────────────────────────── */
+function VarianceBar({ variance, expected }: { variance: number; expected: number }) {
+  const isBalanced = Math.abs(variance) < 0.01;
+  const isOver = variance > 0;
+  const pct = expected > 0 ? Math.min(Math.abs(variance) / expected, 1) * 100 : 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[12px] font-semibold text-[var(--text-muted)]">Variance</span>
+        <span className={cn(
+          "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[13px] font-black",
+          isBalanced
+            ? "bg-emerald-100 text-emerald-700"
+            : isOver
+              ? "bg-amber-100 text-amber-700"
+              : "bg-red-100 text-red-700",
+        )}>
+          {isBalanced ? (
+            <><CheckCircle2 className="h-3.5 w-3.5" /> Balanced</>
+          ) : isOver ? (
+            <><TrendingUp className="h-3.5 w-3.5" /> Over {money(Math.abs(variance))}</>
+          ) : (
+            <><TrendingDown className="h-3.5 w-3.5" /> Short {money(Math.abs(variance))}</>
+          )}
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all duration-300",
+            isBalanced ? "bg-emerald-500" : isOver ? "bg-amber-400" : "bg-red-500",
+          )}
+          style={{ width: isBalanced ? "100%" : `${pct}%`, minWidth: isBalanced ? undefined : "4px" }}
+        />
+      </div>
+      <div className="flex justify-between text-[11px] text-[var(--text-muted)]">
+        <span>Expected {money(expected)}</span>
+        {!isBalanced && (
+          <span className={isOver ? "text-amber-600" : "text-red-600"}>
+            {isOver ? "+" : "−"}{money(Math.abs(variance))}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function PosShiftView() {
   const { toast } = useToast();
@@ -77,11 +126,7 @@ export function PosShiftView() {
       queryClient.invalidateQueries({ queryKey: ["retail-pos-sales"] });
     },
     onError: (error) =>
-      toast({
-        title: "Unable to open shift",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      }),
+      toast({ title: "Unable to open shift", description: getApiErrorMessage(error), variant: "destructive" }),
   });
 
   const closeShiftMutation = useMutation({
@@ -110,14 +155,11 @@ export function PosShiftView() {
       queryClient.invalidateQueries({ queryKey: ["retail-pos-sales"] });
     },
     onError: (error) =>
-      toast({
-        title: "Unable to close shift",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      }),
+      toast({ title: "Unable to close shift", description: getApiErrorMessage(error), variant: "destructive" }),
   });
 
   const variancePreview = round(Number(countedCash || "0") - (currentShift?.expectedCash ?? 0));
+  const varianceIsBalanced = Math.abs(variancePreview) < 0.01;
 
   const handleKeypadAction = (action: PosKeypadAction) => {
     if (!activeNumericTarget) return;
@@ -130,133 +172,148 @@ export function PosShiftView() {
 
   return (
     <div className="h-full min-h-0 overflow-y-auto pr-1">
-      <div className="space-y-4 pb-1">
+      <div className="space-y-4 pb-4">
+
+        {/* ── Shift status ──────────────────────────────── */}
         <PosPanel>
-          <PosPanelHeader
-            eyebrow="Drawer control"
-            title="Shift controls"
-            description="Open the drawer, sell through the shift, then count cash and reconcile the variance calmly."
-            actions={
-              currentShift ? (
-                <PosStatusPill tone="success">{currentShift.shiftNo}</PosStatusPill>
-              ) : (
-                <PosStatusPill tone="warning">Shift closed</PosStatusPill>
-              )
-            }
-          />
-          {closeoutSummary ? (
-            <div className="mb-4 rounded-[1.1rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-3 text-sm">
-              <div className="font-semibold text-[var(--text-strong)]">
-                {closeoutSummary.shiftNo} closeout saved
-              </div>
-              <div className="mt-1 text-[var(--text-muted)]">
-                Expected {money(closeoutSummary.expectedCash)} / Counted{" "}
-                {money(closeoutSummary.countedCash)} / Variance{" "}
-                {money(closeoutSummary.variance)}
+          <div className="mb-5 flex items-start justify-between gap-4">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Drawer control
+              </p>
+              <h2 className="mt-1 text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+                {currentShift
+                  ? `Shift ${currentShift.shiftNo} — ${currentShift.registerName}`
+                  : "No active shift"}
+              </h2>
+              {currentShift?.site?.name && (
+                <p className="mt-0.5 text-sm text-[var(--text-muted)]">{currentShift.site.name}</p>
+              )}
+            </div>
+            <PosStatusPill tone={currentShift ? "success" : "warning"}>
+              {currentShift ? "Open" : "Closed"}
+            </PosStatusPill>
+          </div>
+
+          {/* Closeout result banner */}
+          {closeoutSummary && (
+            <div className={cn(
+              "mb-5 flex items-center gap-4 rounded-2xl px-5 py-4",
+              Math.abs(closeoutSummary.variance) < 0.01
+                ? "border border-emerald-200 bg-emerald-50"
+                : closeoutSummary.variance > 0
+                  ? "border border-amber-200 bg-amber-50"
+                  : "border border-red-100 bg-red-50",
+            )}>
+              <CheckCircle2 className={cn(
+                "h-6 w-6 shrink-0",
+                Math.abs(closeoutSummary.variance) < 0.01 ? "text-emerald-600" : closeoutSummary.variance > 0 ? "text-amber-600" : "text-red-500",
+              )} />
+              <div>
+                <div className="text-sm font-bold text-[var(--text-strong)]">
+                  {closeoutSummary.shiftNo} closed
+                </div>
+                <div className="mt-0.5 text-xs text-[var(--text-muted)]">
+                  Expected {money(closeoutSummary.expectedCash)} · Counted {money(closeoutSummary.countedCash)} · Variance {money(closeoutSummary.variance)}
+                </div>
               </div>
             </div>
-          ) : null}
+          )}
 
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <PosMetricCard
               icon={Clock}
               label="Shift"
               value={currentShift?.shiftNo ?? "Not open"}
-              meta={currentShift?.site?.name ?? "Open a shift to start selling"}
+              meta={currentShift?.site?.name ?? "Open to start selling"}
               tone={currentShift ? "brand" : "warning"}
             />
             <PosMetricCard
-              icon={Payments}
-              label="Register"
-              value={currentShift?.registerName ?? "No register"}
-              meta={currentShift?.actorRole ?? "Register assignment pending"}
-              tone="neutral"
+              icon={Wallet}
+              label="Net sales"
+              value={money(currentShift?.netSalesValue ?? 0)}
+              meta={`${currentShift?.saleCount ?? 0} sale${(currentShift?.saleCount ?? 0) !== 1 ? "s" : ""}`}
+              tone="success"
             />
             <PosMetricCard
-              icon={Wallet}
+              icon={Payments}
               label="Expected cash"
               value={money(currentShift?.expectedCash ?? 0)}
-              meta="Used during closeout"
+              meta="Float + cash sales"
               tone="warning"
             />
             <PosMetricCard
               icon={Payments}
-              label="Net sales"
-              value={money(currentShift?.netSalesValue ?? 0)}
-              meta="Current shift performance"
-              tone="success"
+              label="Non-cash"
+              value={money(currentShift?.nonCashSales ?? 0)}
+              meta="Card, mobile, transfer"
+              tone="neutral"
             />
           </div>
         </PosPanel>
 
+        {/* ── Primary action ────────────────────────────── */}
         <PosPanel>
           <PosPanelHeader
-            eyebrow="Primary action"
+            eyebrow="Action"
             title={currentShift ? "Close this shift" : "Open a new shift"}
             description={
               currentShift
-                ? "Use the closeout flow to count cash, review variance, and finish the drawer."
-                : "Start the register with a site, register, and opening float."
+                ? "Count the cash drawer, reconcile the variance, and finish your trading period."
+                : "Select a site, name your register, and enter the opening float to begin selling."
             }
+            className="mb-4"
           />
-          <div className="flex flex-wrap gap-2">
-            {!currentShift ? (
-              <Button
-                size="sm"
-                className="min-h-11 px-5 text-[15px]"
-                onClick={() => setOpenDialog(true)}
-              >
-                Open shift
-              </Button>
-            ) : (
-              <Button
-                size="sm"
-                className="min-h-11 px-5 text-[15px]"
-                onClick={() => setCloseDialog(true)}
-              >
-                Close shift
-              </Button>
-            )}
-          </div>
+          {!currentShift ? (
+            <Button
+              size="sm"
+              className="h-12 px-6 text-[14px] font-bold rounded-xl"
+              onClick={() => setOpenDialog(true)}
+            >
+              <Clock className="h-4 w-4" />
+              Open shift
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-12 px-6 text-[14px] font-bold rounded-xl border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300"
+              onClick={() => setCloseDialog(true)}
+            >
+              Close shift
+            </Button>
+          )}
         </PosPanel>
+      </div>
 
+      {/* ══ Open Shift Dialog ══════════════════════════════════════════ */}
       <Dialog open={openDialog} onOpenChange={setOpenDialog}>
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
             <DialogTitle>Open shift</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Shift setup
-                  </p>
-                  <h3 className="mt-2 text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
-                    Prepare the drawer before the first sale
-                  </h3>
-                </div>
-                <PosStatusPill tone="brand">Open drawer</PosStatusPill>
-              </div>
-              <div className="mt-4 space-y-2">
-                <label className="block text-sm font-medium text-[var(--text-strong)]">
+            {/* Shift number */}
+            <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
                   Shift number
-                </label>
-                <Input value={shiftNo} readOnly disabled={isReserving} className="h-11" />
-                <FieldHelp
-                  error={reserveError ?? undefined}
-                  hint={reserveError ? undefined : "Generated automatically."}
-                />
+                </p>
+                <PosStatusPill tone="brand">Auto-generated</PosStatusPill>
               </div>
+              <Input value={shiftNo} readOnly disabled={isReserving} className="h-11 font-mono font-bold" />
+              <FieldHelp
+                error={reserveError ?? undefined}
+                hint={reserveError ? undefined : "Generated automatically when a site is selected."}
+              />
             </div>
 
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_260px]">
               <div className="space-y-4">
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                  <div className="text-sm font-semibold text-[var(--text-strong)]">
-                    Register details
-                  </div>
-                  <div className="mt-3 space-y-3">
+                {/* Register */}
+                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                  <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Register details</p>
+                  <div className="space-y-3">
                     <SearchableSelect
                       label="Site"
                       value={selectedSiteId}
@@ -265,24 +322,20 @@ export function PosShiftView() {
                       onValueChange={setSelectedSiteId}
                     />
                     <div className="grid gap-3 md:grid-cols-2">
-                      <div className="space-y-2">
-                        <label className="block text-sm font-medium text-[var(--text-strong)]">
-                          Register name
-                        </label>
+                      <div className="space-y-1.5">
+                        <label className="block text-sm font-medium text-[var(--text-strong)]">Register name</label>
                         <Input
                           value={registerName}
-                          onChange={(event) => setRegisterName(event.target.value)}
+                          onChange={(e) => setRegisterName(e.target.value)}
                           placeholder="Front till"
                           className="h-11"
                         />
                       </div>
-                      <div className="space-y-2">
-                        <label className="block text-sm font-medium text-[var(--text-strong)]">
-                          Register code
-                        </label>
+                      <div className="space-y-1.5">
+                        <label className="block text-sm font-medium text-[var(--text-strong)]">Register code</label>
                         <Input
                           value={registerCode}
-                          onChange={(event) => setRegisterCode(event.target.value)}
+                          onChange={(e) => setRegisterCode(e.target.value)}
                           placeholder="Optional"
                           className="h-11"
                         />
@@ -291,41 +344,28 @@ export function PosShiftView() {
                   </div>
                 </div>
 
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                  <div className="text-sm font-semibold text-[var(--text-strong)]">
-                    Opening float
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
-                    Enter the cash placed in the drawer before trading starts.
-                  </p>
-                  <div className="mt-3">
-                    <PosNumericField
-                      label="Opening float"
-                      value={openingFloat}
-                      active={activeNumericTarget === "opening_float"}
-                      onActivate={() => setActiveNumericTarget("opening_float")}
-                    />
-                  </div>
+                {/* Float */}
+                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                  <p className="mb-1 text-[13px] font-bold text-[var(--text-strong)]">Opening float</p>
+                  <p className="mb-3 text-xs text-[var(--text-muted)]">Cash placed in the drawer before trading starts.</p>
+                  <PosNumericField
+                    label="Float amount"
+                    value={openingFloat}
+                    active={activeNumericTarget === "opening_float"}
+                    onActivate={() => setActiveNumericTarget("opening_float")}
+                  />
                 </div>
               </div>
 
-              <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                <div className="text-sm font-semibold text-[var(--text-strong)]">
-                  Amount keypad
-                </div>
-                <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
-                  Keep numeric entry quick on touch devices and shared terminals.
-                </p>
-                <div className="mt-4">
-                  <PosNumericKeypad onAction={handleKeypadAction} />
-                </div>
+              {/* Keypad */}
+              <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Keypad</p>
+                <PosNumericKeypad onAction={handleKeypadAction} />
               </div>
             </div>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setOpenDialog(false)}>
-              Cancel
-            </Button>
+            <Button type="button" variant="outline" onClick={() => setOpenDialog(false)}>Cancel</Button>
             <Button
               type="button"
               onClick={() => openShiftMutation.mutate()}
@@ -337,153 +377,120 @@ export function PosShiftView() {
         </DialogContent>
       </Dialog>
 
+      {/* ══ Close Shift Dialog ════════════════════════════════════════ */}
       <Dialog open={closeDialog} onOpenChange={setCloseDialog}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{currentShift?.shiftNo ?? "Close shift"}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Closeout
-                  </p>
-                  <h3 className="mt-2 text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
-                    Count the drawer and reconcile the shift
-                  </h3>
+        <DialogContent className="sm:max-w-lg p-0 overflow-hidden">
+          {/* Header */}
+          <div className={cn(
+            "px-6 pt-6 pb-5 border-b",
+            varianceIsBalanced
+              ? "bg-gradient-to-r from-emerald-50 to-transparent border-emerald-100"
+              : variancePreview > 0
+                ? "bg-gradient-to-r from-amber-50 to-transparent border-amber-100"
+                : "bg-gradient-to-r from-red-50 to-transparent border-red-100",
+          )}>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                  Closeout
+                </p>
+                <h3 className="mt-1 text-lg font-bold text-[var(--text-strong)]">
+                  {currentShift?.shiftNo ?? "Close shift"}
+                </h3>
+                <p className="mt-0.5 text-sm text-[var(--text-muted)]">
+                  {currentShift?.registerName} · {currentShift?.site?.name}
+                </p>
+              </div>
+              <div className="text-right shrink-0">
+                <div className="text-[11px] text-[var(--text-muted)]">Net sales</div>
+                <div className="font-mono text-xl font-black text-[var(--text-strong)]">
+                  {money(currentShift?.netSalesValue ?? 0)}
                 </div>
-                <PosStatusPill
-                  tone={
-                    variancePreview === 0
-                      ? "success"
-                      : variancePreview > 0
-                        ? "warning"
-                        : "danger"
-                  }
-                >
-                  {variancePreview === 0
-                    ? "Balanced"
-                    : variancePreview > 0
-                      ? "Over"
-                      : "Short"}
-                </PosStatusPill>
               </div>
             </div>
+          </div>
 
-            <div className="grid gap-3 sm:grid-cols-2">
+          <div className="p-5 space-y-4">
+            {/* Shift summary */}
+            <div className="grid grid-cols-2 gap-3">
               <PosMetricCard
                 icon={Wallet}
                 label="Opening float"
                 value={money(currentShift?.openingFloat ?? 0)}
-                meta="Cash placed in the drawer at start"
+                meta="Cash at start"
                 tone="neutral"
               />
               <PosMetricCard
                 icon={Wallet}
                 label="Expected cash"
                 value={money(currentShift?.expectedCash ?? 0)}
-                meta="What the drawer should contain now"
+                meta="What the drawer should have"
                 tone="warning"
-              />
-              <PosMetricCard
-                icon={Payments}
-                label="Net sales"
-                value={money(currentShift?.netSalesValue ?? 0)}
-                meta="Sales posted during this shift"
-                tone="success"
-              />
-              <PosMetricCard
-                icon={Payments}
-                label="Refunds"
-                value={money(currentShift?.refundValue ?? 0)}
-                meta="Refund value already posted"
-                tone="danger"
               />
             </div>
 
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_240px]">
               <div className="space-y-4">
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                  <div className="text-sm font-semibold text-[var(--text-strong)]">
-                    Counted cash
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
-                    Tap the amount field, count the drawer, then compare against the expected cash.
-                  </p>
-                  <div className="mt-3">
-                    <PosNumericField
-                      label="Counted cash"
-                      value={countedCash}
-                      active={activeNumericTarget === "counted_cash"}
-                      onActivate={() => setActiveNumericTarget("counted_cash")}
-                    />
-                  </div>
+                {/* Counted cash input */}
+                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                  <p className="mb-1 text-[13px] font-bold text-[var(--text-strong)]">Count the drawer</p>
+                  <p className="mb-3 text-xs text-[var(--text-muted)]">Tap the field, count the physical cash, enter the total.</p>
+                  <PosNumericField
+                    label="Counted cash"
+                    value={countedCash}
+                    active={activeNumericTarget === "counted_cash"}
+                    onActivate={() => setActiveNumericTarget("counted_cash")}
+                  />
                 </div>
 
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="text-sm font-semibold text-[var(--text-strong)]">
-                      Variance
-                    </div>
-                    <PosStatusPill
-                      tone={
-                        variancePreview === 0
-                          ? "success"
-                          : variancePreview > 0
-                            ? "warning"
-                            : "danger"
-                      }
-                    >
-                      {money(variancePreview)}
-                    </PosStatusPill>
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
-                    Positive means extra cash is in the drawer. Negative means the drawer is short.
-                  </p>
+                {/* Live variance bar */}
+                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                  <VarianceBar
+                    variance={variancePreview}
+                    expected={currentShift?.expectedCash ?? 0}
+                  />
                 </div>
 
-                <div className="space-y-2 rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                {/* Notes */}
+                <div className="space-y-1.5">
                   <label className="block text-sm font-medium text-[var(--text-strong)]">
-                    Closeout notes
+                    Closeout notes <span className="text-[var(--text-muted)] font-normal">(optional)</span>
                   </label>
                   <Textarea
                     value={closeNotes}
-                    onChange={(event) => setCloseNotes(event.target.value)}
+                    onChange={(e) => setCloseNotes(e.target.value)}
                     rows={3}
-                    placeholder="Optional notes for variance, handoff, or manager review"
+                    placeholder="Variance reason, handoff notes, or manager comments…"
+                    className="resize-none"
                   />
                 </div>
               </div>
 
-              <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
-                <div className="text-sm font-semibold text-[var(--text-strong)]">
-                  Amount keypad
-                </div>
-                <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
-                  Keep closeout entry fast and consistent with checkout and refund flows.
-                </p>
-                <div className="mt-4">
-                  <PosNumericKeypad onAction={handleKeypadAction} />
-                </div>
+              {/* Keypad */}
+              <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Keypad</p>
+                <PosNumericKeypad onAction={handleKeypadAction} />
               </div>
             </div>
           </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setCloseDialog(false)}>
-              Cancel
-            </Button>
+
+          <DialogFooter className="border-t border-[var(--border-subtle)] px-5 py-4">
+            <Button type="button" variant="outline" onClick={() => setCloseDialog(false)}>Cancel</Button>
             <Button
               type="button"
               onClick={() => closeShiftMutation.mutate()}
               disabled={closeShiftMutation.isPending}
+              className={cn(
+                varianceIsBalanced
+                  ? "bg-emerald-600 hover:bg-emerald-700"
+                  : "bg-amber-500 hover:bg-amber-600",
+              )}
             >
               Close shift
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
Checkout:
- Tender buttons now colour-coded per type (cash=green, card=blue, mobile=orange, transfer=violet, voucher=amber)
- Catalog tiles enlarged with price highlighted in brand colour when in-cart; in-cart badge shows ×N quantity
- Amount Due header with stronger gradient and cleaner change indicators
- Cart rows use thicker selection border and discount pill badges
- Charge button has per-state glow and subtle shine overlay
- Sale complete dialog dominates with giant change amount on emerald banner — most critical cashier read at a glance

Overview:
- Live shift identity header (Shift No · Register · Site)
- Quick action buttons have coloured icon badges; Held turns amber when carts are waiting
- Recent sales table: sticky header, type-coloured chips, larger rows

Held Carts:
- Elapsed time indicator (turns amber after 5 min)
- Clean card structure: total top-right, item name preview inline
- Full-width recall button with arrow icon

History:
- Search bar with icon and clear button
- Type-coloured SALE/REFUND/VOID badges; refund amounts in red
- Sticky table header
- Sale detail dialog: tinted header by type, total at hero size, Refund/Void as proper button grid

Shift:
- Shift status header shows No + register + site
- Closeout result banner with balanced/over/short icon
- Live variance bar fills proportionally, colour changes as you type
- Close button changes colour based on variance state

Reports:
- Today / This Week tab toggle
- Today view: hourly sales chart, peak hour callout, payment methods and top items scoped to the current day
- Shift banner shows live counts, cash, non-cash, refunds
- This Week view: daily trend with comparison chip

Keypad:
- Keys 3.5rem tall (up from 3rem) for better touch targets
- Bottom shadow depth gives physical pressable feel
- CLR label, wider gaps between keys

Sidebar:
- Operator initial avatar
- Taller rounder nav items; active item shows brand-coloured dot
- Inactive icons slightly muted for clear active/idle contrast