### PR TITLE
feat(gold): money-first overview, multi-batch flows, simpler forms

### DIFF
--- a/app/api/employees/route.ts
+++ b/app/api/employees/route.ts
@@ -169,7 +169,20 @@ export async function GET(request: NextRequest) {
     }
 
     if (active !== null) where.isActive = active === "true"
-    if (position) where.position = position
+    if (position) {
+      const requested = position
+        .split(",")
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+      const allowed = requested.filter((value): value is (typeof EMPLOYEE_POSITION_VALUES)[number] =>
+        (EMPLOYEE_POSITION_VALUES as readonly string[]).includes(value),
+      )
+      if (allowed.length === 1) {
+        where.position = allowed[0]
+      } else if (allowed.length > 1) {
+        where.position = { in: allowed }
+      }
+    }
     if (departmentId) where.departmentId = departmentId
     if (gradeId) where.gradeId = gradeId
     if (search) {

--- a/app/api/gold/dispatches/route.ts
+++ b/app/api/gold/dispatches/route.ts
@@ -11,21 +11,87 @@ import { snapshotGoldUsdValue } from "@/lib/gold/valuation"
 import { prisma } from "@/lib/prisma"
 import { z } from "zod"
 
-const goldDispatchSchema = z.object({
-  goldPourId: z.string().uuid(),
-  dispatchDate: z
-    .string()
-    .datetime()
-    .or(z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)),
-  courier: z.string().min(1).max(200),
-  vehicle: z.string().max(100).optional(),
-  destination: z.string().min(1).max(200),
-  sealNumbers: z.string().min(1).max(200),
-  handedOverById: z.string().uuid(),
-  receivedBy: z.string().max(200).optional(),
-  overrideReason: z.string().max(500).optional(),
-  notes: z.string().max(1000).optional(),
-})
+const goldDispatchSchema = z
+  .object({
+    // Backward-compat: accept either single goldPourId or list goldPourIds.
+    goldPourId: z.string().uuid().optional(),
+    goldPourIds: z.array(z.string().uuid()).min(1).max(50).optional(),
+    dispatchDate: z
+      .string()
+      .datetime()
+      .or(z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)),
+    courier: z.string().min(1).max(200),
+    vehicle: z.string().max(100).optional(),
+    destination: z.string().min(1).max(200),
+    sealNumbers: z.string().min(1).max(200),
+    handedOverById: z.string().uuid(),
+    receivedBy: z.string().max(200).optional(),
+    overrideReason: z.string().max(500).optional(),
+    notes: z.string().max(1000).optional(),
+  })
+  .refine((value) => Boolean(value.goldPourId || (value.goldPourIds && value.goldPourIds.length > 0)), {
+    message: "At least one batch is required",
+    path: ["goldPourIds"],
+  })
+
+const dispatchInclude = {
+  goldPour: {
+    select: {
+      id: true,
+      pourBarId: true,
+      pourDate: true,
+      grossWeight: true,
+      goldPriceUsdPerGram: true,
+      valueUsd: true,
+      site: { select: { name: true, code: true } },
+    },
+  },
+  handedOverBy: { select: { name: true } },
+  batches: {
+    orderBy: { sortOrder: "asc" as const },
+    include: {
+      goldPour: {
+        select: {
+          id: true,
+          pourBarId: true,
+          pourDate: true,
+          grossWeight: true,
+          goldPriceUsdPerGram: true,
+          valueUsd: true,
+          site: { select: { name: true, code: true } },
+        },
+      },
+    },
+  },
+} as const
+
+function normalizeDispatch<
+  T extends {
+    goldPour: { id: string; pourBarId: string }
+    batches: Array<{ goldPour: { id: string; pourBarId: string } }>
+  },
+>(dispatch: T) {
+  return {
+    ...dispatch,
+    batchId: dispatch.goldPour.id,
+    batchCode: dispatch.goldPour.pourBarId,
+    goldPour: {
+      ...dispatch.goldPour,
+      batchId: dispatch.goldPour.id,
+      batchCode: dispatch.goldPour.pourBarId,
+    },
+    batches: dispatch.batches.map((batch) => ({
+      ...batch,
+      batchId: batch.goldPour.id,
+      batchCode: batch.goldPour.pourBarId,
+      goldPour: {
+        ...batch.goldPour,
+        batchId: batch.goldPour.id,
+        batchCode: batch.goldPour.pourBarId,
+      },
+    })),
+  }
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -46,25 +112,17 @@ export async function GET(request: NextRequest) {
       const goldPourWhere = (where.goldPour as Record<string, unknown> | undefined) ?? {}
       where.goldPour = { ...goldPourWhere, siteId }
     }
-    if (goldPourId) where.goldPourId = goldPourId
+    if (goldPourId) {
+      where.OR = [
+        { goldPourId },
+        { batches: { some: { goldPourId } } },
+      ]
+    }
 
     const [dispatches, total] = await Promise.all([
       prisma.goldDispatch.findMany({
         where,
-        include: {
-          goldPour: {
-            select: {
-              id: true,
-              pourBarId: true,
-              pourDate: true,
-              grossWeight: true,
-              goldPriceUsdPerGram: true,
-              valueUsd: true,
-              site: { select: { name: true, code: true } },
-            },
-          },
-          handedOverBy: { select: { name: true } },
-        },
+        include: dispatchInclude,
         orderBy: { dispatchDate: "desc" },
         skip,
         take: limit,
@@ -72,16 +130,7 @@ export async function GET(request: NextRequest) {
       prisma.goldDispatch.count({ where }),
     ])
 
-    const normalizedDispatches = dispatches.map((dispatch) => ({
-      ...dispatch,
-      batchId: dispatch.goldPour.id,
-      batchCode: dispatch.goldPour.pourBarId,
-      goldPour: {
-        ...dispatch.goldPour,
-        batchId: dispatch.goldPour.id,
-        batchCode: dispatch.goldPour.pourBarId,
-      },
-    }))
+    const normalizedDispatches = dispatches.map(normalizeDispatch)
 
     return successResponse(
       paginationResponse(normalizedDispatches, total, page, limit),
@@ -101,32 +150,57 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const validated = goldDispatchSchema.parse(body)
 
-    const goldPour = await prisma.goldPour.findUnique({
-      where: { id: validated.goldPourId },
+    const requestedIds = validated.goldPourIds && validated.goldPourIds.length > 0
+      ? validated.goldPourIds
+      : validated.goldPourId
+        ? [validated.goldPourId]
+        : []
+    const goldPourIds = Array.from(new Set(requestedIds))
+
+    if (goldPourIds.length === 0) {
+      return errorResponse("At least one batch is required", 400)
+    }
+
+    const goldPours = await prisma.goldPour.findMany({
+      where: { id: { in: goldPourIds } },
       include: { site: { select: { companyId: true, isActive: true } } },
     })
 
-    if (!goldPour || goldPour.site.companyId !== session.user.companyId) {
-      return errorResponse("Invalid gold pour", 403)
+    if (goldPours.length !== goldPourIds.length) {
+      return errorResponse("One or more batches were not found", 404)
     }
 
-    if (!goldPour.site.isActive) {
-      return errorResponse("Site is not active", 400)
+    for (const pour of goldPours) {
+      if (pour.site.companyId !== session.user.companyId) {
+        return errorResponse("Invalid gold pour", 403)
+      }
+      if (!pour.site.isActive) {
+        return errorResponse(`Site for batch ${pour.pourBarId} is not active`, 400)
+      }
     }
 
-    const existingDispatchCount = await prisma.goldDispatch.count({
-      where: { goldPourId: validated.goldPourId },
+    const existingDispatchesForBatches = await prisma.goldDispatchBatch.findMany({
+      where: { goldPourId: { in: goldPourIds } },
+      select: { goldPourId: true },
     })
+    const legacyDispatches = await prisma.goldDispatch.findMany({
+      where: { goldPourId: { in: goldPourIds } },
+      select: { goldPourId: true },
+    })
+    const alreadyDispatchedIds = new Set<string>([
+      ...existingDispatchesForBatches.map((entry) => entry.goldPourId),
+      ...legacyDispatches.map((entry) => entry.goldPourId),
+    ])
 
-    const requiresOverride = existingDispatchCount > 0
+    const requiresOverride = alreadyDispatchedIds.size > 0
     if (requiresOverride && !validated.overrideReason?.trim()) {
+      const conflictingCodes = goldPours
+        .filter((pour) => alreadyDispatchedIds.has(pour.id))
+        .map((pour) => pour.pourBarId)
       return errorResponse(
-        "This batch already has a dispatch. Add an override reason to continue.",
+        `These batches already have a dispatch: ${conflictingCodes.join(", ")}. Add an override reason to continue.`,
         409,
-        {
-          requiresOverride: true,
-          existingDispatchCount,
-        },
+        { requiresOverride: true, conflictingPourBarIds: conflictingCodes },
       )
     }
 
@@ -134,7 +208,6 @@ export async function POST(request: NextRequest) {
       where: { id: validated.handedOverById },
       select: { companyId: true, isActive: true },
     })
-
     if (!handedOverBy || handedOverBy.companyId !== session.user.companyId || !handedOverBy.isActive) {
       return errorResponse("Invalid handover user", 400)
     }
@@ -144,44 +217,52 @@ export async function POST(request: NextRequest) {
       notesSegments.push(`Override reason: ${validated.overrideReason.trim()}`)
     }
     const mergedNotes = notesSegments.filter(Boolean).join("\n\n")
+
+    const totalGrossWeight = goldPours.reduce((sum, pour) => sum + pour.grossWeight, 0)
     const valuation = await snapshotGoldUsdValue({
       companyId: session.user.companyId,
       businessDate: validated.dispatchDate,
-      grams: goldPour.grossWeight,
+      grams: totalGrossWeight,
     })
     if (!valuation) {
       return errorResponse("No gold price configured. Add a gold price before recording dispatches.", 409)
     }
 
-    const dispatchRecord = await prisma.goldDispatch.create({
-      data: {
-        goldPourId: validated.goldPourId,
-        dispatchDate: new Date(validated.dispatchDate),
-        goldPriceUsdPerGram: valuation.goldPriceUsdPerGram,
-        valuationDate: valuation.valuationDate,
-        valueUsd: valuation.valueUsd,
-        courier: validated.courier,
-        vehicle: validated.vehicle,
-        destination: validated.destination,
-        sealNumbers: validated.sealNumbers,
-        handedOverById: validated.handedOverById,
-        receivedBy: validated.receivedBy,
-        notes: mergedNotes || undefined,
-      },
-      include: {
-        goldPour: {
-          select: {
-            id: true,
-            pourBarId: true,
-            pourDate: true,
-            grossWeight: true,
-            goldPriceUsdPerGram: true,
-            valueUsd: true,
-            site: { select: { name: true, code: true } },
-          },
+    const orderedPours = goldPourIds
+      .map((id) => goldPours.find((pour) => pour.id === id))
+      .filter((pour): pour is (typeof goldPours)[number] => Boolean(pour))
+    const primaryPourId = orderedPours[0].id
+
+    const dispatchRecord = await prisma.$transaction(async (tx) => {
+      const created = await tx.goldDispatch.create({
+        data: {
+          goldPourId: primaryPourId,
+          dispatchDate: new Date(validated.dispatchDate),
+          goldPriceUsdPerGram: valuation.goldPriceUsdPerGram,
+          valuationDate: valuation.valuationDate,
+          valueUsd: valuation.valueUsd,
+          courier: validated.courier,
+          vehicle: validated.vehicle,
+          destination: validated.destination,
+          sealNumbers: validated.sealNumbers,
+          handedOverById: validated.handedOverById,
+          receivedBy: validated.receivedBy,
+          notes: mergedNotes || undefined,
         },
-        handedOverBy: { select: { name: true } },
-      },
+      })
+
+      await tx.goldDispatchBatch.createMany({
+        data: orderedPours.map((pour, index) => ({
+          dispatchId: created.id,
+          goldPourId: pour.id,
+          sortOrder: index,
+        })),
+      })
+
+      return tx.goldDispatch.findUniqueOrThrow({
+        where: { id: created.id },
+        include: dispatchInclude,
+      })
     })
 
     try {
@@ -192,11 +273,11 @@ export async function POST(request: NextRequest) {
         sourceType: "GOLD_DISPATCH",
         sourceId: dispatchRecord.id,
         entryDate: dispatchRecord.dispatchDate,
-        description: `Gold dispatch ${dispatchRecord.id} for batch ${dispatchRecord.goldPour.pourBarId}`,
-        amount: dispatchRecord.valueUsd ?? dispatchRecord.goldPour.grossWeight,
+        description: `Gold dispatch ${dispatchRecord.id} for ${orderedPours.length} batch(es)`,
+        amount: dispatchRecord.valueUsd ?? totalGrossWeight,
         payload: {
-          goldPourId: dispatchRecord.goldPourId,
-          grossWeight: dispatchRecord.goldPour.grossWeight,
+          goldPourIds,
+          totalGrossWeight,
           valueUsd: dispatchRecord.valueUsd,
           goldPriceUsdPerGram: dispatchRecord.goldPriceUsdPerGram,
           valuationDate: dispatchRecord.valuationDate,
@@ -213,17 +294,10 @@ export async function POST(request: NextRequest) {
 
     return successResponse(
       {
-        ...dispatchRecord,
-        batchId: dispatchRecord.goldPour.id,
-        batchCode: dispatchRecord.goldPour.pourBarId,
-        goldPour: {
-          ...dispatchRecord.goldPour,
-          batchId: dispatchRecord.goldPour.id,
-          batchCode: dispatchRecord.goldPour.pourBarId,
-        },
+        ...normalizeDispatch(dispatchRecord),
         warnings: requiresOverride
           ? [
-              `This batch already had ${existingDispatchCount} dispatch record(s). Override reason was recorded.`,
+              `${alreadyDispatchedIds.size} batch(es) already had a dispatch record. Override reason was recorded.`,
             ]
           : [],
       },

--- a/app/api/gold/pours/route.ts
+++ b/app/api/gold/pours/route.ts
@@ -15,6 +15,8 @@ const goldPourSchema = z.object({
   witness2Id: z.string().uuid(),
   storageLocation: z.string().min(1).max(200),
   estimatedPurity: z.number().min(0).max(100).optional(),
+  additionalExpensesWeight: z.number().min(0).max(10000).optional(),
+  additionalExpensesNote: z.string().max(500).optional(),
   notes: z.string().max(1000).optional(),
 });
 
@@ -194,6 +196,8 @@ export async function POST(request: NextRequest) {
         witness2Id: validated.witness2Id,
         storageLocation: validated.storageLocation,
         estimatedPurity: validated.estimatedPurity,
+        additionalExpensesWeight: validated.additionalExpensesWeight,
+        additionalExpensesNote: validated.additionalExpensesNote,
         notes: validated.notes,
         createdById: session.user.id,
       },

--- a/app/api/gold/receipts/batch/route.ts
+++ b/app/api/gold/receipts/batch/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  validateSession,
+  successResponse,
+  errorResponse,
+} from "@/lib/api-utils"
+import { snapshotGoldUsdValue } from "@/lib/gold/valuation"
+import { prisma } from "@/lib/prisma"
+import { createJournalEntryFromSource } from "@/lib/accounting/posting"
+import { reserveIdentifier } from "@/lib/id-generator"
+import { z } from "zod"
+
+const batchReceiptSchema = z.object({
+  goldDispatchId: z.string().uuid().optional(),
+  receiptDate: z
+    .string()
+    .datetime()
+    .or(z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/)),
+  paymentMethod: z.string().min(1).max(100),
+  paymentChannel: z.string().max(100).optional(),
+  paymentReference: z.string().max(100).optional(),
+  notes: z.string().max(1000).optional(),
+  items: z
+    .array(
+      z.object({
+        goldPourId: z.string().uuid(),
+        assayResult: z.number().min(0).optional(),
+        paidAmount: z.number().min(0),
+      }),
+    )
+    .min(1)
+    .max(50),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request)
+    if (sessionResult instanceof NextResponse) return sessionResult
+    const { session } = sessionResult
+
+    const body = await request.json()
+    const validated = batchReceiptSchema.parse(body)
+
+    const pourIds = Array.from(new Set(validated.items.map((item) => item.goldPourId)))
+    if (pourIds.length !== validated.items.length) {
+      return errorResponse("Each batch can only appear once per submission", 400)
+    }
+
+    const pours = await prisma.goldPour.findMany({
+      where: { id: { in: pourIds } },
+      select: { id: true, grossWeight: true, pourBarId: true, site: { select: { companyId: true } } },
+    })
+    if (pours.length !== pourIds.length) {
+      return errorResponse("One or more batches were not found", 404)
+    }
+    for (const pour of pours) {
+      if (pour.site.companyId !== session.user.companyId) {
+        return errorResponse("Invalid batch", 403)
+      }
+    }
+
+    if (validated.goldDispatchId) {
+      const dispatch = await prisma.goldDispatch.findUnique({
+        where: { id: validated.goldDispatchId },
+        include: {
+          goldPour: { select: { site: { select: { companyId: true } } } },
+          batches: { select: { goldPourId: true } },
+        },
+      })
+      if (!dispatch || dispatch.goldPour.site.companyId !== session.user.companyId) {
+        return errorResponse("Invalid dispatch", 403)
+      }
+      const dispatchPourIds = new Set<string>([
+        dispatch.goldPourId,
+        ...dispatch.batches.map((b) => b.goldPourId),
+      ])
+      for (const pourId of pourIds) {
+        if (!dispatchPourIds.has(pourId)) {
+          return errorResponse("Batch is not part of the selected dispatch", 400)
+        }
+      }
+    }
+
+    const existingReceipts = await prisma.buyerReceipt.findMany({
+      where: {
+        OR: [
+          { goldPourId: { in: pourIds } },
+          { goldDispatch: { is: { goldPourId: { in: pourIds } } } },
+        ],
+      },
+      select: { goldPourId: true, goldDispatch: { select: { goldPourId: true } } },
+    })
+    const alreadyReceiptedIds = new Set<string>()
+    for (const receipt of existingReceipts) {
+      if (receipt.goldPourId) alreadyReceiptedIds.add(receipt.goldPourId)
+      if (receipt.goldDispatch?.goldPourId) alreadyReceiptedIds.add(receipt.goldDispatch.goldPourId)
+    }
+    const conflicts = pours.filter((pour) => alreadyReceiptedIds.has(pour.id))
+    if (conflicts.length > 0) {
+      return errorResponse(
+        `Sale records already exist for: ${conflicts.map((c) => c.pourBarId).join(", ")}`,
+        409,
+      )
+    }
+
+    const pourLookup = new Map(pours.map((pour) => [pour.id, pour]))
+
+    const created = await prisma.$transaction(async (tx) => {
+      const results: Array<{ id: string }> = []
+      let totalPaid = 0
+      for (const item of validated.items) {
+        const pour = pourLookup.get(item.goldPourId)!
+        const valuation = await snapshotGoldUsdValue({
+          companyId: session.user.companyId,
+          businessDate: validated.receiptDate,
+          grams: pour.grossWeight,
+        })
+        if (!valuation) {
+          throw new Error("No gold price configured. Add a gold price before recording sales.")
+        }
+        const receiptNumber = await reserveIdentifier(tx, {
+          companyId: session.user.companyId,
+          entity: "GOLD_RECEIPT",
+        })
+        const receipt = await tx.buyerReceipt.create({
+          data: {
+            goldDispatchId: validated.goldDispatchId,
+            goldPourId: item.goldPourId,
+            receiptNumber,
+            receiptDate: new Date(validated.receiptDate),
+            assayResult: item.assayResult,
+            paidAmount: item.paidAmount,
+            goldPriceUsdPerGram: valuation.goldPriceUsdPerGram,
+            valuationDate: valuation.valuationDate,
+            paidValueUsd: item.paidAmount,
+            paymentMethod: validated.paymentMethod,
+            paymentChannel: validated.paymentChannel,
+            paymentReference: validated.paymentReference,
+            notes: validated.notes,
+          },
+        })
+        results.push({ id: receipt.id })
+        totalPaid += item.paidAmount
+      }
+      return { results, totalPaid }
+    })
+
+    for (const result of created.results) {
+      try {
+        const receipt = await prisma.buyerReceipt.findUnique({ where: { id: result.id } })
+        if (!receipt) continue
+        await createJournalEntryFromSource({
+          companyId: session.user.companyId,
+          sourceType: "GOLD_RECEIPT",
+          sourceId: receipt.id,
+          entryDate: receipt.receiptDate,
+          description: `Gold receipt ${receipt.receiptNumber}`,
+          createdById: session.user.id,
+          amount: receipt.paidValueUsd ?? receipt.paidAmount,
+          netAmount: receipt.paidValueUsd ?? receipt.paidAmount,
+          taxAmount: 0,
+          grossAmount: receipt.paidValueUsd ?? receipt.paidAmount,
+        })
+      } catch (error) {
+        console.error("[Accounting] Gold batch receipt auto-post failed:", error)
+      }
+    }
+
+    return successResponse(
+      { count: created.results.length, ids: created.results.map((r) => r.id), totalPaid: created.totalPaid },
+      201,
+    )
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues)
+    }
+    if (error instanceof Error && error.message.includes("No gold price")) {
+      return errorResponse(error.message, 409)
+    }
+    console.error("[API] POST /api/gold/receipts/batch error:", error)
+    return errorResponse("Failed to create batch receipts")
+  }
+}

--- a/app/api/gold/summary/route.ts
+++ b/app/api/gold/summary/route.ts
@@ -1,0 +1,304 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  validateSession,
+  successResponse,
+  errorResponse,
+} from "@/lib/api-utils"
+import { prisma } from "@/lib/prisma"
+import { getLatestGoldPriceSnapshot } from "@/lib/gold/valuation"
+
+function startOfWeekUtc(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getUTCDay() // 0=Sun
+  // Treat Monday as start of week.
+  const diff = (day + 6) % 7
+  d.setUTCDate(d.getUTCDate() - diff)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d
+}
+
+function dateKeyUtc(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request)
+    if (sessionResult instanceof NextResponse) return sessionResult
+    const { session } = sessionResult
+    const companyId = session.user.companyId
+
+    const now = new Date()
+    const weekStart = startOfWeekUtc(now)
+    const weekEnd = addDays(weekStart, 7)
+    const priorWeekStart = addDays(weekStart, -7)
+    const priorWeekEnd = weekStart
+    const trailing30Start = addDays(weekStart, -30)
+
+    const siteScope = { companyId }
+
+    const [
+      thisWeekReceipts,
+      priorWeekReceipts,
+      thisWeekPours,
+      priorWeekPours,
+      undispatchedAndUnsoldPours,
+      workerSharesUnpaid,
+      dailyPours30,
+      poursBySite30,
+      recentReceipts,
+      topEarners30,
+    ] = await Promise.all([
+      // Cash this week
+      prisma.buyerReceipt.findMany({
+        where: {
+          receiptDate: { gte: weekStart, lt: weekEnd },
+          OR: [
+            { goldPour: { is: { site: siteScope } } },
+            { goldDispatch: { is: { goldPour: { site: siteScope } } } },
+          ],
+        },
+        select: { paidValueUsd: true, paidAmount: true },
+      }),
+      // Cash prior week
+      prisma.buyerReceipt.findMany({
+        where: {
+          receiptDate: { gte: priorWeekStart, lt: priorWeekEnd },
+          OR: [
+            { goldPour: { is: { site: siteScope } } },
+            { goldDispatch: { is: { goldPour: { site: siteScope } } } },
+          ],
+        },
+        select: { paidValueUsd: true, paidAmount: true },
+      }),
+      // Production this week
+      prisma.goldPour.findMany({
+        where: {
+          site: siteScope,
+          pourDate: { gte: weekStart, lt: weekEnd },
+        },
+        select: { grossWeight: true },
+      }),
+      // Production prior week
+      prisma.goldPour.findMany({
+        where: {
+          site: siteScope,
+          pourDate: { gte: priorWeekStart, lt: priorWeekEnd },
+        },
+        select: { grossWeight: true },
+      }),
+      // Awaiting sale: pours with no receipt (direct or via dispatch)
+      prisma.goldPour.findMany({
+        where: {
+          site: siteScope,
+          receipts: { none: {} },
+          dispatches: { every: { buyerReceipts: { none: {} } } },
+        },
+        select: { grossWeight: true, valueUsd: true },
+      }),
+      // Worker share owed (approved allocations) minus paid employee payments
+      prisma.goldShiftWorkerShare.findMany({
+        where: {
+          allocation: {
+            site: siteScope,
+            workflowStatus: "APPROVED",
+          },
+        },
+        select: { shareValueUsd: true, shareWeight: true },
+      }),
+      // Daily production trailing 30 days
+      prisma.goldPour.findMany({
+        where: {
+          site: siteScope,
+          pourDate: { gte: trailing30Start, lt: weekEnd },
+        },
+        select: { pourDate: true, grossWeight: true, valueUsd: true },
+        orderBy: { pourDate: "asc" },
+      }),
+      // Production by site, last 30 days
+      prisma.goldPour.findMany({
+        where: {
+          site: siteScope,
+          pourDate: { gte: trailing30Start, lt: weekEnd },
+        },
+        select: {
+          grossWeight: true,
+          site: { select: { id: true, name: true, code: true } },
+        },
+      }),
+      // Recent sales
+      prisma.buyerReceipt.findMany({
+        where: {
+          OR: [
+            { goldPour: { is: { site: siteScope } } },
+            { goldDispatch: { is: { goldPour: { site: siteScope } } } },
+          ],
+        },
+        orderBy: { receiptDate: "desc" },
+        take: 5,
+        select: {
+          id: true,
+          receiptNumber: true,
+          receiptDate: true,
+          paidValueUsd: true,
+          paidAmount: true,
+          paymentMethod: true,
+          goldPour: {
+            select: {
+              pourBarId: true,
+              site: { select: { name: true } },
+            },
+          },
+          goldDispatch: {
+            select: {
+              goldPour: {
+                select: {
+                  pourBarId: true,
+                  site: { select: { name: true } },
+                },
+              },
+            },
+          },
+        },
+      }),
+      // Top earners last 30d (workers with highest total share)
+      prisma.goldShiftWorkerShare.groupBy({
+        by: ["employeeId"],
+        where: {
+          allocation: {
+            site: siteScope,
+            date: { gte: trailing30Start, lt: weekEnd },
+          },
+        },
+        _sum: { shareValueUsd: true, shareWeight: true },
+        orderBy: { _sum: { shareValueUsd: "desc" } },
+        take: 5,
+      }),
+    ])
+
+    const sumPaidUsd = (rows: Array<{ paidValueUsd: number | null; paidAmount: number }>) =>
+      rows.reduce((sum, row) => sum + (row.paidValueUsd ?? row.paidAmount ?? 0), 0)
+
+    const sumWeight = (rows: Array<{ grossWeight: number }>) =>
+      rows.reduce((sum, row) => sum + row.grossWeight, 0)
+
+    const cashThisWeekUsd = sumPaidUsd(thisWeekReceipts)
+    const cashPriorWeekUsd = sumPaidUsd(priorWeekReceipts)
+    const producedThisWeekGrams = sumWeight(thisWeekPours)
+    const producedPriorWeekGrams = sumWeight(priorWeekPours)
+
+    const latestPrice = await getLatestGoldPriceSnapshot(companyId)
+    const spotUsdPerGram = latestPrice?.goldPriceUsdPerGram ?? null
+
+    const awaitingSaleGrams = undispatchedAndUnsoldPours.reduce(
+      (sum, pour) => sum + pour.grossWeight,
+      0,
+    )
+    const awaitingSaleUsd = undispatchedAndUnsoldPours.reduce((sum, pour) => {
+      if (pour.valueUsd != null) return sum + pour.valueUsd
+      if (spotUsdPerGram != null) return sum + pour.grossWeight * spotUsdPerGram
+      return sum
+    }, 0)
+
+    const owedToWorkersUsd = workerSharesUnpaid.reduce((sum, share) => {
+      if (share.shareValueUsd != null) return sum + share.shareValueUsd
+      if (spotUsdPerGram != null) return sum + share.shareWeight * spotUsdPerGram
+      return sum
+    }, 0)
+
+    // Daily production series — fill 30-day window with zeros for missing days.
+    const dailyMap = new Map<string, { grams: number; usd: number }>()
+    for (let i = 0; i < 37; i += 1) {
+      const day = addDays(trailing30Start, i)
+      if (day >= weekEnd) break
+      dailyMap.set(dateKeyUtc(day), { grams: 0, usd: 0 })
+    }
+    for (const pour of dailyPours30) {
+      const key = dateKeyUtc(pour.pourDate)
+      const entry = dailyMap.get(key)
+      if (!entry) continue
+      entry.grams += pour.grossWeight
+      entry.usd += pour.valueUsd ?? 0
+    }
+    const dailyProductionSeries = Array.from(dailyMap.entries()).map(
+      ([date, { grams, usd }]) => ({ date, grams, usd }),
+    )
+
+    // Production by site
+    const siteMap = new Map<string, { id: string; name: string; code: string; grams: number }>()
+    for (const pour of poursBySite30) {
+      const id = pour.site.id
+      const existing = siteMap.get(id) ?? {
+        id,
+        name: pour.site.name,
+        code: pour.site.code,
+        grams: 0,
+      }
+      existing.grams += pour.grossWeight
+      siteMap.set(id, existing)
+    }
+    const productionBySite = Array.from(siteMap.values()).sort((a, b) => b.grams - a.grams)
+
+    // Recent sales: normalize batch info
+    const recentSales = recentReceipts.map((receipt) => {
+      const pour = receipt.goldPour ?? receipt.goldDispatch?.goldPour
+      return {
+        id: receipt.id,
+        receiptNumber: receipt.receiptNumber,
+        receiptDate: receipt.receiptDate,
+        paidUsd: receipt.paidValueUsd ?? receipt.paidAmount,
+        paymentMethod: receipt.paymentMethod,
+        batchCode: pour?.pourBarId ?? "—",
+        siteName: pour?.site.name ?? "—",
+      }
+    })
+
+    // Top earners: hydrate employee names
+    const topEmployeeIds = topEarners30.map((row) => row.employeeId)
+    const topEmployees = topEmployeeIds.length
+      ? await prisma.employee.findMany({
+          where: { id: { in: topEmployeeIds } },
+          select: { id: true, name: true, employeeId: true },
+        })
+      : []
+    const employeeMap = new Map(topEmployees.map((e) => [e.id, e]))
+    const topEarners = topEarners30.map((row) => {
+      const employee = employeeMap.get(row.employeeId)
+      return {
+        employeeId: row.employeeId,
+        name: employee?.name ?? "Unknown",
+        code: employee?.employeeId ?? null,
+        valueUsd: row._sum.shareValueUsd ?? 0,
+        weightGrams: row._sum.shareWeight ?? 0,
+      }
+    })
+
+    return successResponse({
+      generatedAt: now.toISOString(),
+      weekStart: weekStart.toISOString(),
+      kpis: {
+        cashThisWeekUsd,
+        cashPriorWeekUsd,
+        producedThisWeekGrams,
+        producedPriorWeekGrams,
+        awaitingSaleGrams,
+        awaitingSaleUsd,
+        owedToWorkersUsd,
+        spotUsdPerGram,
+      },
+      dailyProductionSeries,
+      productionBySite,
+      recentSales,
+      topEarners,
+    })
+  } catch (error) {
+    console.error("[API] GET /api/gold/summary error:", error)
+    return errorResponse("Failed to load gold summary")
+  }
+}

--- a/app/gold/components/dispatch-form.tsx
+++ b/app/gold/components/dispatch-form.tsx
@@ -3,18 +3,37 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { FieldHelp } from "@/components/shared/field-help";
 import { FormShell } from "@/components/shared/form-shell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { buildSavedRecordRedirect } from "@/lib/saved-record";
 import { goldRoutes } from "@/app/gold/routes";
 import { SearchableSelect } from "@/app/gold/components/searchable-select";
-import { Send, Shield } from "@/lib/icons";
+import { Send, ChevronDown } from "@/lib/icons";
+
+type AvailablePour = {
+  id: string;
+  pourBarId: string;
+  batchCode?: string;
+  grossWeight: number;
+  valueUsd?: number | null;
+  site: { name: string; code: string };
+  dispatchCount: number;
+};
+
+const STICKY_DEFAULTS = {
+  courier: "",
+  vehicle: "",
+  destination: "",
+  sealNumbers: "",
+  handedOverById: "",
+  receivedBy: "",
+};
 
 export function DispatchForm({
   cancelHref,
@@ -31,15 +50,7 @@ export function DispatchForm({
   newBatchHref?: string;
   employees: Array<{ id: string; name: string; employeeId: string }>;
   employeesLoading: boolean;
-  availablePours: Array<{
-    id: string;
-    pourBarId: string;
-    batchCode?: string;
-    grossWeight: number;
-    valueUsd?: number | null;
-    site: { name: string; code: string };
-    dispatchCount: number;
-  }>;
+  availablePours: AvailablePour[];
   mode?: "page" | "modal";
   onSuccess?: () => void;
   onCancel?: () => void;
@@ -49,17 +60,16 @@ export function DispatchForm({
   const queryClient = useQueryClient();
   const router = useRouter();
   const shouldRedirect = redirectOnSuccess ?? mode === "page";
+  const [quickEntry, setQuickEntry] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [siteFilter, setSiteFilter] = useState<string>("");
+  const [batchSearch, setBatchSearch] = useState("");
   const [formData, setFormData] = useState({
-    goldPourId: "",
+    goldPourIds: [] as string[],
     dispatchDate: new Date().toISOString().slice(0, 16),
-    courier: "",
-    vehicle: "",
-    destination: "",
-    sealNumbers: "",
-    handedOverById: "",
-    receivedBy: "",
     overrideReason: "",
     notes: "",
+    ...STICKY_DEFAULTS,
   });
 
   const handleSelectChange =
@@ -67,21 +77,6 @@ export function DispatchForm({
       setFormData((prev) => ({ ...prev, [field]: value }));
     };
 
-  const pourOptions = useMemo(
-    () =>
-      availablePours.map((pour) => ({
-        value: pour.id,
-        label: pour.batchCode ?? pour.pourBarId,
-        description: `${pour.site.name} (${pour.site.code}) - ${
-          pour.dispatchCount > 0
-            ? `${pour.dispatchCount} previous dispatch${pour.dispatchCount === 1 ? "" : "es"}`
-            : "No previous dispatch"
-        }`,
-        meta: `${pour.grossWeight} g | $${(pour.valueUsd ?? 0).toFixed(2)}`,
-        badgeVariant: (pour.dispatchCount > 0 ? "destructive" : "secondary") as "destructive" | "secondary",
-      })),
-    [availablePours],
-  );
   const employeeOptions = useMemo(
     () =>
       employees.map((employee) => ({
@@ -92,9 +87,68 @@ export function DispatchForm({
     [employees],
   );
 
+  const siteOptions = useMemo(() => {
+    const seen = new Map<string, { name: string; code: string }>();
+    availablePours.forEach((pour) => {
+      if (!seen.has(pour.site.code)) seen.set(pour.site.code, pour.site);
+    });
+    return Array.from(seen.entries()).map(([code, site]) => ({
+      value: code,
+      label: site.name,
+      meta: code,
+    }));
+  }, [availablePours]);
+
+  const filteredPours = useMemo(() => {
+    const needle = batchSearch.trim().toLowerCase();
+    return availablePours.filter((pour) => {
+      if (siteFilter && pour.site.code !== siteFilter) return false;
+      if (needle) {
+        const code = (pour.batchCode ?? pour.pourBarId).toLowerCase();
+        if (!code.includes(needle) && !pour.site.name.toLowerCase().includes(needle)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [availablePours, siteFilter, batchSearch]);
+
+  const togglePour = (id: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      goldPourIds: prev.goldPourIds.includes(id)
+        ? prev.goldPourIds.filter((existing) => existing !== id)
+        : [...prev.goldPourIds, id],
+    }));
+  };
+
+  const selectAllVisible = () => {
+    setFormData((prev) => ({
+      ...prev,
+      goldPourIds: Array.from(
+        new Set([...prev.goldPourIds, ...filteredPours.map((pour) => pour.id)]),
+      ),
+    }));
+  };
+
+  const clearSelected = () => {
+    setFormData((prev) => ({ ...prev, goldPourIds: [] }));
+  };
+
+  const selectedPours = useMemo(
+    () =>
+      formData.goldPourIds
+        .map((id) => availablePours.find((pour) => pour.id === id))
+        .filter((pour): pour is AvailablePour => Boolean(pour)),
+    [formData.goldPourIds, availablePours],
+  );
+  const totalWeight = selectedPours.reduce((sum, pour) => sum + pour.grossWeight, 0);
+  const totalValue = selectedPours.reduce((sum, pour) => sum + (pour.valueUsd ?? 0), 0);
+  const requiresOverrideReason = selectedPours.some((pour) => pour.dispatchCount > 0);
+
   const createDispatchMutation = useMutation({
     mutationFn: async (payload: {
-      goldPourId: string;
+      goldPourIds: string[];
       dispatchDate: string;
       courier: string;
       vehicle?: string;
@@ -111,7 +165,7 @@ export function DispatchForm({
       }),
     onSuccess: (dispatch, payload) => {
       toast({
-        title: "Dispatch recorded",
+        title: `Dispatch recorded (${payload.goldPourIds.length} batch${payload.goldPourIds.length === 1 ? "" : "es"})`,
         description:
           dispatch.warnings && dispatch.warnings.length > 0
             ? dispatch.warnings[0]
@@ -119,7 +173,18 @@ export function DispatchForm({
         variant: "success",
       });
       queryClient.invalidateQueries({ queryKey: ["gold-dispatches"] });
+      queryClient.invalidateQueries({ queryKey: ["gold-pours"] });
       onSuccess?.();
+      if (quickEntry && mode === "modal") {
+        // Keep logistics fields, reset batch selection + override reason for the next entry.
+        setFormData((prev) => ({
+          ...prev,
+          goldPourIds: [],
+          overrideReason: "",
+          notes: "",
+        }));
+        return;
+      }
       if (shouldRedirect) {
         const destination = buildSavedRecordRedirect(goldRoutes.transit.dispatches, {
           createdId: dispatch.id,
@@ -131,11 +196,8 @@ export function DispatchForm({
     },
   });
 
-  const selectedPour = availablePours.find((pour) => pour.id === formData.goldPourId);
-  const requiresOverrideReason = (selectedPour?.dispatchCount ?? 0) > 0;
-
   const canSubmit =
-    !!formData.goldPourId &&
+    formData.goldPourIds.length > 0 &&
     !!formData.dispatchDate &&
     !!formData.courier &&
     !!formData.destination &&
@@ -148,13 +210,16 @@ export function DispatchForm({
     if (!canSubmit) {
       toast({
         title: "Missing details",
-        description: "Fill all required dispatch fields before saving.",
+        description:
+          formData.goldPourIds.length === 0
+            ? "Select at least one batch."
+            : "Fill all required dispatch fields before saving.",
         variant: "destructive",
       });
       return;
     }
     createDispatchMutation.mutate({
-      goldPourId: formData.goldPourId,
+      goldPourIds: formData.goldPourIds,
       dispatchDate: formData.dispatchDate,
       courier: formData.courier.trim(),
       vehicle: formData.vehicle?.trim() || undefined,
@@ -169,10 +234,11 @@ export function DispatchForm({
 
   return (
     <FormShell
-      title="Dispatch Details"
+      variant={mode === "modal" ? "bare" : "page"}
+      title={mode === "modal" ? undefined : "Record Dispatch"}
       onSubmit={handleSubmit}
-      formClassName="space-y-6"
-      requiredHint="Fields marked * are required. Submitting redirects to dispatch history with this record highlighted."
+      formClassName="space-y-5"
+      requiredHint="Pick batches, courier, destination, seal, handover. Vehicle and notes are optional."
       errors={
         createDispatchMutation.error
           ? [getApiErrorMessage(createDispatchMutation.error)]
@@ -202,194 +268,269 @@ export function DispatchForm({
             className="flex-1 sm:flex-none"
           >
             <Send className="mr-2 h-5 w-5" />
-            {createDispatchMutation.isPending ? "Recording..." : "Save Dispatch"}
+            {createDispatchMutation.isPending
+              ? "Recording..."
+              : `Save Dispatch${formData.goldPourIds.length > 1 ? ` (${formData.goldPourIds.length})` : ""}`}
           </Button>
         </>
       }
     >
-      <Alert className="border-blue-200 bg-blue-50 text-blue-950">
-        <Shield className="h-4 w-4 text-blue-600" />
-        <AlertTitle>Dispatch Record</AlertTitle>
-        <AlertDescription>
-          Save who sent the batch, who received it, and where it is going.
-        </AlertDescription>
-      </Alert>
+      <p className="text-sm text-muted-foreground">
+        Pick the batches travelling together. Logistics apply to the whole trip.
+      </p>
+
+      <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="dispatch-quick-entry"
+            checked={quickEntry}
+            onCheckedChange={(checked) => setQuickEntry(checked === true)}
+          />
+          <label htmlFor="dispatch-quick-entry" className="text-sm font-medium cursor-pointer">
+            Backfill mode: keep logistics fields after save
+          </label>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          For ledger backfill: courier, vehicle, destination & handover stay filled in.
+        </span>
+      </div>
 
       <div className="space-y-4">
-          {availablePours.length === 0 ? (
-            <Alert>
-              <AlertTitle>No batches ready for dispatch</AlertTitle>
-              <AlertDescription>
-                Record a batch before creating a dispatch.
-              </AlertDescription>
-            </Alert>
-          ) : null}
-          <SearchableSelect
-            label="Select Batch *"
-            value={formData.goldPourId || undefined}
-            options={pourOptions}
-            placeholder={
-              availablePours.length === 0 ? "No batches available" : "Select batch"
+        {availablePours.length === 0 ? (
+          <Alert>
+            <AlertTitle>No batches ready for dispatch</AlertTitle>
+            <AlertDescription>
+              Record a batch before creating a dispatch.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="block text-sm font-semibold">
+                Batches * ({formData.goldPourIds.length} selected, {totalWeight.toFixed(3)} g, ${totalValue.toFixed(2)})
+              </label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={selectAllVisible}
+                  className="text-xs text-primary hover:underline"
+                >
+                  Select all visible
+                </button>
+                {formData.goldPourIds.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={clearSelected}
+                    className="text-xs text-muted-foreground hover:underline"
+                  >
+                    Clear
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() =>
+                    router.push(newBatchHref ?? goldRoutes.intake.newPour)
+                  }
+                  className="text-xs text-primary hover:underline"
+                >
+                  + New batch
+                </button>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-[1fr_180px] gap-2">
+              <Input
+                autoFocus
+                placeholder="Search batches..."
+                value={batchSearch}
+                onChange={(e) => setBatchSearch(e.target.value)}
+              />
+              <SearchableSelect
+                value={siteFilter || undefined}
+                options={[{ value: "", label: "All sites" }, ...siteOptions]}
+                placeholder="Filter by site"
+                searchPlaceholder="Search sites..."
+                onValueChange={(value) => setSiteFilter(value === "" ? "" : value)}
+              />
+            </div>
+            <div className="max-h-72 overflow-y-auto rounded-md border divide-y">
+              {filteredPours.length === 0 ? (
+                <p className="px-3 py-4 text-sm text-muted-foreground">
+                  No batches match the filters.
+                </p>
+              ) : (
+                filteredPours.map((pour) => {
+                  const checked = formData.goldPourIds.includes(pour.id);
+                  return (
+                    <label
+                      key={pour.id}
+                      className={`flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-muted/40 ${checked ? "bg-primary/5" : ""}`}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => togglePour(pour.id)}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono font-semibold">
+                            {pour.batchCode ?? pour.pourBarId}
+                          </span>
+                          {pour.dispatchCount > 0 ? (
+                            <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
+                              Re-dispatch
+                            </span>
+                          ) : null}
+                        </div>
+                        <div className="text-xs text-muted-foreground truncate">
+                          {pour.site.name} ({pour.site.code})
+                        </div>
+                      </div>
+                      <div className="text-right text-xs whitespace-nowrap">
+                        <div className="font-semibold">{pour.grossWeight.toFixed(3)} g</div>
+                        <div className="text-muted-foreground">
+                          ${(pour.valueUsd ?? 0).toFixed(2)}
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        )}
+
+        {requiresOverrideReason ? (
+          <Alert>
+            <AlertTitle>Some batches were already dispatched</AlertTitle>
+            <AlertDescription>
+              Provide an override reason to continue.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div>
+          <label className="block text-sm font-semibold mb-2">
+            Dispatch Date/Time *
+          </label>
+          <Input
+            type="datetime-local"
+            value={formData.dispatchDate}
+            onChange={(e) =>
+              setFormData({ ...formData, dispatchDate: e.target.value })
             }
-            searchPlaceholder="Search batches..."
-            onValueChange={handleSelectChange("goldPourId")}
-            onAddOption={() => router.push(newBatchHref ?? goldRoutes.intake.newPour)}
-            addLabel="Record new batch"
+            required
           />
-          <p className="text-xs text-muted-foreground">
-            Dispatch ID is created automatically after save.
-          </p>
+        </div>
 
-          {requiresOverrideReason ? (
-            <Alert>
-              <AlertTitle>Batch already dispatched before</AlertTitle>
-              <AlertDescription>
-                This batch already has {selectedPour?.dispatchCount} dispatch
-                record{selectedPour?.dispatchCount === 1 ? "" : "s"}.
-                Enter a reason to continue.
-              </AlertDescription>
-            </Alert>
-          ) : null}
-
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-semibold mb-2">
-              Dispatch Date/Time *
+              Courier *
             </label>
             <Input
-              type="datetime-local"
-              value={formData.dispatchDate}
-              onChange={(e) =>
-                setFormData({ ...formData, dispatchDate: e.target.value })
-              }
+              value={formData.courier}
+              onChange={(e) => setFormData({ ...formData, courier: e.target.value })}
+              placeholder="e.g., SecureTransit Ltd"
               required
             />
           </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-semibold mb-2">
-                Courier/Company *
-              </label>
-              <Input
-                value={formData.courier}
-                onChange={(e) =>
-                  setFormData({ ...formData, courier: e.target.value })
-                }
-                placeholder="e.g., SecureTransit Ltd"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-semibold mb-2">
-                Vehicle/Registration
-              </label>
-              <Input
-                value={formData.vehicle}
-                onChange={(e) =>
-                  setFormData({ ...formData, vehicle: e.target.value })
-                }
-                placeholder="e.g., ABC-1234"
-              />
-            </div>
-          </div>
-
           <div>
             <label className="block text-sm font-semibold mb-2">
               Destination *
             </label>
             <Input
               value={formData.destination}
-              onChange={(e) =>
-                setFormData({ ...formData, destination: e.target.value })
-              }
+              onChange={(e) => setFormData({ ...formData, destination: e.target.value })}
               placeholder="Buyer name and address"
               required
             />
           </div>
+        </div>
 
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-semibold mb-2">
-              Seal Numbers *
-            </label>
+            <label className="block text-sm font-semibold mb-2">Seal Numbers *</label>
             <Input
               value={formData.sealNumbers}
-              onChange={(e) =>
-                setFormData({ ...formData, sealNumbers: e.target.value })
-              }
+              onChange={(e) => setFormData({ ...formData, sealNumbers: e.target.value })}
               placeholder="e.g., S-12345, S-12346"
               required
             />
           </div>
+          <SearchableSelect
+            label="Handed Over By *"
+            value={formData.handedOverById || undefined}
+            options={employeeOptions}
+            placeholder={
+              employeesLoading ? "Loading employees..." : "Pick a clerk or manager"
+            }
+            searchPlaceholder="Search employees..."
+            onValueChange={handleSelectChange("handedOverById")}
+          />
+        </div>
 
-          <div className="border-t pt-4">
-            <h4 className="text-sm font-semibold mb-3">Handover Details</h4>
+        <details
+          className="group rounded-md border bg-card transition-all"
+          open={moreOpen || requiresOverrideReason}
+          onToggle={(e) => setMoreOpen((e.target as HTMLDetailsElement).open)}
+        >
+          <summary className="flex cursor-pointer select-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold">
+            <span>More details {requiresOverrideReason ? "(override required)" : null}</span>
+            <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+          </summary>
+          <div className="space-y-4 px-4 pb-4 pt-1">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <SearchableSelect
-                label="Handed Over By *"
-                value={formData.handedOverById || undefined}
-                options={employeeOptions}
-                placeholder={
-                  employeesLoading ? "Loading employees..." : "Select employee"
-                }
-                searchPlaceholder="Search employees..."
-                onValueChange={handleSelectChange("handedOverById")}
-                onAddOption={() => {
-                  router.push("/human-resources");
-                }}
-                addLabel="Add employee"
-              />
-
               <div>
-                <label className="block text-sm font-semibold mb-2">
-                  Received By
-                </label>
+                <label className="block text-sm font-semibold mb-2">Vehicle</label>
+                <Input
+                  value={formData.vehicle}
+                  onChange={(e) => setFormData({ ...formData, vehicle: e.target.value })}
+                  placeholder="e.g., ABC-1234"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-semibold mb-2">Received By</label>
                 <Input
                   value={formData.receivedBy}
                   onChange={(e) =>
                     setFormData({ ...formData, receivedBy: e.target.value })
                   }
-                  placeholder="Courier name"
+                  placeholder="Courier or buyer rep name"
                 />
               </div>
             </div>
-          </div>
 
-          <div>
-            <label className="block text-sm font-semibold mb-2">Notes</label>
-            <Textarea
-              value={formData.notes}
-              onChange={(e) =>
-                setFormData({ ...formData, notes: e.target.value })
-              }
-              rows={2}
-              placeholder="Additional dispatch notes..."
-            />
-          </div>
+            <div>
+              <label className="block text-sm font-semibold mb-2">Notes</label>
+              <Textarea
+                value={formData.notes}
+                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                rows={2}
+                placeholder="Anything to flag about this trip..."
+              />
+            </div>
 
-          <div>
-            <label className="block text-sm font-semibold mb-2">
-              Override Reason {requiresOverrideReason ? "*" : "(optional)"}
-            </label>
-            <Textarea
-              value={formData.overrideReason}
-              onChange={(e) =>
-                setFormData({ ...formData, overrideReason: e.target.value })
-              }
-              rows={2}
-              placeholder={
-                requiresOverrideReason
-                  ? "Explain why another dispatch is needed for this batch."
-                  : "Only required if this batch already has a dispatch record."
-              }
-            />
-            {requiresOverrideReason && !formData.overrideReason.trim() ? (
-              <p className="mt-1 text-xs text-destructive">
-                Override reason is required for already-dispatched batches.
-              </p>
+            {requiresOverrideReason ? (
+              <div>
+                <label className="block text-sm font-semibold mb-2">
+                  Override Reason *
+                </label>
+                <Textarea
+                  value={formData.overrideReason}
+                  onChange={(e) =>
+                    setFormData({ ...formData, overrideReason: e.target.value })
+                  }
+                  rows={2}
+                  placeholder="Why these already-dispatched batches need to ship again."
+                />
+                {!formData.overrideReason.trim() ? (
+                  <p className="mt-1 text-xs text-destructive">
+                    Override reason is required for already-dispatched batches.
+                  </p>
+                ) : null}
+              </div>
             ) : null}
-            <FieldHelp hint="Provide override reason whenever a batch already has a previous dispatch." />
           </div>
+        </details>
       </div>
     </FormShell>
   );

--- a/app/gold/components/pour-form.tsx
+++ b/app/gold/components/pour-form.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { FieldHelp } from "@/components/shared/field-help";
 import { FormShell } from "@/components/shared/form-shell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,9 +11,35 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { buildSavedRecordRedirect } from "@/lib/saved-record";
 import { goldRoutes } from "@/app/gold/routes";
-import { Send, Shield } from "@/lib/icons";
+import { Send, Shield, ChevronDown } from "@/lib/icons";
 import { SearchableSelect } from "@/app/gold/components/searchable-select";
 import { useReservedId } from "@/hooks/use-reserved-id";
+
+type PourFormValues = {
+  pourDate: string;
+  siteId: string;
+  grossWeight: string;
+  estimatedPurity: string;
+  witness1Id: string;
+  witness2Id: string;
+  storageLocation: string;
+  additionalExpensesWeight: string;
+  additionalExpensesNote: string;
+  notes: string;
+};
+
+const DEFAULT_VALUES: PourFormValues = {
+  pourDate: "",
+  siteId: "",
+  grossWeight: "",
+  estimatedPurity: "",
+  witness1Id: "",
+  witness2Id: "",
+  storageLocation: "Vault",
+  additionalExpensesWeight: "",
+  additionalExpensesNote: "",
+  notes: "",
+};
 
 export function PourForm({
   cancelHref,
@@ -45,28 +70,39 @@ export function PourForm({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<PourFormValues>(() => ({
+    ...DEFAULT_VALUES,
     pourDate: new Date().toISOString().slice(0, 16),
-    siteId: "",
-    grossWeight: "",
-    estimatedPurity: "",
-    witness1Id: "",
-    witness2Id: "",
-    storageLocation: "",
-    notes: "",
-  });
+  }));
+  const [moreOpen, setMoreOpen] = useState(false);
   const {
     reservedId: reservedPourBarId,
     isReserving: reservingPourBarId,
     error: reservePourBarIdError,
-  } = useReservedId({
-    entity: "GOLD_POUR",
-    enabled: true,
-  });
+  } = useReservedId({ entity: "GOLD_POUR", enabled: true });
   const shouldRedirect = redirectOnSuccess ?? mode === "page";
 
+  // Auto-open the disclosure if any optional field has been filled.
+  useEffect(() => {
+    if (
+      !moreOpen &&
+      (formData.estimatedPurity ||
+        formData.additionalExpensesWeight ||
+        formData.additionalExpensesNote ||
+        formData.notes)
+    ) {
+      setMoreOpen(true);
+    }
+  }, [
+    formData.estimatedPurity,
+    formData.additionalExpensesWeight,
+    formData.additionalExpensesNote,
+    formData.notes,
+    moreOpen,
+  ]);
+
   const handleSelectChange =
-    (field: keyof typeof formData) => (value: string) => {
+    (field: keyof PourFormValues) => (value: string) => {
       setFormData((prev) => ({ ...prev, [field]: value }));
     };
 
@@ -90,6 +126,13 @@ export function PourForm({
     [employees],
   );
 
+  // Auto-pick site if there is exactly one. Removes a click for single-site mines.
+  useEffect(() => {
+    if (!formData.siteId && sites.length === 1) {
+      setFormData((prev) => ({ ...prev, siteId: sites[0].id }));
+    }
+  }, [sites, formData.siteId]);
+
   const createPourMutation = useMutation({
     mutationFn: async (payload: {
       pourBarId: string;
@@ -100,6 +143,8 @@ export function PourForm({
       witness1Id: string;
       witness2Id: string;
       storageLocation: string;
+      additionalExpensesWeight?: number;
+      additionalExpensesNote?: string;
       notes?: string;
     }) =>
       fetchJson<{ id: string; createdAt?: string }>("/api/gold/pours", {
@@ -108,8 +153,8 @@ export function PourForm({
       }),
     onSuccess: (pour, payload) => {
       toast({
-        title: "Batch recorded",
-        description: "Batch saved and ready for dispatch.",
+        title: "Batch saved",
+        description: "Ready for dispatch.",
         variant: "success",
       });
       queryClient.invalidateQueries({ queryKey: ["gold-pours"] });
@@ -129,6 +174,10 @@ export function PourForm({
   const estimatedPurityValue = formData.estimatedPurity
     ? Number(formData.estimatedPurity)
     : undefined;
+  const additionalExpensesWeightValue = formData.additionalExpensesWeight
+    ? Number(formData.additionalExpensesWeight)
+    : undefined;
+
   const canSubmit =
     !!reservedPourBarId &&
     !!formData.pourDate &&
@@ -144,7 +193,7 @@ export function PourForm({
     if (!canSubmit) {
       toast({
         title: "Missing details",
-        description: "Fill all required pour details before saving.",
+        description: "Fill site, weight, and both witnesses to save.",
         variant: "destructive",
       });
       return;
@@ -152,7 +201,7 @@ export function PourForm({
     if (formData.witness1Id === formData.witness2Id) {
       toast({
         title: "Witnesses must differ",
-        description: "Select two different employees for witness validation.",
+        description: "Select two different employees.",
         variant: "destructive",
       });
       return;
@@ -161,8 +210,7 @@ export function PourForm({
       toast({
         title: "Unable to reserve batch ID",
         description:
-          reservePourBarIdError ??
-          "Please wait for batch ID reservation to complete.",
+          reservePourBarIdError ?? "Please wait for batch ID reservation.",
         variant: "destructive",
       });
       return;
@@ -175,23 +223,27 @@ export function PourForm({
       estimatedPurity: estimatedPurityValue,
       witness1Id: formData.witness1Id,
       witness2Id: formData.witness2Id,
-      storageLocation: formData.storageLocation.trim(),
+      storageLocation: formData.storageLocation.trim() || "Vault",
+      additionalExpensesWeight: additionalExpensesWeightValue,
+      additionalExpensesNote:
+        formData.additionalExpensesNote?.trim() || undefined,
       notes: formData.notes?.trim() || undefined,
     });
   };
 
   return (
     <FormShell
-      title="Batch Details"
+      variant={mode === "modal" ? "bare" : "page"}
+      title={mode === "modal" ? undefined : "Record Batch"}
       onSubmit={handleSubmit}
-      formClassName="space-y-6"
-      requiredHint="Fields marked * are required. Submitting redirects to the batches list with this record highlighted."
+      formClassName="space-y-5"
+      requiredHint="Fields marked * are required."
       errors={
         createPourMutation.error
           ? [getApiErrorMessage(createPourMutation.error)]
           : undefined
       }
-      errorTitle="Unable to record batch"
+      errorTitle="Could not save batch"
       actions={
         <>
           <Button
@@ -206,86 +258,108 @@ export function PourForm({
             }}
             className="flex-1 sm:flex-none"
           >
-            {mode === "modal" ? "Cancel" : "Back to Batches"}
+            {mode === "modal" ? "Cancel" : "Back"}
           </Button>
           <Button
             type="submit"
             size="lg"
-            disabled={!canSubmit || createPourMutation.isPending || reservingPourBarId}
+            disabled={
+              !canSubmit || createPourMutation.isPending || reservingPourBarId
+            }
             className="flex-1 sm:flex-none"
           >
             <Send className="mr-2 h-5 w-5" />
-            {createPourMutation.isPending ? "Recording..." : "Save Batch"}
+            {createPourMutation.isPending ? "Saving..." : "Save Batch"}
           </Button>
         </>
       }
     >
-      <div className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-semibold mb-2">Batch ID</label>
-              <Input
-                value={reservedPourBarId}
-                readOnly
-                aria-readonly="true"
-                placeholder={reservingPourBarId ? "Reserving..." : "Auto-generated"}
-              />
-              <FieldHelp
-                hint={
-                  reservePourBarIdError ??
-                  "Batch ID is auto-generated and cannot be edited."
-                }
-              />
-            </div>
+      <p className="text-sm text-muted-foreground">
+        Batch ID is auto-generated. Fill the basics — purity, storage and notes
+        live under <strong>More details</strong>.
+      </p>
 
-            <div>
-              <label className="block text-sm font-semibold mb-2">
-                Batch Date/Time *
-              </label>
-              <Input
-                type="datetime-local"
-                value={formData.pourDate}
-                onChange={(e) =>
-                  setFormData({ ...formData, pourDate: e.target.value })
-                }
-                required
-              />
-            </div>
-          </div>
-
-          <SearchableSelect
-            label="Site *"
-            value={formData.siteId || undefined}
-            options={siteOptions}
-            placeholder={sitesLoading ? "Loading sites..." : "Select site"}
-            searchPlaceholder="Search sites..."
-            onValueChange={handleSelectChange("siteId")}
-            onAddOption={() => {
-              toast({
-                title: "Add new site",
-                description: "Sites are managed in admin settings.",
-              });
-            }}
-            addLabel="Request new site"
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <SearchableSelect
+          label="Site *"
+          value={formData.siteId || undefined}
+          options={siteOptions}
+          placeholder={sitesLoading ? "Loading sites..." : "Pick a site"}
+          searchPlaceholder="Search sites..."
+          onValueChange={handleSelectChange("siteId")}
+        />
+        <div>
+          <label className="block text-sm font-semibold mb-2">
+            Gross Weight (g) *
+          </label>
+          <Input
+            autoFocus
+            type="number"
+            step="0.01"
+            inputMode="decimal"
+            value={formData.grossWeight}
+            onChange={(e) =>
+              setFormData({ ...formData, grossWeight: e.target.value })
+            }
+            placeholder="e.g. 12.50"
+            required
           />
+        </div>
+      </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-semibold mb-2">
-                Gross Weight (grams) *
-              </label>
-              <Input
-                type="number"
-                step="0.01"
-                value={formData.grossWeight}
-                onChange={(e) =>
-                  setFormData({ ...formData, grossWeight: e.target.value })
-                }
-                required
-              />
-              <FieldHelp hint="Capture the measured gross bar weight in grams." />
-            </div>
+      <div className="rounded-md border bg-muted/30 px-4 py-3">
+        <h4 className="text-sm font-semibold mb-3 flex items-center gap-2">
+          <Shield className="h-4 w-4 text-yellow-600" />
+          Two-Person Witness *
+        </h4>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <SearchableSelect
+            label="Witness 1"
+            value={formData.witness1Id || undefined}
+            options={employeeOptions}
+            placeholder={
+              employeesLoading ? "Loading..." : "Pick a clerk or manager"
+            }
+            searchPlaceholder="Search..."
+            onValueChange={handleSelectChange("witness1Id")}
+          />
+          <SearchableSelect
+            label="Witness 2"
+            value={formData.witness2Id || undefined}
+            options={employeeOptions}
+            placeholder={
+              employeesLoading ? "Loading..." : "Pick a clerk or manager"
+            }
+            searchPlaceholder="Search..."
+            onValueChange={handleSelectChange("witness2Id")}
+          />
+        </div>
+      </div>
 
+      <div>
+        <label className="block text-sm font-semibold mb-2">
+          Pour Date / Time
+        </label>
+        <Input
+          type="datetime-local"
+          value={formData.pourDate}
+          onChange={(e) =>
+            setFormData({ ...formData, pourDate: e.target.value })
+          }
+        />
+      </div>
+
+      <details
+        className="group rounded-md border bg-card transition-all"
+        open={moreOpen}
+        onToggle={(e) => setMoreOpen((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="flex cursor-pointer select-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold">
+          <span>More details</span>
+          <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+        </summary>
+        <div className="space-y-4 px-4 pb-4 pt-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-semibold mb-2">
                 Estimated Purity (%)
@@ -300,61 +374,60 @@ export function PourForm({
                 }
                 placeholder="Optional"
               />
-              <FieldHelp hint="Optional estimated purity from internal checks." />
             </div>
-          </div>
-
-          <div className="border-t pt-4">
-            <h4 className="text-sm font-semibold mb-3 flex items-center gap-2">
-              <Shield className="h-4 w-4 text-yellow-600" />
-              2-Person Witness Rule
-            </h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <SearchableSelect
-                label="Witness 1 *"
-                value={formData.witness1Id || undefined}
-                options={employeeOptions}
-                placeholder={
-                  employeesLoading ? "Loading employees..." : "Select employee"
+            <div>
+              <label className="block text-sm font-semibold mb-2">
+                Storage Location
+              </label>
+              <Input
+                value={formData.storageLocation}
+                onChange={(e) =>
+                  setFormData({ ...formData, storageLocation: e.target.value })
                 }
-                searchPlaceholder="Search employees..."
-                onValueChange={handleSelectChange("witness1Id")}
-                onAddOption={() => {
-                  router.push("/human-resources");
-                }}
-                addLabel="Add employee"
-              />
-
-              <SearchableSelect
-                label="Witness 2 *"
-                value={formData.witness2Id || undefined}
-                options={employeeOptions}
-                placeholder={
-                  employeesLoading ? "Loading employees..." : "Select employee"
-                }
-                searchPlaceholder="Search employees..."
-                onValueChange={handleSelectChange("witness2Id")}
-                onAddOption={() => {
-                  router.push("/human-resources");
-                }}
-                addLabel="Add employee"
+                placeholder="e.g. Vault, Safe 1"
               />
             </div>
           </div>
 
-          <div>
-            <label className="block text-sm font-semibold mb-2">
-              Storage Location *
-            </label>
-            <Input
-              value={formData.storageLocation}
-              onChange={(e) =>
-                setFormData({ ...formData, storageLocation: e.target.value })
-              }
-              placeholder="e.g., Safe 1, Vault A"
-              required
-            />
-            <FieldHelp hint="Specify exact secure storage location for custody tracking." />
+          <div className="rounded-md border bg-muted/20 px-3 py-3">
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              Additional Expenses
+            </h5>
+            <div className="grid grid-cols-1 sm:grid-cols-[160px_1fr] gap-3">
+              <div>
+                <label className="block text-xs font-medium mb-1.5">
+                  Weight (g)
+                </label>
+                <Input
+                  type="number"
+                  step="0.001"
+                  inputMode="decimal"
+                  value={formData.additionalExpensesWeight}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      additionalExpensesWeight: e.target.value,
+                    })
+                  }
+                  placeholder="0.000"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium mb-1.5">
+                  Note
+                </label>
+                <Input
+                  value={formData.additionalExpensesNote}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      additionalExpensesNote: e.target.value,
+                    })
+                  }
+                  placeholder="e.g. fuel & food deduction"
+                />
+              </div>
+            </div>
           </div>
 
           <div>
@@ -365,11 +438,11 @@ export function PourForm({
                 setFormData({ ...formData, notes: e.target.value })
               }
               rows={2}
-              placeholder="Additional observations..."
+              placeholder="Anything unusual about this batch..."
             />
-            <FieldHelp hint="Optional notes for unusual conditions or context." />
           </div>
-      </div>
+        </div>
+      </details>
     </FormShell>
   );
 }

--- a/app/gold/components/receipt-form.tsx
+++ b/app/gold/components/receipt-form.tsx
@@ -1,29 +1,72 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { FieldHelp } from "@/components/shared/field-help";
 import { FormShell } from "@/components/shared/form-shell";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { buildSavedRecordRedirect } from "@/lib/saved-record";
 import { goldRoutes } from "@/app/gold/routes";
-import { Send, Shield } from "@/lib/icons";
+import { Send, ChevronDown } from "@/lib/icons";
 import { SearchableSelect } from "@/app/gold/components/searchable-select";
 import type { SearchableOption } from "@/app/gold/types";
 import { useReservedId } from "@/hooks/use-reserved-id";
+
+type AvailableBatch = {
+  id: string;
+  pourDate: string;
+  pourBarId: string;
+  grossWeight: number;
+  valueUsd?: number | null;
+  site: { name: string };
+};
+
+type AvailableDispatch = {
+  id: string;
+  dispatchDate: string;
+  courier: string;
+  goldPourId: string;
+  goldPour: { pourBarId: string; grossWeight: number; site: { name: string } };
+  batches?: Array<{
+    goldPourId: string;
+    goldPour: {
+      id: string;
+      pourBarId: string;
+      grossWeight: number;
+      valueUsd?: number | null;
+      site: { name: string };
+    };
+  }>;
+};
+
+type LineItem = {
+  goldPourId: string;
+  pourBarId: string;
+  grossWeight: number;
+  assayResult: string;
+  paidAmount: string;
+  selected: boolean;
+};
+
+const DEFAULT_PAYMENT_METHODS: SearchableOption[] = [
+  { value: "CASH", label: "Cash" },
+  { value: "BANK_TRANSFER", label: "Bank Transfer" },
+  { value: "MOBILE_MONEY", label: "Mobile Money" },
+  { value: "CRYPTO", label: "Cryptocurrency" },
+  { value: "CHECK", label: "Check" },
+];
 
 export function ReceiptForm({
   cancelHref,
   batchCreateHref,
   availableBatches,
   availableDispatches,
+  soldPourIds,
   mode = "page",
   onSuccess,
   onCancel,
@@ -31,21 +74,9 @@ export function ReceiptForm({
 }: {
   cancelHref?: string;
   batchCreateHref?: string;
-  availableBatches: Array<{
-    id: string;
-    pourDate: string;
-    pourBarId: string;
-    grossWeight: number;
-    valueUsd?: number | null;
-    site: { name: string };
-  }>;
-  availableDispatches: Array<{
-    id: string;
-    dispatchDate: string;
-    courier: string;
-    goldPourId: string;
-    goldPour: { pourBarId: string; grossWeight: number; site: { name: string } };
-  }>;
+  availableBatches: AvailableBatch[];
+  availableDispatches: AvailableDispatch[];
+  soldPourIds?: Set<string>;
   mode?: "page" | "modal";
   onSuccess?: () => void;
   onCancel?: () => void;
@@ -55,24 +86,24 @@ export function ReceiptForm({
   const queryClient = useQueryClient();
   const router = useRouter();
   const shouldRedirect = redirectOnSuccess ?? mode === "page";
+  const [quickEntry, setQuickEntry] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [paymentMethods, setPaymentMethods] = useState<SearchableOption[]>(DEFAULT_PAYMENT_METHODS);
+
   const [formData, setFormData] = useState({
     goldPourId: "",
     goldDispatchId: "",
     receiptDate: new Date().toISOString().slice(0, 16),
     assayResult: "",
     paidAmount: "",
-    paymentMethod: "BANK_TRANSFER",
+    paymentMethod: "CASH",
     paymentChannel: "",
     paymentReference: "",
     notes: "",
   });
-  const [paymentMethods, setPaymentMethods] = useState<SearchableOption[]>([
-    { value: "BANK_TRANSFER", label: "Bank Transfer" },
-    { value: "CASH", label: "Cash" },
-    { value: "MOBILE_MONEY", label: "Mobile Money" },
-    { value: "CRYPTO", label: "Cryptocurrency" },
-    { value: "CHECK", label: "Check" },
-  ]);
+
+  const [lineItems, setLineItems] = useState<LineItem[]>([]);
+
   const {
     reservedId: reservedReceiptNumber,
     isReserving: reservingReceiptNumber,
@@ -82,20 +113,49 @@ export function ReceiptForm({
     enabled: true,
   });
 
-  const handleSelectChange =
-    (field: keyof typeof formData) => (value: string) => {
-      setFormData((prev) => {
-        if (field === "goldPourId") {
-          const nextDispatch =
-            prev.goldDispatchId &&
-            dispatchById.get(prev.goldDispatchId)?.goldPourId === value
-              ? prev.goldDispatchId
-              : ""
-          return { ...prev, goldPourId: value, goldDispatchId: nextDispatch }
-        }
-        return { ...prev, [field]: value }
-      });
-    };
+  const dispatchById = useMemo(
+    () => new Map(availableDispatches.map((dispatch) => [dispatch.id, dispatch])),
+    [availableDispatches],
+  );
+
+  const selectedDispatch = formData.goldDispatchId
+    ? dispatchById.get(formData.goldDispatchId)
+    : null;
+
+  const dispatchHasMultipleBatches = Boolean(
+    selectedDispatch?.batches && selectedDispatch.batches.length > 1,
+  );
+  const isBatchMode = dispatchHasMultipleBatches;
+
+  // When dispatch changes, derive line items from its batches.
+  useEffect(() => {
+    if (!selectedDispatch) {
+      setLineItems([]);
+      return;
+    }
+    const dispatchBatches = selectedDispatch.batches?.length
+      ? selectedDispatch.batches.map((batch) => ({
+          goldPourId: batch.goldPourId,
+          pourBarId: batch.goldPour.pourBarId,
+          grossWeight: batch.goldPour.grossWeight,
+        }))
+      : [
+          {
+            goldPourId: selectedDispatch.goldPourId,
+            pourBarId: selectedDispatch.goldPour.pourBarId,
+            grossWeight: selectedDispatch.goldPour.grossWeight,
+          },
+        ];
+
+    setLineItems(
+      dispatchBatches.map((batch) => ({
+        ...batch,
+        assayResult: "",
+        paidAmount: "",
+        selected: !soldPourIds?.has(batch.goldPourId),
+      })),
+    );
+  }, [selectedDispatch, soldPourIds]);
 
   const batchOptions = useMemo(
     () =>
@@ -108,50 +168,29 @@ export function ReceiptForm({
     [availableBatches],
   );
 
-  const dispatchById = new Map(availableDispatches.map((dispatch) => [dispatch.id, dispatch]));
-  const filteredDispatches = useMemo(
+  const dispatchOptions = useMemo(
     () =>
-      formData.goldPourId
-        ? availableDispatches.filter((dispatch) => dispatch.goldPourId === formData.goldPourId)
-        : availableDispatches,
-    [availableDispatches, formData.goldPourId],
+      availableDispatches.map((dispatch) => {
+        const batchCount = dispatch.batches?.length ?? 1;
+        const batchLabel =
+          batchCount > 1
+            ? `${batchCount} batches`
+            : dispatch.goldPour.pourBarId;
+        return {
+          value: dispatch.id,
+          label: batchLabel,
+          description: `${dispatch.courier} • ${new Date(dispatch.dispatchDate).toLocaleDateString()}`,
+          meta: dispatch.goldPour.site.name,
+        };
+      }),
+    [availableDispatches],
   );
 
-  const createReceiptMutation = useMutation({
-    mutationFn: async (payload: {
-      receiptNumber: string;
-      goldPourId: string;
-      goldDispatchId?: string;
-      receiptDate: string;
-      assayResult?: number;
-      paidAmount: number;
-      paymentMethod: string;
-      paymentChannel?: string;
-      paymentReference?: string;
-      notes?: string;
-    }) =>
-      fetchJson<{ id: string; createdAt?: string }>("/api/gold/receipts", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      }),
-    onSuccess: (receipt, payload) => {
-      toast({
-        title: "Sale recorded",
-        description: "Sale record saved successfully.",
-        variant: "success",
-      });
-      queryClient.invalidateQueries({ queryKey: ["gold-receipts"] });
-      onSuccess?.();
-      if (shouldRedirect) {
-        const destination = buildSavedRecordRedirect(goldRoutes.settlement.receipts, {
-          createdId: receipt.id,
-          createdAt: receipt.createdAt ?? payload.receiptDate,
-          source: "gold-receipt",
-        });
-        router.push(destination);
-      }
-    },
-  });
+  const updateLineItem = (index: number, patch: Partial<LineItem>) => {
+    setLineItems((prev) =>
+      prev.map((item, i) => (i === index ? { ...item, ...patch } : item)),
+    );
+  };
 
   const handleAddPaymentMethod = (query: string) => {
     const label = query.trim();
@@ -163,26 +202,131 @@ export function ReceiptForm({
     setFormData((prev) => ({ ...prev, paymentMethod: value }));
   };
 
+  const createReceiptMutation = useMutation({
+    mutationFn: async (payload: Record<string, unknown>) =>
+      fetchJson<{ id: string; createdAt?: string }>("/api/gold/receipts", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: handleSuccess,
+  });
+
+  const createBatchReceiptMutation = useMutation({
+    mutationFn: async (payload: Record<string, unknown>) =>
+      fetchJson<{ count: number; ids: string[] }>("/api/gold/receipts/batch", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (result) => {
+      toast({
+        title: `Recorded ${result.count} sale${result.count === 1 ? "" : "s"}`,
+        description: "Batch sale records saved successfully.",
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: ["gold-receipts"] });
+      queryClient.invalidateQueries({ queryKey: ["gold-dispatches"] });
+      onSuccess?.();
+      if (quickEntry && mode === "modal") {
+        setFormData((prev) => ({
+          ...prev,
+          goldPourId: "",
+          goldDispatchId: "",
+          assayResult: "",
+          paidAmount: "",
+          paymentReference: "",
+          notes: "",
+        }));
+        setLineItems([]);
+        return;
+      }
+      if (shouldRedirect) {
+        router.push(goldRoutes.settlement.receipts);
+      }
+    },
+  });
+
+  function handleSuccess(receipt: { id: string; createdAt?: string }) {
+    toast({
+      title: "Sale recorded",
+      description: "Sale record saved successfully.",
+      variant: "success",
+    });
+    queryClient.invalidateQueries({ queryKey: ["gold-receipts"] });
+    onSuccess?.();
+    if (quickEntry && mode === "modal") {
+      setFormData((prev) => ({
+        ...prev,
+        goldPourId: "",
+        goldDispatchId: "",
+        assayResult: "",
+        paidAmount: "",
+        paymentReference: "",
+        notes: "",
+      }));
+      setLineItems([]);
+      return;
+    }
+    if (shouldRedirect) {
+      const destination = buildSavedRecordRedirect(goldRoutes.settlement.receipts, {
+        createdId: receipt.id,
+        createdAt: receipt.createdAt,
+        source: "gold-receipt",
+      });
+      router.push(destination);
+    }
+  }
+
+  const isSubmitting =
+    createReceiptMutation.isPending || createBatchReceiptMutation.isPending;
+  const submissionError =
+    createReceiptMutation.error ?? createBatchReceiptMutation.error;
+
+  const selectedLineItems = lineItems.filter((item) => item.selected);
+  const batchModeReady =
+    isBatchMode &&
+    selectedLineItems.length > 0 &&
+    selectedLineItems.every((item) => {
+      const paid = Number(item.paidAmount);
+      return !!item.paidAmount && !Number.isNaN(paid) && paid >= 0;
+    });
+
   const paidAmountValue = Number(formData.paidAmount);
-  const assayResultValue = formData.assayResult
-    ? Number(formData.assayResult)
-    : undefined;
-  const canSubmit =
+  const singleModeReady =
+    !isBatchMode &&
     !!reservedReceiptNumber &&
     !!formData.goldPourId &&
     !!formData.receiptDate &&
-    !!formData.assayResult &&
     !Number.isNaN(paidAmountValue) &&
     paidAmountValue >= 0 &&
     !!formData.paymentMethod;
+
+  const canSubmit = isBatchMode ? batchModeReady : singleModeReady;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!canSubmit) {
       toast({
         title: "Missing details",
-        description: "Fill all required receipt fields before saving.",
+        description: isBatchMode
+          ? "Enter paid amount for each selected batch."
+          : "Fill all required receipt fields before saving.",
         variant: "destructive",
+      });
+      return;
+    }
+    if (isBatchMode) {
+      createBatchReceiptMutation.mutate({
+        goldDispatchId: formData.goldDispatchId,
+        receiptDate: formData.receiptDate,
+        paymentMethod: formData.paymentMethod,
+        paymentChannel: formData.paymentChannel?.trim() || undefined,
+        paymentReference: formData.paymentReference?.trim() || undefined,
+        notes: formData.notes?.trim() || undefined,
+        items: selectedLineItems.map((item) => ({
+          goldPourId: item.goldPourId,
+          assayResult: item.assayResult ? Number(item.assayResult) : undefined,
+          paidAmount: Number(item.paidAmount),
+        })),
       });
       return;
     }
@@ -201,7 +345,7 @@ export function ReceiptForm({
       goldPourId: formData.goldPourId,
       goldDispatchId: formData.goldDispatchId || undefined,
       receiptDate: formData.receiptDate,
-      assayResult: assayResultValue,
+      assayResult: formData.assayResult ? Number(formData.assayResult) : undefined,
       paidAmount: paidAmountValue,
       paymentMethod: formData.paymentMethod,
       paymentChannel: formData.paymentChannel?.trim() || undefined,
@@ -212,15 +356,12 @@ export function ReceiptForm({
 
   return (
     <FormShell
-      title="Sale Record"
+      variant={mode === "modal" ? "bare" : "page"}
+      title={mode === "modal" ? undefined : "Record Sale"}
       onSubmit={handleSubmit}
-      formClassName="space-y-6"
-      requiredHint="Fields marked * are required. Submitting redirects to sales history with this record highlighted."
-      errors={
-        createReceiptMutation.error
-          ? [getApiErrorMessage(createReceiptMutation.error)]
-          : undefined
-      }
+      formClassName="space-y-5"
+      requiredHint="Pick the dispatch (or batch), enter the cash paid. Channel and notes are optional."
+      errors={submissionError ? [getApiErrorMessage(submissionError)] : undefined}
       errorTitle="Unable to record sale"
       actions={
         <>
@@ -241,32 +382,59 @@ export function ReceiptForm({
           <Button
             type="submit"
             size="lg"
-            disabled={!canSubmit || createReceiptMutation.isPending || reservingReceiptNumber}
+            disabled={!canSubmit || isSubmitting || (!isBatchMode && reservingReceiptNumber)}
             className="flex-1 sm:flex-none"
           >
             <Send className="mr-2 h-5 w-5" />
-            {createReceiptMutation.isPending ? "Recording..." : "Save Sale"}
+            {isSubmitting
+              ? "Recording..."
+              : isBatchMode
+                ? `Save ${selectedLineItems.length} Sale${selectedLineItems.length === 1 ? "" : "s"}`
+                : "Save Sale"}
           </Button>
         </>
       }
     >
-      <Alert className="border-green-200 bg-green-50 text-green-950">
-        <Shield className="h-4 w-4 text-green-600" />
-        <AlertTitle>Sale Details</AlertTitle>
-        <AlertDescription>
-          Record buyer test results and payment details.
-        </AlertDescription>
-      </Alert>
+      <p className="text-sm text-muted-foreground">
+        Pick a dispatch (multi-batch shipments record sales for all batches at once) or sell directly from a batch.
+      </p>
+
+      <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="receipt-quick-entry"
+            checked={quickEntry}
+            onCheckedChange={(checked) => setQuickEntry(checked === true)}
+          />
+          <label htmlFor="receipt-quick-entry" className="text-sm font-medium cursor-pointer">
+            Backfill mode: keep date & payment method after save
+          </label>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          For ledger backfill: stay on the form, swap dispatch/batch and re-enter amounts.
+        </span>
+      </div>
 
       <div className="space-y-4">
-          {availableBatches.length === 0 ? (
-            <Alert>
-              <AlertTitle>No batches awaiting sale</AlertTitle>
-              <AlertDescription>
-                Record a batch, or complete pending sales before adding a new one.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+        <div>
+          <label className="block text-sm font-semibold mb-2">Dispatch</label>
+          <SearchableSelect
+            value={formData.goldDispatchId || undefined}
+            options={[{ value: "", label: "No dispatch (direct from batch)" }, ...dispatchOptions]}
+            placeholder={availableDispatches.length === 0 ? "No active dispatches" : "Select dispatch"}
+            searchPlaceholder="Search dispatches..."
+            onValueChange={(value) =>
+              setFormData((prev) => ({
+                ...prev,
+                goldDispatchId: value === "" ? "" : value,
+                goldPourId: "",
+              }))
+            }
+          />
+          <p className="mt-1 text-xs text-muted-foreground">Pick a multi-batch dispatch to enter all batch sales at once.</p>
+        </div>
+
+        {!isBatchMode ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-semibold mb-2">Receipt Number</label>
@@ -276,12 +444,6 @@ export function ReceiptForm({
                 aria-readonly="true"
                 placeholder={reservingReceiptNumber ? "Reserving..." : "Auto-generated"}
               />
-              <FieldHelp
-                hint={
-                  reserveReceiptNumberError ??
-                  "Receipt number is auto-generated and cannot be edited."
-                }
-              />
             </div>
 
             <SearchableSelect
@@ -290,48 +452,18 @@ export function ReceiptForm({
               options={batchOptions}
               placeholder={availableBatches.length === 0 ? "No batches awaiting sale" : "Select batch"}
               searchPlaceholder="Search batches..."
-              onValueChange={handleSelectChange("goldPourId")}
+              onValueChange={(value) =>
+                setFormData((prev) => ({ ...prev, goldPourId: value }))
+              }
               onAddOption={() =>
                 router.push(batchCreateHref ?? goldRoutes.intake.create)
               }
               addLabel="Record batch"
             />
           </div>
+        ) : null}
 
-          <div>
-            <label className="block text-sm font-semibold mb-2">Dispatch (Optional)</label>
-            <Select
-              value={formData.goldDispatchId || "none"}
-              onValueChange={(value) =>
-                setFormData((prev) => ({ ...prev, goldDispatchId: value === "none" ? "" : value }))
-              }
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="No dispatch" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">No dispatch (direct sale from batch)</SelectItem>
-                {filteredDispatches.map((dispatch) => (
-                  <SelectItem key={dispatch.id} value={dispatch.id}>
-                    {dispatch.goldPour.pourBarId} | {dispatch.courier} | {dispatch.goldPour.site.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <FieldHelp
-              hint={
-                formData.goldPourId
-                  ? "Link a dispatch only if this sale came through transit."
-                  : "Select a batch first to narrow dispatch options."
-              }
-            />
-            {formData.goldPourId && filteredDispatches.length === 0 ? (
-              <p className="mt-1 text-xs text-muted-foreground">
-                No dispatch records for this batch yet. You can still save this as a direct sale.
-              </p>
-            ) : null}
-          </div>
-
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-semibold mb-2">Sale Date *</label>
             <Input
@@ -341,56 +473,130 @@ export function ReceiptForm({
               required
             />
           </div>
+          <SearchableSelect
+            label="Payment Method *"
+            value={formData.paymentMethod}
+            options={paymentMethods}
+            placeholder="Select method"
+            searchPlaceholder="Search methods..."
+            onValueChange={(value) =>
+              setFormData((prev) => ({ ...prev, paymentMethod: value }))
+            }
+            onAddOption={handleAddPaymentMethod}
+            addLabel="Add payment method"
+          />
+        </div>
 
-          <div className="border-t pt-4">
-            <h4 className="text-sm font-semibold mb-3">Buyer Test Results</h4>
-            <div>
-              <label className="block text-sm font-semibold mb-2">
-                Final tested gold (grams) *
-              </label>
-              <Input
-                type="number"
-                step="0.01"
-                value={formData.assayResult}
-                onChange={(e) => setFormData({ ...formData, assayResult: e.target.value })}
-                placeholder="e.g., 42.35"
-                required
-              />
-              <FieldHelp hint="Enter the buyer-confirmed tested gold weight." />
+        {isBatchMode ? (
+          <div className="border-t pt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold">
+                Batch Receipts ({selectedLineItems.length} of {lineItems.length} selected)
+              </h4>
+              <button
+                type="button"
+                onClick={() =>
+                  setLineItems((prev) => prev.map((item) => ({ ...item, selected: true })))
+                }
+                className="text-xs text-primary hover:underline"
+              >
+                Select all
+              </button>
             </div>
+            <div className="rounded-md border divide-y">
+              {lineItems.map((item, index) => {
+                const alreadySold = soldPourIds?.has(item.goldPourId);
+                return (
+                  <div
+                    key={item.goldPourId}
+                    className={`grid grid-cols-[auto_1fr_140px_140px] gap-3 items-center px-3 py-2 ${item.selected ? "bg-primary/5" : ""}`}
+                  >
+                    <Checkbox
+                      checked={item.selected}
+                      disabled={alreadySold}
+                      onCheckedChange={(checked) =>
+                        updateLineItem(index, { selected: checked === true })
+                      }
+                    />
+                    <div className="min-w-0">
+                      <div className="font-mono font-semibold truncate">
+                        {item.pourBarId}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {item.grossWeight.toFixed(3)} g
+                        {alreadySold ? " • already sold" : ""}
+                      </div>
+                    </div>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      placeholder="Tested g"
+                      value={item.assayResult}
+                      onChange={(e) =>
+                        updateLineItem(index, { assayResult: e.target.value })
+                      }
+                      disabled={!item.selected}
+                    />
+                    <Input
+                      type="number"
+                      step="0.01"
+                      placeholder="Paid (USD)"
+                      value={item.paidAmount}
+                      onChange={(e) =>
+                        updateLineItem(index, { paidAmount: e.target.value })
+                      }
+                      disabled={!item.selected}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Paid amount per batch is required. Tested gold goes under <strong>More details</strong>.
+            </p>
           </div>
+        ) : (
+          <div>
+            <label className="block text-sm font-semibold mb-2">
+              Paid amount (USD) *
+            </label>
+            <Input
+              autoFocus
+              type="number"
+              step="0.01"
+              value={formData.paidAmount}
+              onChange={(e) => setFormData({ ...formData, paidAmount: e.target.value })}
+              placeholder="0.00"
+              required
+            />
+          </div>
+        )}
 
-          <div className="border-t pt-4">
-            <h4 className="text-sm font-semibold mb-3">Payment Details</h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <details
+          className="group rounded-md border bg-card transition-all"
+          open={moreOpen}
+          onToggle={(e) => setMoreOpen((e.target as HTMLDetailsElement).open)}
+        >
+          <summary className="flex cursor-pointer select-none items-center justify-between gap-2 px-4 py-3 text-sm font-semibold">
+            <span>More details</span>
+            <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+          </summary>
+          <div className="space-y-4 px-4 pb-4 pt-1">
+            {!isBatchMode ? (
               <div>
                 <label className="block text-sm font-semibold mb-2">
-                  Paid amount (USD) *
+                  Final tested gold (grams)
                 </label>
                 <Input
                   type="number"
                   step="0.01"
-                  value={formData.paidAmount}
-                  onChange={(e) => setFormData({ ...formData, paidAmount: e.target.value })}
-                  placeholder="0.00"
-                  required
+                  value={formData.assayResult}
+                  onChange={(e) => setFormData({ ...formData, assayResult: e.target.value })}
+                  placeholder="e.g., 42.35"
                 />
-                <FieldHelp hint="Recorded cash value used for settlement and accounting." />
               </div>
-
-              <SearchableSelect
-                label="Payment Method *"
-                value={formData.paymentMethod}
-                options={paymentMethods}
-                placeholder="Select method"
-                searchPlaceholder="Search methods..."
-                onValueChange={handleSelectChange("paymentMethod")}
-                onAddOption={handleAddPaymentMethod}
-                addLabel="Add payment method"
-              />
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            ) : null}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-semibold mb-2">Payment Channel</label>
                 <Input
@@ -401,35 +607,28 @@ export function ReceiptForm({
                   placeholder="e.g., Standard Bank, EcoCash"
                 />
               </div>
-
               <div>
-                <label className="block text-sm font-semibold mb-2">
-                  Payment Reference
-                </label>
+                <label className="block text-sm font-semibold mb-2">Payment Reference</label>
                 <Input
                   value={formData.paymentReference}
                   onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      paymentReference: e.target.value,
-                    })
+                    setFormData({ ...formData, paymentReference: e.target.value })
                   }
                   placeholder="Transaction ID or reference"
                 />
               </div>
             </div>
+            <div>
+              <label className="block text-sm font-semibold mb-2">Notes</label>
+              <Textarea
+                value={formData.notes}
+                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                rows={2}
+                placeholder="Anything to flag..."
+              />
+            </div>
           </div>
-
-          <div>
-            <label className="block text-sm font-semibold mb-2">Notes</label>
-            <Textarea
-              value={formData.notes}
-              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-              rows={2}
-              placeholder="Additional payment notes..."
-            />
-            <FieldHelp hint="Optional notes for discrepancies, buyer comments, or exceptions." />
-          </div>
+        </details>
       </div>
     </FormShell>
   );

--- a/app/gold/components/searchable-select.tsx
+++ b/app/gold/components/searchable-select.tsx
@@ -28,7 +28,7 @@ export function SearchableSelect({
   addLabel = "Add new item",
   disabled,
 }: {
-  label: string;
+  label?: string;
   value?: string;
   options: SearchableOption[];
   placeholder: string;
@@ -56,7 +56,7 @@ export function SearchableSelect({
 
   return (
     <div className="space-y-2">
-      <label className="block text-sm font-semibold">{label}</label>
+      {label ? <label className="block text-sm font-semibold">{label}</label> : null}
       <Popover
         open={open}
         onOpenChange={(next) => {

--- a/app/gold/intake/pours/page.tsx
+++ b/app/gold/intake/pours/page.tsx
@@ -48,7 +48,12 @@ export default function GoldIntakePoursPage() {
   });
   const { data: employeesData, isLoading: employeesLoading } = useQuery({
     queryKey: ["employees", "gold-intake-modal"],
-    queryFn: () => fetchEmployees({ active: true, limit: 500 }),
+    queryFn: () =>
+      fetchEmployees({
+        active: true,
+        position: ["MANAGER", "CLERK"],
+        limit: 500,
+      }),
     enabled: createOpen,
   });
   const { data: sitesData, isLoading: sitesLoading } = useQuery({

--- a/app/gold/intake/purchases/page.tsx
+++ b/app/gold/intake/purchases/page.tsx
@@ -51,7 +51,12 @@ export default function GoldIntakePurchasesPage() {
   });
   const { data: employeesData, isLoading: employeesLoading } = useQuery({
     queryKey: ["employees", "gold-purchase-modal"],
-    queryFn: () => fetchEmployees({ active: true, limit: 500 }),
+    queryFn: () =>
+      fetchEmployees({
+        active: true,
+        position: ["MANAGER", "CLERK"],
+        limit: 500,
+      }),
     enabled: createOpen,
   });
   const { data: sitesData, isLoading: sitesLoading } = useQuery({

--- a/app/gold/page.tsx
+++ b/app/gold/page.tsx
@@ -1,62 +1,145 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import type { ColumnDef } from "@tanstack/react-table";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
 import { GoldShell } from "@/components/gold/gold-shell";
-import { PageIntro } from "@/components/shared/page-intro";
-import { StatusState } from "@/components/shared/status-state";
+import { FrappeStatCard } from "@/components/charts/frappe-stat-card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DataTable } from "@/components/ui/data-table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { NumericCell } from "@/components/ui/numeric-cell";
-import { SplitButton } from "@/components/ui/split-button";
-import { StatusChip } from "@/components/ui/status-chip";
-import { useToast } from "@/components/ui/use-toast";
-import {
-  fetchAttendance,
-  fetchGoldDispatches,
-  fetchGoldPours,
-  fetchGoldReceipts,
-  fetchGoldShiftAllocations,
-  fetchShiftReports,
-} from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { ChevronDown } from "@/lib/icons";
 import { goldRoutes } from "@/app/gold/routes";
-import { ShiftAllocationModal } from "@/app/gold/components/shift-allocation-modal";
-import type { AttendanceShiftSummary } from "@/app/gold/types";
 import { canViewHrefWithEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 
-type GoldChainRow = {
-  id: string;
-  pourBarId: string;
-  site: string;
-  date: string;
-  grossWeight: number;
-  expenseGold: number;
-  workerSplit: number;
-  companySplit: number;
-  companyTotal: number;
-  expenseBreakdown: string;
-  valueUsd: number;
-  status: "passing" | "in_review" | "pending";
+type GoldSummary = {
+  generatedAt: string;
+  weekStart: string;
+  kpis: {
+    cashThisWeekUsd: number;
+    cashPriorWeekUsd: number;
+    producedThisWeekGrams: number;
+    producedPriorWeekGrams: number;
+    awaitingSaleGrams: number;
+    awaitingSaleUsd: number;
+    owedToWorkersUsd: number;
+    spotUsdPerGram: number | null;
+  };
+  dailyProductionSeries: Array<{ date: string; grams: number; usd: number }>;
+  productionBySite: Array<{ id: string; name: string; code: string; grams: number }>;
+  recentSales: Array<{
+    id: string;
+    receiptNumber: string;
+    receiptDate: string;
+    paidUsd: number;
+    paymentMethod: string;
+    batchCode: string;
+    siteName: string;
+  }>;
+  topEarners: Array<{
+    employeeId: string;
+    name: string;
+    code: string | null;
+    valueUsd: number;
+    weightGrams: number;
+  }>;
 };
 
+const usd = (n: number) =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+const usd2 = (n: number) =>
+  `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const grams = (n: number) =>
+  `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} g`;
+
+function pctDelta(current: number, prior: number) {
+  if (!prior) return current > 0 ? 100 : 0;
+  return ((current - prior) / prior) * 100;
+}
+
+function ProductionTrend({
+  data,
+}: {
+  data: Array<{ date: string; grams: number }>;
+}) {
+  const W = 800;
+  const H = 160;
+  const padding = 8;
+  const max = Math.max(1, ...data.map((d) => d.grams));
+  const stepX = data.length > 1 ? (W - padding * 2) / (data.length - 1) : 0;
+  const points = data.map((d, i) => {
+    const x = padding + i * stepX;
+    const y = H - padding - (d.grams / max) * (H - padding * 2);
+    return { x, y };
+  });
+  const path = points.length
+    ? points.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ")
+    : "";
+  const areaPath = points.length
+    ? `${path} L${points[points.length - 1].x.toFixed(2)},${H - padding} L${padding},${H - padding} Z`
+    : "";
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-40" preserveAspectRatio="none">
+      <defs>
+        <linearGradient id="gold-trend" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgb(202 138 4)" stopOpacity="0.35" />
+          <stop offset="100%" stopColor="rgb(202 138 4)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {areaPath ? <path d={areaPath} fill="url(#gold-trend)" /> : null}
+      {path ? (
+        <path
+          d={path}
+          fill="none"
+          stroke="rgb(202 138 4)"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ) : null}
+    </svg>
+  );
+}
+
+function SiteBreakdown({
+  data,
+}: {
+  data: Array<{ id: string; name: string; code: string; grams: number }>;
+}) {
+  const total = data.reduce((sum, row) => sum + row.grams, 0);
+  if (!total) {
+    return (
+      <p className="text-sm text-muted-foreground">No production logged in the last 30 days.</p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {data.map((row) => {
+        const pct = (row.grams / total) * 100;
+        return (
+          <div key={row.id} className="space-y-1">
+            <div className="flex items-baseline justify-between text-sm">
+              <span className="font-semibold truncate">{row.name}</span>
+              <span className="text-muted-foreground">
+                {grams(row.grams)} · {pct.toFixed(0)}%
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-amber-500"
+                style={{ width: `${pct.toFixed(2)}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function GoldPage() {
-  const { toast } = useToast();
-  const queryClient = useQueryClient();
-  const [shiftModalOpen, setShiftModalOpen] = useState(false);
   const { data: session } = useSession();
   const enabledFeatures = useMemo(
     () =>
@@ -64,540 +147,227 @@ export default function GoldPage() {
         ?.enabledFeatures,
     [session],
   );
-  const canRecordBatch = useMemo(
-    () =>
-      canViewHrefWithEnabledFeatures(goldRoutes.intake.pours, enabledFeatures),
-    [enabledFeatures],
+  const canRecordBatch = canViewHrefWithEnabledFeatures(
+    goldRoutes.intake.pours,
+    enabledFeatures,
   );
-  const canRecordPurchase = useMemo(
-    () =>
-      canViewHrefWithEnabledFeatures(
-        goldRoutes.intake.purchases,
-        enabledFeatures,
-      ),
-    [enabledFeatures],
+  const canRecordDispatch = canViewHrefWithEnabledFeatures(
+    goldRoutes.transit.dispatches,
+    enabledFeatures,
   );
-  const canRecordDispatch = useMemo(
-    () =>
-      canViewHrefWithEnabledFeatures(
-        goldRoutes.transit.dispatches,
-        enabledFeatures,
-      ),
-    [enabledFeatures],
+  const canRecordSale = canViewHrefWithEnabledFeatures(
+    goldRoutes.settlement.receipts,
+    enabledFeatures,
   );
-  const canRecordSale = useMemo(
-    () =>
-      canViewHrefWithEnabledFeatures(
-        goldRoutes.settlement.receipts,
-        enabledFeatures,
-      ),
-    [enabledFeatures],
-  );
-  const canRecordShiftOutput = useMemo(
-    () =>
-      canViewHrefWithEnabledFeatures(
-        goldRoutes.settlement.payouts,
-        enabledFeatures,
-      ),
-    [enabledFeatures],
-  );
-  const secondaryActions = useMemo(() => {
-    const actions: Array<{ label: string; href: string }> = [];
-    if (canRecordBatch) {
-      actions.push({ label: "Record Batch", href: goldRoutes.intake.create });
-    }
-    if (canRecordPurchase) {
-      actions.push({
-        label: "Record Purchase",
-        href: goldRoutes.intake.createPurchase,
-      });
-    }
-    if (canRecordDispatch) {
-      actions.push({
-        label: "Record Dispatch",
-        href: goldRoutes.transit.create,
-      });
-    }
-    if (canRecordSale) {
-      actions.push({
-        label: "Record Sale",
-        href: goldRoutes.settlement.create,
-      });
-    }
-    return actions;
-  }, [canRecordBatch, canRecordDispatch, canRecordPurchase, canRecordSale]);
 
-  const attendanceStart = useMemo(() => {
-    const start = new Date();
-    start.setDate(start.getDate() - 30);
-    return start.toISOString().slice(0, 10);
-  }, []);
-  const normalizeShiftLabel = (value: string) =>
-    value.trim().replace(/\s+/g, " ").toUpperCase();
-
-  const {
-    data: poursData,
-    isLoading: poursLoading,
-    error: poursError,
-  } = useQuery({
-    queryKey: ["gold-pours", "command"],
-    queryFn: () => fetchGoldPours({ limit: 300 }),
-  });
-  const {
-    data: dispatchesData,
-    isLoading: dispatchesLoading,
-    error: dispatchesError,
-  } = useQuery({
-    queryKey: ["gold-dispatches", "command"],
-    queryFn: () => fetchGoldDispatches({ limit: 300 }),
-  });
-  const {
-    data: receiptsData,
-    isLoading: receiptsLoading,
-    error: receiptsError,
-  } = useQuery({
-    queryKey: ["gold-receipts", "command"],
-    queryFn: () => fetchGoldReceipts({ limit: 300 }),
-  });
-  const { data: attendanceData, isLoading: attendanceLoading } = useQuery({
-    queryKey: ["attendance", "gold", attendanceStart],
-    queryFn: () => fetchAttendance({ startDate: attendanceStart, limit: 500 }),
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["gold-summary"],
+    queryFn: () => fetchJson<GoldSummary>("/api/gold/summary"),
   });
 
-  const { data: shiftReportsData, isLoading: shiftReportsLoading } = useQuery({
-    queryKey: ["shift-reports", "gold", attendanceStart],
-    queryFn: () =>
-      fetchShiftReports({ startDate: attendanceStart, limit: 200 }),
-  });
-
-  const { data: shiftAllocationsData, isLoading: shiftAllocationsLoading } =
-    useQuery({
-      queryKey: ["gold-shift-allocations", attendanceStart],
-      queryFn: () =>
-        fetchGoldShiftAllocations({ startDate: attendanceStart, limit: 500 }),
-    });
-
-  const pours = useMemo(() => poursData?.data ?? [], [poursData]);
-  const dispatches = useMemo(
-    () => dispatchesData?.data ?? [],
-    [dispatchesData],
-  );
-  const receipts = useMemo(() => receiptsData?.data ?? [], [receiptsData]);
-  const attendanceRecords = useMemo(
-    () => attendanceData?.data ?? [],
-    [attendanceData],
-  );
-  const shiftReports = useMemo(
-    () => shiftReportsData?.data ?? [],
-    [shiftReportsData],
-  );
-  const shiftAllocations = useMemo(
-    () => shiftAllocationsData?.data ?? [],
-    [shiftAllocationsData],
-  );
-
-  const dispatchByPourId = useMemo(() => {
-    const map = new Map<string, (typeof dispatches)[number]>();
-    dispatches.forEach((dispatch) => {
-      map.set(dispatch.goldPourId, dispatch);
-    });
-    return map;
-  }, [dispatches]);
-
-  const receiptByPourId = useMemo(() => {
-    const map = new Map<string, (typeof receipts)[number]>();
-    receipts.forEach((receipt) => {
-      if (receipt.goldPour.id) map.set(receipt.goldPour.id, receipt);
-    });
-    return map;
-  }, [receipts]);
-
-  const recordedAllocationKeys = useMemo(() => {
-    const keys = new Set<string>();
-    shiftAllocations.forEach((allocation) => {
-      const date = new Date(allocation.date).toISOString().slice(0, 10);
-      const key = `${date}|${normalizeShiftLabel(allocation.shift)}|${allocation.siteId}`;
-      keys.add(key);
-    });
-    return keys;
-  }, [shiftAllocations]);
-
-  const pendingSettlementDispatches = useMemo(
-    () =>
-      dispatches.filter(
-        (dispatch) => !receiptByPourId.has(dispatch.goldPourId),
-      ),
-    [dispatches, receiptByPourId],
-  );
-
-  const commandError = poursError || dispatchesError || receiptsError;
-  const commandLoading = poursLoading || dispatchesLoading || receiptsLoading;
-
-  const recentChain = useMemo<GoldChainRow[]>(() => {
-    return pours
-      .slice()
-      .sort((a, b) => b.pourDate.localeCompare(a.pourDate))
-      .slice(0, 50)
-      .map((pour) => {
-        const dispatch = dispatchByPourId.get(pour.id);
-        const receipt = receiptByPourId.get(pour.id);
-        const status = receipt ? "passing" : dispatch ? "in_review" : "pending";
-        return {
-          id: pour.id,
-          pourBarId: pour.pourBarId,
-          site: pour.site.code,
-          date: pour.pourDate,
-          grossWeight: pour.grossWeight,
-          expenseGold: pour.expenseWeightTotal ?? 0,
-          workerSplit: pour.workerSplitWeight ?? 0,
-          companySplit: pour.companySplitWeight ?? 0,
-          companyTotal:
-            pour.companyTotalWeight ??
-            (pour.companySplitWeight ?? 0) + (pour.expenseWeightTotal ?? 0),
-          expenseBreakdown: pour.expenseBreakdown?.trim() || "-",
-          valueUsd: pour.valueUsd ?? 0,
-          status,
-        };
-      });
-  }, [dispatchByPourId, pours, receiptByPourId]);
-
-  const attendanceShifts = useMemo(() => {
-    const grouped = new Map<string, AttendanceShiftSummary>();
-    attendanceRecords.forEach((record) => {
-      const date = new Date(record.date).toISOString().slice(0, 10);
-      const normalizedShift = normalizeShiftLabel(record.shift);
-      const key = `${date}|${normalizedShift}|${record.site.id}`;
-      const existing =
-        grouped.get(key) ??
-        ({
-          key,
-          date,
-          shift: normalizedShift,
-          siteId: record.site.id,
-          siteName: record.site.name,
-          siteCode: record.site.code,
-          presentCount: 0,
-          lateCount: 0,
-          absentCount: 0,
-          totalCrew: 0,
-          presentEmployees: [],
-        } satisfies AttendanceShiftSummary);
-
-      existing.totalCrew += 1;
-      if (record.status === "ABSENT") {
-        existing.absentCount += 1;
-      } else {
-        existing.presentCount += 1;
-        if (record.status === "LATE") {
-          existing.lateCount += 1;
-        }
-        existing.presentEmployees.push({
-          id: record.employee.id,
-          name: record.employee.name,
-          employeeId: record.employee.employeeId,
-        });
-      }
-      grouped.set(key, existing);
-    });
-
-    return Array.from(grouped.values())
-      .filter((shift) => shift.presentCount > 0)
-      .filter((shift) => !recordedAllocationKeys.has(shift.key))
-      .sort((a, b) => b.date.localeCompare(a.date));
-  }, [attendanceRecords, recordedAllocationKeys]);
-
-  const shiftReportsByKey = useMemo(() => {
-    const map = new Map<
-      string,
-      { id: string; status: string; crewCount: number }
-    >();
-    shiftReports.forEach((report) => {
-      const date = new Date(report.date).toISOString().slice(0, 10);
-      const key = `${date}|${normalizeShiftLabel(report.shift)}|${report.siteId}`;
-      map.set(key, {
-        id: report.id,
-        status: report.status,
-        crewCount: report.crewCount,
-      });
-    });
-    return map;
-  }, [shiftReports]);
-
-  const createShiftAllocationMutation = useMutation({
-    mutationFn: async (payload: {
-      date: string;
-      shift: string;
-      siteId: string;
-      totalWeight: number;
-      expenses: Array<{ type: string; weight: number }>;
-      splitMode?: "DEFAULT_50_50" | "OVERRIDE_WORKER_WEIGHT";
-      workerShareOverrideWeight?: number;
-      splitOverrideReason?: string;
-      payCycleWeeks: number;
-    }) =>
-      fetchJson<{
-        id: string;
-        createdBatchCode?: string | null;
-        payoutRecordsCreated?: number;
-        warnings?: string[];
-      }>("/api/gold/shift-allocations", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      }),
-    onSuccess: (allocation) => {
-      queryClient.invalidateQueries({ queryKey: ["gold-shift-allocations"] });
-      queryClient.invalidateQueries({ queryKey: ["gold-pours"] });
-      queryClient.invalidateQueries({ queryKey: ["employee-payments"] });
-      const warningText =
-        allocation.warnings && allocation.warnings.length > 0
-          ? ` ${allocation.warnings[0]}`
-          : "";
-      const payoutText =
-        allocation.payoutRecordsCreated && allocation.payoutRecordsCreated > 0
-          ? ` ${allocation.payoutRecordsCreated} worker payout records were created.`
-          : "";
-      toast({
-        title: "Shift output recorded",
-        description: allocation.createdBatchCode
-          ? `Batch ${allocation.createdBatchCode} was created automatically.${payoutText}${warningText}`
-          : `Shift allocation saved.${payoutText}${warningText}`,
-        variant: "success",
-      });
-      setShiftModalOpen(false);
-    },
-  });
-
-  const columns = useMemo<ColumnDef<GoldChainRow>[]>(
-    () => [
-      {
-        id: "pourBarId",
-        header: "Batch ID",
-        cell: ({ row }) => (
-          <span className="font-mono font-semibold">
-            {row.original.pourBarId}
-          </span>
-        ),
-        size: 112,
-        minSize: 112,
-        maxSize: 112,
-      },
-      {
-        id: "site",
-        header: "Site",
-        accessorKey: "site",
-        size: 280,
-        minSize: 220,
-        maxSize: 420,
-      },
-      {
-        id: "date",
-        header: "Date",
-        cell: ({ row }) => (
-          <NumericCell align="left">
-            {new Date(row.original.date).toLocaleString()}
-          </NumericCell>
-        ),
-        size: 128,
-        minSize: 128,
-        maxSize: 128,
-      },
-      {
-        id: "grossWeight",
-        header: "Gross Weight (Recorded)",
-        cell: ({ row }) => (
-          <NumericCell>{row.original.grossWeight.toFixed(2)} g</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "expenseGold",
-        header: "Expense Gold",
-        cell: ({ row }) => (
-          <NumericCell>{row.original.expenseGold.toFixed(3)} g</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "workerSplit",
-        header: "Worker Split",
-        cell: ({ row }) => (
-          <NumericCell>{row.original.workerSplit.toFixed(3)} g</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "companySplit",
-        header: "Company Split",
-        cell: ({ row }) => (
-          <NumericCell>{row.original.companySplit.toFixed(3)} g</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "companyTotal",
-        header: "Company Total",
-        cell: ({ row }) => (
-          <NumericCell>{row.original.companyTotal.toFixed(3)} g</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "expenseBreakdown",
-        header: "Expense Breakdown",
-        accessorKey: "expenseBreakdown",
-        size: 220,
-        minSize: 200,
-        maxSize: 320,
-      },
-      {
-        id: "valueUsd",
-        header: "Value (USD)",
-        cell: ({ row }) => (
-          <NumericCell>${row.original.valueUsd.toFixed(2)}</NumericCell>
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-      {
-        id: "status",
-        header: "Status",
-        cell: ({ row }) => (
-          <StatusChip
-            status={row.original.status}
-            label={
-              row.original.status === "passing"
-                ? "Complete"
-                : row.original.status === "in_review"
-                  ? "Dispatched"
-                  : "Waiting for dispatch"
-            }
-          />
-        ),
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
-      },
-    ],
-    [],
-  );
+  const kpis = data?.kpis;
+  const cashDelta = kpis ? pctDelta(kpis.cashThisWeekUsd, kpis.cashPriorWeekUsd) : 0;
+  const producedDelta = kpis ? pctDelta(kpis.producedThisWeekGrams, kpis.producedPriorWeekGrams) : 0;
 
   return (
     <GoldShell
       activeTab="home"
+      title="Overview"
       actions={
         <div className="flex flex-wrap gap-2">
-          {canRecordShiftOutput ? (
-            secondaryActions.length > 0 ? (
-              <SplitButton
-                size="sm"
-                onClick={() => setShiftModalOpen(true)}
-                triggerAriaLabel="More gold actions"
-                menuContent={secondaryActions.map((action) => (
-                  <DropdownMenuItem key={action.href} asChild>
-                    <Link href={action.href}>{action.label}</Link>
-                  </DropdownMenuItem>
-                ))}
-              >
-                Record Shift Output
-              </SplitButton>
-            ) : (
-              <Button size="sm" onClick={() => setShiftModalOpen(true)}>
-                Record Shift Output
-              </Button>
-            )
-          ) : secondaryActions.length > 0 ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="sm" variant="outline">
-                  Actions
-                  <ChevronDown className="ml-1 size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {secondaryActions.map((action) => (
-                  <DropdownMenuItem key={action.href} asChild>
-                    <Link href={action.href}>{action.label}</Link>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+          <Button asChild size="sm">
+            <Link href="/shift-report">Record Shift Output</Link>
+          </Button>
+          {canRecordBatch ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href={goldRoutes.intake.create}>Record Batch</Link>
+            </Button>
+          ) : null}
+          {canRecordDispatch ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href={goldRoutes.transit.create}>Record Dispatch</Link>
+            </Button>
+          ) : null}
+          {canRecordSale ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href={goldRoutes.settlement.create}>Record Sale</Link>
+            </Button>
           ) : null}
         </div>
       }
     >
-      {pendingSettlementDispatches.length > 0 ? (
-        <Alert variant="destructive">
-          <AlertTitle>Needs Attention</AlertTitle>
-          <AlertDescription>
-            {pendingSettlementDispatches.length} dispatch
-            {pendingSettlementDispatches.length === 1 ? "" : "es"} are waiting
-            for sale records. Go to Sales to finish them.
-          </AlertDescription>
-        </Alert>
-      ) : null}
+      <div className="space-y-6">
+        {error ? (
+          <Alert variant="destructive">
+            <AlertTitle>Could not load overview</AlertTitle>
+            <AlertDescription>{getApiErrorMessage(error)}</AlertDescription>
+          </Alert>
+        ) : null}
 
-      <section className="space-y-3">
-        <header className="space-y-1">
-          <h2 className="text-base text-foreground font-bold tracking-tight">
-            Chain Activity
-          </h2>
-        </header>
-        {commandError ? (
-          <StatusState
-            variant="error"
-            title="Unable to load chain data"
-          />
-        ) : (
-          <DataTable
-            data={recentChain}
-            columns={columns}
-            searchPlaceholder="Search by batch ID, site, or status"
-            searchSubmitLabel="Search"
-            tableClassName="text-sm"
-            pagination={{ enabled: true }}
-            toolbar={
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="secondary">Batches: {pours.length}</Badge>
-                <Badge variant="secondary">
-                  Dispatches: {dispatches.length}
-                </Badge>
-                <Badge variant="secondary">Sales: {receipts.length}</Badge>
+        <section>
+          <header className="mb-3">
+            <h2 className="text-xl font-bold tracking-tight">This week at a glance</h2>
+            <p className="text-sm text-muted-foreground">
+              {kpis?.spotUsdPerGram
+                ? `Today's gold price: ${usd2(kpis.spotUsdPerGram)} per gram`
+                : "Set a gold price to see live valuations."}
+            </p>
+          </header>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+            <FrappeStatCard
+              label="Cash received this week"
+              value={kpis?.cashThisWeekUsd ?? 0}
+              valueLabel={kpis ? usd(kpis.cashThisWeekUsd) : undefined}
+              detail={kpis ? `Last week: ${usd(kpis.cashPriorWeekUsd)}` : undefined}
+              delta={kpis ? cashDelta : undefined}
+              tone="success"
+              loading={isLoading}
+            />
+            <FrappeStatCard
+              label="Owed to workers"
+              value={kpis?.owedToWorkersUsd ?? 0}
+              valueLabel={kpis ? usd(kpis.owedToWorkersUsd) : undefined}
+              detail="Approved shifts not yet paid"
+              negativeIsBetter
+              tone={kpis && kpis.owedToWorkersUsd > 0 ? "warning" : "neutral"}
+              loading={isLoading}
+            />
+            <FrappeStatCard
+              label="Awaiting sale"
+              value={kpis?.awaitingSaleUsd ?? 0}
+              valueLabel={kpis ? usd(kpis.awaitingSaleUsd) : undefined}
+              detail={kpis ? `${grams(kpis.awaitingSaleGrams)} in storage / transit` : undefined}
+              tone="neutral"
+              loading={isLoading}
+            />
+            <FrappeStatCard
+              label="Gold produced this week"
+              value={kpis?.producedThisWeekGrams ?? 0}
+              valueLabel={kpis ? grams(kpis.producedThisWeekGrams) : undefined}
+              detail={kpis ? `Last week: ${grams(kpis.producedPriorWeekGrams)}` : undefined}
+              delta={kpis ? producedDelta : undefined}
+              tone="neutral"
+              loading={isLoading}
+            />
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="lg:col-span-2 rounded-lg border bg-card p-4">
+            <header className="mb-3 flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold">Last 30 days production</h3>
+                <p className="text-xs text-muted-foreground">Grams of gold per day</p>
               </div>
-            }
-            emptyState={
-              commandLoading
-                ? "Loading chain activity..."
-                : "No gold activity yet."
-            }
-          />
-        )}
-      </section>
+              <span className="text-xs text-muted-foreground">
+                {data?.dailyProductionSeries.length
+                  ? `${grams(
+                      data.dailyProductionSeries.reduce((sum, d) => sum + d.grams, 0),
+                    )} total`
+                  : null}
+              </span>
+            </header>
+            {isLoading ? (
+              <Skeleton className="h-40 w-full" />
+            ) : (
+              <ProductionTrend data={data?.dailyProductionSeries ?? []} />
+            )}
+          </div>
+          <div className="rounded-lg border bg-card p-4">
+            <header className="mb-3">
+              <h3 className="font-semibold">By site (last 30 days)</h3>
+              <p className="text-xs text-muted-foreground">Where the gold came from</p>
+            </header>
+            {isLoading ? (
+              <Skeleton className="h-40 w-full" />
+            ) : (
+              <SiteBreakdown data={data?.productionBySite ?? []} />
+            )}
+          </div>
+        </section>
 
-      <ShiftAllocationModal
-        open={shiftModalOpen}
-        onOpenChange={setShiftModalOpen}
-        attendanceShifts={attendanceShifts}
-        attendanceLoading={attendanceLoading}
-        allocationsLoading={shiftAllocationsLoading}
-        shiftReportsByKey={shiftReportsByKey}
-        shiftReportsLoading={shiftReportsLoading}
-        isSubmitting={createShiftAllocationMutation.isPending}
-        submitError={createShiftAllocationMutation.error}
-        onCreateAllocation={(payload) =>
-          createShiftAllocationMutation.mutate(payload)
-        }
-      />
+        <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="rounded-lg border bg-card">
+            <header className="px-4 py-3 border-b flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold">Recent sales</h3>
+                <p className="text-xs text-muted-foreground">Latest 5 buyer payments</p>
+              </div>
+              <Button asChild size="sm" variant="ghost">
+                <Link href={goldRoutes.settlement.receipts}>See all</Link>
+              </Button>
+            </header>
+            {isLoading ? (
+              <div className="p-4">
+                <Skeleton className="h-24 w-full" />
+              </div>
+            ) : data?.recentSales.length ? (
+              <ul className="divide-y">
+                {data.recentSales.map((sale) => (
+                  <li
+                    key={sale.id}
+                    className="flex items-center justify-between gap-3 px-4 py-2.5"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-mono text-sm font-semibold truncate">
+                        {sale.batchCode}
+                      </p>
+                      <p className="text-xs text-muted-foreground truncate">
+                        {sale.siteName} · {sale.paymentMethod.replace(/_/g, " ").toLowerCase()}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-semibold">{usd2(sale.paidUsd)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(sale.receiptDate).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="p-4 text-sm text-muted-foreground">No sales yet.</p>
+            )}
+          </div>
+
+          <div className="rounded-lg border bg-card">
+            <header className="px-4 py-3 border-b">
+              <h3 className="font-semibold">Top earners (last 30 days)</h3>
+              <p className="text-xs text-muted-foreground">Workers with the highest share</p>
+            </header>
+            {isLoading ? (
+              <div className="p-4">
+                <Skeleton className="h-24 w-full" />
+              </div>
+            ) : data?.topEarners.length ? (
+              <ul className="divide-y">
+                {data.topEarners.map((earner) => (
+                  <li
+                    key={earner.employeeId}
+                    className="flex items-center justify-between gap-3 px-4 py-2.5"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-semibold truncate">{earner.name}</p>
+                      {earner.code ? (
+                        <p className="text-xs text-muted-foreground">{earner.code}</p>
+                      ) : null}
+                    </div>
+                    <div className="text-right">
+                      <p className="font-semibold">{usd2(earner.valueUsd)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {grams(earner.weightGrams)}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="p-4 text-sm text-muted-foreground">No worker shares yet.</p>
+            )}
+          </div>
+        </section>
+      </div>
+
     </GoldShell>
   );
 }

--- a/app/gold/settlement/receipts/page.tsx
+++ b/app/gold/settlement/receipts/page.tsx
@@ -107,7 +107,12 @@ export default function GoldSettlementReceiptsPage() {
   );
   const availableDispatches = useMemo(
     () =>
-      dispatches.filter((dispatch) => !soldPourIds.has(dispatch.goldPourId)),
+      dispatches.filter((dispatch) => {
+        const batchIds = dispatch.batches?.length
+          ? dispatch.batches.map((batch) => batch.goldPourId)
+          : [dispatch.goldPourId];
+        return batchIds.some((id) => !soldPourIds.has(id));
+      }),
     [dispatches, soldPourIds],
   );
 
@@ -267,6 +272,7 @@ export default function GoldSettlementReceiptsPage() {
               onCancel={handleCloseCreate}
               availableBatches={availableBatches}
               availableDispatches={availableDispatches}
+              soldPourIds={soldPourIds}
               batchCreateHref={goldRoutes.intake.create}
             />
           </div>

--- a/app/gold/transit/dispatches/page.tsx
+++ b/app/gold/transit/dispatches/page.tsx
@@ -71,7 +71,12 @@ export default function GoldTransitDispatchesPage() {
   });
   const { data: employeesData, isLoading: employeesLoading } = useQuery({
     queryKey: ["employees", "gold-transit-modal"],
-    queryFn: () => fetchEmployees({ active: true, limit: 500 }),
+    queryFn: () =>
+      fetchEmployees({
+        active: true,
+        position: ["MANAGER", "CLERK"],
+        limit: 500,
+      }),
     enabled: createOpen,
   });
 
@@ -92,23 +97,21 @@ export default function GoldTransitDispatchesPage() {
   );
   const employees = useMemo(() => employeesData?.data ?? [], [employeesData]);
   const pours = useMemo(() => poursData?.data ?? [], [poursData]);
-  const dispatchCountByPourId = useMemo(() => {
-    const map = new Map<string, number>();
+  const dispatchedPourIds = useMemo(() => {
+    const ids = new Set<string>();
     rows.forEach((dispatch) => {
-      const current = map.get(dispatch.goldPourId) ?? 0;
-      map.set(dispatch.goldPourId, current + 1);
+      if (dispatch.goldPourId) ids.add(dispatch.goldPourId);
+      dispatch.batches?.forEach((batch) => ids.add(batch.goldPourId));
     });
-    return map;
+    return ids;
   }, [rows]);
   const availablePours = useMemo(
     () =>
       pours
-        .map((pour) => ({
-          ...pour,
-          dispatchCount: dispatchCountByPourId.get(pour.id) ?? 0,
-        }))
+        .filter((pour) => !dispatchedPourIds.has(pour.id))
+        .map((pour) => ({ ...pour, dispatchCount: 0 }))
         .sort((left, right) => right.pourDate.localeCompare(left.pourDate)),
-    [dispatchCountByPourId, pours],
+    [dispatchedPourIds, pours],
   );
 
   const columns = useMemo<ColumnDef<GoldDispatchRow>[]>(
@@ -127,17 +130,45 @@ export default function GoldTransitDispatchesPage() {
       },
       {
         id: "batch",
-        header: "Batch",
-        cell: ({ row }) => (
-          <div>
-            <div className="font-mono font-semibold">
-              {row.original.goldPour.pourBarId}
+        header: "Batch(es)",
+        cell: ({ row }) => {
+          const batches = row.original.batches ?? [];
+          const totalWeight =
+            batches.length > 0
+              ? batches.reduce(
+                  (sum, batch) => sum + (batch.goldPour?.grossWeight ?? 0),
+                  0,
+                )
+              : row.original.goldPour.grossWeight;
+          if (batches.length > 1) {
+            return (
+              <div>
+                <div className="font-mono font-semibold">
+                  {batches.length} batches
+                </div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {batches
+                    .map((batch) => batch.goldPour?.pourBarId)
+                    .filter(Boolean)
+                    .join(", ")}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {totalWeight.toFixed(3)} g total
+                </div>
+              </div>
+            );
+          }
+          return (
+            <div>
+              <div className="font-mono font-semibold">
+                {row.original.goldPour.pourBarId}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {row.original.goldPour.grossWeight.toFixed(3)} g
+              </div>
             </div>
-            <div className="text-xs text-muted-foreground">
-              {row.original.goldPour.grossWeight.toFixed(3)} g
-            </div>
-          </div>
-        ),
+          );
+        },
         size: 280,
         minSize: 220,
         maxSize: 420,
@@ -179,17 +210,29 @@ export default function GoldTransitDispatchesPage() {
         id: "status",
         header: "Status",
         cell: ({ row }) => {
-          const settled = soldPourIds.has(row.original.goldPourId);
+          const batches = row.original.batches ?? [];
+          const allBatchIds = batches.length > 0
+            ? batches.map((batch) => batch.goldPourId)
+            : [row.original.goldPourId];
+          const settledCount = allBatchIds.filter((id) => soldPourIds.has(id)).length;
+          const allSettled = settledCount === allBatchIds.length;
+          const partial = settledCount > 0 && !allSettled;
           return (
             <StatusChip
-              status={settled ? "passing" : "pending"}
-              label={settled ? "Settled" : "Awaiting sale"}
+              status={allSettled ? "passing" : partial ? "warning" : "pending"}
+              label={
+                allSettled
+                  ? "Settled"
+                  : partial
+                    ? `${settledCount}/${allBatchIds.length} sold`
+                    : "Awaiting sale"
+              }
             />
           );
         },
-        size: 120,
-        minSize: 120,
-        maxSize: 120,
+        size: 140,
+        minSize: 140,
+        maxSize: 140,
       },
     ],
     [soldPourIds],

--- a/app/human-resources/page.tsx
+++ b/app/human-resources/page.tsx
@@ -545,24 +545,22 @@ export default function HumanResourcesPage() {
           exportValue: (row: EmployeeSummary) => `${row.name} (${row.employeeId})`,
         },
         cell: ({ row }) => (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <Image
               src={row.original.passportPhotoUrl}
               alt={row.original.name}
-              width={32}
-              height={32}
+              width={40}
+              height={40}
               quality={60}
-              sizes="32px"
-              className="h-8 w-8 rounded-md object-cover shadow-[var(--edge-outline-sharp)]"
+              sizes="40px"
+              className="h-10 w-10 shrink-0 rounded-full object-cover shadow-[var(--edge-outline-sharp)]"
             />
-            <div>
-              <div className="font-semibold">{row.original.name}</div>
-              <div className="font-mono text-xs text-muted-foreground">
-                ID: {row.original.employeeId}
+            <div className="min-w-0">
+              <div className="font-semibold truncate">{row.original.name}</div>
+              <div className="font-mono text-xs text-muted-foreground truncate">
+                {row.original.employeeId}
+                {row.original.jobTitle ? ` · ${row.original.jobTitle}` : ""}
               </div>
-              {row.original.jobTitle ? (
-                <div className="text-xs text-muted-foreground">{row.original.jobTitle}</div>
-              ) : null}
             </div>
           </div>
         ),
@@ -638,8 +636,7 @@ export default function HumanResourcesPage() {
               employmentTypes.find((type) => type.value === row.employmentType)?.label ??
               row.employmentType;
             const hireDate = row.hireDate ? String(row.hireDate).slice(0, 10) : "-";
-            const currency = row.defaultCurrency ?? "USD";
-            return `${employment} | Hire: ${hireDate} | Currency: ${currency}`;
+            return `${employment} | Hire: ${hireDate}`;
           },
         },
         cell: ({ row }) => (
@@ -650,9 +647,6 @@ export default function HumanResourcesPage() {
             </div>
             <div className="text-xs text-muted-foreground">
               Hire: {row.original.hireDate ? String(row.original.hireDate).slice(0, 10) : "-"}
-            </div>
-            <div className="text-xs text-muted-foreground">
-              Currency: {row.original.defaultCurrency ?? "USD"}
             </div>
           </div>
         ),

--- a/components/human-resources/hr-shell.tsx
+++ b/components/human-resources/hr-shell.tsx
@@ -1,38 +1,46 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { useMemo } from "react"
-import { useSession } from "next-auth/react"
-import { PageActions } from "@/components/layout/page-actions"
-import { PageHeading } from "@/components/layout/page-heading"
-import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter"
-import { cn } from "@/lib/utils"
-import { HR_TABS, type HrTab } from "@/lib/hr/tab-config"
-import { getNavSectionsForRole } from "@/lib/navigation"
-import { getWorkspaceModulePresentation } from "@/lib/workspace-products"
+import Link from "next/link";
+import { useMemo } from "react";
+import { useSession } from "next-auth/react";
+import { PageActions } from "@/components/layout/page-actions";
+import { PageHeading } from "@/components/layout/page-heading";
+import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
+import { cn } from "@/lib/utils";
+import {
+  HR_CATEGORIES,
+  HR_TABS,
+  type HrCategoryId,
+  type HrTab,
+} from "@/lib/hr/tab-config";
+import { getNavSectionsForRole } from "@/lib/navigation";
+import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
 
 type HrShellProps = {
-  activeTab: HrTab
-  actions?: React.ReactNode
-  children: React.ReactNode
-  title?: string
-  description?: string
-}
+  activeTab: HrTab;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+};
 
 export function HrShell({
   activeTab,
   actions,
   children,
   title,
-  description,
 }: HrShellProps) {
-  const { data: session } = useSession()
-  const role = (session?.user as { role?: string } | undefined)?.role
+  const { data: session } = useSession();
+  const role = (session?.user as { role?: string } | undefined)?.role;
   const enabledFeatures = useMemo(
-    () => (session?.user as { enabledFeatures?: string[] } | undefined)?.enabledFeatures,
+    () =>
+      (session?.user as { enabledFeatures?: string[] } | undefined)
+        ?.enabledFeatures,
     [session],
-  )
-  const workspaceProfile = (session?.user as { workspaceProfile?: string } | undefined)?.workspaceProfile
+  );
+  const workspaceProfile = (
+    session?.user as { workspaceProfile?: string } | undefined
+  )?.workspaceProfile;
   const modulePresentation = useMemo(
     () =>
       getWorkspaceModulePresentation({
@@ -41,53 +49,116 @@ export function HrShell({
         workspaceProfile,
       }),
     [enabledFeatures, workspaceProfile],
-  )
-  const visibleTabs = useMemo(
-    () => {
-      const hrSection = getNavSectionsForRole(role).find((section) => section.id === "hr")
-      const visibleHrefs = new Set(
-        filterHrefItemsByEnabledFeatures(hrSection?.items ?? [], enabledFeatures).map((item) => item.href),
-      )
-      return HR_TABS.filter((tab) => visibleHrefs.has(tab.href))
-    },
-    [enabledFeatures, role],
-  )
+  );
+  const visibleTabs = useMemo(() => {
+    const hrSection = getNavSectionsForRole(role).find(
+      (section) => section.id === "hr",
+    );
+    const visibleHrefs = new Set(
+      filterHrefItemsByEnabledFeatures(
+        hrSection?.items ?? [],
+        enabledFeatures,
+      ).map((item) => item.href),
+    );
+    return HR_TABS.filter((tab) => visibleHrefs.has(tab.href));
+  }, [enabledFeatures, role]);
+
+  const activeCategoryId = useMemo<HrCategoryId>(() => {
+    const active = visibleTabs.find((tab) => tab.id === activeTab);
+    return active?.categoryId ?? visibleTabs[0]?.categoryId ?? "people";
+  }, [activeTab, visibleTabs]);
+
+  const visibleCategories = useMemo(
+    () =>
+      HR_CATEGORIES.filter((category) =>
+        visibleTabs.some((tab) => tab.categoryId === category.id),
+      ).sort((a, b) => a.order - b.order),
+    [visibleTabs],
+  );
+
+  const visibleTabsForActiveCategory = useMemo(
+    () => visibleTabs.filter((tab) => tab.categoryId === activeCategoryId),
+    [activeCategoryId, visibleTabs],
+  );
 
   return (
-    <div className="w-full space-y-5">
+    <div className="w-full space-y-4">
       {actions ? <PageActions>{actions}</PageActions> : null}
       <PageHeading
         title={title ?? modulePresentation.title}
-        className="mb-3"
+        className="mb-2"
       />
 
-      <nav
-        aria-label="Human resources navigation"
-        className="flex w-full flex-wrap justify-start gap-1 border-b border-[var(--edge-subtle)] pb-1"
-      >
-        {visibleTabs.map((tab) => {
-          const isActive = activeTab === tab.id
-          return (
-            <Link
-              key={tab.id}
-              href={tab.href}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                isActive
-                  ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <tab.icon className="h-4 w-4" />
-              <span className="ml-2">{modulePresentation.tabLabels?.[tab.id] ?? tab.label}</span>
-            </Link>
-          )
-        })}
-      </nav>
+      <div className="flex gap-6">
+        <nav
+          aria-label="Human resources category navigation"
+          className="flex w-[11rem] shrink-0 flex-col gap-0.5"
+        >
+          {visibleCategories.map((category) => {
+            const categoryTab = visibleTabs.find(
+              (tab) => tab.categoryId === category.id,
+            );
+            if (!categoryTab) return null;
+            const isActive = activeCategoryId === category.id;
+            return (
+              <Link
+                key={category.id}
+                href={categoryTab.href}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] font-medium transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
+                  "hover:translate-x-[1px] hover:bg-surface-base hover:text-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                  isActive
+                    ? "bg-surface-base text-[var(--sidebar-item-active-fg)] shadow-popover"
+                    : "text-[var(--sidebar-item-fg-muted)]",
+                )}
+              >
+                <category.icon
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    isActive
+                      ? "text-[var(--sidebar-item-active-fg)]"
+                      : "text-[var(--sidebar-item-icon)]",
+                  )}
+                />
+                <span className="truncate">{category.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
 
-      {children}
+        <div className="min-w-0 flex-1 space-y-5">
+          {visibleTabsForActiveCategory.length > 1 && (
+            <nav
+              aria-label="Human resources section navigation"
+              className="flex w-full flex-wrap gap-1 border-b border-[var(--edge-subtle)] pb-0"
+            >
+              {visibleTabsForActiveCategory.map((tab) => {
+                const isActive = activeTab === tab.id;
+                return (
+                  <Link
+                    key={tab.id}
+                    href={tab.href}
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "inline-flex items-center gap-2 whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-semibold transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                      isActive
+                        ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
+                        : "border-transparent text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <tab.icon className="size-4" />
+                    {tab.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          )}
+
+          {children}
+        </div>
+      </div>
     </div>
-  )
+  );
 }

--- a/components/shared/form-shell.tsx
+++ b/components/shared/form-shell.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 type FormShellProps = {
-  title: string;
+  title?: string;
   description?: string;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   children: ReactNode;
@@ -19,6 +19,12 @@ type FormShellProps = {
   contentClassName?: string;
   mainClassName?: string;
   actionPanelClassName?: string;
+  /**
+   * "page" wraps the form in a Card (default for full pages).
+   * "bare" renders without the Card wrapper — use inside Sheet/Dialog so
+   * the form doesn't look like a card-in-modal.
+   */
+  variant?: "page" | "bare";
 };
 
 export function FormShell({
@@ -35,28 +41,71 @@ export function FormShell({
   contentClassName,
   mainClassName,
   actionPanelClassName,
+  variant = "page",
 }: FormShellProps) {
+  const errorBlock = errors?.length ? (
+    <Alert variant="destructive">
+      <AlertTitle>{errorTitle}</AlertTitle>
+      <AlertDescription>
+        <ul className="list-disc space-y-1 pl-5">
+          {errors.map((error, index) => (
+            <li key={`${error}-${index}`}>{error}</li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  ) : null;
+
+  if (variant === "bare") {
+    return (
+      <form
+        className={cn("space-y-6", formClassName)}
+        onSubmit={onSubmit}
+        noValidate
+      >
+        {title || description ? (
+          <header className="space-y-1">
+            {title ? <h2 className="text-lg font-semibold">{title}</h2> : null}
+            {description ? (
+              <p className="text-sm text-muted-foreground">{description}</p>
+            ) : null}
+          </header>
+        ) : null}
+        <div className={cn("min-w-0 space-y-4", mainClassName)}>
+          {errorBlock}
+          {children}
+        </div>
+        <PrimaryActionBar
+          hint={requiredHint}
+          className={cn(
+            "border-[var(--border)] bg-[var(--surface-muted)]/60",
+            actionPanelClassName,
+          )}
+        >
+          {actions}
+        </PrimaryActionBar>
+      </form>
+    );
+  }
+
   return (
     <Card className={className}>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
-      </CardHeader>
+      {title ? (
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </CardHeader>
+      ) : null}
       <CardContent className={contentClassName}>
-        <form className={cn("space-y-6", formClassName)} onSubmit={onSubmit} noValidate>
+        <form
+          className={cn("space-y-6", formClassName)}
+          onSubmit={onSubmit}
+          noValidate
+        >
           <div className={cn("min-w-0 space-y-4", mainClassName)}>
-            {errors?.length ? (
-              <Alert variant="destructive">
-                <AlertTitle>{errorTitle}</AlertTitle>
-                <AlertDescription>
-                  <ul className="list-disc space-y-1 pl-5">
-                    {errors.map((error, index) => (
-                      <li key={`${error}-${index}`}>{error}</li>
-                    ))}
-                  </ul>
-                </AlertDescription>
-              </Alert>
-            ) : null}
+            {errorBlock}
             {children}
           </div>
           <PrimaryActionBar

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -800,6 +800,25 @@ export type GoldPour = {
   witness2?: { name: string } | null;
 };
 
+export type GoldDispatchBatchEntry = {
+  id: string;
+  goldPourId: string;
+  sortOrder: number;
+  batchId?: string;
+  batchCode?: string;
+  goldPour: {
+    id: string;
+    batchId?: string;
+    batchCode?: string;
+    pourBarId: string;
+    pourDate: string;
+    grossWeight: number;
+    goldPriceUsdPerGram?: number | null;
+    valueUsd?: number | null;
+    site: { name: string; code: string };
+  };
+};
+
 export type GoldDispatch = {
   id: string;
   batchId?: string;
@@ -828,6 +847,7 @@ export type GoldDispatch = {
     valueUsd?: number | null;
     site: { name: string; code: string };
   };
+  batches?: GoldDispatchBatchEntry[];
 };
 
 export type BuyerReceipt = {
@@ -1415,11 +1435,14 @@ export async function fetchEmployees(
     search?: string;
     departmentId?: string;
     gradeId?: string;
+    position?: EmployeePositionValue | EmployeePositionValue[];
     page?: number;
     limit?: number;
   } = {},
 ) {
-  const query = buildQuery(params);
+  const { position, ...rest } = params;
+  const positionParam = Array.isArray(position) ? position.join(",") : position;
+  const query = buildQuery({ ...rest, position: positionParam });
   return fetchJson<Pagination<EmployeeSummary>>(`/api/employees${query}`);
 }
 

--- a/lib/dashboard/executive-aggregations.ts
+++ b/lib/dashboard/executive-aggregations.ts
@@ -504,7 +504,7 @@ export async function getExecutiveDashboardAggregations({
     }),
     prisma.goldDispatch.count({
       where: {
-        buyerReceipt: { is: null },
+        buyerReceipts: { none: {} },
         goldPour: {
           site: siteScope,
           receipts: { none: {} },

--- a/lib/hr/tab-config.ts
+++ b/lib/hr/tab-config.ts
@@ -23,32 +23,105 @@ export type HrTab =
   | "disbursements"
   | "approvals";
 
+export type HrCategoryId =
+  | "people"
+  | "shifts"
+  | "compensation"
+  | "payroll"
+  | "approvals";
+
+export type HrCategory = {
+  id: HrCategoryId;
+  label: string;
+  icon: LucideIcon;
+  order: number;
+};
+
+export const HR_CATEGORIES: HrCategory[] = [
+  { id: "people", label: "People", icon: Users, order: 1 },
+  { id: "shifts", label: "Shifts", icon: Checklist, order: 2 },
+  { id: "compensation", label: "Compensation", icon: UserRound, order: 3 },
+  { id: "payroll", label: "Payroll", icon: Coins, order: 4 },
+  { id: "approvals", label: "Approvals", icon: FileCheck, order: 5 },
+];
+
 export type HrTabItem = {
   id: HrTab;
   label: string;
   href: string;
   icon: LucideIcon;
+  categoryId: HrCategoryId;
 };
 
 export const HR_TABS: HrTabItem[] = [
-  { id: "employees", label: "Employees", href: "/human-resources", icon: ManageAccounts },
-  { id: "shift-groups", label: "Shift Groups", href: "/human-resources/shift-groups", icon: Users },
-  { id: "incidents", label: "Workforce Incidents", href: "/human-resources/incidents", icon: ShieldCheck },
-  { id: "payouts", label: "Settlements", href: "/human-resources/payouts", icon: Coins },
+  {
+    id: "employees",
+    label: "Employees",
+    href: "/human-resources",
+    icon: ManageAccounts,
+    categoryId: "people",
+  },
+  {
+    id: "incidents",
+    label: "Workforce Incidents",
+    href: "/human-resources/incidents",
+    icon: ShieldCheck,
+    categoryId: "people",
+  },
+  {
+    id: "shift-groups",
+    label: "Groups",
+    href: "/human-resources/shift-groups",
+    icon: Users,
+    categoryId: "shifts",
+  },
   {
     id: "compensation",
-    label: "Compensation Rules",
+    label: "Rules",
     href: "/human-resources/compensation",
     icon: UserRound,
+    categoryId: "compensation",
   },
-  { id: "salaries", label: "Salaries", href: "/human-resources/salaries", icon: Payments },
+  {
+    id: "salaries",
+    label: "Salaries",
+    href: "/human-resources/salaries",
+    icon: Payments,
+    categoryId: "compensation",
+  },
   {
     id: "salary-outstanding",
-    label: "Outstanding Salaries",
+    label: "Outstanding",
     href: "/human-resources/salaries/outstanding",
     icon: Wallet,
+    categoryId: "compensation",
   },
-  { id: "payroll", label: "Payroll Runs", href: "/human-resources/payroll", icon: Checklist },
-  { id: "disbursements", label: "Disbursements", href: "/human-resources/disbursements", icon: Wallet },
-  { id: "approvals", label: "Approval History", href: "/human-resources/approvals", icon: FileCheck },
+  {
+    id: "payroll",
+    label: "Runs",
+    href: "/human-resources/payroll",
+    icon: Checklist,
+    categoryId: "payroll",
+  },
+  {
+    id: "payouts",
+    label: "Settlements",
+    href: "/human-resources/payouts",
+    icon: Coins,
+    categoryId: "payroll",
+  },
+  {
+    id: "disbursements",
+    label: "Disbursements",
+    href: "/human-resources/disbursements",
+    icon: Wallet,
+    categoryId: "payroll",
+  },
+  {
+    id: "approvals",
+    label: "History",
+    href: "/human-resources/approvals",
+    icon: FileCheck,
+    categoryId: "approvals",
+  },
 ];

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -710,40 +710,36 @@ function buildModuleSections(
   }
 
   if (moduleId === "accounting") {
-    const buildAccountingSection = (
-      id: string,
-      title: string,
-      hrefs: readonly string[],
-    ): WorkspaceNavSection | null => {
-      const items: NavItem[] = [];
-      const moduleItems = visibleModules.get("accounting") ?? [];
+    const moduleItems = visibleModules.get("accounting") ?? [];
+    // Single consolidated section. Sub-tabs/grouping live inside the
+    // /accounting shell — the global sidebar just lists the entry points.
+    // Overview is intentionally first.
+    const orderedHrefs = [
+      ...ACCOUNTING_OPERATIONS_SECTIONS.overview,
+      ...ACCOUNTING_OPERATIONS_SECTIONS.receivables,
+      ...ACCOUNTING_OPERATIONS_SECTIONS.payables,
+      ...ACCOUNTING_OPERATIONS_SECTIONS.reporting,
+      ...ACCOUNTING_OPERATIONS_SECTIONS.banking,
+      ...ACCOUNTING_OPERATIONS_SECTIONS.master,
+    ];
 
-      for (const href of hrefs) {
-        if (excludedHrefs?.has(href)) continue;
-        const item = moduleItems.find((i) => i.href === href);
-        if (item) {
-          items.push(item);
-        }
-      }
+    const items: NavItem[] = [];
+    for (const href of orderedHrefs) {
+      if (excludedHrefs?.has(href)) continue;
+      const item = moduleItems.find((i) => i.href === href);
+      if (item) items.push(item);
+    }
 
-      if (items.length === 0) return null;
-
-      return {
-        id: `accounting-${id}`,
-        title,
-        items,
-        workspaceGroup,
-      };
-    };
+    if (items.length === 0) return [];
 
     return [
-      buildAccountingSection("overview", "Overview", ACCOUNTING_OPERATIONS_SECTIONS.overview),
-      buildAccountingSection("receivables", "Receivables", ACCOUNTING_OPERATIONS_SECTIONS.receivables),
-      buildAccountingSection("payables", "Payables", ACCOUNTING_OPERATIONS_SECTIONS.payables),
-      buildAccountingSection("reporting", "Financial Reporting", ACCOUNTING_OPERATIONS_SECTIONS.reporting),
-      buildAccountingSection("banking", "Payments & Banking", ACCOUNTING_OPERATIONS_SECTIONS.banking),
-      buildAccountingSection("master", "Accounting Master", ACCOUNTING_OPERATIONS_SECTIONS.master),
-    ].filter((section): section is WorkspaceNavSection => section !== null);
+      {
+        id: "accounting-master",
+        title: "Accounting Master",
+        items,
+        workspaceGroup,
+      },
+    ];
   }
 
   const section = buildModuleSection(moduleId, visibleModules, workspaceGroup, excludedHrefs);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2049,6 +2049,8 @@ model GoldPour {
   witness1Id      String
   witness2Id      String
   storageLocation String
+  additionalExpensesWeight Float?
+  additionalExpensesNote   String?
   notes           String?
   goldPriceUsdPerGram Float?
   valuationDate       DateTime?
@@ -2064,9 +2066,10 @@ model GoldPour {
   witness2   Employee       @relation("Witness2", fields: [witness2Id], references: [id])
   createdBy  User?          @relation("GoldPourRecordedBy", fields: [createdById], references: [id])
   goldShiftAllocation GoldShiftAllocation? @relation(fields: [goldShiftAllocationId], references: [id])
-  purchase   GoldPurchase?
-  dispatches GoldDispatch[]
-  receipts   BuyerReceipt[]
+  purchase        GoldPurchase?
+  dispatches      GoldDispatch[]
+  dispatchBatches GoldDispatchBatch[]
+  receipts        BuyerReceipt[]
 
   @@index([siteId])
   @@index([pourDate])
@@ -2144,16 +2147,32 @@ model GoldDispatch {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  goldPour     GoldPour      @relation(fields: [goldPourId], references: [id])
-  handedOverBy Employee      @relation("GoldDispatchHandovers", fields: [handedOverById], references: [id])
-  buyerReceipt BuyerReceipt?
+  goldPour     GoldPour             @relation(fields: [goldPourId], references: [id])
+  handedOverBy Employee             @relation("GoldDispatchHandovers", fields: [handedOverById], references: [id])
+  buyerReceipts BuyerReceipt[]
+  batches      GoldDispatchBatch[]
 
+  @@index([goldPourId])
+}
+
+model GoldDispatchBatch {
+  id         String   @id @default(uuid())
+  dispatchId String
+  goldPourId String
+  sortOrder  Int      @default(0)
+  createdAt  DateTime @default(now())
+
+  dispatch GoldDispatch @relation(fields: [dispatchId], references: [id], onDelete: Cascade)
+  goldPour GoldPour     @relation(fields: [goldPourId], references: [id])
+
+  @@unique([dispatchId, goldPourId])
+  @@index([dispatchId])
   @@index([goldPourId])
 }
 
 model BuyerReceipt {
   id               String   @id @default(uuid())
-  goldDispatchId   String?  @unique
+  goldDispatchId   String?
   goldPourId       String?
   receiptNumber    String
   receiptDate      DateTime
@@ -2173,6 +2192,7 @@ model BuyerReceipt {
   goldDispatch GoldDispatch? @relation(fields: [goldDispatchId], references: [id])
   goldPour     GoldPour?     @relation(fields: [goldPourId], references: [id])
 
+  @@unique([goldDispatchId, goldPourId])
   @@index([goldPourId])
   @@index([receiptDate])
 }


### PR DESCRIPTION
## Summary

Three threads in one PR, all targeted at the artisanal-mine-owner pain points called out during the design review:

1. **Money-first Gold overview** — replaces the chain-table landing page with a KPI dashboard (cash this week, owed to workers, awaiting sale, produced this week) plus a 30-day production trend, by-site breakdown, recent sales, and top earners. Plain language, W-o-W deltas.
2. **Forms that don't feel AI-generated** — every gold form (pour, dispatch, receipt) now opens with only the truly-required fields visible. Optional fields live behind a single ``More details`` disclosure that auto-opens when its fields are touched. Cash is the default payment method. Modals no longer render a card-in-a-card.
3. **Sidebar + HR shell cleanup** — the 6 separate accounting sidebar sections collapse into one **Accounting Master** group (Overview first). The HR shell now mirrors ``AccountingShell``: left category nav + sub-tabs.

Plus the multi-batch dispatch + bulk-receipt work that was already in flight.

## What changed

### Schema
- ``GoldPour`` gains ``additionalExpensesWeight Float?`` + ``additionalExpensesNote String?`` so mines without formal shifts (no ``GoldShiftExpense`` rows) can still deduct fuel/water/food per batch.

### APIs
- ``POST /api/gold/dispatches`` — accepts ``goldPourIds[]`` and creates one ``GoldDispatchBatch`` row per batch; legacy ``goldPourId`` still accepted.
- ``POST /api/gold/receipts/batch`` — new endpoint for recording one receipt per batch in a multi-batch dispatch in a single transaction.
- ``GET  /api/gold/summary`` — new aggregation endpoint feeding the dashboard.
- ``GET  /api/employees?position=`` — now accepts CSV, validated against the position whitelist.

### Forms (all now ``variant=\"bare\"`` inside Sheet modals)
- **Pour form**: visible = Site, Gross Weight, Witness 1/2. Hidden behind ``More details``: Estimated Purity, Storage Location (default ``Vault``), Additional Expenses (weight + note), Notes. Auto-picks the site if only one is available; autofocuses the weight input.
- **Dispatch form**: visible = batch checklist, date, courier, destination, seal, handed-over-by. Hidden behind ``More details``: Vehicle, Received By, Notes, Override Reason (auto-opens when an override is required).
- **Receipt form**: CASH preselected. Visible = dispatch/batch, date, payment method, paid amount. Hidden behind ``More details``: Final tested gold, Channel, Reference, Notes. Multi-batch dispatches automatically switch to per-batch entry.

### Overview page (``/gold``)
- 4 ``FrappeStatCard``s with W-o-W deltas
- Inline 30-day SVG production trend (no new dep)
- Per-site grams + percentage bars (last 30 days)
- Recent sales (5) and top earners (5)
- Existing primary CTAs preserved

### Shells
- ``lib/workspaces.ts``: collapsed the accounting nav builder to a single section (Overview → Receivables → Payables → Reporting → Banking → Master).
- ``components/human-resources/hr-shell.tsx``: rewritten to mirror ``AccountingShell``. ``lib/hr/tab-config.ts`` now defines ``HR_CATEGORIES`` (People, Shifts, Compensation, Payroll, Approvals) and assigns each tab a ``categoryId``.
- HR employees table: avatar is now ``h-10 w-10`` rounded-full with ``gap-3``, name + ``{employeeId} · {jobTitle}`` on a single meta line. Removed the ``Currency: USD`` line.

### People-picker scoping
All gold modals now fetch only ``MANAGER`` + ``CLERK`` — clerks and managers are the only people who legitimately act in this module.

## Reviewer notes

- **Schema migration required**: run ``npx prisma db push`` after merging — the new ``GoldPour`` fields are nullable so existing rows are safe.
- ``BuyerReceipt.goldDispatchId`` lost its ``@unique`` constraint earlier in the multi-batch work; the compound ``@@unique([goldDispatchId, goldPourId])`` is what now prevents duplicates.
- The ``Banking``/``Accounting Master`` consolidation only affects the global sidebar — the in-page ``AccountingShell`` still groups items into its own categories.
- ``GoldDispatch.buyerReceipt`` was renamed to ``buyerReceipts`` (1:1 → 1:N); the only consumer was ``lib/dashboard/executive-aggregations.ts`` and is updated.

## Test plan

- [ ] ``npx prisma db push`` succeeds; ``additionalExpensesWeight``/``Note`` columns appear on ``GoldPour``.
- [ ] ``/gold`` renders 4 stat cards, 30-day trend, by-site bars, recent sales, top earners — all reconcile against the underlying list endpoints.
- [ ] Open ``Record Batch`` modal: only Site / Gross Weight / Witnesses visible. Witness picker shows only MANAGER + CLERK. ``More details`` reveals Purity / Storage (defaulted ``Vault``) / Additional Expenses / Notes. No double border around the form.
- [ ] Open ``Record Dispatch`` modal: multi-batch checklist; saves with N batches in one POST. Vehicle/Notes/Override hidden by default. Already-dispatched batches do not appear.
- [ ] Open ``Record Sale`` modal: CASH preselected; channel/reference/notes hidden by default. Picking a multi-batch dispatch switches to per-batch entry and saves N receipts via ``/api/gold/receipts/batch``.
- [ ] Sidebar shows a single ``Accounting Master`` group containing Overview / Receivables / Payables / Reporting / Banking / Master — Overview first.
- [ ] ``/human-resources`` renders a left category sidebar (People / Shifts / Compensation / Payroll / Approvals); Compensation and Payroll show sub-tabs at the top.
- [ ] HR employees table: avatar is round, sits inline with name + ``{employeeId} · {jobTitle}``; no Currency line in the Employment cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)