### PR TITLE
design-migration: POS mobile, retail consolidation, scrap MobileList,…

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,220 @@
+# Design Migration Spec
+
+## Attio Design Principles (from strategybreakdowns.com)
+1. **Progressive disclosure** - Only show what's needed at the moment. Depth reveals itself as users explore.
+2. **Systems thinking** - Unified interaction patterns. Same cursor/menu patterns everywhere.
+3. **Flow state** - Creative flow, building feels like playing a puzzle game.
+4. **Remove cognitive overload** - Strip unnecessary text, explanations, subtitles.
+5. **Mobile-first** - Everything must work flawlessly on iPhone (390px viewport).
+
+---
+
+## Workstream 1: Scrap Metal — MobileList Migration + Text Stripping
+
+### 1.1 Settlements Page (`app/scrap-metal/settlements/page.tsx`)
+**Current**: Custom `<article>` elements for balance cards with inline mobile view.
+**Target**: Use `MobileList` component family for the balance list view.
+
+Replace the balances rendering (lines ~583-672) with:
+```tsx
+<MobileList>
+  {balances.map((balance) => (
+    <MobileListItem key={balance.id} onClick={() => setSelectedBalance(balance)}>
+      <MobileListIcon variant="brand">{balance.employee.name[0]}</MobileListIcon>
+      <MobileListContent>
+        <MobileListTitle>{balance.employee.name}</MobileListTitle>
+        <MobileListSubtitle>{balance.employee.employeeId}</MobileListSubtitle>
+      </MobileListContent>
+      <MobileListMeta>
+        <MobileListMetaText className={balance.balance > 0 ? "text-warning" : "text-info"}>
+          {formatMoney(Math.abs(balance.balance))}
+        </MobileListMetaText>
+      </MobileListMeta>
+      <MobileListChevron />
+    </MobileListItem>
+  ))}
+</MobileList>
+```
+
+**Keep the existing desktop DataTable** - only replace the mobile card view.
+
+### 1.2 Text Stripping Across Scrap Pages
+Remove these patterns across all scrap-metal pages:
+- `<p className="text-[11px] text-muted-foreground">...</p>` explanatory subtitles
+- `<FieldHelp>` components (hint text under inputs)
+- `description` props in `StatusState` where redundant
+- Alert/Description text that restates the obvious
+- Extra labels like "Batch value and average payout by due date" - keep only the chart title
+
+Pages to clean:
+- `app/scrap-metal/settlements/page.tsx`
+- `app/scrap-metal/batches/page.tsx`
+- `app/scrap-metal/tickets/page.tsx`
+- `app/scrap-metal/page.tsx` (daily snapshot)
+
+### 1.3 Batch History Dialog
+In the settlements page history dialog (lines 880-1050), the balance history entries are already card-based. Keep them but remove redundant explanatory `<h3>` subtitles like "Balance history", "Delivered scrap", "Settlement batches" if the context is obvious.
+
+---
+
+## Workstream 2: POS — Full Mobile Compatibility for iPhone
+
+### 2.1 Problem
+Current POS layout uses `xl:grid-cols-[1.15fr_0.85fr_0.8fr]` which stacks to single column below 1280px. On iPhone (390px):
+- Catalog grid is visible but cart is way below
+- Payment section is at the very bottom
+- Keypad takes too much horizontal space
+- Tender buttons are too small for thumbs
+- The search bar is fine
+
+### 2.2 Mobile Layout Strategy (< 768px)
+**Primary view**: Catalog with floating cart button
+**Cart + Payment**: Bottom sheet that slides up
+
+```tsx
+// Mobile layout structure:
+<div className="flex h-full flex-col md:hidden">
+  {/* Search bar (sticky top) */}
+  {/* Catalog grid */}
+  {/* Floating cart FAB */}
+  {/* Bottom Sheet for Cart + Payment */}
+</div>
+
+// Desktop layout (keep existing):
+<div className="hidden md:grid ...">
+  {/* Existing 3-column layout */}
+</div>
+```
+
+### 2.3 Mobile Cart Bottom Sheet
+- Swipe up from bottom or tap FAB
+- Shows cart items (condensed)
+- Payment tender grid (2x3 larger buttons)
+- Charge button (full width, prominent)
+- Total amount large and visible
+
+### 2.4 Mobile Catalog Grid
+- 2-column grid on mobile (not single)
+- Larger touch targets (min 80px height)
+- Simplified item card (name + price only, stock badge smaller)
+
+### 2.5 Tender Buttons
+- On mobile: 2-column grid with larger buttons
+- Minimum 56px height
+- Color-coded but simplified (no complex shadow)
+
+### 2.6 Keypad on Mobile
+- Show keypad in bottom sheet alongside payment
+- Full-width number buttons (60px min)
+- Preset amounts as chips above keypad
+
+### 2.7 Top Bar on Mobile
+- Keep search (full width)
+- Hide shift badge text, show only dot indicator
+- Hide Hold/Recall buttons (move to bottom sheet menu)
+- Hide shortcut hints completely
+
+---
+
+## Workstream 3: Retail — Consolidation + Simplification + Sidebar Fix
+
+### 3.1 Retail Overview (`app/retail/page.tsx`) — Navbar Button Bloat
+**Current**: 8 buttons in actions bar
+**Target**: Maximum 3 buttons + overflow menu
+
+```tsx
+actions={
+  <div className="flex flex-wrap gap-2">
+    <Button asChild size="sm">
+      <Link href="/portal/pos"><Payments className="h-4 w-4" />Open POS</Link>
+    </Button>
+    <Button asChild size="sm" variant="outline">
+      <Link href="/retail/sell"><ClipboardList className="h-4 w-4" />Sell</Link>
+    </Button>
+    {/* More actions in a split button / dropdown */}
+    <SplitButton size="sm" variant="outline" menuContent={...}>
+      More
+    </SplitButton>
+  </div>
+}
+```
+
+Move to dropdown: Insights, Accounting, Stock, Buy, Customers, Setup
+
+### 3.2 Text Stripping — Retail Overview
+Remove these:
+- `SectionCard` subtitle: "Date range Last 12 months · Compare Previous period" → keep only the section title
+- `KpiCard` detail text is fine (margin % is data, not explanation)
+- "Priorities" section subtitle "Owner-level operating focus" → remove
+- "Cash and demand mix" subtitle "Where money is coming from" → remove
+- "Opportunities" section - keep the data, remove the "Profit model source" card (it's metadata, not actionable)
+- Remove the low-stock explanatory text: "{count} low-stock items out of {total} active SKUs"
+
+### 3.3 Reports Consolidation (`app/retail/reports/page.tsx`)
+**Current**: Reports at `/retail/reports`, insights redirects there. But buttons link to Sales Queue, Receipts, Shifts separately.
+**Target**: Make `/retail/reports` the single source for all retail reporting.
+
+- Keep the trend chart + tender mix at top
+- Add quick-link cards to sub-reports: Sales Queue, Receipts, Shifts
+- Remove the redundant "Retail performance" subtitle
+- Remove the "Trend, tender mix, and stock pressure" subtitle
+- Remove "Contribution" subtitle "Top items and stock exceptions"
+
+### 3.4 Accounting Sidebar Fix (`lib/workspaces.ts`)
+**Current**: Line 231-233 includes `/retail/accounting` as a top-level retail module item
+**Target**: Remove it. It's already in the "Controls & Growth" section.
+
+```ts
+// REMOVE this block:
+if (has("/retail/accounting")) {
+  items.push({ href: "/retail/accounting", label: "Accounting", icon: Scale });
+}
+```
+
+The accounting page will still be accessible via `/retail/accounting` → `/accounting` redirect, and via the "Controls & Growth" sidebar section.
+
+### 3.5 Retail Reports Page — MobileDataList for Tables
+Use `MobileList` for the data tables on mobile in the reports page.
+
+---
+
+## Component Reference
+
+### MobileList (from `components/ui/mobile-list.tsx`)
+Components available:
+- `MobileList` - container with border/divider styling
+- `MobileListItem` - individual row, variants: default, compact, touchable
+- `MobileListIcon` - avatar/icon area, variants: default, brand, ghost, image
+- `MobileListContent` - text content wrapper
+- `MobileListTitle` - primary text
+- `MobileListSubtitle` - secondary text
+- `MobileListMeta` - right-aligned content wrapper
+- `MobileListMetaText` - right-aligned text
+- `MobileListChevron` - arrow indicator
+- `MobileListBadge` - badge wrapper
+- `MobileListStatus` - status dot
+- `MobileListEmpty` - empty state
+- `MobileListSectionHeader` - section divider
+
+### Design Tokens (CSS variables)
+Use these for colors:
+- `--surface-base`, `--surface-muted`, `--surface-subtle`
+- `--text-strong`, `--text-body`, `--text-muted`, `--text-subtle`
+- `--edge-subtle`, `--edge-default`, `--edge-strong`
+- `--action-primary-bg`, `--action-primary-fg`
+- `--status-success-border`, `--status-warning-border`, `--status-info-border`
+- `--border-default`
+- `--card-radius`, `--card-shadow-rest`
+- `--mobile-list-*` tokens
+- `--motion-duration-fast`, `--motion-ease-default`
+
+---
+
+## Verification Checklist
+- [ ] All pages compile without TypeScript errors
+- [ ] No `FieldHelp` imports left on cleaned pages
+- [ ] `MobileList` components render correctly on mobile
+- [ ] POS works on 390px viewport (iPhone)
+- [ ] Retail overview has max 3 primary action buttons
+- [ ] Accounting does not appear as top-level retail sidebar item
+- [ ] No unnecessary explanatory text left on cleaned pages

--- a/app/retail/page.tsx
+++ b/app/retail/page.tsx
@@ -14,13 +14,20 @@ import {
 import { RetailShell } from "@/components/retail/retail-shell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   BarChart3,
   Building2,
-  CheckCircle2,
   ClipboardList,
+  ChevronDown,
   LocalShipping,
+  MoreHorizontal,
   Package,
   Payments,
   ReceiptLong,
@@ -179,13 +186,7 @@ function SectionCard({
   return (
     <section className="bg-[var(--surface-base)] px-1 py-1">
       <div className="flex items-center justify-between gap-3 border-b border-[var(--edge-subtle)] pb-3">
-        <div>
-          <h3 className="text-xl font-semibold text-[var(--text-strong)]">{title}</h3>
-          <p className="mt-1 text-xs text-[var(--text-muted)]">
-            Date range <span className="font-semibold text-[var(--text-strong)]">Last 12 months</span> ·
-            Compare <span className="font-semibold text-[var(--text-strong)]">Previous period</span>
-          </p>
-        </div>
+        <h3 className="text-xl font-semibold text-[var(--text-strong)]">{title}</h3>
         <div className="text-right">
           <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
             {metricLabel}
@@ -272,47 +273,11 @@ export default function RetailOverviewPage() {
     <RetailShell
       title="Business overview"
       actions={
-        <div className="flex flex-wrap gap-2">
+        <div className="flex items-center gap-2">
           <Button asChild size="sm">
             <Link href="/portal/pos">
               <Payments className="h-4 w-4" />
-              Open POS
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/insights">
-              <BarChart3 className="h-4 w-4" />
-              Detailed insights
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/accounting">
-              <ReceiptLong className="h-4 w-4" />
-              Accounting
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/stock">
-              <Package className="h-4 w-4" />
-              Stock
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/buy">
-              <LocalShipping className="h-4 w-4" />
-              Buy
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/customers">
-              <Users className="h-4 w-4" />
-              Customers
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/setup">
-              <Building2 className="h-4 w-4" />
-              Setup
+              POS
             </Link>
           </Button>
           <Button asChild size="sm" variant="outline">
@@ -321,6 +286,42 @@ export default function RetailOverviewPage() {
               Sell
             </Link>
           </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm" variant="outline" className="gap-1">
+                <MoreHorizontal className="h-4 w-4" />
+                <span className="hidden sm:inline">More</span>
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href="/retail/stock" className="flex items-center gap-2">
+                  <Package className="h-4 w-4" /> Stock
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/retail/buy" className="flex items-center gap-2">
+                  <LocalShipping className="h-4 w-4" /> Buy
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/retail/customers" className="flex items-center gap-2">
+                  <Users className="h-4 w-4" /> Customers
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/retail/reports" className="flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4" /> Reports
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/retail/setup" className="flex items-center gap-2">
+                  <Building2 className="h-4 w-4" /> Setup
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       }
     >
@@ -435,10 +436,7 @@ export default function RetailOverviewPage() {
         <aside className="space-y-4">
           <section className="bg-[var(--surface-base)] px-1 py-1">
             <div className="flex items-start justify-between gap-3">
-              <div>
-                <h3 className="text-xl font-semibold text-[var(--text-strong)]">Priorities</h3>
-                <p className="mt-1 text-xs text-[var(--text-muted)]">Owner-level operating focus</p>
-              </div>
+              <h3 className="text-xl font-semibold text-[var(--text-strong)]">Priorities</h3>
               <span className="rounded-full bg-[var(--surface-muted)] px-2 py-1 text-xs font-semibold">
                 {(data?.ownerMetrics.highlights?.length ?? 0).toString()}
               </span>
@@ -461,7 +459,6 @@ export default function RetailOverviewPage() {
 
           <section className="bg-[var(--surface-base)] px-1 py-1">
             <h3 className="text-xl font-semibold text-[var(--text-strong)]">Cash and demand mix</h3>
-            <p className="mt-1 text-xs text-[var(--text-muted)]">Where money is coming from</p>
             <div className="mt-3">
               <AdminDonutChart
                 rows={tenderRows}
@@ -491,20 +488,15 @@ export default function RetailOverviewPage() {
                 <div className="mt-1 font-mono text-lg">
                   {(data?.ownerMetrics.kpis.inventoryPressurePct ?? 0).toFixed(1)}%
                 </div>
-                <p className="mt-1 text-xs text-[var(--text-muted)]">
-                  {data?.summary.lowStockCount ?? 0} low-stock items out of{" "}
-                  {data?.summary.activeCatalogCount ?? 0} active SKUs
-                </p>
               </div>
-              <div className="bg-[var(--surface-base)] px-1 py-3">
-                <div className="flex items-center gap-2 text-sm font-semibold">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--text-muted)]" />
-                  Profit model source
-                </div>
-                <p className="mt-1 text-sm">
-                  {data?.ownerMetrics.model === "ACCOUNTING_POSTED"
-                    ? "Accounting-posted journals"
-                    : "Engineered estimate from retail operations"}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </RetailShell>
+  );
+}
+ons"}
                 </p>
               </div>
             </div>

--- a/app/retail/reports/page.tsx
+++ b/app/retail/reports/page.tsx
@@ -132,10 +132,7 @@ export default function RetailReportsPage() {
     >
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Retail performance</p>
-            <h2 className="mt-1 text-2xl font-semibold text-[var(--text-strong)]">Trend, tender mix, and stock pressure</h2>
-          </div>
+          <h2 className="text-2xl font-semibold text-[var(--text-strong)]">Trend and tender mix</h2>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
             <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Recent tickets</p>
             <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
@@ -168,10 +165,7 @@ export default function RetailReportsPage() {
 
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Contribution</p>
-            <h3 className="mt-1 text-xl font-semibold text-[var(--text-strong)]">Top items and stock exceptions</h3>
-          </div>
+          <h3 className="text-xl font-semibold text-[var(--text-strong)]">Top items and stock</h3>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
             <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Top item value</p>
             <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
@@ -217,7 +211,7 @@ export default function RetailReportsPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search top items"
             emptyState={isLoading ? "Loading report..." : "No item data yet"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Best-performing items</span>}
+            toolbar={undefined}
           />
         ) : null}
         {activeView === "sales" ? (
@@ -228,7 +222,7 @@ export default function RetailReportsPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search sales detail"
             emptyState={isLoading ? "Loading report..." : "No sales yet"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Recent posted tickets</span>}
+            toolbar={undefined}
           />
         ) : null}
         {activeView === "stock" ? (
@@ -239,10 +233,11 @@ export default function RetailReportsPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search stock exceptions"
             emptyState={isLoading ? "Loading report..." : "No stock exceptions"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Low-stock watchlist</span>}
+            toolbar={undefined}
           />
         ) : null}
       </VerticalDataViews>
     </RetailShell>
   );
 }
+                                                                      

--- a/app/scrap-metal/batches/page.tsx
+++ b/app/scrap-metal/batches/page.tsx
@@ -12,7 +12,6 @@ import type { SearchableOption } from "@/app/gold/types";
 import { fetchSites } from "@/lib/api";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { ScrapShell } from "@/components/scrap-metal/scrap-shell";
-import { FieldHelp } from "@/components/shared/field-help";
 import { StatusState } from "@/components/shared/status-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -639,13 +638,7 @@ export default function ScrapMetalBatchesPage() {
                   aria-readonly="true"
                   placeholder={editing ? "Lot number" : reservingBatchNumber ? "Reserving..." : "Auto-generated"}
                 />
-                <FieldHelp
-                  hint={
-                    editing
-                      ? "Lot number stays locked after creation."
-                      : reserveBatchNumberError ?? "Lot number is generated automatically after site selection."
-                  }
-                />
+
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Collection Start</label>

--- a/app/scrap-metal/settlements/page.tsx
+++ b/app/scrap-metal/settlements/page.tsx
@@ -7,7 +7,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { AdminDualBarChart, AdminTrendChart, type AdminChartSeries } from "@/components/charts/admin-headless-charts";
 import { ScrapShell } from "@/components/scrap-metal/scrap-shell";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -20,6 +19,17 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { NumericCell } from "@/components/ui/numeric-cell";
+import {
+  MobileList,
+  MobileListChevron,
+  MobileListContent,
+  MobileListIcon,
+  MobileListItem,
+  MobileListMeta,
+  MobileListMetaText,
+  MobileListSubtitle,
+  MobileListTitle,
+} from "@/components/ui/mobile-list";
 import {
   Select,
   SelectContent,
@@ -495,7 +505,6 @@ export default function ScrapSettlementsPage() {
               <div className="space-y-1">
                 <Badge variant="success">Trend</Badge>
                 <h3 className="text-base font-semibold leading-tight text-[var(--text-strong)]">Settlement trend</h3>
-                <p className="text-[11px] text-[var(--text-muted)]">Batch value and average payout by due date</p>
               </div>
               <div className="text-right">
                 <div className="text-[11px] text-[var(--text-muted)]">Settled value</div>
@@ -528,7 +537,6 @@ export default function ScrapSettlementsPage() {
               <div className="space-y-1">
                 <Badge variant="info">Exposure</Badge>
                 <h3 className="text-base font-semibold leading-tight text-[var(--text-strong)]">Delivered vs exposure</h3>
-                <p className="text-[11px] text-[var(--text-muted)]">Top operators by delivered value and open balance</p>
               </div>
               <div className="text-right">
                 <div className="text-[11px] text-[var(--text-muted)]">Net exposure</div>
@@ -571,104 +579,42 @@ export default function ScrapSettlementsPage() {
         {activeView === "balances" ? (
           <div className="space-y-2">
             {balancesQuery.isLoading ? (
-              <div className="rounded-2xl bg-[var(--surface-muted)] px-4 py-8 text-sm text-muted-foreground">
+              <div className="rounded-2xl bg-[var(--surface-muted)] px-4 py-8 text-sm text-[var(--text-muted)]">
                 Loading balances...
               </div>
             ) : null}
             {!balancesQuery.isLoading && balances.length === 0 ? (
-              <div className="rounded-2xl bg-[var(--surface-muted)] px-4 py-8 text-sm text-muted-foreground">
+              <div className="rounded-2xl bg-[var(--surface-muted)] px-4 py-8 text-sm text-[var(--text-muted)]">
                 No open balances.
               </div>
             ) : null}
             {!balancesQuery.isLoading && balances.length > 0 ? (
-              <div className="surface-framed overflow-hidden rounded-2xl bg-[var(--surface-subtle)]">
-                {balances.map((balance, index) => {
-                  const deliveredRatio = Math.max(balance.deliveredValue / maxDeliveredValue, 0.04);
-                  const balanceRatio = Math.max(Math.abs(balance.balance) / maxBalanceValue, 0.04);
+              <MobileList>
+                {balances.map((balance) => {
                   const owesUs = balance.balance > 0;
                   const amountLabel = owesUs ? "Owes us" : "We owe";
-
                   return (
-                    <article
+                    <MobileListItem
                       key={balance.id}
-                      className={cn(
-                        "px-4 py-3 sm:px-5",
-                        index > 0 && "shadow-[inset_0_1px_0_0_var(--edge-subtle)]",
-                        "bg-[var(--surface-base)]",
-                      )}
+                      onClick={() => setSelectedBalance(balance)}
                     >
-                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                        <div className="min-w-0 space-y-1">
-                          <div className="text-[15px] font-semibold leading-tight">{balance.employee.name}</div>
-                          <div className="font-mono text-[11px] text-muted-foreground">
-                            {balance.employee.employeeId}
-                          </div>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Badge variant={owesUs ? "warning" : "info"}>{amountLabel}</Badge>
-                          <Button type="button" size="sm" variant="ghost" onClick={() => openAdjustmentModal(balance)}>
-                            Update balance
-                          </Button>
-                          <Button type="button" size="sm" variant="ghost" onClick={() => setSelectedBalance(balance)}>
-                            History
-                          </Button>
-                        </div>
-                      </div>
-
-                      <div className="mt-3.5 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
-                        <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-                          <div>
-                            <div className="text-[11px] text-muted-foreground">Delivered</div>
-                            <div className="mt-1 font-semibold">{formatMoney(balance.deliveredValue)}</div>
-                            <div className="text-[11px] text-muted-foreground">{balance.deliveredWeight.toFixed(2)} kg</div>
-                          </div>
-                          <div>
-                            <div className="text-[11px] text-muted-foreground">{amountLabel}</div>
-                            <div className="mt-1 font-semibold text-[var(--text-strong)]">
-                              {formatMoney(Math.abs(balance.balance))}
-                            </div>
-                            <div className="text-[11px] text-muted-foreground">{balance.historyCount} entries</div>
-                          </div>
-                          <div>
-                            <div className="text-[11px] text-muted-foreground">Last delivery</div>
-                            <div className="mt-1 font-semibold">{formatDate(balance.lastPurchaseDate)}</div>
-                            <div className="text-[11px] text-muted-foreground">{balance.purchaseCount} purchases</div>
-                          </div>
-                        </div>
-
-                        <div className="space-y-2.5">
-                          <div className="space-y-1.5">
-                            <div className="flex items-center justify-between gap-3 text-[11px]">
-                              <span className="text-muted-foreground">Delivered value</span>
-                              <span className="font-mono text-foreground">{formatMoney(balance.deliveredValue)}</span>
-                            </div>
-                            <div className="h-2 rounded-full bg-[var(--surface-base)]/80">
-                              <div
-                                className="h-2 rounded-full bg-[var(--status-success-border)]"
-                                style={{ width: `${Math.min(deliveredRatio * 100, 100)}%` }}
-                              />
-                            </div>
-                          </div>
-                          <div className="space-y-1.5">
-                            <div className="flex items-center justify-between gap-3 text-[11px]">
-                              <span className="text-[var(--text-muted)]">{amountLabel}</span>
-                              <span className="font-mono text-[var(--text-strong)]">
-                                {formatMoney(Math.abs(balance.balance))}
-                              </span>
-                            </div>
-                            <div className="h-2 rounded-full bg-[var(--surface-base)]/80">
-                              <div
-                                className={owesUs ? "h-2 rounded-full bg-[var(--status-warning-border)]" : "h-2 rounded-full bg-[var(--status-info-border)]"}
-                                style={{ width: `${Math.min(balanceRatio * 100, 100)}%` }}
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </article>
+                      <MobileListIcon variant="brand">
+                        {balance.employee.name.charAt(0)}
+                      </MobileListIcon>
+                      <MobileListContent>
+                        <MobileListTitle>{balance.employee.name}</MobileListTitle>
+                        <MobileListSubtitle>{balance.employee.employeeId} · {balance.purchaseCount} purchases</MobileListSubtitle>
+                      </MobileListContent>
+                      <MobileListMeta>
+                        <MobileListMetaText className={cn(owesUs ? "text-[var(--color-warning)]" : "text-[var(--color-info)]")}>
+                          {amountLabel} {formatMoney(Math.abs(balance.balance))}
+                        </MobileListMetaText>
+                      </MobileListMeta>
+                      <MobileListChevron />
+                    </MobileListItem>
                   );
                 })}
-              </div>
+              </MobileList>
             ) : null}
           </div>
         ) : (
@@ -685,36 +631,14 @@ export default function ScrapSettlementsPage() {
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <div className="font-semibold">{batch.label}</div>
-                    <div className="text-xs text-muted-foreground">{batch.items.length} people</div>
+                    <div className="text-xs text-[var(--text-muted)]">{batch.items.length} people · {formatDate(batch.dueDate)}</div>
                   </div>
                   <Badge variant={getWorkflowBadgeVariant(batch.workflowStatus)}>
                     {formatWorkflowStatus(batch.workflowStatus)}
                   </Badge>
                 </div>
-                <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
-                  <div>
-                    <div className="inline-flex items-center gap-1 text-muted-foreground">
-                      <Calendar className="h-3.5 w-3.5" />
-                      Due
-                    </div>
-                    <div className="mt-1 font-mono">{formatDate(batch.dueDate)}</div>
-                  </div>
-                  <div>
-                    <div className="inline-flex items-center gap-1 text-muted-foreground">
-                      <Wallet className="h-3.5 w-3.5" />
-                      Value
-                    </div>
-                    <div className="mt-1 font-mono">
-                      {formatMoney(batch.items.reduce((sum, item) => sum + item.amount, 0))}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="inline-flex items-center gap-1 text-muted-foreground">
-                      <Users className="h-3.5 w-3.5" />
-                      People
-                    </div>
-                    <div className="mt-1 font-mono">{batch.items.length}</div>
-                  </div>
+                <div className="mt-2 flex items-center justify-between text-sm">
+                  <span className="font-mono font-semibold">{formatMoney(batch.items.reduce((sum, item) => sum + item.amount, 0))}</span>
                 </div>
               </div>
             )}
@@ -1039,3 +963,4 @@ export default function ScrapSettlementsPage() {
     </ScrapShell>
   );
 }
+                                                                                                                   

--- a/components/retail/portal/pos-checkout-view.tsx
+++ b/components/retail/portal/pos-checkout-view.tsx
@@ -209,6 +209,7 @@ export function PosCheckoutView() {
   const [activeTarget, setActiveTarget] = useState<CheckoutNumericTarget | null>(null);
   const [customerSheetOpen, setCustomerSheetOpen] = useState(false);
   const [adjustmentsOpen, setAdjustmentsOpen] = useState(false);
+  const [mobileCartOpen, setMobileCartOpen] = useState(false);
 
   /* ── Global POS state ────────────────────────── */
   const {
@@ -620,8 +621,8 @@ export function PosCheckoutView() {
         </div>
       </div>
 
-      {/* ── Three-column layout ─────────────────────────── */}
-      <div className="grid min-h-0 flex-1 overflow-hidden xl:grid-cols-[minmax(0,1.15fr)_minmax(260px,0.85fr)_minmax(300px,0.8fr)]">
+      {/* ── Three-column layout (desktop) ─────────────── */}
+      <div className="hidden min-h-0 flex-1 overflow-hidden md:grid xl:grid-cols-[minmax(0,1.15fr)_minmax(260px,0.85fr)_minmax(300px,0.8fr)]">
 
         {/* ┄ Column 1 — Catalog ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ */}
         <div className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--edge-subtle)] bg-[var(--surface-base)]">
@@ -1206,6 +1207,175 @@ export function PosCheckoutView() {
           </div>
         </div>
       </div>
+
+      {/* ── Mobile layout (< md) ────────────────────────── */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:hidden">
+        {/* Mobile catalog — full width, 2-col grid */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-[var(--surface-base)]">
+          <div className="min-h-0 flex-1 overflow-y-auto p-3">
+            {catalogItems.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--surface-muted)]">
+                  <Search className="h-7 w-7 text-[var(--text-muted)]" />
+                </div>
+                <p className="text-sm font-medium text-[var(--text-muted)]">No items found</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-2">
+                {catalogItems.map((item) => {
+                  const inCart = cart.find((c) => c.catalogItemId === item.id);
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => handleAddCatalogItem(item)}
+                      disabled={!currentShift}
+                      className={cn(
+                        "group relative flex flex-col gap-2 rounded-xl border p-2.5 text-left transition-all duration-100 active:scale-[0.97]",
+                        inCart
+                          ? "border-[color-mix(in_srgb,var(--action-primary-bg)_50%,var(--border-default))] bg-[color-mix(in_srgb,var(--action-primary-bg)_3%,var(--surface-base))]"
+                          : "border-[var(--border-default)] bg-[var(--surface-base)]",
+                      )}
+                    >
+                      {item.imageUrl ? (
+                        <div className="flex h-20 w-full items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-muted)]">
+                          <Image src={item.imageUrl} alt={item.name} width={80} height={80} className="h-full w-full object-cover" unoptimized />
+                        </div>
+                      ) : (
+                        <div className="flex h-20 w-full items-center justify-center rounded-lg bg-[var(--surface-muted)]">
+                          <Package className="h-8 w-8 text-[var(--text-muted)]" />
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <div className="line-clamp-2 text-xs font-semibold leading-tight text-[var(--text-strong)]">
+                          {item.name}
+                        </div>
+                        <div className="mt-1 font-mono text-sm font-bold text-[var(--text-strong)]">
+                          {money(item.unitPrice)}
+                        </div>
+                      </div>
+                      {inCart ? (
+                        <div className="absolute -right-1.5 -top-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--action-primary-bg)] px-1 text-[10px] font-black text-white">
+                          {inCart.quantity % 1 === 0 ? inCart.quantity : inCart.quantity.toFixed(1)}
+                        </div>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile cart FAB */}
+      <button
+        type="button"
+        onClick={() => setMobileCartOpen(true)}
+        className="fixed right-4 bottom-4 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[var(--action-primary-bg)] text-white shadow-lg transition-transform active:scale-95 md:hidden"
+      >
+        <Wallet className="h-6 w-6" />
+        {cart.length > 0 ? (
+          <span className="absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+            {cart.length}
+          </span>
+        ) : null}
+      </button>
+
+      {/* Mobile cart + payment sheet */}
+      <Sheet open={mobileCartOpen} onOpenChange={setMobileCartOpen}>
+        <SheetContent side="bottom" size="lg" className="h-[92dvh] p-0">
+          <div className="flex h-full flex-col">
+            <SheetHeader className="shrink-0 border-b border-[var(--edge-subtle)] px-4 py-3">
+              <SheetTitle className="flex items-center justify-between">
+                <span>Cart</span>
+                {cart.length > 0 ? (
+                  <span className="rounded-full bg-[var(--action-primary-bg)] px-2 py-0.5 text-xs font-bold text-white">
+                    {cart.length}
+                  </span>
+                ) : null}
+              </SheetTitle>
+            </SheetHeader>
+
+            {/* Cart items */}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {cart.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-2 p-8 text-center">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface-muted)]">
+                    <Payments className="h-6 w-6 text-[var(--text-muted)]" />
+                  </div>
+                  <p className="text-sm font-medium text-[var(--text-muted)]">No items yet</p>
+                </div>
+              ) : (
+                <div className="divide-y divide-[var(--edge-subtle)]">
+                  {cart.map((item) => (
+                    <div key={item.catalogItemId} className="flex items-center gap-3 px-4 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-semibold text-[var(--text-strong)]">{item.name}</div>
+                        <div className="text-xs text-[var(--text-muted)]">{money(item.unitPrice)} x {item.quantity}</div>
+                      </div>
+                      <div className="font-mono text-sm font-bold">{money(item.quantity * item.unitPrice - (item.lineDiscountAmount ?? 0))}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Payment summary */}
+            {cart.length > 0 ? (
+              <div className="shrink-0 border-t border-[var(--edge-subtle)] bg-[var(--surface-base)] p-4">
+                <div className="flex items-baseline justify-between">
+                  <span className="text-sm font-semibold text-[var(--text-muted)]">Total</span>
+                  <span className="font-mono text-2xl font-black text-[var(--text-strong)]">{money(total)}</span>
+                </div>
+
+                {/* Tender buttons */}
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  {TENDER_TYPES.slice(0, 4).map((type) => (
+                    <button
+                      key={type}
+                      type="button"
+                      onClick={() => {
+                        setPayments([{ tenderType: type, amount: String(total.toFixed(2)), reference: "" }]);
+                        setActiveTarget({ type: "tender_amount", index: 0 });
+                      }}
+                      className={cn(
+                        "flex h-14 items-center justify-center gap-2 rounded-xl border font-semibold transition-all active:scale-[0.98]",
+                        payments[0]?.tenderType === type
+                          ? TENDER_TYPE_STYLES[type].selected
+                          : TENDER_TYPE_STYLES[type].idle,
+                      )}
+                    >
+                      <TenderIcon type={type} />
+                      <span className="text-sm">{tenderLabel(type)}</span>
+                    </button>
+                  ))}
+                </div>
+
+                {/* Charge button */}
+                <button
+                  type="button"
+                  onClick={() => { setMobileCartOpen(false); handleCharge(); }}
+                  disabled={charging || total <= 0 || cart.length === 0}
+                  className={cn(
+                    "mt-3 flex h-14 w-full items-center justify-center gap-2 rounded-2xl text-base font-black text-white transition-all duration-150 active:scale-[0.98]",
+                    charging || total <= 0 || cart.length === 0
+                      ? "bg-[var(--text-muted)] opacity-60"
+                      : "bg-[var(--action-primary-bg)] shadow-[0_8px_24px_rgba(0,0,0,0.18)] hover:shadow-[0_12px_32px_rgba(0,0,0,0.22)]",
+                  )}
+                >
+                  {charging ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Zap className="h-5 w-5" />
+                  )}
+                  {charging ? "Processing…" : `Charge ${money(total)}`}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
 
       {/* ════════════════════════════════════════════════════
          DIALOGS & SHEETS

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -228,9 +228,6 @@ const WORKSPACE_MODULES: Record<WorkspaceModuleId, WorkspaceModuleDefinition> = 
           { href: "/retail/purchasing/receipts", label: "Goods Receipts", icon: LocalShipping },
         );
       }
-      if (has("/retail/accounting")) {
-        items.push({ href: "/retail/accounting", label: "Accounting", icon: Scale });
-      }
       if (has("/retail/insights")) {
         items.push({ href: "/retail/reports", label: "Reports", icon: BarChart3 });
       }


### PR DESCRIPTION
… sidebar fix

Scrap Metal:
- Settlements: Replace custom mobile cards with MobileList component
- Batches: Remove FieldHelp explanatory text
- Strip unnecessary text-muted-foreground explanatory text

POS Mobile Compatibility:
- Add mobile-first layout (< md): catalog grid with 2-column grid
- Add floating cart FAB with item count badge
- Add mobile cart + payment bottom sheet with tender buttons
- Keep existing desktop 3-column layout unchanged
- Tender buttons: 2x2 grid, 56px touch targets on mobile
- Charge button: full-width, prominent in bottom sheet

Retail Dashboard:
- Consolidate 8 navbar buttons → 3 primary + More dropdown Primary: POS, Sell, More (dropdown with Stock, Buy, Customers, Reports, Setup)
- Strip SectionCard subtitle text (Date range/Compare)
- Strip 'Owner-level operating focus' subtitle
- Strip 'Where money is coming from' subtitle
- Remove profit model source card and low-stock explanatory text
- Reports page: strip redundant subtitles and toolbar labels

Sidebar:
- Remove Accounting from retail top-level sidebar items Still accessible via Controls & Growth section