### PR TITLE
fix: restore scrap ticket lookups and cashier POS access

### DIFF
--- a/app/api/scrap-metal/ticket-context/route.ts
+++ b/app/api/scrap-metal/ticket-context/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  errorResponse,
+  successResponse,
+  validateSession,
+} from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const companyId = session.user.companyId;
+    const userId = session.user.id;
+
+    const [sites, buyers, linkedEmployee] = await Promise.all([
+      prisma.site.findMany({
+        where: {
+          companyId,
+          isActive: true,
+        },
+        select: {
+          id: true,
+          name: true,
+          code: true,
+        },
+        orderBy: { name: "asc" },
+      }),
+      prisma.employee.findMany({
+        where: {
+          companyId,
+          isActive: true,
+        },
+        select: {
+          id: true,
+          employeeId: true,
+          userId: true,
+          name: true,
+        },
+        orderBy: { name: "asc" },
+      }),
+      prisma.employee.findFirst({
+        where: {
+          companyId,
+          userId,
+          isActive: true,
+        },
+        select: {
+          id: true,
+        },
+      }),
+    ]);
+
+    return successResponse({
+      buyers,
+      sites,
+      defaultBuyerId: linkedEmployee?.id ?? null,
+      buyerLinkMissing: !linkedEmployee,
+    });
+  } catch (error) {
+    console.error("[API] GET /api/scrap-metal/ticket-context error:", error);
+    return errorResponse("Failed to fetch scrap ticket context");
+  }
+}

--- a/app/retail/page.tsx
+++ b/app/retail/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 import {
   AdminDonutChart,
   AdminTrendChart,
@@ -35,6 +36,7 @@ import {
   Users,
   Wallet,
 } from "@/lib/icons";
+import { canAccessPosPortal } from "@/lib/retail/pos-host";
 
 type RetailDashboardPayload = {
   summary: {
@@ -199,6 +201,8 @@ function SectionCard({
 }
 
 export default function RetailOverviewPage() {
+  const { data: session } = useSession();
+  const canOpenPos = canAccessPosPortal(session?.user?.role);
   const { data, isLoading, error } = useQuery({
     queryKey: ["retail-dashboard-owner-overview"],
     queryFn: () => fetchJson<RetailDashboardPayload>("/api/v2/retail"),
@@ -273,12 +277,14 @@ export default function RetailOverviewPage() {
       title="Business overview"
       actions={
         <div className="flex items-center gap-2">
-          <Button asChild size="sm">
-            <Link href="/portal/pos">
-              <Payments className="h-4 w-4" />
-              POS
-            </Link>
-          </Button>
+          {canOpenPos ? (
+            <Button asChild size="sm">
+              <Link href="/portal/pos">
+                <Payments className="h-4 w-4" />
+                POS
+              </Link>
+            </Button>
+          ) : null}
           <Button asChild size="sm" variant="outline">
             <Link href="/retail/sell">
               <ClipboardList className="h-4 w-4" />

--- a/app/retail/sales/page.tsx
+++ b/app/retail/sales/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 import {
   AdminDistributionChart,
   AdminDonutChart,
@@ -24,6 +25,7 @@ import { NumericCell } from "@/components/ui/numeric-cell";
 import { VerticalDataViews } from "@/components/ui/vertical-data-views";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { BarChart3, Package, Payments, ReceiptLong } from "@/lib/icons";
+import { canAccessPosPortal } from "@/lib/retail/pos-host";
 
 type SaleRow = {
   id: string;
@@ -88,6 +90,8 @@ function typeLabel(value: string) {
 }
 
 export default function RetailSalesPage() {
+  const { data: session } = useSession();
+  const canOpenPos = canAccessPosPortal(session?.user?.role);
   const [activeView, setActiveView] = useState("posted");
   const [selectedSaleId, setSelectedSaleId] = useState<string | null>(null);
 
@@ -251,12 +255,14 @@ export default function RetailSalesPage() {
       title="Sales"
       actions={
         <div className="flex flex-wrap gap-2">
-          <Button asChild size="sm">
-            <Link href="/portal/pos">
-              <Payments className="h-4 w-4" />
-              Open POS
-            </Link>
-          </Button>
+          {canOpenPos ? (
+            <Button asChild size="sm">
+              <Link href="/portal/pos">
+                <Payments className="h-4 w-4" />
+                Open POS
+              </Link>
+            </Button>
+          ) : null}
           <Button asChild size="sm" variant="outline">
             <Link href="/retail/shifts">
               <ReceiptLong className="h-4 w-4" />

--- a/app/retail/shifts/page.tsx
+++ b/app/retail/shifts/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 import {
   AdminDistributionChart,
   AdminDualBarChart,
@@ -29,6 +30,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchSites } from "@/lib/api";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { BarChart3, Payments, Plus, ReceiptLong } from "@/lib/icons";
+import { canAccessPosPortal } from "@/lib/retail/pos-host";
 import { useReservedId } from "@/hooks/use-reserved-id";
 
 type Shift = {
@@ -69,6 +71,8 @@ function emptyForm(siteId = ""): ShiftForm {
 }
 
 export default function RetailShiftsPage() {
+  const { data: session } = useSession();
+  const canOpenPos = canAccessPosPortal(session?.user?.role);
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [openDialog, setOpenDialog] = useState(false);
@@ -256,12 +260,14 @@ export default function RetailShiftsPage() {
             <Plus className="h-4 w-4" />
             Open shift
           </Button>
-          <Button asChild size="sm" variant="outline">
-            <Link href="/portal/pos">
-              <Payments className="h-4 w-4" />
-              POS
-            </Link>
-          </Button>
+          {canOpenPos ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href="/portal/pos">
+                <Payments className="h-4 w-4" />
+                POS
+              </Link>
+            </Button>
+          ) : null}
           <Button asChild size="sm" variant="outline">
             <Link href="/retail/sales">
               <ReceiptLong className="h-4 w-4" />

--- a/app/scrap-metal/tickets/page.tsx
+++ b/app/scrap-metal/tickets/page.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useOfflineRuntime } from "@/components/providers/offline-provider";
-import { fetchEmployees, fetchSites } from "@/lib/api";
+import { fetchScrapTicketContext } from "@/lib/api";
 import { ApiError, fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { OFFLINE_ENTITIES_CHANGED_EVENT } from "@/lib/offline/events";
 import { hasRole } from "@/lib/roles";
@@ -207,7 +207,6 @@ export default function ScrapMetalTicketWorkbenchPage() {
       | { id?: string; userId?: string; role?: string; name?: string }
       | undefined) ?? undefined;
   const role = sessionUser?.role;
-  const sessionUserId = sessionUser?.id ?? sessionUser?.userId ?? null;
   const canCreateOutbound = hasRole(role, ["SUPERADMIN", "MANAGER"]);
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -232,13 +231,9 @@ export default function ScrapMetalTicketWorkbenchPage() {
   const [inboundMetaOpen, setInboundMetaOpen] = useState(false);
   const [outboundMetaOpen, setOutboundMetaOpen] = useState(false);
 
-  const sitesQuery = useQuery({
-    queryKey: ["sites", "scrap-tickets"],
-    queryFn: fetchSites,
-  });
-  const employeesQuery = useQuery({
-    queryKey: ["employees", "scrap-tickets"],
-    queryFn: () => fetchEmployees({ active: true, limit: 500 }),
+  const ticketContextQuery = useQuery({
+    queryKey: ["scrap-ticket-context"],
+    queryFn: fetchScrapTicketContext,
   });
   const materialsQuery = useQuery({
     queryKey: ["scrap-materials", "tickets"],
@@ -283,9 +278,13 @@ export default function ScrapMetalTicketWorkbenchPage() {
     () => materialsQuery.data?.data ?? [],
     [materialsQuery.data?.data],
   );
-  const employees = useMemo(
-    () => employeesQuery.data?.data ?? [],
-    [employeesQuery.data?.data],
+  const buyers = useMemo(
+    () => ticketContextQuery.data?.buyers ?? [],
+    [ticketContextQuery.data?.buyers],
+  );
+  const sites = useMemo(
+    () => ticketContextQuery.data?.sites ?? [],
+    [ticketContextQuery.data?.sites],
   );
   const sellers = useMemo(
     () => [
@@ -323,16 +322,11 @@ export default function ScrapMetalTicketWorkbenchPage() {
     selectedInboundMaterial?.category ?? inbound.category;
   const selectedInboundBuyer = useMemo(
     () =>
-      employees.find((employee) => employee.id === inbound.employeeId) ?? null,
-    [employees, inbound.employeeId],
+      buyers.find((buyer) => buyer.id === inbound.employeeId) ?? null,
+    [buyers, inbound.employeeId],
   );
-  const defaultBuyerId = useMemo(() => {
-    if (!sessionUserId) return "";
-    const linkedEmployee = employees.find(
-      (employee) => employee.userId === sessionUserId,
-    );
-    return linkedEmployee?.id ?? "";
-  }, [employees, sessionUserId]);
+  const defaultBuyerId = ticketContextQuery.data?.defaultBuyerId ?? "";
+  const buyerLinkMissing = ticketContextQuery.data?.buyerLinkMissing ?? false;
   const canOverrideBuyer = hasRole(role, ["OPERATOR", "MANAGER", "SUPERADMIN"]);
   const showBuyerOverride = canOverrideBuyer || !defaultBuyerId;
   const inboundRequirementsQuery = useQuery({
@@ -394,10 +388,10 @@ export default function ScrapMetalTicketWorkbenchPage() {
     if (!defaultBuyerId) return;
     const selectedIsValid =
       inbound.employeeId &&
-      employees.some((employee) => employee.id === inbound.employeeId);
+      buyers.some((buyer) => buyer.id === inbound.employeeId);
     if (selectedIsValid) return;
     setInbound((prev) => ({ ...prev, employeeId: defaultBuyerId }));
-  }, [defaultBuyerId, inbound.employeeId, employees]);
+  }, [buyers, defaultBuyerId, inbound.employeeId]);
 
   useEffect(() => {
     if (!selectedInboundMaterial) return;
@@ -1254,6 +1248,12 @@ export default function ScrapMetalTicketWorkbenchPage() {
                 </div>
               ) : null}
 
+              {buyerLinkMissing ? (
+                <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-amber-900">
+                  Your account is not linked to an active employee profile yet, so buyer could not be auto-selected.
+                </div>
+              ) : null}
+
               <div className="space-y-2">
                 <label className="font-semibold">Buyer</label>
                 {showBuyerOverride ? (
@@ -1274,9 +1274,9 @@ export default function ScrapMetalTicketWorkbenchPage() {
                       <SelectValue placeholder="Select buyer" />
                     </SelectTrigger>
                     <SelectContent>
-                      {employees.map((employee) => (
-                        <SelectItem key={employee.id} value={employee.id}>
-                          {employee.name}
+                      {buyers.map((buyer) => (
+                        <SelectItem key={buyer.id} value={buyer.id}>
+                          {buyer.name}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -1384,7 +1384,7 @@ export default function ScrapMetalTicketWorkbenchPage() {
                       <SelectValue placeholder="Select site" />
                     </SelectTrigger>
                     <SelectContent>
-                      {(sitesQuery.data ?? []).map((site) => (
+                      {sites.map((site) => (
                         <SelectItem key={site.id} value={site.id}>
                           {site.name} ({site.code})
                         </SelectItem>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -103,6 +103,26 @@ export type EmployeeSummary = {
   salaryOwed: number;
 };
 
+export type ScrapTicketBuyerOption = {
+  id: string;
+  employeeId: string;
+  userId?: string | null;
+  name: string;
+};
+
+export type ScrapTicketSiteOption = {
+  id: string;
+  name: string;
+  code: string;
+};
+
+export type ScrapTicketContext = {
+  buyers: ScrapTicketBuyerOption[];
+  sites: ScrapTicketSiteOption[];
+  defaultBuyerId: string | null;
+  buyerLinkMissing: boolean;
+};
+
 export type ShiftGroupRecord = {
   id: string;
   companyId: string;
@@ -1401,6 +1421,10 @@ export async function fetchEmployees(
 ) {
   const query = buildQuery(params);
   return fetchJson<Pagination<EmployeeSummary>>(`/api/employees${query}`);
+}
+
+export async function fetchScrapTicketContext() {
+  return fetchJson<ScrapTicketContext>("/api/scrap-metal/ticket-context");
 }
 
 export async function fetchShiftGroups(

--- a/lib/offline/module-registry.ts
+++ b/lib/offline/module-registry.ts
@@ -1,7 +1,7 @@
 import {
   fetchDisciplinaryActions,
-  fetchEmployees,
   fetchHrIncidents,
+  fetchScrapTicketContext,
   fetchShiftGroups,
   fetchShiftGroupSchedules,
   fetchSites,
@@ -243,14 +243,9 @@ async function syncRetailSale(payload: Record<string, unknown>): Promise<Offline
 
 const scrapTicketingPreloadQueries: OfflinePreloadQuery[] = [
   {
-    key: "scrap-sites",
-    queryKey: ["sites", "scrap-tickets"],
-    fetcher: async () => fetchSites(),
-  },
-  {
-    key: "scrap-employees",
-    queryKey: ["employees", "scrap-tickets"],
-    fetcher: async () => fetchEmployees({ active: true, limit: 500 }),
+    key: "scrap-ticket-context",
+    queryKey: ["scrap-ticket-context"],
+    fetcher: async () => fetchScrapTicketContext(),
   },
   {
     key: "scrap-materials",

--- a/lib/offline/offline-eligibility.ts
+++ b/lib/offline/offline-eligibility.ts
@@ -173,11 +173,10 @@ export const ROLE_PREFETCH_CONFIG: Record<string, PrefetchConfig> = {
   },
   OPERATOR: {
     immediateQueries: [
-      "scrap-sites",
+      "scrap-ticket-context",
       "scrap-materials",
       "scrap-sellers",
       "scrap-prices",
-      "scrap-employees",
       "scrap-batches",
     ],
     immediateRoutes: ["/scrap-metal", "/scrap-metal/tickets"],
@@ -192,7 +191,7 @@ export const ROLE_PREFETCH_CONFIG: Record<string, PrefetchConfig> = {
   },
   CLERK: {
     immediateQueries: [
-      "scrap-sites",
+      "scrap-ticket-context",
       "scrap-materials",
       "scrap-sellers",
       "scrap-batches",

--- a/lib/platform/gating/route-registry.ts
+++ b/lib/platform/gating/route-registry.ts
@@ -240,6 +240,7 @@ export const API_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "api", prefix: "/api/gold/prices", featureKey: "gold.home" },
 
   { scope: "api", prefix: "/api/scrap-metal/purchases", featureKey: "scrap-metal.purchases" },
+  { scope: "api", prefix: "/api/scrap-metal/ticket-context", featureKey: "scrap-metal.home" },
   { scope: "api", prefix: "/api/scrap-metal/batches", featureKey: "scrap-metal.batches" },
   { scope: "api", prefix: "/api/scrap-metal/sales", featureKey: "scrap-metal.sales" },
   { scope: "api", prefix: "/api/scrap-metal/employee-balances", featureKey: "scrap-metal.purchases" },

--- a/lib/platform/user-entitlements.ts
+++ b/lib/platform/user-entitlements.ts
@@ -139,8 +139,10 @@ const ROLE_PREFIX_ALLOWLIST: Record<string, readonly string[] | null> = {
     "core.help.",
     "core.notifications.",
     "core.multitenancy.",
+    "retail.core",
     "retail.pos",
     "retail.catalog",
+    "portal.core",
     "portal.pos",
   ],
   STOCK_CLERK: [

--- a/lib/primary-actions.ts
+++ b/lib/primary-actions.ts
@@ -98,7 +98,7 @@ const PROFILE_PRIMARY_ACTIONS: Record<Exclude<WorkspaceProfileKey, "GENERAL">, N
     { href: "/car-sales/deals", icon: Wallet, label: "Deals" },
   ],
   RETAIL: [
-    { href: "/portal/pos", icon: Payments, label: "Open POS" },
+    { href: "/portal/pos", icon: Payments, label: "Open POS", roles: ["CASHIER"] },
     { href: "/retail/sales", icon: ClipboardList, label: "Sales" },
     { href: "/retail/stock", icon: Package, label: "Stock" },
     { href: "/retail/purchasing/orders", icon: Package, label: "Purchase Orders" },

--- a/lib/retail/pos-host.ts
+++ b/lib/retail/pos-host.ts
@@ -26,16 +26,7 @@ const POS_PORTAL_HREFS: Record<PosPortalNavKey, { publicHref: string | null; int
   "price-check": { publicHref: "/price-check", internalHref: "/portal/pos/price-check" },
 };
 
-const POS_PORTAL_ALLOWED_ROLES = new Set([
-  "SUPERADMIN",
-  "MANAGER",
-  "CLERK",
-  "SHOP_MANAGER",
-  "CASHIER",
-  "POS_CASHIER",
-  "STOCK_CLERK",
-  "FINANCE_OFFICER",
-]);
+const POS_PORTAL_ALLOWED_ROLES = new Set(["CASHIER", "POS_CASHIER"]);
 
 export function isCashierRole(role: string | null | undefined): boolean {
   const normalizedRole = role?.trim().toUpperCase();

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -5,6 +5,7 @@ import { getNavSectionsForRole } from "@/lib/navigation";
 import { normalizeFeatureKey } from "@/lib/platform/gating/catalog-utils";
 import { filterNavSectionsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 import { getPrimaryQuickActions } from "@/lib/primary-actions";
+import { canAccessPosPortal } from "@/lib/retail/pos-host";
 import type { UserRole } from "@/lib/roles";
 import {
   inferWorkspaceProfileFromEnabledFeatures,
@@ -197,10 +198,10 @@ const WORKSPACE_MODULES: Record<WorkspaceModuleId, WorkspaceModuleDefinition> = 
         items.push({ href: "/retail", label: "Overview", icon: Wallet });
       }
       if (has("/retail/sell")) {
-        items.push(
-          { href: "/portal/pos", label: "Open POS", icon: Payments },
-          { href: "/retail/sales", label: "Sales", icon: ClipboardList },
-        );
+        if (canAccessPosPortal(context.role)) {
+          items.push({ href: "/portal/pos", label: "Open POS", icon: Payments });
+        }
+        items.push({ href: "/retail/sales", label: "Sales", icon: ClipboardList });
       }
       if (has("/retail/customers")) {
         items.push({ href: "/retail/customers", label: "Customers", icon: Users });
@@ -481,7 +482,7 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
     label: "Retail",
     preferredHomeHref: "/retail",
     quickActions: [
-      roleItem("/portal/pos", "Open POS", Payments),
+      roleItem("/portal/pos", "Open POS", Payments, ["CASHIER"]),
       roleItem("/retail/sales", "Sales", ReceiptLong),
       roleItem("/retail/stock/count", "Stock Count", Package),
       roleItem("/retail/purchasing/receipts", "Receive Stock", LocalShipping),

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,8 +36,6 @@ const PORTAL_HOME_BY_ROLE = {
   TEACHER: "/portal/teacher",
   POS_CASHIER: "/portal/pos",
   CASHIER: "/portal/pos",
-  SHOP_MANAGER: "/portal/pos",
-  STOCK_CLERK: "/portal/pos",
 } as const;
 const HR_MODULE_ALLOWED_ROLES = new Set(["SUPERADMIN", "MANAGER", "CLERK"]);
 const SCRAP_LOTS_ONLY_ROLES = new Set(["OPERATOR", "CLERK"]);
@@ -122,9 +120,7 @@ function getPortalHomeForRole(role: string | undefined | null) {
     role === "STUDENT" ||
     role === "TEACHER" ||
     role === "POS_CASHIER" ||
-    role === "CASHIER" ||
-    role === "SHOP_MANAGER" ||
-    role === "STOCK_CLERK"
+    role === "CASHIER"
   ) {
     return PORTAL_HOME_BY_ROLE[role as keyof typeof PORTAL_HOME_BY_ROLE];
   }


### PR DESCRIPTION
## Summary
- add a scrap-scoped ticket context endpoint so operators can load buyers and sites without broadening generic HR/admin API access
- default scrap ticket buyer selection to the logged-in operator's linked employee profile while still allowing buyer override
- restrict POS portal access to cashier roles and align cashier entitlements and retail launch points with that policy

## Testing
- not run: `pnpm lint` is currently unavailable in this workspace because `node_modules` is missing and `eslint` is not installed

## Notes
- generic `/api/employees` and `/api/sites` access remains unchanged
- offline scrap ticket prefetch now uses the new scrap ticket context lookup