### PR TITLE
fix(gold): ledger import showstopper + discoverable detail links + auto-save wizard

### DIFF
--- a/app/api/gold/imports/[id]/commit/route.ts
+++ b/app/api/gold/imports/[id]/commit/route.ts
@@ -48,6 +48,11 @@ export async function POST(
     let rowsSkipped = 0
     let rowsAnomaly = 0
     let rowsFailed = 0
+    let allocationsCreated = 0
+    let poursCreated = 0
+    let salesCreated = 0
+    let totalSaleGrams = 0
+    let totalDeficitGrams = 0
 
     // Production rows (have grams + mapping)
     const productionEntries = importRecord.entries.filter(
@@ -114,7 +119,6 @@ export async function POST(
               employeeId,
               status: "PRESENT",
               notes: `Imported from ledger line ${entry.lineNo}`,
-              createdById: userId,
             })),
             skipDuplicates: true,
           })
@@ -136,23 +140,22 @@ export async function POST(
           const splitMode =
             Math.abs(boys - netWeight / 2) < 0.001 ? "DEFAULT_50_50" : "OVERRIDE_WORKER_WEIGHT"
 
-          // Valuation snapshot
+          // Valuation snapshot — soft-fail if no gold price is configured
+          // (the user can post-import set a price; events still capture weights).
           const valuation = await snapshotGoldUsdValue({
             companyId,
             businessDate: entry.parsedDate!,
             grams: 1,
           })
-          if (!valuation) {
-            throw new Error("No gold price configured for this date")
-          }
-          const goldPrice = valuation.goldPriceUsdPerGram
-          const totalWeightValueUsd = +(totalWeight * goldPrice).toFixed(2)
-          const netWeightValueUsd = +(netWeight * goldPrice).toFixed(2)
-          const workerShareValueUsd = +(boys * goldPrice).toFixed(2)
-          const companyShareValueUsd = +(mdara * goldPrice).toFixed(2)
+          const goldPrice = valuation?.goldPriceUsdPerGram ?? 0
+          const valuationDate = valuation?.valuationDate ?? null
+          const totalWeightValueUsd = goldPrice ? +(totalWeight * goldPrice).toFixed(2) : null
+          const netWeightValueUsd = goldPrice ? +(netWeight * goldPrice).toFixed(2) : null
+          const workerShareValueUsd = goldPrice ? +(boys * goldPrice).toFixed(2) : null
+          const companyShareValueUsd = goldPrice ? +(mdara * goldPrice).toFixed(2) : null
           const presentList = Array.from(presentEmployeeIds)
           const perWorkerWeight = +(boys / presentList.length).toFixed(4)
-          const perWorkerValueUsd = +(perWorkerWeight * goldPrice).toFixed(2)
+          const perWorkerValueUsd = goldPrice ? +(perWorkerWeight * goldPrice).toFixed(2) : null
 
           const allocation = await tx.goldShiftAllocation.create({
             data: {
@@ -171,8 +174,8 @@ export async function POST(
               workerShareWeight: boys,
               companyShareWeight: mdara,
               perWorkerWeight,
-              goldPriceUsdPerGram: goldPrice,
-              valuationDate: valuation.valuationDate,
+              goldPriceUsdPerGram: goldPrice || null,
+              valuationDate,
               totalWeightValueUsd,
               netWeightValueUsd,
               workerShareValueUsd,
@@ -206,8 +209,8 @@ export async function POST(
                 pourBarId,
                 pourDate: entry.parsedDate!,
                 grossWeight: totalWeight,
-                goldPriceUsdPerGram: goldPrice,
-                valuationDate: valuation.valuationDate,
+                goldPriceUsdPerGram: goldPrice || null,
+                valuationDate,
                 valueUsd: totalWeightValueUsd,
                 witness1Id: presentList[0],
                 witness2Id: presentList[1],
@@ -226,7 +229,7 @@ export async function POST(
               eventDate: entry.parsedDate!,
               direction: "IN",
               grams: totalWeight,
-              goldPriceUsdPerGram: goldPrice,
+              goldPriceUsdPerGram: goldPrice || null,
               valueUsd: totalWeightValueUsd,
               sourceType: "POUR",
               sourceId: pour.id,
@@ -244,6 +247,8 @@ export async function POST(
               errorMessage: null,
             },
           })
+          allocationsCreated += 1
+          if (createdPourId) poursCreated += 1
 
           // Accounting events (Mdara, Boys, per-expense)
           const sharedPayload = {
@@ -255,7 +260,7 @@ export async function POST(
             ledgerImportId: importRecord.id,
             ledgerLineNo: entry.lineNo,
           }
-          if (mdara > 0) {
+          if (mdara > 0 && goldPrice) {
             await captureAccountingEvent({
               companyId,
               sourceDomain: "gold",
@@ -264,7 +269,7 @@ export async function POST(
               sourceId: allocation.id,
               entryDate: allocation.date,
               description: `Mdara share — allocation ${allocation.id} (line ${entry.lineNo})`,
-              amount: companyShareValueUsd,
+              amount: companyShareValueUsd ?? 0,
               netAmount: companyShareValueUsd,
               grossAmount: companyShareValueUsd,
               payload: { ...sharedPayload, shareWeight: mdara, shareValueUsd: companyShareValueUsd },
@@ -272,7 +277,7 @@ export async function POST(
               status: "PENDING",
             })
           }
-          if (boys > 0) {
+          if (boys > 0 && goldPrice) {
             await captureAccountingEvent({
               companyId,
               sourceDomain: "gold",
@@ -281,7 +286,7 @@ export async function POST(
               sourceId: allocation.id,
               entryDate: allocation.date,
               description: `Boys share — allocation ${allocation.id} (line ${entry.lineNo})`,
-              amount: workerShareValueUsd,
+              amount: workerShareValueUsd ?? 0,
               netAmount: workerShareValueUsd,
               grossAmount: workerShareValueUsd,
               payload: { ...sharedPayload, shareWeight: boys, shareValueUsd: workerShareValueUsd },
@@ -289,23 +294,25 @@ export async function POST(
               status: "PENDING",
             })
           }
-          for (const expense of allocation.expenses) {
-            const expenseValueUsd = +(expense.weight * goldPrice).toFixed(2)
-            await captureAccountingEvent({
-              companyId,
-              sourceDomain: "gold",
-              sourceAction: "shift-expense",
-              sourceType: "GOLD_SHIFT_EXPENSE",
-              sourceId: expense.id,
-              entryDate: allocation.date,
-              description: `${expense.type} — allocation ${allocation.id} (line ${entry.lineNo})`,
-              amount: expenseValueUsd,
-              netAmount: expenseValueUsd,
-              grossAmount: expenseValueUsd,
-              payload: { ...sharedPayload, expenseId: expense.id, expenseType: expense.type, weight: expense.weight, valueUsd: expenseValueUsd },
-              createdById: userId,
-              status: "PENDING",
-            })
+          if (goldPrice) {
+            for (const expense of allocation.expenses) {
+              const expenseValueUsd = +(expense.weight * goldPrice).toFixed(2)
+              await captureAccountingEvent({
+                companyId,
+                sourceDomain: "gold",
+                sourceAction: "shift-expense",
+                sourceType: "GOLD_SHIFT_EXPENSE",
+                sourceId: expense.id,
+                entryDate: allocation.date,
+                description: `${expense.type} — allocation ${allocation.id} (line ${entry.lineNo})`,
+                amount: expenseValueUsd,
+                netAmount: expenseValueUsd,
+                grossAmount: expenseValueUsd,
+                payload: { ...sharedPayload, expenseId: expense.id, expenseType: expense.type, weight: expense.weight, valueUsd: expenseValueUsd },
+                createdById: userId,
+                status: "PENDING",
+              })
+            }
           }
 
           if (presentList.length < 2) {
@@ -381,8 +388,14 @@ export async function POST(
           })
           return r
         })
-        if (result.isAnomaly) rowsAnomaly += 1
-        else rowsCreated += 1
+        salesCreated += result.receiptIds.length
+        totalSaleGrams += result.consumedGrams
+        if (result.isAnomaly) {
+          totalDeficitGrams += result.remainingGrams
+          rowsAnomaly += 1
+        } else {
+          rowsCreated += 1
+        }
       } catch (rowError) {
         const message = rowError instanceof Error ? rowError.message : String(rowError)
         await prisma.goldLedgerEntry.update({
@@ -408,7 +421,20 @@ export async function POST(
       },
     })
 
-    return successResponse(updated)
+    return successResponse({
+      ...updated,
+      summary: {
+        rowsCreated,
+        rowsSkipped,
+        rowsAnomaly,
+        rowsFailed,
+        allocationsCreated,
+        poursCreated,
+        salesCreated,
+        totalSaleGrams: +totalSaleGrams.toFixed(3),
+        totalDeficitGrams: +totalDeficitGrams.toFixed(3),
+      },
+    })
   } catch (error) {
     console.error("[API] POST /api/gold/imports/[id]/commit error:", error)
     return errorResponse("Failed to commit import")

--- a/app/gold/exceptions/page.tsx
+++ b/app/gold/exceptions/page.tsx
@@ -138,7 +138,8 @@ export default function GoldExceptionsPage() {
           pourDate: pour.pourDate,
           grossWeight: pour.grossWeight,
           valueUsd: pour.valueUsd ?? 0,
-        })),
+        }))
+        .sort((a, b) => b.pourDate.localeCompare(a.pourDate)),
     [dispatchByPourId, pours],
   );
 
@@ -152,20 +153,23 @@ export default function GoldExceptionsPage() {
           courier: dispatch.courier,
           destination: dispatch.destination,
           dispatchDate: dispatch.dispatchDate,
-        })),
+        }))
+        .sort((a, b) => b.dispatchDate.localeCompare(a.dispatchDate)),
     [dispatches, soldPourIds],
   );
 
   const correctionRows = useMemo<CorrectionRow[]>(
     () =>
-      corrections.map((correction) => ({
-        id: correction.id,
-        createdAt: correction.createdAt,
-        entityType: correction.entityType,
-        reference: correction.pour.pourBarId,
-        reason: correction.reason,
-        createdBy: correction.createdBy.name,
-      })),
+      corrections
+        .map((correction) => ({
+          id: correction.id,
+          createdAt: correction.createdAt,
+          entityType: correction.entityType,
+          reference: correction.pour.pourBarId,
+          reason: correction.reason,
+          createdBy: correction.createdBy.name,
+        }))
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
     [corrections],
   );
 

--- a/app/gold/import/[id]/page.tsx
+++ b/app/gold/import/[id]/page.tsx
@@ -48,6 +48,19 @@ type ImportDetail = {
   uploadedBy: { id: string; name: string } | null;
   site: { id: string; name: string; code: string } | null;
   entries: LedgerEntry[];
+  summary?: CommitSummary;
+};
+
+type CommitSummary = {
+  rowsCreated: number;
+  rowsSkipped: number;
+  rowsAnomaly: number;
+  rowsFailed: number;
+  allocationsCreated: number;
+  poursCreated: number;
+  salesCreated: number;
+  totalSaleGrams: number;
+  totalDeficitGrams: number;
 };
 
 const grams = (n: number | null | undefined) =>
@@ -58,8 +71,7 @@ export default function GoldImportDetailPage() {
   const router = useRouter();
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [pendingMappings, setPendingMappings] = useState<Record<string, string>>({});
-  const [pendingSiteId, setPendingSiteId] = useState<string | undefined>();
+  const [commitResult, setCommitResult] = useState<CommitSummary | null>(null);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["gold-import", id],
@@ -68,10 +80,10 @@ export default function GoldImportDetailPage() {
   });
 
   const { data: groupsData } = useQuery({
-    queryKey: ["shift-groups", "import", data?.siteId ?? pendingSiteId],
+    queryKey: ["shift-groups", "import", data?.siteId],
     queryFn: () =>
-      fetchShiftGroups({ active: true, limit: 200, siteId: data?.siteId ?? pendingSiteId }),
-    enabled: !!(data?.siteId ?? pendingSiteId),
+      fetchShiftGroups({ active: true, limit: 200, siteId: data?.siteId ?? undefined }),
+    enabled: !!data?.siteId,
   });
 
   const { data: sitesData } = useQuery({
@@ -97,20 +109,32 @@ export default function GoldImportDetailPage() {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["gold-import", id] });
-      toast({ title: "Saved", variant: "success" });
+    },
+    onError: (err) => {
+      toast({
+        title: "Could not save",
+        description: getApiErrorMessage(err),
+        variant: "destructive",
+      });
     },
   });
 
   const commitMutation = useMutation({
     mutationFn: async () =>
-      fetchJson<ImportDetail>(`/api/gold/imports/${id}/commit`, { method: "POST" }),
-    onSuccess: () => {
+      fetchJson<ImportDetail & { summary?: CommitSummary }>(
+        `/api/gold/imports/${id}/commit`,
+        { method: "POST" },
+      ),
+    onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["gold-import", id] });
       queryClient.invalidateQueries({ queryKey: ["gold-imports"] });
       queryClient.invalidateQueries({ queryKey: ["gold-summary"] });
+      if (result.summary) setCommitResult(result.summary);
       toast({
-        title: "Committed",
-        description: "Allocations and sales created.",
+        title: result.summary
+          ? `${result.summary.allocationsCreated} allocations · ${result.summary.salesCreated} sales`
+          : "Committed",
+        description: "Ledger imported.",
         variant: "success",
       });
     },
@@ -135,34 +159,25 @@ export default function GoldImportDetailPage() {
   }
 
   const isLocked = data.status === "COMMITTED";
-  const allMapped = distinctNames.every((name) => {
-    const fromState = pendingMappings[name];
-    if (fromState) return true;
-    if (data.mappingsJson) {
-      const m = JSON.parse(data.mappingsJson) as Record<string, string>;
-      if (m[name]) return true;
-    }
-    return false;
-  });
-  const siteIsSet = !!(data.siteId || pendingSiteId);
-  const canCommit = !isLocked && allMapped && siteIsSet;
-
-  const saveMappings = () => {
-    if (Object.keys(pendingMappings).length === 0 && !pendingSiteId) {
-      toast({ title: "Nothing to save", variant: "destructive" });
-      return;
-    }
-    patchMutation.mutate({
-      siteId: pendingSiteId,
-      mappings: Object.keys(pendingMappings).length > 0 ? pendingMappings : undefined,
-    });
-    setPendingMappings({});
-    setPendingSiteId(undefined);
-  };
-
   const existingMappings: Record<string, string> = data.mappingsJson
     ? JSON.parse(data.mappingsJson)
     : {};
+  const allMapped =
+    distinctNames.length > 0 && distinctNames.every((name) => !!existingMappings[name]);
+  const siteIsSet = !!data.siteId;
+  const canCommit = !isLocked && allMapped && siteIsSet;
+  const mappedCount = distinctNames.filter((n) => !!existingMappings[n]).length;
+
+  const setSiteAndSave = (newSiteId: string) => {
+    if (!newSiteId || newSiteId === data.siteId) return;
+    patchMutation.mutate({ siteId: newSiteId });
+  };
+
+  const setMappingAndSave = (name: string, shiftGroupId: string) => {
+    if (!shiftGroupId) return;
+    if (existingMappings[name] === shiftGroupId) return;
+    patchMutation.mutate({ mappings: { [name]: shiftGroupId } });
+  };
 
   return (
     <GoldShell
@@ -209,6 +224,34 @@ export default function GoldImportDetailPage() {
           </span>
         </div>
 
+        {/* Step indicator */}
+        <ol className="flex flex-wrap gap-2 text-xs">
+          <li
+            className={`flex items-center gap-2 rounded-full border px-3 py-1.5 ${
+              siteIsSet ? "border-emerald-500 bg-emerald-50 text-emerald-700" : "border-amber-500 bg-amber-50 text-amber-700"
+            }`}
+          >
+            <span className="font-bold">1</span>
+            <span>Site {siteIsSet ? "✓" : "needed"}</span>
+          </li>
+          <li
+            className={`flex items-center gap-2 rounded-full border px-3 py-1.5 ${
+              allMapped ? "border-emerald-500 bg-emerald-50 text-emerald-700" : "border-amber-500 bg-amber-50 text-amber-700"
+            }`}
+          >
+            <span className="font-bold">2</span>
+            <span>Mappings ({mappedCount}/{distinctNames.length})</span>
+          </li>
+          <li
+            className={`flex items-center gap-2 rounded-full border px-3 py-1.5 ${
+              isLocked ? "border-emerald-500 bg-emerald-50 text-emerald-700" : canCommit ? "border-blue-500 bg-blue-50 text-blue-700" : "border-muted text-muted-foreground"
+            }`}
+          >
+            <span className="font-bold">3</span>
+            <span>{isLocked ? "Committed" : canCommit ? "Ready to commit" : "Commit"}</span>
+          </li>
+        </ol>
+
         {commitMutation.error ? (
           <Alert variant="destructive">
             <AlertTitle>Commit failed</AlertTitle>
@@ -216,74 +259,125 @@ export default function GoldImportDetailPage() {
           </Alert>
         ) : null}
 
+        {(commitResult ?? data.summary) ? (
+          (() => {
+            const summary = commitResult ?? data.summary!;
+            return (
+              <section className="rounded-lg border border-emerald-200 bg-emerald-50 p-5">
+                <header className="flex items-center justify-between gap-3 mb-3">
+                  <h2 className="font-semibold text-emerald-900">Commit results</h2>
+                  <StatusChip status="passing" label="Done" />
+                </header>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+                  <div>
+                    <p className="text-xs text-emerald-800">Allocations</p>
+                    <p className="text-lg font-semibold">{summary.allocationsCreated}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-emerald-800">Auto-pours</p>
+                    <p className="text-lg font-semibold">{summary.poursCreated}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-emerald-800">Sales (FIFO)</p>
+                    <p className="text-lg font-semibold">
+                      {summary.salesCreated}
+                      <span className="ml-1 text-xs font-normal text-muted-foreground">
+                        ({summary.totalSaleGrams.toFixed(2)} g)
+                      </span>
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-emerald-800">Inventory deficit</p>
+                    <p className={`text-lg font-semibold ${summary.totalDeficitGrams > 0 ? "text-rose-700" : ""}`}>
+                      {summary.totalDeficitGrams.toFixed(2)} g
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-3 text-xs text-emerald-800">
+                  {summary.rowsAnomaly > 0
+                    ? `${summary.rowsAnomaly} rows flagged as anomalies — see the table below.`
+                    : "All rows clean."}
+                  {summary.rowsFailed > 0
+                    ? ` ${summary.rowsFailed} rows failed and need attention.`
+                    : ""}
+                </p>
+              </section>
+            );
+          })()
+        ) : null}
+
         {!isLocked ? (
           <section className="rounded-lg border bg-card p-5 space-y-4">
             <header>
               <h2 className="font-semibold">1 · Pick site</h2>
               <p className="text-sm text-muted-foreground">
-                Every row in this ledger belongs to one mine site.
+                Every row in this ledger belongs to one mine site. Saved instantly.
               </p>
             </header>
             <SearchableSelect
-              value={pendingSiteId ?? data.siteId ?? undefined}
+              value={data.siteId ?? undefined}
               options={sites.map((s) => ({ value: s.id, label: s.name, meta: s.code }))}
               placeholder="Pick site"
               searchPlaceholder="Search sites..."
-              onValueChange={(v) => setPendingSiteId(v || undefined)}
+              onValueChange={(v) => v && setSiteAndSave(v)}
             />
           </section>
         ) : null}
 
         {!isLocked ? (
           <section className="rounded-lg border bg-card p-5 space-y-4">
-            <header className="flex items-center justify-between gap-3">
-              <div>
-                <h2 className="font-semibold">2 · Map shift leaders</h2>
-                <p className="text-sm text-muted-foreground">
-                  Each name maps to a shift group. Group members will be marked
-                  PRESENT for every shift in this ledger.
-                </p>
-              </div>
-              <Button
-                size="sm"
-                disabled={
-                  patchMutation.isPending ||
-                  (Object.keys(pendingMappings).length === 0 && !pendingSiteId)
-                }
-                onClick={saveMappings}
-              >
-                Save mappings
-              </Button>
+            <header>
+              <h2 className="font-semibold">
+                2 · Map shift leaders ({mappedCount}/{distinctNames.length})
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {data.siteId
+                  ? "Each name maps to a shift group. Members of that group will be marked PRESENT for every shift this leader logged. Saved instantly."
+                  : "Pick a site first to load shift groups."}
+              </p>
             </header>
 
-            <ul className="divide-y">
-              {distinctNames.map((name) => {
-                const current = pendingMappings[name] ?? existingMappings[name] ?? "";
-                return (
-                  <li
-                    key={name}
-                    className="grid grid-cols-1 sm:grid-cols-[200px_1fr] gap-3 py-3 items-center"
-                  >
-                    <span className="font-mono font-semibold">{name}</span>
-                    <SearchableSelect
-                      value={current || undefined}
-                      options={groups.map((g) => ({
-                        value: g.id,
-                        label: g.name,
-                        meta: g.leader?.name,
-                      }))}
-                      placeholder={
-                        groups.length === 0 ? "Set site first to load groups" : "Pick a shift group"
-                      }
-                      searchPlaceholder="Search groups..."
-                      onValueChange={(v) =>
-                        setPendingMappings((prev) => ({ ...prev, [name]: v }))
-                      }
-                    />
-                  </li>
-                );
-              })}
-            </ul>
+            {distinctNames.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No leader names parsed.</p>
+            ) : (
+              <ul className="divide-y">
+                {distinctNames.map((name) => {
+                  const current = existingMappings[name] ?? "";
+                  const isMapped = !!current;
+                  return (
+                    <li
+                      key={name}
+                      className={`grid grid-cols-1 sm:grid-cols-[220px_1fr_24px] gap-3 py-3 items-center ${isMapped ? "" : "bg-amber-50/30 -mx-5 px-5"}`}
+                    >
+                      <span className="font-mono font-semibold">{name}</span>
+                      <SearchableSelect
+                        value={current || undefined}
+                        options={groups.map((g) => ({
+                          value: g.id,
+                          label: g.name,
+                          meta: g.leader?.name,
+                        }))}
+                        placeholder={
+                          groups.length === 0
+                            ? data.siteId
+                              ? "No shift groups for this site"
+                              : "Pick a site first"
+                            : "Pick a shift group"
+                        }
+                        searchPlaceholder="Search groups..."
+                        disabled={!data.siteId || groups.length === 0}
+                        onValueChange={(v) => setMappingAndSave(name, v)}
+                      />
+                      {isMapped ? (
+                        <span className="text-emerald-600 text-lg">✓</span>
+                      ) : (
+                        <span className="text-amber-500 text-lg">!</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
           </section>
         ) : null}
 

--- a/app/gold/intake/pours/page.tsx
+++ b/app/gold/intake/pours/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { ChevronRight } from "@/lib/icons";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -93,14 +94,16 @@ export default function GoldIntakePoursPage() {
         cell: ({ row }) => (
           <Link
             href={`/gold/intake/pours/${row.original.id}`}
-            className="font-mono font-semibold hover:underline"
+            className="inline-flex items-center gap-1 font-mono font-semibold text-primary hover:underline"
+            title="View batch details"
           >
             {row.original.pourBarId}
+            <ChevronRight className="h-3 w-3 opacity-60" />
           </Link>
         ),
-        size: 112,
-        minSize: 112,
-        maxSize: 112,
+        size: 130,
+        minSize: 130,
+        maxSize: 160,
       },
       {
         id: "site",

--- a/app/gold/settlement/receipts/page.tsx
+++ b/app/gold/settlement/receipts/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { ChevronRight } from "@/lib/icons";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
@@ -136,14 +137,16 @@ export default function GoldSettlementReceiptsPage() {
         cell: ({ row }) => (
           <Link
             href={`/gold/settlement/receipts/${row.original.id}`}
-            className="font-mono font-semibold hover:underline"
+            className="inline-flex items-center gap-1 font-mono font-semibold text-primary hover:underline"
+            title="View sale details"
           >
             {row.original.receiptNumber}
+            <ChevronRight className="h-3 w-3 opacity-60" />
           </Link>
         ),
-        size: 112,
-        minSize: 112,
-        maxSize: 112,
+        size: 130,
+        minSize: 130,
+        maxSize: 160,
       },
       {
         id: "batch",

--- a/app/gold/transit/dispatches/page.tsx
+++ b/app/gold/transit/dispatches/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { ChevronRight } from "@/lib/icons";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -124,15 +125,17 @@ export default function GoldTransitDispatchesPage() {
           <NumericCell align="left">
             <Link
               href={`/gold/transit/dispatches/${row.original.id}`}
-              className="hover:underline"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+              title="View dispatch details"
             >
               {new Date(row.original.dispatchDate).toLocaleString()}
+              <ChevronRight className="h-3 w-3 opacity-60" />
             </Link>
           </NumericCell>
         ),
-        size: 128,
-        minSize: 128,
-        maxSize: 128,
+        size: 180,
+        minSize: 180,
+        maxSize: 200,
       },
       {
         id: "batch",


### PR DESCRIPTION
## Why

Three real complaints from QA:

1. **Sales from negative-balance ledger rows weren't being created.**
   Root cause: every production-row transaction was throwing ``Unknown argument 'createdById'`` because the ``Attendance`` model has no ``createdById`` field. That killed the allocation + auto-pour, which left the FIFO sales pass with **zero pours to draw against** — so even though sales rows were processed, every one of them silently anomalied with deficit = full sale weight.
2. **Couldn't find detail pages.** The leading ID column was a plain mono-text link with no visual cue.
3. **Import wizard wasn't intuitive.** The single ``Save mappings`` button conflated site-save and mapping-save, and the commit response gave no breakdown of what got created.

## What changed

### Showstopper fix
- ``app/api/gold/imports/[id]/commit/route.ts``: drop ``createdById`` from ``Attendance.createMany``.
- Same file: soft-fail the gold-price snapshot. If no price is configured for a row's date, save the allocation + pour with null USD values and skip the Mdara/Boys/Expense accounting events for that row — instead of throwing and aborting the whole row. The inventory IN event still records weight, which is what matters for FIFO downstream.
- Commit endpoint now returns a ``summary`` block: ``{ allocationsCreated, poursCreated, salesCreated, totalSaleGrams, totalDeficitGrams, rowsCreated, rowsAnomaly, rowsFailed, rowsSkipped }``.

### Detail-page discoverability
- ``app/gold/intake/pours/page.tsx`` Batch ID column → ``text-primary`` mono link with trailing ``ChevronRight`` and a "View batch details" tooltip.
- ``app/gold/settlement/receipts/page.tsx`` Sale No. column → same treatment.
- ``app/gold/transit/dispatches/page.tsx`` Date column → same treatment (the dispatch list doesn't have a natural ID column to anchor on, so the date is the click target).

### Ordering
- ``app/gold/exceptions/page.tsx`` Missing-dispatch / Missing-sale / Corrections tables now sort by their respective date column descending (the rest of the gold pages already did).

### Import wizard
- ``app/gold/import/[id]/page.tsx``:
  - Step-indicator chips at the top: **1 Site / 2 Mappings (n/m) / 3 Commit** with green/amber/blue states so users know exactly what's left.
  - Site picker auto-saves on change. No more separate "Save" click.
  - Each mapping row auto-saves on change. Unmapped rows are highlighted with an amber background and a ``!`` glyph; mapped rows show ``✓``.
  - After commit, a green results panel shows ``Allocations / Auto-pours / Sales (FIFO) / Inventory deficit`` with the actual numbers, plus a one-line summary noting how many rows are anomalies and how many failed.

## Test plan

- [ ] Re-upload the same ``ledger_v4.xlsx`` (Save As CSV). Pick a site — should auto-save. Map all 16-ish leader names — each save should be instant. Step chips should turn green.
- [ ] Click Commit. Expect ~96 allocations, ~96 auto-pours, ~8 sales (one per negative-Bal row) totalling roughly 155g of sale weight (matching the ledger's net).
- [ ] Spot-check ``/gold/intake/pours`` — the Batch ID column should look obviously clickable; clicking opens the detail page.
- [ ] Spot-check ``/gold/settlement/receipts`` and ``/gold/transit/dispatches`` — same.
- [ ] If any sale tries to over-consume the on-hand pool, expect a CRITICAL ``GoldException`` row with the deficit grams in the metadata, and the wizard's results panel should show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)