### PR TITLE
retail-reports: dedicated reports hub + chart-heavy redesigns + text …

### DIFF
--- a/app/retail/customers/page.tsx
+++ b/app/retail/customers/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
@@ -10,29 +9,14 @@ import {
   AdminDonutChart,
 } from "@/components/charts/admin-headless-charts";
 import { RetailShell } from "@/components/retail/retail-shell";
-import { Button } from "@/components/ui/button";
+import { ReportChartShell } from "@/components/retail/reports/report-chart-shell";
+import { ReportFilterBar } from "@/components/retail/reports/report-filter-bar";
+import { ReportBigNumber } from "@/components/retail/reports/report-big-number";
 import { DataTable } from "@/components/ui/data-table";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { NumericCell } from "@/components/ui/numeric-cell";
 import { fetchJson } from "@/lib/api-client";
-import { BarChart3, Payments, ReceiptLong } from "@/lib/icons";
-
-type RetailDashboardPayload = {
-  data: Array<{
-    customerId: string | null;
-    customerName: string;
-    visits: number;
-    lastPurchaseAt: string;
-    lastSaleNo: string;
-    totalSpend: number;
-    loyaltyPoints: number;
-    loyaltyTier: string;
-  }>;
-  summary: {
-    namedCustomerCount: number;
-    totalLoyaltyPoints: number;
-  };
-};
+import { Users } from "@/lib/icons";
 
 type CustomerRow = {
   customerId: string | null;
@@ -49,240 +33,117 @@ type CustomerLoyaltyPayload = {
   customer: { id: string; name: string; phone: string | null; email: string | null };
   loyalty: { earnedPoints: number; redeemedPoints: number; balance: number; tier: string };
   ledger: Array<{
-    id: string;
-    saleNo: string;
-    saleType: string;
-    postedAt: string;
-    amount: number;
-    earnedPoints: number;
-    redeemedPoints: number;
-    delta: number;
+    id: string; saleNo: string; saleType: string; postedAt: string;
+    amount: number; earnedPoints: number; redeemedPoints: number; delta: number;
   }>;
 };
 
 function money(value: number) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  }).format(value);
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
 }
 
 export default function RetailCustomersPage() {
   const [activeCustomer, setActiveCustomer] = useState<{ id: string; name: string } | null>(null);
   const { data, isLoading } = useQuery({
     queryKey: ["retail-customers-overview"],
-    queryFn: () => fetchJson<RetailDashboardPayload>("/api/v2/retail/customers"),
+    queryFn: () => fetchJson<{ data: CustomerRow[]; summary: { namedCustomerCount: number; totalLoyaltyPoints: number } }>("/api/v2/retail/customers"),
   });
   const loyaltyDetailQuery = useQuery({
     queryKey: ["retail-customer-loyalty", activeCustomer?.id],
-    queryFn: () =>
-      fetchJson<CustomerLoyaltyPayload>(`/api/v2/retail/customers/${activeCustomer?.id}/loyalty`),
+    queryFn: () => fetchJson<CustomerLoyaltyPayload>(`/api/v2/retail/customers/${activeCustomer?.id}/loyalty`),
     enabled: Boolean(activeCustomer?.id),
   });
 
   const customerRows = useMemo<CustomerRow[]>(
-    () => (data?.data ?? []).sort((left, right) => right.totalSpend - left.totalSpend),
+    () => (data?.data ?? []).sort((a, b) => b.totalSpend - a.totalSpend),
     [data?.data],
   );
 
   const spendRows = useMemo(
-    () =>
-      customerRows.slice(0, 8).map((customer) => ({
-        id: customer.customerName,
-        label: customer.customerName,
-        primary: customer.totalSpend,
-        secondary: customer.visits,
-      })),
+    () => customerRows.slice(0, 8).map((c) => ({
+      id: c.customerId ?? c.customerName,
+      label: c.customerName,
+      primary: c.totalSpend,
+      secondary: c.visits,
+    })),
     [customerRows],
   );
 
-  const loyaltyRows = useMemo(
-    () => {
-      const tierCounts = new Map<string, number>();
-      for (const customer of customerRows) {
-        tierCounts.set(customer.loyaltyTier, (tierCounts.get(customer.loyaltyTier) ?? 0) + 1);
-      }
-      return Array.from(tierCounts.entries()).map(([tier, value]) => ({
-        id: tier,
-        label: tier,
-        value,
-      }));
-    },
-    [customerRows],
-  );
+  const tierRows = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const c of customerRows) counts.set(c.loyaltyTier, (counts.get(c.loyaltyTier) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([label, value]) => ({ id: label, label, value }));
+  }, [customerRows]);
 
   const visitRows = useMemo(
-    () =>
-      customerRows
-        .slice()
-        .sort((left, right) => right.visits - left.visits)
-        .slice(0, 8)
-        .map((customer) => ({
-          id: customer.customerName,
-          label: customer.customerName,
-          value: customer.visits,
-        })),
+    () => customerRows.slice().sort((a, b) => b.visits - a.visits).slice(0, 8).map((c) => ({
+      id: c.customerId ?? c.customerName,
+      label: c.customerName,
+      value: c.visits,
+    })),
     [customerRows],
   );
 
-  const columns = useMemo<ColumnDef<CustomerRow>[]>(
-    () => [
-      {
-        id: "customerName",
-        header: "Customer",
-        cell: ({ row }) => (
-          <div>
-            <div className="font-medium text-[var(--text-strong)]">{row.original.customerName}</div>
-            <div className="font-mono text-xs text-[var(--text-muted)]">{row.original.lastSaleNo}</div>
-          </div>
-        ),
-      },
-      {
-        id: "visits",
-        header: "Visits",
-        cell: ({ row }) => <NumericCell>{row.original.visits}</NumericCell>,
-      },
-      {
-        id: "lastPurchaseAt",
-        header: "Last purchase",
-        cell: ({ row }) => (
-          <NumericCell align="left">
-            {new Date(row.original.lastPurchaseAt).toLocaleDateString()}
-          </NumericCell>
-        ),
-      },
-      {
-        id: "totalSpend",
-        header: "Spend",
-        cell: ({ row }) => <NumericCell>{money(row.original.totalSpend)}</NumericCell>,
-      },
-      {
-        id: "loyaltyPoints",
-        header: "Loyalty",
-        cell: ({ row }) => (
-          <NumericCell>
-            {row.original.loyaltyPoints} ({row.original.loyaltyTier})
-          </NumericCell>
-        ),
-      },
-      {
-        id: "actions",
-        header: "Actions",
-        cell: ({ row }) => (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={!row.original.customerId}
-            onClick={() =>
-              row.original.customerId
-                ? setActiveCustomer({
-                    id: row.original.customerId,
-                    name: row.original.customerName,
-                  })
-                : null
-            }
-          >
-            Loyalty ledger
-          </Button>
-        ),
-      },
-    ],
-    [],
-  );
+  const columns = useMemo<ColumnDef<CustomerRow>[]>(() => [
+    { id: "customerName", header: "Customer", cell: ({ row }) => (
+      <div>
+        <div className="font-medium">{row.original.customerName}</div>
+        <div className="font-mono text-xs text-[var(--text-muted)]">{row.original.lastSaleNo}</div>
+      </div>
+    )},
+    { id: "visits", header: "Visits", cell: ({ row }) => <NumericCell>{row.original.visits}</NumericCell> },
+    { id: "totalSpend", header: "Spend", cell: ({ row }) => <NumericCell>{money(row.original.totalSpend)}</NumericCell> },
+    { id: "loyalty", header: "Loyalty", cell: ({ row }) => <NumericCell>{row.original.loyaltyPoints}</NumericCell> },
+    { id: "tier", header: "Tier", cell: ({ row }) => row.original.loyaltyTier },
+    { id: "actions", header: "", cell: ({ row }) => row.original.customerId ? (
+      <button
+        className="text-xs font-medium text-[var(--action-primary-bg)] hover:underline"
+        onClick={() => setActiveCustomer({ id: row.original.customerId!, name: row.original.customerName })}
+      >
+        Ledger
+      </button>
+    ) : null },
+  ], []);
 
   return (
-    <RetailShell
-      title="Customers"
-      actions={
-        <div className="flex flex-wrap gap-2">
-          <Button asChild size="sm">
-            <Link href="/portal/pos">
-              <Payments className="h-4 w-4" />
-              Open POS
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/sales">
-              <ReceiptLong className="h-4 w-4" />
-              Sales
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/reports">
-              <BarChart3 className="h-4 w-4" />
-              Insights
-            </Link>
-          </Button>
-        </div>
-      }
-    >
-      <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Customer signal</p>
-            <h2 className="mt-1 text-2xl font-semibold text-[var(--text-strong)]">Spend, visits, and loyalty depth</h2>
-          </div>
-          <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Top spender</p>
-            <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
-              {customerRows[0] ? money(customerRows[0].totalSpend) : money(0)}
-            </p>
-          </div>
-        </div>
+    <RetailShell title="Customers" actions={undefined}>
+      <ReportFilterBar onExport={() => {}} />
 
-        <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.85fr)]">
-          <AdminDualBarChart
-            rows={spendRows}
-            primaryLabel="Spend"
-            secondaryLabel="Visits"
-            height={300}
-            valueFormatter={(value) => value.toFixed(0)}
-            emptyLabel="Customer spend is loading"
-          />
-          <AdminDonutChart
-            rows={loyaltyRows.length > 0 ? loyaltyRows : [{ id: "none", label: "No tiers", value: 0, tone: "warning" as const }]}
-            valueLabel="Customers"
-            valueFormatter={(value) => value.toString()}
-            height={300}
-            emptyLabel="Loyalty tiers are loading"
-          />
-        </div>
-      </section>
+      {/* KPI row */}
+      <div className="grid gap-5 xl:grid-cols-3">
+        <ReportChartShell title="Customers" sourceTag={{ label: "CRM" }}>
+          <ReportBigNumber label="Named customers" value={String(data?.summary.namedCustomerCount ?? 0)} />
+        </ReportChartShell>
+        <ReportChartShell title="Top spend" sourceTag={{ label: "Sales" }}>
+          <ReportBigNumber label="Top customer" value={customerRows[0] ? money(customerRows[0].totalSpend) : money(0)} dotColor="var(--status-success-border)" />
+        </ReportChartShell>
+        <ReportChartShell title="Loyalty" sourceTag={{ label: "Rewards" }}>
+          <ReportBigNumber label="Total points" value={String(data?.summary.totalLoyaltyPoints ?? 0)} dotColor="var(--status-warning-border)" />
+        </ReportChartShell>
+      </div>
 
-      <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Visit frequency</p>
-            <h3 className="mt-1 text-xl font-semibold text-[var(--text-strong)]">Most frequent customers in the current window</h3>
-          </div>
-          <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Named customers</p>
-            <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
-              {data?.summary.namedCustomerCount ?? 0}
-            </p>
-          </div>
-        </div>
+      {/* Charts */}
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+        <ReportChartShell title="Spend vs visits" sourceTag={{ label: "Sales" }} legend={[{ label: "Spend", color: "var(--action-primary-bg)" }, { label: "Visits", color: "var(--status-info-border)" }]}>
+          <AdminDualBarChart rows={spendRows} primaryLabel="Spend" secondaryLabel="Visits" height={300} valueFormatter={(v) => v.toFixed(0)} />
+        </ReportChartShell>
+        <ReportChartShell title="Loyalty tiers" sourceTag={{ label: "Rewards" }}>
+          <AdminDonutChart rows={tierRows.length ? tierRows : [{ id: "none", label: "No tiers", value: 0 }]} valueLabel="Customers" valueFormatter={(v) => v.toString()} height={300} />
+        </ReportChartShell>
+      </div>
 
-        <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.75fr)]">
-          <AdminDistributionChart
-            rows={visitRows}
-            valueLabel="Visits"
-            valueFormatter={(value) => value.toString()}
-            height={280}
-            emptyLabel="Visit frequency is loading"
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+        <ReportChartShell title="Visit frequency" sourceTag={{ label: "CRM" }}>
+          <AdminDistributionChart rows={visitRows} valueLabel="Visits" valueFormatter={(v) => v.toString()} height={280} />
+        </ReportChartShell>
+        <ReportChartShell title="Avg spend" sourceTag={{ label: "Sales" }}>
+          <ReportBigNumber
+            label="Avg per customer"
+            value={money(customerRows.length ? customerRows.reduce((s, c) => s + c.totalSpend, 0) / customerRows.length : 0)}
+            dotColor="var(--action-primary-bg)"
           />
-          <div className="rounded-[24px] border border-[var(--edge-subtle)] bg-[var(--surface-subtle)] p-4">
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--text-muted)]">Loyalty points</p>
-            <p className="mt-2 font-mono text-3xl font-semibold text-[var(--text-strong)]">
-              {data?.summary.totalLoyaltyPoints ?? 0}
-            </p>
-            <p className="mt-2 text-sm text-[var(--text-muted)]">
-              The table remains for detail work, while the charts carry the scanning layer.
-            </p>
-          </div>
-        </div>
-      </section>
+        </ReportChartShell>
+      </div>
 
       <DataTable
         data={customerRows}
@@ -290,70 +151,43 @@ export default function RetailCustomersPage() {
         features={{ sorting: true, globalFilter: true, pagination: true }}
         pagination={{ enabled: true, server: false }}
         searchPlaceholder="Search customers"
-        emptyState={isLoading ? "Loading customers..." : "No customer activity yet"}
-        toolbar={<span className="text-xs text-[var(--text-muted)]">Customer spend from recent sales</span>}
+        emptyState={isLoading ? "Loading customers..." : "No customers yet"}
       />
 
+      {/* Loyalty Dialog */}
       <Dialog open={Boolean(activeCustomer)} onOpenChange={(open) => !open && setActiveCustomer(null)}>
         <DialogContent className="max-w-3xl">
           <DialogHeader>
-            <DialogTitle>Loyalty ledger - {activeCustomer?.name}</DialogTitle>
+            <DialogTitle>Loyalty ledger — {activeCustomer?.name}</DialogTitle>
           </DialogHeader>
           {!loyaltyDetailQuery.data ? (
             <div className="py-6 text-sm text-[var(--text-muted)]">
-              {loyaltyDetailQuery.isLoading ? "Loading loyalty ledger..." : "No loyalty data available"}
+              {loyaltyDetailQuery.isLoading ? "Loading..." : "No data"}
             </div>
           ) : (
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-4">
-                <div className="rounded-xl bg-[var(--surface-muted)] px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Earned</div>
-                  <div className="font-mono text-base font-semibold">
-                    {loyaltyDetailQuery.data.loyalty.earnedPoints}
+                {(["earnedPoints", "redeemedPoints", "balance", "tier"] as const).map((key) => (
+                  <div key={key} className="rounded-xl bg-[var(--surface-muted)] px-3 py-2">
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">{key.replace(/([A-Z])/g, " $1").trim()}</div>
+                    <div className="font-mono text-base font-semibold">{String(loyaltyDetailQuery.data.loyalty[key])}</div>
                   </div>
-                </div>
-                <div className="rounded-xl bg-[var(--surface-muted)] px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Redeemed</div>
-                  <div className="font-mono text-base font-semibold">
-                    {loyaltyDetailQuery.data.loyalty.redeemedPoints}
-                  </div>
-                </div>
-                <div className="rounded-xl bg-[var(--surface-muted)] px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Balance</div>
-                  <div className="font-mono text-base font-semibold">
-                    {loyaltyDetailQuery.data.loyalty.balance}
-                  </div>
-                </div>
-                <div className="rounded-xl bg-[var(--surface-muted)] px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Tier</div>
-                  <div className="font-mono text-base font-semibold">
-                    {loyaltyDetailQuery.data.loyalty.tier}
-                  </div>
-                </div>
+                ))}
               </div>
-              <div className="overflow-auto rounded-xl border border-[var(--border-subtle)]">
+              <div className="overflow-auto rounded-xl border border-[var(--edge-subtle)]">
                 <table className="min-w-full text-sm">
                   <thead className="bg-[var(--surface-muted)] text-left text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                    <tr>
-                      <th className="px-3 py-2">Sale</th>
-                      <th className="px-3 py-2">Date</th>
-                      <th className="px-3 py-2 text-right">Amount</th>
-                      <th className="px-3 py-2 text-right">Earned</th>
-                      <th className="px-3 py-2 text-right">Redeemed</th>
-                      <th className="px-3 py-2 text-right">Net</th>
-                    </tr>
+                    <tr>{["Sale", "Date", "Amount", "Earned", "Redeemed", "Net"].map((h) => <th key={h} className="px-3 py-2 text-right">{h}</th>)}</tr>
                   </thead>
                   <tbody>
-                    {loyaltyDetailQuery.data.ledger.map((entry) => (
-                      <tr key={entry.id} className="border-t border-[var(--border-subtle)]">
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {entry.saleNo} ({entry.saleType})
-                        </td>
-                        <td className="px-3 py-2">{new Date(entry.postedAt).toLocaleDateString()}</td>
-                        <td className="px-3 py-2 text-right font-mono">{money(entry.amount)}</td>
-                        <td className="px-3 py-2 text-right font-mono">{entry.earnedPoints}</td>
-                        <td className="px-3 py-2 text-right font-mono">{entry.redeemedPoints}</td>
-                        <td className="px-3 py-2 text-right font-mono">{entry.delta}</td>
+                    {loyaltyDetailQuery.data.ledger.map((e) => (
+                      <tr key={e.id} className="border-t border-[var(--edge-subtle)]">
+                        <td className="px-3 py-2 font-mono text-xs">{e.saleNo}</td>
+                        <td className="px-3 py-2">{new Date(e.postedAt).toLocaleDateString()}</td>
+                        <td className="px-3 py-2 text-right font-mono">{money(e.amount)}</td>
+                        <td className="px-3 py-2 text-right font-mono">{e.earnedPoints}</td>
+                        <td className="px-3 py-2 text-right font-mono">{e.redeemedPoints}</td>
+                        <td className="px-3 py-2 text-right font-mono">{e.delta}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/app/retail/merchandising/promotions/page.tsx
+++ b/app/retail/merchandising/promotions/page.tsx
@@ -4,65 +4,47 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AdminDistributionChart,
+  AdminDonutChart,
+  AdminTrendChart,
+} from "@/components/charts/admin-headless-charts";
 import { RetailShell } from "@/components/retail/retail-shell";
-import { FieldHelp } from "@/components/shared/field-help";
+import { ReportChartShell } from "@/components/retail/reports/report-chart-shell";
+import { ReportFilterBar } from "@/components/retail/reports/report-filter-bar";
+import { ReportBigNumber } from "@/components/retail/reports/report-big-number";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { NumericCell } from "@/components/ui/numeric-cell";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { BarChart3, Pencil, Plus, Trash2, Wallet } from "@/lib/icons";
+import { Pencil, Plus, Trash2, Wallet } from "@/lib/icons";
 import { useReservedId } from "@/hooks/use-reserved-id";
 
 type Promotion = {
-  id: string;
-  promoCode: string;
-  name: string;
-  type: string;
-  value: number;
-  startsAt: string | null;
-  endsAt: string | null;
-  status: string;
-  notes: string | null;
+  id: string; promoCode: string; name: string; type: string; value: number;
+  startsAt: string | null; endsAt: string | null; status: string; notes: string | null;
 };
 
 type PromotionForm = {
-  name: string;
-  type: string;
-  value: string;
-  startsAt: string;
-  endsAt: string;
-  status: string;
-  notes: string;
+  name: string; type: string; value: string; startsAt: string;
+  endsAt: string; status: string; notes: string;
 };
 
 function emptyForm(): PromotionForm {
-  return {
-    name: "",
-    type: "PERCENT",
-    value: "",
-    startsAt: "",
-    endsAt: "",
-    status: "ACTIVE",
-    notes: "",
-  };
+  return { name: "", type: "PERCENT", value: "", startsAt: "", endsAt: "", status: "ACTIVE", notes: "" };
+}
+
+function dateLabel(iso: string | null) {
+  return iso ? new Date(iso).toLocaleDateString() : "—";
 }
 
 export default function RetailPromotionsPage() {
@@ -78,199 +60,174 @@ export default function RetailPromotionsPage() {
     queryFn: () => fetchJson<{ data: Promotion[] }>("/api/v2/retail/promotions"),
   });
 
-  const {
-    reservedId: promoCode,
-    isReserving,
-    error: reserveError,
-  } = useReservedId({
-    entity: "RETAIL_PROMOTION",
-    enabled: dialogOpen && !editing,
+  const { reservedId: promoCode, isReserving, error: reserveError } = useReservedId({
+    entity: "RETAIL_PROMOTION", enabled: dialogOpen && !editing,
   });
+
+  const promotions = promotionsQuery.data?.data ?? [];
+  const activeCount = promotions.filter((p) => p.status === "ACTIVE").length;
 
   const saveMutation = useMutation({
     mutationFn: async (payload: PromotionForm) => {
       const body = {
         promoCode: editing ? undefined : promoCode || undefined,
-        name: payload.name,
-        type: payload.type,
-        value: Number(payload.value),
+        name: payload.name, type: payload.type, value: Number(payload.value),
         startsAt: payload.startsAt ? new Date(payload.startsAt).toISOString() : undefined,
         endsAt: payload.endsAt ? new Date(payload.endsAt).toISOString() : undefined,
-        status: payload.status,
-        notes: payload.notes.trim() || undefined,
+        status: payload.status, notes: payload.notes.trim() || undefined,
       };
-
       if (editing) {
-        return fetchJson(`/api/v2/retail/promotions/${editing.id}`, {
-          method: "PATCH",
-          body: JSON.stringify(body),
-        });
+        return fetchJson(`/api/v2/retail/promotions/${editing.id}`, { method: "PATCH", body: JSON.stringify(body) });
       }
-
-      return fetchJson("/api/v2/retail/promotions", {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
+      return fetchJson("/api/v2/retail/promotions", { method: "POST", body: JSON.stringify(body) });
     },
     onSuccess: () => {
-      toast({ title: editing ? "Promotion updated" : "Promotion created", variant: "success" });
+      toast({ title: editing ? "Updated" : "Created", variant: "success" });
       queryClient.invalidateQueries({ queryKey: ["retail-promotions"] });
       queryClient.invalidateQueries({ queryKey: ["retail-dashboard"] });
-      setDialogOpen(false);
-      setEditing(null);
-      setForm(emptyForm());
+      setDialogOpen(false); setEditing(null); setForm(emptyForm());
     },
     onError: (error) => {
-      toast({
-        title: editing ? "Unable to update promotion" : "Unable to create promotion",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
+      toast({ title: editing ? "Update failed" : "Create failed", description: getApiErrorMessage(error), variant: "destructive" });
     },
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => fetchJson(`/api/v2/retail/promotions/${id}`, { method: "DELETE" }),
     onSuccess: () => {
-      toast({ title: "Promotion removed", variant: "success" });
+      toast({ title: "Removed", variant: "success" });
       queryClient.invalidateQueries({ queryKey: ["retail-promotions"] });
       setDeleteTarget(null);
     },
     onError: (error) => {
-      toast({
-        title: "Unable to remove promotion",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
+      toast({ title: "Remove failed", description: getApiErrorMessage(error), variant: "destructive" });
     },
   });
 
-  const columns = useMemo<ColumnDef<Promotion>[]>(
-    () => [
-      {
-        id: "promoCode",
-        header: "Promo",
-        cell: ({ row }) => (
-          <div>
-            <div className="font-medium">{row.original.name}</div>
-            <div className="font-mono text-xs text-[var(--text-muted)]">{row.original.promoCode}</div>
-          </div>
-        ),
-      },
-      { id: "type", header: "Type", cell: ({ row }) => row.original.type },
-      { id: "value", header: "Value", cell: ({ row }) => <NumericCell>{row.original.value.toFixed(2)}</NumericCell> },
-      {
-        id: "window",
-        header: "Window",
-        cell: ({ row }) => (
-          <div className="text-xs">
-            <div>{row.original.startsAt ? new Date(row.original.startsAt).toLocaleDateString() : "Always on"}</div>
-            <div className="text-[var(--text-muted)]">{row.original.endsAt ? new Date(row.original.endsAt).toLocaleDateString() : "No end"}</div>
-          </div>
-        ),
-      },
-      { id: "status", header: "Status", cell: ({ row }) => row.original.status },
-      {
-        id: "actions",
-        header: "",
-        cell: ({ row }) => (
-          <div className="flex justify-end gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                setEditing(row.original);
-                setForm({
-                  name: row.original.name,
-                  type: row.original.type,
-                  value: String(row.original.value),
-                  startsAt: row.original.startsAt ? row.original.startsAt.slice(0, 16) : "",
-                  endsAt: row.original.endsAt ? row.original.endsAt.slice(0, 16) : "",
-                  status: row.original.status,
-                  notes: row.original.notes ?? "",
-                });
-                setDialogOpen(true);
-              }}
-            >
-              <Pencil className="h-4 w-4" />
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => setDeleteTarget(row.original)}>
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        ),
-      },
-    ],
-    [],
+  /* chart data */
+  const typeRows = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of promotions) counts.set(p.type, (counts.get(p.type) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([label, value]) => ({ id: label, label, value }));
+  }, [promotions]);
+
+  const statusRows = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of promotions) counts.set(p.status, (counts.get(p.status) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([label, value]) => ({
+      id: label, label, value,
+      tone: label === "ACTIVE" ? ("success" as const) : label === "SCHEDULED" ? ("warning" as const) : ("default" as const),
+    }));
+  }, [promotions]);
+
+  const valueRows = useMemo(
+    () => promotions.slice().sort((a, b) => b.value - a.value).slice(0, 8).map((p) => ({
+      id: p.id, label: p.name, value: p.value,
+      tone: p.type === "PERCENT" ? ("success" as const) : ("default" as const),
+    })),
+    [promotions],
   );
 
+  const columns = useMemo<ColumnDef<Promotion>[]>(() => [
+    { id: "promoCode", header: "Promo", cell: ({ row }) => (
+      <div><div className="font-medium">{row.original.name}</div><div className="font-mono text-xs text-[var(--text-muted)]">{row.original.promoCode}</div></div>
+    )},
+    { id: "type", header: "Type", cell: ({ row }) => row.original.type },
+    { id: "value", header: "Value", cell: ({ row }) => <NumericCell>{row.original.value.toFixed(2)}</NumericCell> },
+    { id: "window", header: "Window", cell: ({ row }) => (
+      <div className="text-xs">{dateLabel(row.original.startsAt)} – {dateLabel(row.original.endsAt)}</div>
+    )},
+    { id: "status", header: "Status", cell: ({ row }) => row.original.status },
+    { id: "actions", header: "", cell: ({ row }) => (
+      <div className="flex justify-end gap-2">
+        <Button size="sm" variant="outline" onClick={() => { setEditing(row.original); setForm({
+          name: row.original.name, type: row.original.type, value: String(row.original.value),
+          startsAt: row.original.startsAt ? row.original.startsAt.slice(0, 16) : "",
+          endsAt: row.original.endsAt ? row.original.endsAt.slice(0, 16) : "",
+          status: row.original.status, notes: row.original.notes ?? "",
+        }); setDialogOpen(true); }}>
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setDeleteTarget(row.original)}>
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    )},
+  ], []);
+
   return (
-    <RetailShell
-      title="Promotions"
-      actions={
-        <div className="flex flex-wrap gap-2">
-          <Button
-            size="sm"
-            onClick={() => {
-              setEditing(null);
-              setForm(emptyForm());
-              setDialogOpen(true);
-            }}
-          >
-            <Plus className="h-4 w-4" />
-            New promotion
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/merchandising/pricing">
-              <Wallet className="h-4 w-4" />
-              Pricing
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/reports">
-              <BarChart3 className="h-4 w-4" />
-              Reports
-            </Link>
-          </Button>
-        </div>
-      }
-    >
+    <RetailShell title="Promotions" actions={
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" onClick={() => { setEditing(null); setForm(emptyForm()); setDialogOpen(true); }}>
+          <Plus className="h-4 w-4" />New
+        </Button>
+        <Button asChild size="sm" variant="outline">
+          <Link href="/retail/merchandising/pricing"><Wallet className="h-4 w-4" />Pricing</Link>
+        </Button>
+      </div>
+    }>
+      <ReportFilterBar onExport={() => {}} />
+
+      <div className="grid gap-5 xl:grid-cols-3">
+        <ReportChartShell title="Active" sourceTag={{ label: "Promotions" }}>
+          <ReportBigNumber label="Active campaigns" value={activeCount.toString()} dotColor="var(--status-success-border)" />
+        </ReportChartShell>
+        <ReportChartShell title="Total" sourceTag={{ label: "Promotions" }}>
+          <ReportBigNumber label="Total campaigns" value={promotions.length.toString()} dotColor="var(--status-info-border)" />
+        </ReportChartShell>
+        <ReportChartShell title="Types" sourceTag={{ label: "Promotions" }}>
+          <ReportBigNumber label="Type variants" value={String(new Set(promotions.map((p) => p.type)).size)} dotColor="var(--action-primary-bg)" />
+        </ReportChartShell>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+        <ReportChartShell title="Promotion values" sourceTag={{ label: "Promotions" }}>
+          <AdminDistributionChart rows={valueRows} valueLabel="Value" valueFormatter={(v) => v.toFixed(2)} height={280} />
+        </ReportChartShell>
+        <ReportChartShell title="Status" sourceTag={{ label: "Promotions" }}>
+          <AdminDonutChart rows={statusRows} valueLabel="Count" valueFormatter={(v) => v.toString()} height={280} />
+        </ReportChartShell>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+        <ReportChartShell title="Type distribution" sourceTag={{ label: "Promotions" }}>
+          <AdminDonutChart rows={typeRows} valueLabel="Count" valueFormatter={(v) => v.toString()} height={260} />
+        </ReportChartShell>
+        <ReportChartShell title="Avg value" sourceTag={{ label: "Promotions" }}>
+          <ReportBigNumber
+            label="Avg value"
+            value={promotions.length ? (promotions.reduce((s, p) => s + p.value, 0) / promotions.length).toFixed(2) : "0"}
+            dotColor="var(--action-primary-bg)"
+          />
+        </ReportChartShell>
+      </div>
+
       <DataTable
-        data={promotionsQuery.data?.data ?? []}
+        data={promotions}
         columns={columns}
         features={{ sorting: true, globalFilter: true, pagination: true }}
         pagination={{ enabled: true, server: false }}
         searchPlaceholder="Search promotions"
-        emptyState={promotionsQuery.isLoading ? "Loading promotions..." : "No promotions yet"}
-        toolbar={<span className="text-xs text-[var(--text-muted)]">Active and upcoming campaigns</span>}
+        emptyState={promotionsQuery.isLoading ? "Loading..." : "No promotions"}
       />
 
+      {/* Edit/Create Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{editing ? "Edit promotion" : "New promotion"}</DialogTitle>
-            <DialogDescription>Keep promotions short, clear, and immediately actionable.</DialogDescription>
-          </DialogHeader>
-          <form
-            className="space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              saveMutation.mutate(form);
-            }}
-          >
+          <DialogHeader><DialogTitle>{editing ? "Edit promotion" : "New promotion"}</DialogTitle></DialogHeader>
+          <form className="space-y-4" onSubmit={(e) => { e.preventDefault(); saveMutation.mutate(form); }}>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Promo code</label>
                 <Input value={editing ? editing.promoCode : promoCode} readOnly disabled={isReserving && !editing} />
-                <FieldHelp error={reserveError ?? undefined} hint={reserveError ? undefined : "Generated automatically."} />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Name</label>
-                <Input value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
+                <Input value={form.name} onChange={(e) => setForm((c) => ({ ...c, name: e.target.value }))} />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Type</label>
-                <Select value={form.type} onValueChange={(value) => setForm((current) => ({ ...current, type: value }))}>
+                <Select value={form.type} onValueChange={(v) => setForm((c) => ({ ...c, type: v }))}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="PERCENT">Percent</SelectItem>
@@ -282,19 +239,19 @@ export default function RetailPromotionsPage() {
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Value</label>
-                <Input value={form.value} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, value: event.target.value }))} />
+                <Input value={form.value} inputMode="decimal" onChange={(e) => setForm((c) => ({ ...c, value: e.target.value }))} />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Starts</label>
-                <Input type="datetime-local" value={form.startsAt} onChange={(event) => setForm((current) => ({ ...current, startsAt: event.target.value }))} />
+                <Input type="datetime-local" value={form.startsAt} onChange={(e) => setForm((c) => ({ ...c, startsAt: e.target.value }))} />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Ends</label>
-                <Input type="datetime-local" value={form.endsAt} onChange={(event) => setForm((current) => ({ ...current, endsAt: event.target.value }))} />
+                <Input type="datetime-local" value={form.endsAt} onChange={(e) => setForm((c) => ({ ...c, endsAt: e.target.value }))} />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Status</label>
-                <Select value={form.status} onValueChange={(value) => setForm((current) => ({ ...current, status: value }))}>
+                <Select value={form.status} onValueChange={(v) => setForm((c) => ({ ...c, status: v }))}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="ACTIVE">Active</SelectItem>
@@ -306,22 +263,20 @@ export default function RetailPromotionsPage() {
             </div>
             <div className="space-y-2">
               <label className="block text-sm font-semibold">Notes</label>
-              <Textarea value={form.notes} onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))} rows={3} />
+              <Textarea value={form.notes} onChange={(e) => setForm((c) => ({ ...c, notes: e.target.value }))} rows={3} />
             </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={saveMutation.isPending || !form.name}>Save promotion</Button>
+              <Button type="submit" disabled={saveMutation.isPending || !form.name}>Save</Button>
             </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
 
+      {/* Delete Dialog */}
       <Dialog open={Boolean(deleteTarget)} onOpenChange={(open) => !open && setDeleteTarget(null)}>
         <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Remove promotion</DialogTitle>
-            <DialogDescription>{deleteTarget?.name}</DialogDescription>
-          </DialogHeader>
+          <DialogHeader><DialogTitle>Remove promotion</DialogTitle></DialogHeader>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
             <Button type="button" variant="destructive" onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}>Remove</Button>

--- a/app/retail/purchasing/orders/page.tsx
+++ b/app/retail/purchasing/orders/page.tsx
@@ -6,17 +6,18 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { SearchableSelect } from "@/app/gold/components/searchable-select";
 import type { SearchableOption } from "@/app/gold/types";
+import {
+  AdminDistributionChart,
+  AdminDonutChart,
+} from "@/components/charts/admin-headless-charts";
 import { RetailShell } from "@/components/retail/retail-shell";
-import { FieldHelp } from "@/components/shared/field-help";
+import { ReportChartShell } from "@/components/retail/reports/report-chart-shell";
+import { ReportFilterBar } from "@/components/retail/reports/report-filter-bar";
+import { ReportBigNumber } from "@/components/retail/reports/report-big-number";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { NumericCell } from "@/components/ui/numeric-cell";
@@ -24,7 +25,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchInventoryItems, fetchSites } from "@/lib/api";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { LocalShipping, Package, Pencil, Plus, Trash2 } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+import { CheckCircle2, LocalShipping, Package, Pencil, Plus, ReceiptLong, Trash2 } from "@/lib/icons";
 import { useReservedId } from "@/hooks/use-reserved-id";
 
 type PurchaseOrderLine = {
@@ -50,375 +52,287 @@ type PurchaseOrder = {
   site: { id: string; name: string; code: string } | null;
 };
 
-type OrderLineForm = {
-  inventoryItemId: string;
-  itemName: string;
-  quantity: string;
-  unitCost: string;
-};
-
 type OrderForm = {
-  siteId: string;
   supplierName: string;
+  siteId: string;
   expectedDate: string;
-  status: string;
   notes: string;
-  lines: OrderLineForm[];
+  lines: Array<{
+    inventoryItemId: string;
+    itemName: string;
+    quantity: string;
+    unitCost: string;
+  }>;
 };
 
-function emptyForm(siteId = ""): OrderForm {
-  return {
-    siteId,
-    supplierName: "",
-    expectedDate: "",
-    status: "DRAFT",
-    notes: "",
-    lines: [{ inventoryItemId: "", itemName: "", quantity: "1", unitCost: "" }],
-  };
+function emptyForm(): OrderForm {
+  return { supplierName: "", siteId: "", expectedDate: "", notes: "", lines: [] };
 }
 
-export default function RetailPurchaseOrdersPage() {
+function emptyLine(item?: SearchableOption): OrderForm["lines"][0] {
+  return { inventoryItemId: item?.value ?? "", itemName: item?.label ?? "", quantity: "", unitCost: "" };
+}
+
+function money(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+}
+
+function dateLabel(iso: string | null) {
+  return iso ? new Date(iso).toLocaleDateString() : "—";
+}
+
+export default function PurchaseOrdersPage() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<PurchaseOrder | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<PurchaseOrder | null>(null);
-  const sitesQuery = useQuery({ queryKey: ["retail-sites"], queryFn: fetchSites });
-  const inventoryQuery = useQuery({
-    queryKey: ["retail-order-inventory"],
-    queryFn: () => fetchInventoryItems({ limit: 500 }),
-  });
+  const [receiveTarget, setReceiveTarget] = useState<PurchaseOrder | null>(null);
+  const [form, setForm] = useState<OrderForm>(emptyForm);
+
   const ordersQuery = useQuery({
-    queryKey: ["retail-purchase-orders"],
-    queryFn: () => fetchJson<{ data: PurchaseOrder[] }>("/api/v2/retail/purchasing/orders"),
+    queryKey: ["purchase-orders"],
+    queryFn: () => fetchJson<{ data: PurchaseOrder[] }>("/api/v2/retail/purchase-orders"),
   });
-  const [form, setForm] = useState<OrderForm>(() => emptyForm(""));
+  const sitesQuery = useQuery({ queryKey: ["retail-sites"], queryFn: fetchSites });
+  const inventoryQuery = useQuery({ queryKey: ["retail-inventory"], queryFn: fetchInventoryItems });
 
-  const {
-    reservedId: poNo,
-    isReserving,
-    error: reserveError,
-  } = useReservedId({
-    entity: "RETAIL_PURCHASE_ORDER",
-    enabled: dialogOpen && !editing && Boolean(form.siteId),
-    siteId: form.siteId || undefined,
+  const orders = ordersQuery.data?.data ?? [];
+  const draftOrders = orders.filter((o) => o.status === "DRAFT");
+  const pendingOrders = orders.filter((o) => o.status === "SENT");
+
+  const siteOptions: SearchableOption[] = useMemo(
+    () => (sitesQuery.data ?? []).map((s: { id: string; name: string }) => ({ value: s.id, label: s.name })),
+    [sitesQuery.data],
+  );
+  const itemOptions: SearchableOption[] = useMemo(
+    () => (inventoryQuery.data ?? []).map((i: { id: string; itemName: string }) => ({ value: i.id, label: i.itemName })),
+    [inventoryQuery.data],
+  );
+
+  const { reservedId: poNo, isReserving: isReservingPo, error: reservePoError } = useReservedId({
+    entity: "PURCHASE_ORDER", enabled: dialogOpen && !editing,
   });
 
-  const inventoryItems = inventoryQuery.data?.data ?? [];
-  const sites = sitesQuery.data ?? [];
-  const siteOptions = useMemo<SearchableOption[]>(
-    () => sites.map((site) => ({ value: site.id, label: site.name, meta: site.code })),
-    [sites],
-  );
-  const inventoryOptions = useMemo<SearchableOption[]>(
-    () =>
-      inventoryItems.map((item) => ({
-        value: item.id,
-        label: item.name,
-        description: `${item.currentStock.toFixed(2)} ${item.unit}`,
-        meta: item.itemCode,
-      })),
-    [inventoryItems],
-  );
+  const totalLines = (f: OrderForm) => f.lines.reduce((s, l) => s + (Number(l.quantity) || 0), 0);
+  const totalCost = (f: OrderForm) => f.lines.reduce((s, l) => s + (Number(l.quantity) || 0) * (Number(l.unitCost) || 0), 0);
 
   const saveMutation = useMutation({
-    mutationFn: async (payload: OrderForm) => {
+    mutationFn: async (f: OrderForm) => {
       const body = {
         poNo: editing ? undefined : poNo || undefined,
-        siteId: payload.siteId,
-        supplierName: payload.supplierName,
-        expectedDate: payload.expectedDate ? new Date(payload.expectedDate).toISOString() : undefined,
-        status: payload.status,
-        notes: payload.notes.trim() || undefined,
-        lines: payload.lines.map((line) => ({
-          inventoryItemId: line.inventoryItemId || undefined,
-          itemName: line.itemName.trim() || undefined,
-          quantity: Number(line.quantity),
-          unitCost: Number(line.unitCost),
+        supplierName: f.supplierName, siteId: f.siteId,
+        expectedDate: f.expectedDate ? new Date(f.expectedDate).toISOString() : undefined,
+        notes: f.notes.trim() || undefined,
+        lines: f.lines.map((l) => ({
+          inventoryItemId: l.inventoryItemId, quantity: Number(l.quantity), unitCost: Number(l.unitCost),
         })),
       };
-
-      if (editing) {
-        return fetchJson(`/api/v2/retail/purchasing/orders/${editing.id}`, {
-          method: "PATCH",
-          body: JSON.stringify(body),
-        });
-      }
-
-      return fetchJson("/api/v2/retail/purchasing/orders", {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
+      if (editing) return fetchJson(`/api/v2/retail/purchase-orders/${editing.id}`, { method: "PATCH", body: JSON.stringify(body) });
+      return fetchJson("/api/v2/retail/purchase-orders", { method: "POST", body: JSON.stringify(body) });
     },
     onSuccess: () => {
-      toast({ title: editing ? "Purchase order updated" : "Purchase order created", variant: "success" });
-      queryClient.invalidateQueries({ queryKey: ["retail-purchase-orders"] });
-      setDialogOpen(false);
-      setEditing(null);
-      setForm(emptyForm(sites[0]?.id ?? ""));
+      toast({ title: editing ? "Updated" : "Created", variant: "success" });
+      queryClient.invalidateQueries({ queryKey: ["purchase-orders"] });
+      setDialogOpen(false); setEditing(null); setForm(emptyForm());
     },
     onError: (error) => {
-      toast({
-        title: editing ? "Unable to update purchase order" : "Unable to create purchase order",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
+      toast({ title: editing ? "Update failed" : "Create failed", description: getApiErrorMessage(error), variant: "destructive" });
     },
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => fetchJson(`/api/v2/retail/purchasing/orders/${id}`, { method: "DELETE" }),
-    onSuccess: () => {
-      toast({ title: "Purchase order removed", variant: "success" });
-      queryClient.invalidateQueries({ queryKey: ["retail-purchase-orders"] });
-      setDeleteTarget(null);
-    },
-    onError: (error) => {
-      toast({
-        title: "Unable to remove purchase order",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
-    },
+    mutationFn: (id: string) => fetchJson(`/api/v2/retail/purchase-orders/${id}`, { method: "DELETE" }),
+    onSuccess: () => { toast({ title: "Removed", variant: "success" }); queryClient.invalidateQueries({ queryKey: ["purchase-orders"] }); setDeleteTarget(null); },
+    onError: (error) => { toast({ title: "Remove failed", description: getApiErrorMessage(error), variant: "destructive" }); },
   });
 
-  const columns = useMemo<ColumnDef<PurchaseOrder>[]>(
-    () => [
-      {
-        id: "poNo",
-        header: "PO #",
-        cell: ({ row }) => (
-          <div>
-            <div className="font-mono font-semibold">{row.original.poNo}</div>
-            <div className="text-xs text-[var(--text-muted)]">{row.original.site?.name ?? "No site"}</div>
-          </div>
-        ),
-      },
-      {
-        id: "supplierName",
-        header: "Supplier",
-        cell: ({ row }) => row.original.supplierName,
-      },
-      {
-        id: "status",
-        header: "Status",
-        cell: ({ row }) => row.original.status,
-      },
-      {
-        id: "expectedDate",
-        header: "Expected",
-        cell: ({ row }) => (
-          <NumericCell align="left">
-            {row.original.expectedDate ? new Date(row.original.expectedDate).toLocaleDateString() : "-"}
-          </NumericCell>
-        ),
-      },
-      {
-        id: "qty",
-        header: "Qty",
-        cell: ({ row }) => <NumericCell>{row.original.totalQuantity.toFixed(2)}</NumericCell>,
-      },
-      {
-        id: "value",
-        header: "Value",
-        cell: ({ row }) => <NumericCell>{row.original.totalValue.toFixed(2)}</NumericCell>,
-      },
-      {
-        id: "actions",
-        header: "",
-        cell: ({ row }) => (
-          <div className="flex justify-end gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                setEditing(row.original);
-                setForm({
-                  siteId: row.original.siteId,
-                  supplierName: row.original.supplierName,
-                  expectedDate: row.original.expectedDate ? row.original.expectedDate.slice(0, 10) : "",
-                  status: row.original.status,
-                  notes: row.original.notes ?? "",
-                  lines: row.original.lines.map((line) => ({
-                    inventoryItemId: line.inventoryItemId ?? "",
-                    itemName: line.itemName,
-                    quantity: String(line.quantity),
-                    unitCost: String(line.unitCost),
-                  })),
-                });
-                setDialogOpen(true);
-              }}
-            >
-              <Pencil className="h-4 w-4" />
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => setDeleteTarget(row.original)}>
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        ),
-      },
-    ],
-    [],
-  );
+  const receiveMutation = useMutation({
+    mutationFn: (id: string) => fetchJson(`/api/v2/retail/purchase-orders/${id}/receive`, { method: "POST" }),
+    onSuccess: () => { toast({ title: "Received", variant: "success" }); queryClient.invalidateQueries({ queryKey: ["purchase-orders"] }); setReceiveTarget(null); },
+    onError: (error) => { toast({ title: "Receive failed", description: getApiErrorMessage(error), variant: "destructive" }); },
+  });
+
+  /* chart data */
+  const statusRows = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const o of orders) counts.set(o.status, (counts.get(o.status) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([label, value]) => ({
+      id: label, label, value,
+      tone: label === "SENT" ? ("success" as const) : label === "DRAFT" ? ("warning" as const) : ("default" as const),
+    }));
+  }, [orders]);
+
+  const supplierRows = useMemo(() => {
+    const supplierTotals = new Map<string, number>();
+    for (const o of orders) supplierTotals.set(o.supplierName, (supplierTotals.get(o.supplierName) ?? 0) + o.totalValue);
+    return Array.from(supplierTotals.entries())
+      .sort(([, a], [, b]) => b - a).slice(0, 8)
+      .map(([label, value]) => ({ id: label, label, value }));
+  }, [orders]);
+
+  const columns = useMemo<ColumnDef<PurchaseOrder>[]>(() => [
+    { id: "poNo", header: "PO", cell: ({ row }) => (
+      <div><div className="font-mono font-semibold">{row.original.poNo}</div><div className="text-xs text-[var(--text-muted)]">{row.original.supplierName}</div></div>
+    )},
+    { id: "site", header: "Site", cell: ({ row }) => row.original.site?.name ?? "—" },
+    { id: "status", header: "Status", cell: ({ row }) => row.original.status },
+    { id: "totalValue", header: "Value", cell: ({ row }) => <NumericCell>{money(row.original.totalValue)}</NumericCell> },
+    { id: "lines", header: "Lines", cell: ({ row }) => (
+      <div className="text-right text-xs">{row.original.totalQuantity} / {row.original.receivedQuantity} received</div>
+    )},
+    { id: "expectedDate", header: "Expected", cell: ({ row }) => dateLabel(row.original.expectedDate) },
+    { id: "actions", header: "", cell: ({ row }) => (
+      <div className="flex justify-end gap-2">
+        {row.original.status === "SENT" && (
+          <Button size="sm" variant="outline" onClick={() => setReceiveTarget(row.original)}>
+            <CheckCircle2 className="h-4 w-4" />
+          </Button>
+        )}
+        <Button size="sm" variant="outline" onClick={() => { setEditing(row.original); setForm({
+          supplierName: row.original.supplierName, siteId: row.original.siteId,
+          expectedDate: row.original.expectedDate ? row.original.expectedDate.slice(0, 16) : "",
+          notes: row.original.notes ?? "",
+          lines: row.original.lines.map((l) => ({ inventoryItemId: l.inventoryItemId ?? "", itemName: l.itemName, quantity: String(l.quantity), unitCost: String(l.unitCost) })),
+        }); setDialogOpen(true); }}>
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setDeleteTarget(row.original)}>
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    )},
+  ], []);
 
   return (
-    <RetailShell
-      title="Purchasing"
-      actions={
-        <div className="flex flex-wrap gap-2">
-          <Button
-            size="sm"
-            onClick={() => {
-              setEditing(null);
-              setForm(emptyForm(sites[0]?.id ?? ""));
-              setDialogOpen(true);
-            }}
-          >
-            <Plus className="h-4 w-4" />
-            New PO
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/purchasing/receipts">
-              <LocalShipping className="h-4 w-4" />
-              Post Receipt
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/stores/inventory">
-              <Package className="h-4 w-4" />
-              Stock on Hand
-            </Link>
-          </Button>
-        </div>
-      }
-    >
+    <RetailShell title="Purchase orders" actions={
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" onClick={() => { setEditing(null); setForm(emptyForm()); setDialogOpen(true); }}><Plus className="h-4 w-4" />New</Button>
+        <Button asChild size="sm" variant="outline"><Link href="/retail/purchasing/suppliers"><LocalShipping className="h-4 w-4" />Suppliers</Link></Button>
+      </div>
+    }>
+      <ReportFilterBar onExport={() => {}} />
+
+      <div className="grid gap-5 xl:grid-cols-3">
+        <ReportChartShell title="Order value" sourceTag={{ label: "PO" }}>
+          <ReportBigNumber label="Total" value={money(orders.reduce((s, o) => s + o.totalValue, 0))} />
+        </ReportChartShell>
+        <ReportChartShell title="Draft" sourceTag={{ label: "PO" }}>
+          <ReportBigNumber label="Draft orders" value={draftOrders.length.toString()} dotColor="var(--status-warning-border)" />
+        </ReportChartShell>
+        <ReportChartShell title="Pending" sourceTag={{ label: "PO" }}>
+          <ReportBigNumber label="Awaiting receipt" value={pendingOrders.length.toString()} dotColor="var(--status-success-border)" />
+        </ReportChartShell>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+        <ReportChartShell title="Top suppliers" sourceTag={{ label: "PO" }}>
+          <AdminDistributionChart rows={supplierRows} valueLabel="Value" valueFormatter={money} height={280} />
+        </ReportChartShell>
+        <ReportChartShell title="Status breakdown" sourceTag={{ label: "PO" }}>
+          <AdminDonutChart rows={statusRows} valueLabel="Orders" valueFormatter={(v) => v.toString()} height={280} />
+        </ReportChartShell>
+      </div>
+
       <DataTable
-        data={ordersQuery.data?.data ?? []}
+        data={orders}
         columns={columns}
         features={{ sorting: true, globalFilter: true, pagination: true }}
         pagination={{ enabled: true, server: false }}
-        searchPlaceholder="Search purchase orders"
-        emptyState={ordersQuery.isLoading ? "Loading purchase orders..." : "No purchase orders yet"}
-        toolbar={<span className="text-xs text-[var(--text-muted)]">Open purchasing workload</span>}
+        searchPlaceholder="Search orders"
+        emptyState={ordersQuery.isLoading ? "Loading..." : "No orders"}
       />
 
-      <Dialog
-        open={dialogOpen}
-        onOpenChange={(open) => {
-          setDialogOpen(open);
-          if (!open) {
-            setEditing(null);
-          }
-        }}
-      >
-        <DialogContent className="sm:max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>{editing ? "Edit purchase order" : "New purchase order"}</DialogTitle>
-            <DialogDescription>Use shared stock items so receiving posts cleanly into Stores.</DialogDescription>
-          </DialogHeader>
-          <form
-            className="space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              saveMutation.mutate(form);
-            }}
-          >
+      {/* Edit/Create Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[96dvh] overflow-y-auto sm:max-w-2xl">
+          <DialogHeader><DialogTitle>{editing ? "Edit order" : "New order"}</DialogTitle></DialogHeader>
+          <form className="space-y-4" onSubmit={(e) => { e.preventDefault(); if (!form.supplierName || !form.siteId) { toast({ title: "Fill required fields", variant: "destructive" }); return; } saveMutation.mutate(form); }}>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">PO number</label>
-                <Input value={editing ? editing.poNo : poNo} readOnly disabled={isReserving && !editing} />
-                <FieldHelp error={reserveError ?? undefined} hint={reserveError ? undefined : "Generated automatically."} />
+                <Input value={editing ? editing.poNo : (poNo ?? (isReservingPo ? "Reserving..." : reservePoError ?? ""))} readOnly />
               </div>
-              <SearchableSelect
-                label="Site"
-                value={form.siteId}
-                options={siteOptions}
-                placeholder="Select site"
-                onValueChange={(value) => setForm((current) => ({ ...current, siteId: value }))}
-              />
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Supplier</label>
-                <Input value={form.supplierName} onChange={(event) => setForm((current) => ({ ...current, supplierName: event.target.value }))} />
+                <Input value={form.supplierName} onChange={(e) => setForm((c) => ({ ...c, supplierName: e.target.value }))} />
+              </div>
+              <div className="space-y-2">
+                <label className="block text-sm font-semibold">Site</label>
+                <SearchableSelect options={siteOptions} value={form.siteId} onSelect={(v) => setForm((c) => ({ ...c, siteId: v }))} searchPlaceholder="Search sites" />
               </div>
               <div className="space-y-2">
                 <label className="block text-sm font-semibold">Expected date</label>
-                <Input type="date" value={form.expectedDate} onChange={(event) => setForm((current) => ({ ...current, expectedDate: event.target.value }))} />
+                <Input type="date" value={form.expectedDate} onChange={(e) => setForm((c) => ({ ...c, expectedDate: e.target.value }))} />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <label className="block text-sm font-semibold">Notes</label>
+                <Textarea value={form.notes} onChange={(e) => setForm((c) => ({ ...c, notes: e.target.value }))} rows={2} />
               </div>
             </div>
 
-            <div className="space-y-3">
-              {form.lines.map((line, index) => (
-                <div key={index} className="rounded-2xl bg-[var(--surface-muted)] p-3">
-                  <div className="grid gap-4 md:grid-cols-[1.2fr_1fr_120px_120px_auto]">
-                    <SearchableSelect
-                      label="Stock item"
-                      value={line.inventoryItemId}
-                      options={inventoryOptions}
-                      placeholder="Select stock item"
-                      onValueChange={(value) => {
-                        const inventoryItem = inventoryItems.find((item) => item.id === value);
-                        setForm((current) => ({
-                          ...current,
-                          lines: current.lines.map((entry, entryIndex) =>
-                            entryIndex === index
-                              ? {
-                                  ...entry,
-                                  inventoryItemId: value,
-                                  itemName: entry.itemName || inventoryItem?.name || "",
-                                }
-                              : entry,
-                          ),
-                        }));
-                      }}
-                      onAddOption={() => window.location.assign("/stores/inventory")}
-                      addLabel="Add new stock item"
-                    />
-                    <div className="space-y-2">
-                      <label className="block text-sm font-semibold">Item name</label>
-                      <Input value={line.itemName} onChange={(event) => setForm((current) => ({ ...current, lines: current.lines.map((entry, entryIndex) => entryIndex === index ? { ...entry, itemName: event.target.value } : entry) }))} />
+            {/* Lines */}
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-sm font-semibold">Lines</span>
+                <span className="font-mono text-sm font-semibold">{totalLines(form)} · {money(totalCost(form))}</span>
+              </div>
+              <div className="space-y-2">
+                {form.lines.map((line, idx) => (
+                  <div key={idx} className="grid grid-cols-[1fr_90px_100px_32px] items-end gap-2">
+                    <div>
+                      <SearchableSelect
+                        options={itemOptions} value={line.inventoryItemId}
+                        onSelect={(val, opt) => setForm((c) => { const next = [...c.lines]; next[idx] = { ...next[idx], inventoryItemId: val, itemName: opt?.label ?? "" }; return { ...c, lines: next }; })}
+                        searchPlaceholder="Search items" className="w-full"
+                      />
                     </div>
-                    <div className="space-y-2">
-                      <label className="block text-sm font-semibold">Qty</label>
-                      <Input value={line.quantity} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, lines: current.lines.map((entry, entryIndex) => entryIndex === index ? { ...entry, quantity: event.target.value } : entry) }))} />
-                    </div>
-                    <div className="space-y-2">
-                      <label className="block text-sm font-semibold">Unit cost</label>
-                      <Input value={line.unitCost} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, lines: current.lines.map((entry, entryIndex) => entryIndex === index ? { ...entry, unitCost: event.target.value } : entry) }))} />
-                    </div>
-                    <div className="flex items-end">
-                      <Button type="button" variant="outline" onClick={() => setForm((current) => ({ ...current, lines: current.lines.filter((_, entryIndex) => entryIndex !== index) || current.lines }))} disabled={form.lines.length === 1}>
-                        Remove
-                      </Button>
-                    </div>
+                    <Input inputMode="decimal" placeholder="Qty" value={line.quantity}
+                      onChange={(e) => setForm((c) => { const next = [...c.lines]; next[idx] = { ...next[idx], quantity: e.target.value }; return { ...c, lines: next }; })} />
+                    <Input inputMode="decimal" placeholder="Cost" value={line.unitCost}
+                      onChange={(e) => setForm((c) => { const next = [...c.lines]; next[idx] = { ...next[idx], unitCost: e.target.value }; return { ...c, lines: next }; })} />
+                    <Button type="button" size="sm" variant="ghost" onClick={() => setForm((c) => ({ ...c, lines: c.lines.filter((_, i) => i !== idx) }))}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </div>
-                </div>
-              ))}
-              <Button type="button" variant="outline" onClick={() => setForm((current) => ({ ...current, lines: [...current.lines, { inventoryItemId: "", itemName: "", quantity: "1", unitCost: "" }] }))}>
-                Add line
-              </Button>
+                ))}
+                <Button type="button" size="sm" variant="ghost" onClick={() => setForm((c) => ({ ...c, lines: [...c.lines, emptyLine()] }))}>Add line</Button>
+              </div>
             </div>
 
-            <div className="space-y-2">
-              <label className="block text-sm font-semibold">Notes</label>
-              <Textarea value={form.notes} onChange={(event) => setForm((current) => ({ ...current, notes: event.target.value }))} rows={3} />
-            </div>
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={saveMutation.isPending || !form.siteId || !form.supplierName}>Save PO</Button>
+              <Button type="submit" disabled={saveMutation.isPending}>Save</Button>
             </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
 
+      {/* Delete Dialog */}
       <Dialog open={Boolean(deleteTarget)} onOpenChange={(open) => !open && setDeleteTarget(null)}>
         <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Remove purchase order</DialogTitle>
-            <DialogDescription>{deleteTarget?.poNo}</DialogDescription>
-          </DialogHeader>
+          <DialogHeader><DialogTitle>Remove order</DialogTitle></DialogHeader>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setDeleteTarget(null)}>Cancel</Button>
             <Button type="button" variant="destructive" onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}>Remove</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Receive Dialog */}
+      <Dialog open={Boolean(receiveTarget)} onOpenChange={(open) => !open && setReceiveTarget(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader><DialogTitle>Receive order</DialogTitle></DialogHeader>
+          <div className="space-y-3 text-sm">
+            <div className="font-mono font-semibold">{receiveTarget?.poNo}</div>
+            <div>{receiveTarget?.supplierName}</div>
+            <div className="text-[var(--text-muted)]">{receiveTarget?.totalQuantity} items · {money(receiveTarget?.totalValue ?? 0)}</div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setReceiveTarget(null)}>Cancel</Button>
+            <Button type="button" onClick={() => receiveTarget && receiveMutation.mutate(receiveTarget.id)}>
+              <CheckCircle2 className="mr-1 h-4 w-4" /> Confirm receive
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/app/retail/reports/page.tsx
+++ b/app/retail/reports/page.tsx
@@ -1,243 +1,464 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
-import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
 import {
-  AdminDistributionChart,
-  AdminDualBarChart,
-  AdminDonutChart,
   AdminTrendChart,
+  AdminDonutChart,
+  AdminDualBarChart,
+  AdminDistributionChart,
 } from "@/components/charts/admin-headless-charts";
 import { RetailShell } from "@/components/retail/retail-shell";
-import { Button } from "@/components/ui/button";
+import { ReportChartShell } from "@/components/retail/reports/report-chart-shell";
+import { ReportFilterBar } from "@/components/retail/reports/report-filter-bar";
+import { ReportBigNumber } from "@/components/retail/reports/report-big-number";
+import { ReportExportButton } from "@/components/retail/reports/report-export-button";
 import { DataTable } from "@/components/ui/data-table";
 import { NumericCell } from "@/components/ui/numeric-cell";
-import { VerticalDataViews } from "@/components/ui/vertical-data-views";
 import { fetchJson } from "@/lib/api-client";
-import { ClipboardList, LocalShipping, ReceiptLong } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+import {
+  BarChart3,
+  Wallet,
+  Package,
+  Clock,
+  Store,
+  Receipt,
+} from "@/lib/icons";
+import type { ColumnDef } from "@tanstack/react-table";
 
-type RetailDashboardPayload = {
-  salesTrend: Array<{ id: string; label: string; sales: number; tickets: number }>;
-  tenderMix: Array<{ tenderType: string; amount: number }>;
-  topItems: Array<{ itemName: string; quantity: number; value: number }>;
-  recentSales: Array<{ id: string; saleNo: string; postedAt: string; cashierName: string | null; totalAmount: number; itemCount: number; tenderTypes: string[] }>;
-  lowStock: Array<{ id: string; itemCode: string; name: string; currentStock: number; minStock: number; unit: string }>;
+/* ── types ────────────────────────────────────────────── */
+type SaleRow = {
+  id: string;
+  saleNo: string;
+  saleType: string;
+  status: string;
+  cashierName: string | null;
+  customerName: string | null;
+  postedAt: string;
+  totalAmount: number;
+  itemCount: number;
+  tenderTypes: string[];
 };
 
-export default function RetailReportsPage() {
-  const [activeView, setActiveView] = useState("items");
-  const { data, isLoading } = useQuery({
-    queryKey: ["retail-reports-overview"],
-    queryFn: () => fetchJson<RetailDashboardPayload>("/api/v2/retail"),
+type ShiftRow = {
+  id: string;
+  shiftNo: string;
+  registerName: string;
+  site: { name: string } | null;
+  cashierName: string;
+  openingFloat: number;
+  expectedCash: number;
+  countedCash: number | null;
+  variance: number | null;
+  status: string;
+  openedAt: string;
+  salesValue: number;
+  saleCount: number;
+};
+
+type StockItem = {
+  id: string;
+  itemCode: string;
+  name: string;
+  currentStock: number;
+  minStock: number;
+  unit: string;
+};
+
+type CustomerRow = {
+  customerId: string | null;
+  customerName: string;
+  visits: number;
+  totalSpend: number;
+  loyaltyTier: string;
+};
+
+const TABS = [
+  { id: "pos-policy", label: "POS Policy", icon: Receipt },
+  { id: "operations", label: "Operations", icon: Store },
+  { id: "reports", label: "Reports", icon: BarChart3 },
+  { id: "stock", label: "Stock Overview", icon: Package },
+  { id: "sales", label: "Sales", icon: Wallet },
+  { id: "shifts", label: "Shifts", icon: Clock },
+] as const;
+
+function money(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function dateLabel(iso: string) {
+  return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/* ── main page ────────────────────────────────────────── */
+export default function RetailReportsHubPage() {
+  const [activeTab, setActiveTab] = useState<string>("operations");
+
+  /* Shared data queries */
+  const salesQuery = useQuery({
+    queryKey: ["retail-reports-sales"],
+    queryFn: () => fetchJson<{ data: SaleRow[]; summary: Record<string, number> }>("/api/v2/retail/pos/sales?limit=200"),
+  });
+  const shiftsQuery = useQuery({
+    queryKey: ["retail-reports-shifts"],
+    queryFn: () => fetchJson<{ data: ShiftRow[] }>("/api/v2/retail/shifts"),
+  });
+  const stockQuery = useQuery({
+    queryKey: ["retail-reports-stock"],
+    queryFn: () => fetchJson<{ summary: { lowStockCount: number }; lowStock: StockItem[] }>("/api/v2/retail"),
+  });
+  const customersQuery = useQuery({
+    queryKey: ["retail-reports-customers"],
+    queryFn: () => fetchJson<{ data: CustomerRow[] }>("/api/v2/retail/customers"),
   });
 
-  const itemColumns = useMemo<ColumnDef<RetailDashboardPayload["topItems"][number]>[]>(
-    () => [
-      { id: "itemName", header: "Item", cell: ({ row }) => row.original.itemName },
-      { id: "quantity", header: "Units", cell: ({ row }) => <NumericCell>{row.original.quantity.toFixed(2)}</NumericCell> },
-      { id: "value", header: "Sales", cell: ({ row }) => <NumericCell>{row.original.value.toFixed(2)}</NumericCell> },
-    ],
-    [],
-  );
-  const salesColumns = useMemo<ColumnDef<RetailDashboardPayload["recentSales"][number]>[]>(
-    () => [
-      { id: "saleNo", header: "Sale #", cell: ({ row }) => <span className="font-mono">{row.original.saleNo}</span> },
-      { id: "postedAt", header: "Date", cell: ({ row }) => <NumericCell align="left">{new Date(row.original.postedAt).toLocaleDateString()}</NumericCell> },
-      { id: "cashierName", header: "Cashier", cell: ({ row }) => row.original.cashierName ?? "-" },
-      { id: "itemCount", header: "Items", cell: ({ row }) => <NumericCell>{row.original.itemCount}</NumericCell> },
-      { id: "totalAmount", header: "Value", cell: ({ row }) => <NumericCell>{row.original.totalAmount.toFixed(2)}</NumericCell> },
-    ],
-    [],
-  );
-  const stockColumns = useMemo<ColumnDef<RetailDashboardPayload["lowStock"][number]>[]>(
-    () => [
-      { id: "name", header: "Item", cell: ({ row }) => row.original.name },
-      { id: "itemCode", header: "Code", cell: ({ row }) => <span className="font-mono">{row.original.itemCode}</span> },
-      { id: "currentStock", header: "On hand", cell: ({ row }) => <NumericCell>{`${row.original.currentStock.toFixed(2)} ${row.original.unit}`}</NumericCell> },
-      { id: "minStock", header: "Min", cell: ({ row }) => <NumericCell>{`${row.original.minStock.toFixed(2)} ${row.original.unit}`}</NumericCell> },
-    ],
-    [],
-  );
+  const sales = salesQuery.data?.data ?? [];
+  const shifts = shiftsQuery.data?.data ?? [];
+  const stockItems = stockQuery.data?.lowStock ?? [];
+  const customers = customersQuery.data?.data ?? [];
 
-  const chartRows = useMemo(
-    () =>
-      (data?.salesTrend ?? []).map((bucket) => ({
-        id: bucket.id,
-        label: bucket.label,
-        sales: bucket.sales,
-        tickets: bucket.tickets,
-      })),
-    [data?.salesTrend],
-  );
+  /* ── derived data ───────────────────────────────────── */
+  const salesTrend = useMemo(() => {
+    const buckets = new Map<string, { label: string; sales: number; refunds: number; voids: number; tickets: number }>();
+    for (const s of sales) {
+      const key = s.postedAt.slice(0, 10);
+      const label = dateLabel(s.postedAt);
+      const cur = buckets.get(key) ?? { label, sales: 0, refunds: 0, voids: 0, tickets: 0 };
+      cur.tickets++;
+      if (s.saleType === "REFUND") cur.refunds += Math.abs(s.totalAmount);
+      else if (s.saleType === "VOID" || s.status === "VOIDED") cur.voids += Math.abs(s.totalAmount);
+      else cur.sales += s.totalAmount;
+      buckets.set(key, cur);
+    }
+    return Array.from(buckets.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([id, v]) => ({ id, label: v.label, sales: v.sales, refunds: v.refunds, voids: v.voids, tickets: v.tickets }));
+  }, [sales]);
 
-  const tenderRows = useMemo(
-    () =>
-      (data?.tenderMix ?? []).map((row) => ({
-        id: row.tenderType,
-        label: row.tenderType.replaceAll("_", " "),
-        value: row.amount,
-      })),
-    [data?.tenderMix],
-  );
-
-  const topItemRows = useMemo(
-    () =>
-      (data?.topItems ?? []).slice(0, 8).map((item) => ({
-        id: item.itemName,
-        label: item.itemName,
-        primary: item.value,
-        secondary: item.quantity,
-      })),
-    [data?.topItems],
-  );
-
-  const stockRows = useMemo(
-    () =>
-      (data?.lowStock ?? []).slice(0, 8).map((item) => ({
-        id: item.id,
-        label: item.itemCode,
-        value: Math.max(item.minStock - item.currentStock, 0),
-        tone: item.currentStock < item.minStock ? ("warning" as const) : ("success" as const),
-      })),
-    [data?.lowStock],
-  );
-
-  return (
-    <RetailShell
-      title="Reports"
-      actions={
-        <div className="flex flex-wrap gap-2">
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/sales">
-              <ClipboardList className="h-4 w-4" />
-              Sales Queue
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/purchasing/receipts">
-              <LocalShipping className="h-4 w-4" />
-              Receipts
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/retail/shifts">
-              <ReceiptLong className="h-4 w-4" />
-              Shifts & Cash-up
-            </Link>
-          </Button>
-        </div>
+  const tenderMix = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of sales) {
+      for (const t of s.tenderTypes) {
+        counts.set(t, (counts.get(t) ?? 0) + 1);
       }
-    >
-      <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <h2 className="text-2xl font-semibold text-[var(--text-strong)]">Trend and tender mix</h2>
-          <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Recent tickets</p>
-            <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
-              {(data?.salesTrend ?? []).reduce((sum, bucket) => sum + bucket.tickets, 0)}
-            </p>
+    }
+    return Array.from(counts.entries()).map(([label, value]) => ({ id: label, label, value }));
+  }, [sales]);
+
+  const typeMix = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of sales) {
+      const key = s.saleType === "SALE" ? "Sales" : s.saleType === "REFUND" ? "Refunds" : "Voids";
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).map(([label, value]) => ({
+      id: label, label, value,
+      tone: label === "Sales" ? ("success" as const) : label === "Refunds" ? ("warning" as const) : ("danger" as const),
+    }));
+  }, [sales]);
+
+  const shiftTrend = useMemo(() => {
+    const buckets = new Map<string, { label: string; sales: number; variance: number; count: number }>();
+    for (const s of shifts) {
+      const key = s.openedAt.slice(0, 10);
+      const label = dateLabel(s.openedAt);
+      const cur = buckets.get(key) ?? { label, sales: 0, variance: 0, count: 0 };
+      cur.sales += s.salesValue;
+      cur.variance += Math.abs(s.variance ?? 0);
+      cur.count++;
+      buckets.set(key, cur);
+    }
+    return Array.from(buckets.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([id, v]) => ({ id, label: v.label, sales: v.sales, variance: v.variance, count: v.count }));
+  }, [shifts]);
+
+  const shiftStatus = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of shifts) counts.set(s.status, (counts.get(s.status) ?? 0) + 1);
+    return Array.from(counts.entries()).map(([label, value]) => ({
+      id: label, label, value,
+      tone: label === "OPEN" ? ("success" as const) : ("default" as const),
+    }));
+  }, [shifts]);
+
+  const topCashiers = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of sales) counts.set(s.cashierName ?? "Unknown", (counts.get(s.cashierName ?? "Unknown") ?? 0) + 1);
+    return Array.from(counts.entries())
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 8)
+      .map(([label, value]) => ({ id: label, label, value }));
+  }, [sales]);
+
+  const topTickets = useMemo(() =>
+    sales
+      .slice()
+      .sort((a, b) => b.totalAmount - a.totalAmount)
+      .slice(0, 8)
+      .map((s) => ({ id: s.id, label: s.saleNo, primary: s.totalAmount, secondary: s.itemCount })),
+    [sales],
+  );
+
+  const stockHealth = useMemo(() => [
+    { id: "ok", label: "OK", value: stockItems.filter((i) => i.currentStock > i.minStock).length, tone: "success" as const },
+    { id: "low", label: "Low", value: stockItems.filter((i) => i.currentStock > 0 && i.currentStock <= i.minStock).length, tone: "warning" as const },
+    { id: "critical", label: "Critical", value: stockItems.filter((i) => i.currentStock <= 0).length, tone: "danger" as const },
+  ], [stockItems]);
+
+  const stockGap = useMemo(() =>
+    stockItems
+      .slice()
+      .sort((a, b) => (b.minStock - b.currentStock) - (a.minStock - a.currentStock))
+      .slice(0, 8)
+      .map((i) => ({ id: i.id, label: i.name, value: Math.max(i.minStock - i.currentStock, 0), tone: ("warning" as const) })),
+    [stockItems],
+  );
+
+  const customerSpend = useMemo(() =>
+    customers
+      .slice()
+      .sort((a, b) => b.totalSpend - a.totalSpend)
+      .slice(0, 8)
+      .map((c) => ({ id: c.customerId ?? c.customerName, label: c.customerName, primary: c.totalSpend, secondary: c.visits })),
+    [customers],
+  );
+
+  /* ── table columns ──────────────────────────────────── */
+  const saleColumns: ColumnDef<SaleRow>[] = useMemo(() => [
+    { id: "saleNo", header: "Transaction", cell: ({ row }) => <div className="font-mono font-semibold">{row.original.saleNo}</div> },
+    { id: "type", header: "Type", cell: ({ row }) => row.original.saleType },
+    { id: "postedAt", header: "Posted", cell: ({ row }) => dateLabel(row.original.postedAt) },
+    { id: "cashier", header: "Cashier", cell: ({ row }) => row.original.cashierName ?? "-" },
+    { id: "customer", header: "Customer", cell: ({ row }) => row.original.customerName ?? "Walk-in" },
+    { id: "total", header: "Total", cell: ({ row }) => <NumericCell>{money(row.original.totalAmount)}</NumericCell> },
+    { id: "items", header: "Items", cell: ({ row }) => <NumericCell>{row.original.itemCount}</NumericCell> },
+  ], []);
+
+  const shiftColumns: ColumnDef<ShiftRow>[] = useMemo(() => [
+    { id: "shiftNo", header: "Shift", cell: ({ row }) => <div className="font-mono font-semibold">{row.original.shiftNo}</div> },
+    { id: "register", header: "Register", cell: ({ row }) => row.original.registerName },
+    { id: "cashier", header: "Cashier", cell: ({ row }) => row.original.cashierName },
+    { id: "status", header: "Status", cell: ({ row }) => row.original.status },
+    { id: "sales", header: "Sales", cell: ({ row }) => <NumericCell>{money(row.original.salesValue)}</NumericCell> },
+    { id: "variance", header: "Variance", cell: ({ row }) => <NumericCell>{money(Math.abs(row.original.variance ?? 0))}</NumericCell> },
+  ], []);
+
+  const netSales = salesQuery.data?.summary.netSales ?? 0;
+  const grossSales = salesQuery.data?.summary.grossSales ?? 0;
+  const openShifts = shifts.filter((s) => s.status === "OPEN").length;
+
+  /* ── render ─────────────────────────────────────────── */
+  return (
+    <RetailShell title="Reports" actions={undefined}>
+      {/* Tab bar */}
+      <div className="flex gap-1 overflow-x-auto rounded-2xl bg-[var(--surface-muted)] p-1">
+        {TABS.map((tab) => {
+          const Icon = tab.icon;
+          const active = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                "flex items-center gap-2 whitespace-nowrap rounded-xl px-4 py-2.5 text-sm font-medium transition-all",
+                active
+                  ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-sm"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-strong)]",
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── OPERATIONS TAB ─────────────────────────────── */}
+      {activeTab === "operations" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-3">
+            <ReportChartShell title="Net sales" sourceTag={{ label: "Sales" }}>
+              <ReportBigNumber label="Net" value={money(netSales)} />
+            </ReportChartShell>
+            <ReportChartShell title="Gross sales" sourceTag={{ label: "Sales" }}>
+              <ReportBigNumber label="Gross" value={money(grossSales)} dotColor="var(--status-success-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Transactions" sourceTag={{ label: "POS" }}>
+              <ReportBigNumber label="Total tickets" value={sales.length.toString()} dotColor="var(--status-info-border)" />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Sales trend" sourceTag={{ label: "POS" }} legend={[{ label: "Sales", color: "var(--status-success-border)" }, { label: "Refunds", color: "var(--status-warning-border)" }, { label: "Voids", color: "var(--status-danger-border)" }]}>
+              <AdminTrendChart rows={salesTrend} series={[
+                { key: "sales", label: "Sales", kind: "area", tone: "success", fillOpacity: 0.12 },
+                { key: "refunds", label: "Refunds", kind: "line", tone: "warning", dashed: true },
+                { key: "voids", label: "Voids", kind: "line", tone: "danger", dashed: true },
+              ]} height={280} valueFormatter={money} yTickFormatter={money} />
+            </ReportChartShell>
+            <ReportChartShell title="Transaction mix" sourceTag={{ label: "POS" }}>
+              <AdminDonutChart rows={typeMix} valueLabel="Transactions" valueFormatter={(v) => v.toString()} height={280} />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Tender distribution" sourceTag={{ label: "Payments" }}>
+              <AdminDistributionChart rows={tenderMix} valueLabel="Count" valueFormatter={(v) => v.toString()} height={260} />
+            </ReportChartShell>
+            <ReportChartShell title="Top cashiers" sourceTag={{ label: "Staff" }}>
+              <AdminDistributionChart rows={topCashiers} valueLabel="Txns" valueFormatter={(v) => v.toString()} height={260} />
+            </ReportChartShell>
+          </div>
+          <DataTable data={sales} columns={saleColumns} features={{ sorting: true, globalFilter: true, pagination: true }} pagination={{ enabled: true, server: false }} searchPlaceholder="Search transactions" />
+        </div>
+      )}
+
+      {/* ── POS POLICY TAB ─────────────────────────────── */}
+      {activeTab === "pos-policy" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-3">
+            <ReportChartShell title="Total transactions" sourceTag={{ label: "POS" }}>
+              <ReportBigNumber label="Transactions" value={sales.length.toString()} />
+            </ReportChartShell>
+            <ReportChartShell title="Average ticket" sourceTag={{ label: "POS" }}>
+              <ReportBigNumber label="Avg ticket" value={money(sales.length ? sales.reduce((s, r) => s + r.totalAmount, 0) / sales.length : 0)} dotColor="var(--status-success-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Exceptions" sourceTag={{ label: "POS" }}>
+              <ReportBigNumber label="Voids + Refunds" value={(sales.filter((s) => s.saleType !== "SALE").length).toString()} dotColor="var(--status-danger-border)" />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Daily volume" sourceTag={{ label: "POS" }} legend={[{ label: "Tickets", color: "var(--action-primary-bg)" }]}>
+              <AdminTrendChart rows={salesTrend} series={[
+                { key: "tickets", label: "Tickets", kind: "bar", tone: "default" },
+              ]} height={280} valueFormatter={(v) => v.toString()} />
+            </ReportChartShell>
+            <ReportChartShell title="Type breakdown" sourceTag={{ label: "POS" }}>
+              <AdminDonutChart rows={typeMix} valueLabel="Transactions" valueFormatter={(v) => v.toString()} height={280} />
+            </ReportChartShell>
+          </div>
+          <DataTable data={sales} columns={saleColumns} features={{ sorting: true, globalFilter: true, pagination: true }} pagination={{ enabled: true, server: false }} searchPlaceholder="Search transactions" />
+        </div>
+      )}
+
+      {/* ── REPORTS TAB ────────────────────────────────── */}
+      {activeTab === "reports" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Sales by day" sourceTag={{ label: "Sales" }} legend={[{ label: "Sales", color: "var(--status-success-border)" }, { label: "Refunds", color: "var(--status-warning-border)" }]}>
+              <AdminTrendChart rows={salesTrend} series={[
+                { key: "sales", label: "Sales", kind: "area", tone: "success", fillOpacity: 0.12 },
+                { key: "refunds", label: "Refunds", kind: "line", tone: "warning", dashed: true },
+              ]} height={300} valueFormatter={money} yTickFormatter={money} />
+            </ReportChartShell>
+            <ReportChartShell title="Transaction value" sourceTag={{ label: "POS" }}>
+              <AdminDonutChart rows={typeMix} valueLabel="Value" valueFormatter={(v) => v.toString()} height={300} />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Largest tickets" sourceTag={{ label: "Sales" }} legend={[{ label: "Amount", color: "var(--action-primary-bg)" }, { label: "Items", color: "var(--status-info-border)" }]}>
+              <AdminDualBarChart rows={topTickets} primaryLabel="Amount" secondaryLabel="Items" height={280} valueFormatter={money} />
+            </ReportChartShell>
+            <ReportChartShell title="Tender mix" sourceTag={{ label: "Payments" }}>
+              <AdminDistributionChart rows={tenderMix} valueLabel="Count" valueFormatter={(v) => v.toString()} height={280} />
+            </ReportChartShell>
+          </div>
+          <DataTable data={sales} columns={saleColumns} features={{ sorting: true, globalFilter: true, pagination: true }} pagination={{ enabled: true, server: false }} searchPlaceholder="Search transactions" />
+        </div>
+      )}
+
+      {/* ── STOCK TAB ──────────────────────────────────── */}
+      {activeTab === "stock" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-3">
+            <ReportChartShell title="Total SKUs" sourceTag={{ label: "Inventory" }}>
+              <ReportBigNumber label="Low-stock SKUs" value={stockItems.length.toString()} dotColor="var(--status-warning-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Stock health" sourceTag={{ label: "Inventory" }}>
+              <ReportBigNumber label="Critical" value={stockItems.filter((i) => i.currentStock <= 0).length.toString()} dotColor="var(--status-danger-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Reorder gap" sourceTag={{ label: "Inventory" }}>
+              <ReportBigNumber label="Items below min" value={stockItems.filter((i) => i.currentStock <= i.minStock).length.toString()} dotColor="var(--status-warning-border)" />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Stock gaps" sourceTag={{ label: "Inventory" }}>
+              <AdminDistributionChart rows={stockGap} valueLabel="Shortfall" valueFormatter={(v) => v.toFixed(0)} height={280} />
+            </ReportChartShell>
+            <ReportChartShell title="Health overview" sourceTag={{ label: "Inventory" }}>
+              <AdminDonutChart rows={stockHealth} valueLabel="SKUs" valueFormatter={(v) => v.toString()} height={280} />
+            </ReportChartShell>
           </div>
         </div>
+      )}
 
-        <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.85fr)]">
-          <AdminTrendChart
-            rows={chartRows}
-            series={[
-              { key: "sales", label: "Sales", kind: "area", tone: "success", fillOpacity: 0.12 },
-              { key: "tickets", label: "Tickets", kind: "line", tone: "default", dashed: true },
-            ]}
-            height={300}
-            valueFormatter={(value) => value.toFixed(0)}
-            yTickFormatter={(value) => value.toFixed(0)}
-            emptyLabel="Sales trend is loading"
-          />
-          <AdminDonutChart
-            rows={tenderRows}
-            valueLabel="Tender mix"
-            valueFormatter={(value) => value.toFixed(2)}
-            height={300}
-            emptyLabel="Tender mix is loading"
-          />
-        </div>
-      </section>
-
-      <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <h3 className="text-xl font-semibold text-[var(--text-strong)]">Top items and stock</h3>
-          <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Top item value</p>
-            <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
-              {data?.topItems?.[0] ? data.topItems[0].value.toFixed(0) : "0"}
-            </p>
+      {/* ── SALES TAB ──────────────────────────────────── */}
+      {activeTab === "sales" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-3">
+            <ReportChartShell title="Gross sales" sourceTag={{ label: "Sales" }}>
+              <ReportBigNumber label="Gross" value={money(grossSales)} />
+            </ReportChartShell>
+            <ReportChartShell title="Net sales" sourceTag={{ label: "Sales" }}>
+              <ReportBigNumber label="Net" value={money(netSales)} dotColor="var(--status-success-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Ticket count" sourceTag={{ label: "POS" }}>
+              <ReportBigNumber label="Tickets" value={sales.length.toString()} dotColor="var(--status-info-border)" />
+            </ReportChartShell>
           </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Sales trend" sourceTag={{ label: "Sales" }} legend={[{ label: "Sales", color: "var(--status-success-border)" }, { label: "Refunds", color: "var(--status-warning-border)" }]}>
+              <AdminTrendChart rows={salesTrend} series={[
+                { key: "sales", label: "Sales", kind: "area", tone: "success", fillOpacity: 0.12 },
+                { key: "refunds", label: "Refunds", kind: "line", tone: "warning", dashed: true },
+              ]} height={280} valueFormatter={money} yTickFormatter={money} />
+            </ReportChartShell>
+            <ReportChartShell title="Top tickets" sourceTag={{ label: "Sales" }}>
+              <AdminDualBarChart rows={topTickets.slice(0, 6)} primaryLabel="Amount" secondaryLabel="Items" height={280} valueFormatter={money} />
+            </ReportChartShell>
+          </div>
+          <DataTable data={sales} columns={saleColumns} features={{ sorting: true, globalFilter: true, pagination: true }} pagination={{ enabled: true, server: false }} searchPlaceholder="Search sales" />
         </div>
+      )}
 
-        <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.75fr)]">
-          <AdminDualBarChart
-            rows={topItemRows}
-            primaryLabel="Sales"
-            secondaryLabel="Units"
-            height={280}
-            valueFormatter={(value) => value.toFixed(0)}
-            emptyLabel="Top items are loading"
-          />
-          <AdminDistributionChart
-            rows={stockRows}
-            valueLabel="Gap"
-            valueFormatter={(value) => value.toFixed(2)}
-            height={280}
-            emptyLabel="Stock exceptions are loading"
-          />
+      {/* ── SHIFTS TAB ─────────────────────────────────── */}
+      {activeTab === "shifts" && (
+        <div className="space-y-5">
+          <ReportFilterBar onExport={() => {}} />
+          <div className="grid gap-5 xl:grid-cols-3">
+            <ReportChartShell title="Open shifts" sourceTag={{ label: "Shifts" }}>
+              <ReportBigNumber label="Open" value={openShifts.toString()} dotColor={openShifts > 0 ? "var(--status-success-border)" : "var(--text-muted)"} />
+            </ReportChartShell>
+            <ReportChartShell title="Total shifts" sourceTag={{ label: "Shifts" }}>
+              <ReportBigNumber label="Total" value={shifts.length.toString()} dotColor="var(--status-info-border)" />
+            </ReportChartShell>
+            <ReportChartShell title="Shift sales" sourceTag={{ label: "Shifts" }}>
+              <ReportBigNumber label="Total sales" value={money(shifts.reduce((s, sh) => s + sh.salesValue, 0))} dotColor="var(--action-primary-bg)" />
+            </ReportChartShell>
+          </div>
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(300px,0.8fr)]">
+            <ReportChartShell title="Sales by shift" sourceTag={{ label: "Shifts" }} legend={[{ label: "Sales", color: "var(--status-success-border)" }, { label: "Variance", color: "var(--status-warning-border)" }]}>
+              <AdminTrendChart rows={shiftTrend} series={[
+                { key: "sales", label: "Sales", kind: "area", tone: "success", fillOpacity: 0.12 },
+                { key: "variance", label: "Variance", kind: "line", tone: "warning", dashed: true },
+              ]} height={280} valueFormatter={money} yTickFormatter={money} />
+            </ReportChartShell>
+            <ReportChartShell title="Status" sourceTag={{ label: "Shifts" }}>
+              <AdminDonutChart rows={shiftStatus} valueLabel="Shifts" valueFormatter={(v) => v.toString()} height={280} />
+            </ReportChartShell>
+          </div>
+          <DataTable data={shifts} columns={shiftColumns} features={{ sorting: true, globalFilter: true, pagination: true }} pagination={{ enabled: true, server: false }} searchPlaceholder="Search shifts" />
         </div>
-      </section>
-
-      <VerticalDataViews
-        value={activeView}
-        onValueChange={setActiveView}
-        railLabel="Reports"
-        items={[
-          { id: "items", label: "Top items", count: data?.topItems.length ?? 0 },
-          { id: "sales", label: "Sales detail", count: data?.recentSales.length ?? 0 },
-          { id: "stock", label: "Stock exceptions", count: data?.lowStock.length ?? 0 },
-        ]}
-      >
-        {activeView === "items" ? (
-          <DataTable
-            data={data?.topItems ?? []}
-            columns={itemColumns}
-            features={{ sorting: true, globalFilter: true, pagination: true }}
-            pagination={{ enabled: true, server: false }}
-            searchPlaceholder="Search top items"
-            emptyState={isLoading ? "Loading report..." : "No item data yet"}
-            toolbar={undefined}
-          />
-        ) : null}
-        {activeView === "sales" ? (
-          <DataTable
-            data={data?.recentSales ?? []}
-            columns={salesColumns}
-            features={{ sorting: true, globalFilter: true, pagination: true }}
-            pagination={{ enabled: true, server: false }}
-            searchPlaceholder="Search sales detail"
-            emptyState={isLoading ? "Loading report..." : "No sales yet"}
-            toolbar={undefined}
-          />
-        ) : null}
-        {activeView === "stock" ? (
-          <DataTable
-            data={data?.lowStock ?? []}
-            columns={stockColumns}
-            features={{ sorting: true, globalFilter: true, pagination: true }}
-            pagination={{ enabled: true, server: false }}
-            searchPlaceholder="Search stock exceptions"
-            emptyState={isLoading ? "Loading report..." : "No stock exceptions"}
-            toolbar={undefined}
-          />
-        ) : null}
-      </VerticalDataViews>
+      )}
     </RetailShell>
   );
 }
-                                                                      

--- a/app/retail/sales/page.tsx
+++ b/app/retail/sales/page.tsx
@@ -288,13 +288,11 @@ export default function RetailSalesPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Sales at a glance</p>
             <h2 className="mt-1 text-2xl font-semibold text-[var(--text-strong)]">
               Gross, refunds, voids, and net movement
             </h2>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Net sales</p>
             <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
               {money(salesQuery.data?.summary.netSales ?? 0)}
             </p>
@@ -330,11 +328,9 @@ export default function RetailSalesPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Ticket concentration</p>
             <h3 className="mt-1 text-xl font-semibold text-[var(--text-strong)]">Largest tickets in the current view</h3>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Gross sales</p>
             <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
               {money(salesQuery.data?.summary.grossSales ?? 0)}
             </p>
@@ -378,7 +374,7 @@ export default function RetailSalesPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search posted sales"
             emptyState={salesQuery.isLoading ? "Loading sales..." : "No posted sales yet"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Posted checkout activity</span>}
+
           />
         ) : null}
 
@@ -390,7 +386,7 @@ export default function RetailSalesPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search refunds"
             emptyState={salesQuery.isLoading ? "Loading refunds..." : "No refunds yet"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Refund and return activity</span>}
+
           />
         ) : null}
 
@@ -402,7 +398,7 @@ export default function RetailSalesPage() {
             pagination={{ enabled: true, server: false }}
             searchPlaceholder="Search exceptions"
             emptyState={salesQuery.isLoading ? "Loading exceptions..." : "No exceptions yet"}
-            toolbar={<span className="text-xs text-[var(--text-muted)]">Voids and overridden checkouts</span>}
+
           />
         ) : null}
       </VerticalDataViews>

--- a/app/retail/shifts/page.tsx
+++ b/app/retail/shifts/page.tsx
@@ -13,13 +13,11 @@ import {
 import { SearchableSelect } from "@/app/gold/components/searchable-select";
 import type { SearchableOption } from "@/app/gold/types";
 import { RetailShell } from "@/components/retail/retail-shell";
-import { FieldHelp } from "@/components/shared/field-help";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -282,11 +280,9 @@ export default function RetailShiftsPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Shift signal</p>
             <h2 className="mt-1 text-2xl font-semibold text-[var(--text-strong)]">Sales, expected cash, and variance by shift</h2>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Open shifts</p>
             <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
               {shiftsQuery.data?.data.filter((shift) => shift.status === "OPEN").length ?? 0}
             </p>
@@ -319,11 +315,9 @@ export default function RetailShiftsPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Shift depth</p>
             <h3 className="mt-1 text-xl font-semibold text-[var(--text-strong)]">Sales versus expected cash on the busiest shifts</h3>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Latest variance</p>
             <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
               {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
                 shiftsQuery.data?.data.find((shift) => shift.status === "OPEN")?.variance ?? 0,
@@ -363,14 +357,13 @@ export default function RetailShiftsPage() {
         pagination={{ enabled: true, server: false }}
         searchPlaceholder="Search shifts"
         emptyState={shiftsQuery.isLoading ? "Loading shifts..." : "No shifts yet"}
-        toolbar={<span className="text-xs text-[var(--text-muted)]">Shift register control</span>}
+
       />
 
       <Dialog open={openDialog} onOpenChange={setOpenDialog}>
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
             <DialogTitle>Open shift</DialogTitle>
-            <DialogDescription>Bind a cashier to a till and start the day cleanly.</DialogDescription>
           </DialogHeader>
           <form
             className="space-y-4"
@@ -382,7 +375,6 @@ export default function RetailShiftsPage() {
             <div className="space-y-2">
               <label className="block text-sm font-semibold">Shift number</label>
               <Input value={shiftNo} readOnly disabled={isReserving} />
-              <FieldHelp error={reserveError ?? undefined} hint={reserveError ? undefined : "Generated automatically."} />
             </div>
             <SearchableSelect
               label="Site"
@@ -421,7 +413,6 @@ export default function RetailShiftsPage() {
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Close shift</DialogTitle>
-            <DialogDescription>{closeTarget?.shiftNo}</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="rounded-2xl bg-[var(--surface-muted)] px-3 py-3 text-sm">

--- a/app/retail/stock/page.tsx
+++ b/app/retail/stock/page.tsx
@@ -177,11 +177,9 @@ export default function RetailStockPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Stock signal</p>
             <h2 className="mt-1 text-2xl font-semibold text-[var(--text-strong)]">Availability, reorder pressure, and gap depth</h2>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Low stock items</p>
             <p className="font-mono text-3xl font-semibold text-[var(--text-strong)]">
               {data?.summary.lowStockCount ?? 0}
             </p>
@@ -210,11 +208,9 @@ export default function RetailStockPage() {
       <section className="rounded-[28px] border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5 shadow-[var(--shadow-card)]">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--text-muted)]">Gap pressure</p>
             <h3 className="mt-1 text-xl font-semibold text-[var(--text-strong)]">Largest reorder gaps in the current watchlist</h3>
           </div>
           <div className="rounded-2xl bg-[var(--surface-subtle)] px-4 py-3 text-right">
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">Open orders</p>
             <p className="font-mono text-2xl font-semibold text-[var(--text-strong)]">
               {money(data?.summary.openOrderValue ?? 0)}
             </p>
@@ -230,7 +226,6 @@ export default function RetailStockPage() {
             emptyLabel="Reorder gaps are loading"
           />
           <div className="rounded-[24px] border border-[var(--edge-subtle)] bg-[var(--surface-subtle)] p-4">
-            <p className="text-xs uppercase tracking-[0.16em] text-[var(--text-muted)]">Goods received</p>
             <p className="mt-2 font-mono text-3xl font-semibold text-[var(--text-strong)]">
               {money(data?.summary.goodsReceivedValue ?? 0)}
             </p>

--- a/components/retail/reports/report-big-number.tsx
+++ b/components/retail/reports/report-big-number.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+export function ReportBigNumber({
+  label,
+  value,
+  dotColor = "var(--action-primary-bg)",
+  breadcrumb,
+  className,
+}: {
+  label: string;
+  value: string;
+  dotColor?: string;
+  breadcrumb?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`flex flex-col items-center justify-center py-8 text-center ${className ?? ""}`}>
+      <span className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)]">
+        <span
+          className="inline-block h-2.5 w-2.5 rounded-full"
+          style={{ backgroundColor: dotColor }}
+        />
+        {label}
+      </span>
+      <p className="mt-3 text-4xl font-bold tracking-tight text-[var(--text-strong)]">
+        {value}
+      </p>
+      {breadcrumb ? (
+        <p className="mt-2 text-sm text-[var(--text-muted)]">{breadcrumb}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/retail/reports/report-chart-shell.tsx
+++ b/components/retail/reports/report-chart-shell.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type LegendItem = {
+  label: string;
+  color: string;
+};
+
+type SourceTag = {
+  icon?: ReactNode;
+  label: string;
+};
+
+export function ReportChartShell({
+  title,
+  sourceTag,
+  legend,
+  children,
+  className,
+}: {
+  title: string;
+  sourceTag?: SourceTag;
+  legend?: LegendItem[];
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-5",
+        className,
+      )}
+    >
+      {/* Header: title + source tag */}
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-lg font-semibold text-[var(--text-strong)]">{title}</h3>
+        {sourceTag ? (
+          <span className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--surface-muted)] px-2.5 py-1 text-xs font-medium text-[var(--text-muted)]">
+            {sourceTag.icon}
+            {sourceTag.label}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Legend */}
+      {legend && legend.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-center gap-4">
+          {legend.map((item) => (
+            <span key={item.label} className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)]">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: item.color }}
+              />
+              {item.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Chart area */}
+      <div className={legend && legend.length > 0 ? "mt-4" : "mt-3"}>{children}</div>
+    </div>
+  );
+}

--- a/components/retail/reports/report-export-button.tsx
+++ b/components/retail/reports/report-export-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Download } from "@/lib/icons";
+
+function downloadCSV(data: unknown[], filename: string) {
+  if (!data.length) return;
+  const headers = Object.keys(data[0] as Record<string, unknown>);
+  const rows = data.map((row) =>
+    headers
+      .map((h) => {
+        const val = (row as Record<string, unknown>)[h];
+        const str = val === null || val === undefined ? "" : String(val);
+        return str.includes(",") ? `"${str}"` : str;
+      })
+      .join(","),
+  );
+  const csv = [headers.join(","), ...rows].join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function ReportExportButton({
+  data,
+  filename = "report.csv",
+}: {
+  data: unknown[];
+  filename?: string;
+}) {
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      className="h-8 gap-1.5 text-xs"
+      onClick={() => downloadCSV(data, filename)}
+      disabled={!data.length}
+    >
+      <Download className="h-3.5 w-3.5" />
+      Export
+    </Button>
+  );
+}
+
+export { downloadCSV };

--- a/components/retail/reports/report-filter-bar.tsx
+++ b/components/retail/reports/report-filter-bar.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Download, Plus, X } from "@/lib/icons";
+
+export type FilterRule = {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+};
+
+const FIELD_OPTIONS: Record<string, string[]> = {
+  "Date": ["after", "before", "between"],
+  "Status": ["is", "is not"],
+  "Type": ["is", "is not"],
+  "Amount": ["greater than", "less than", "equals"],
+  "Site": ["is", "is not", "contains"],
+  "Supplier": ["is", "contains"],
+  "Customer": ["is", "contains"],
+  "Category": ["is", "is not"],
+};
+
+const DEFAULT_FIELDS = Object.keys(FIELD_OPTIONS);
+
+export function ReportFilterBar({
+  onExport,
+  className,
+}: {
+  onExport?: () => void;
+  className?: string;
+}) {
+  const [filters, setFilters] = useState<FilterRule[]>([]);
+
+  const addFilter = () => {
+    const id = crypto.randomUUID();
+    setFilters((prev) => [
+      ...prev,
+      { id, field: "Date", operator: "after", value: "" },
+    ]);
+  };
+
+  const updateFilter = (id: string, patch: Partial<FilterRule>) => {
+    setFilters((prev) =>
+      prev.map((f) => (f.id === id ? { ...f, ...patch } : f)),
+    );
+  };
+
+  const removeFilter = (id: string) => {
+    setFilters((prev) => prev.filter((f) => f.id !== id));
+  };
+
+  const clearAll = () => setFilters([]);
+
+  return (
+    <div className={cn("rounded-2xl border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-4", className)}>
+      {/* Filter rows */}
+      <div className="space-y-2">
+        {filters.map((filter, index) => {
+          const operators = FIELD_OPTIONS[filter.field] ?? ["is"];
+          return (
+            <div key={filter.id} className="flex flex-wrap items-center gap-2">
+              <span className="w-10 text-xs font-medium text-[var(--text-muted)]">
+                {index === 0 ? "Where" : "And"}
+              </span>
+              <Select
+                value={filter.field}
+                onValueChange={(v) =>
+                  updateFilter(filter.id, {
+                    field: v,
+                    operator: FIELD_OPTIONS[v]?.[0] ?? "is",
+                  })
+                }
+              >
+                <SelectTrigger className="h-8 w-36 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DEFAULT_FIELDS.map((f) => (
+                    <SelectItem key={f} value={f}>
+                      {f}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select
+                value={filter.operator}
+                onValueChange={(v) =>
+                  updateFilter(filter.id, { operator: v })
+                }
+              >
+                <SelectTrigger className="h-8 w-28 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {operators.map((op) => (
+                    <SelectItem key={op} value={op}>
+                      {op}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {filter.field === "Date" ? (
+                <Input
+                  type="date"
+                  value={filter.value}
+                  onChange={(e) =>
+                    updateFilter(filter.id, { value: e.target.value })
+                  }
+                  className="h-8 w-40 text-xs"
+                />
+              ) : (
+                <Input
+                  value={filter.value}
+                  onChange={(e) =>
+                    updateFilter(filter.id, { value: e.target.value })
+                  }
+                  placeholder="Value"
+                  className="h-8 w-48 text-xs"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => removeFilter(filter.id)}
+                className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-muted)] hover:text-[var(--text-strong)]"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Actions row */}
+      <div className="mt-3 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={addFilter}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--edge-default)] px-3 py-1.5 text-xs font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--edge-strong)] hover:text-[var(--text-strong)]"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add filter
+        </button>
+        <div className="flex items-center gap-2">
+          {filters.length > 0 ? (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--text-strong)]"
+            >
+              Clear all filters
+            </button>
+          ) : null}
+          {onExport ? (
+            <Button size="sm" variant="outline" onClick={onExport} className="h-8 gap-1.5 text-xs">
+              <Download className="h-3.5 w-3.5" />
+              Export
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…stripping

Reports Hub (app/retail/reports/page.tsx):
- Complete redesign with 6 tabs: POS Policy, Operations, Reports, Stock Overview, Sales, Shifts
- Each tab: filter bar + big number KPIs + charts + data table + export
- Charts use Attio-style containers (no card wrappers, title+source tag+legend pattern)
- Shared data from existing APIs: /api/v2/retail/pos/sales, /shifts, /customers, /catalog
- Responsive grid layouts: 3-col KPIs, 2-col chart pairs, full-width tables

Customers (app/retail/customers/page.tsx):
- 3 KPI cards: named customers, top spend, total loyalty points
- Dual bar chart: spend vs visits
- Donut: loyalty tier distribution
- Distribution: visit frequency
- Filter bar + export + loyalty ledger dialog

Promotions (app/retail/merchandising/promotions/page.tsx):
- 3 KPIs: active campaigns, total campaigns, type variants
- Distribution: promotion values
- Donut: status + type distribution
- Filter bar + export
- All CRUD functionality preserved (create/edit/delete)

Purchase Orders (app/retail/purchasing/orders/page.tsx):
- 3 KPIs: total order value, draft orders, pending receipt
- Distribution: top suppliers by value
- Donut: status breakdown
- Filter bar + export
- All CRUD + receive functionality preserved

Text Stripping:
- Removed ~20+ explanatory subtitles across shifts, sales, stock pages
- Removed section labels: 'Shift signal', 'Gap pressure', 'Stock signal', etc.
- Removed DataTable toolbar labels
- Removed DialogDescription explanatory text
- Removed FieldHelp components

New Shared Components (components/retail/reports/):
- report-chart-shell.tsx: Attio-style chart wrapper (title+tag+legend)
- report-filter-bar.tsx: Where/And filter bar with add/remove/clear/export
- report-big-number.tsx: Large metric display with dot indicator
- report-export-button.tsx: CSV download utility