### PR TITLE
fix(gold): make import commit defensive (no more throw-on-flaggable rows)

### DIFF
--- a/app/api/gold/imports/[id]/commit/route.ts
+++ b/app/api/gold/imports/[id]/commit/route.ts
@@ -54,18 +54,27 @@ export async function POST(
     let totalSaleGrams = 0
     let totalDeficitGrams = 0
 
-    // Production rows (have grams + mapping)
+    // Production rows: process anything not yet anchored to an allocation.
+    // PENDING (fresh), ANOMALY (parser warnings — still saveable, just flagged),
+    // FAILED (previous-attempt remnants from a bug we've since fixed).
+    // Once a row has goldShiftAllocationId it's done — we don't re-create.
     const productionEntries = importRecord.entries.filter(
       (e) =>
         e.gramsTotal != null &&
         e.gramsTotal > 0 &&
         e.mappedShiftGroupId &&
         e.parsedDate &&
-        (e.status === "PENDING" || e.status === "ANOMALY"),
+        !e.goldShiftAllocationId &&
+        (e.status === "PENDING" || e.status === "ANOMALY" || e.status === "FAILED"),
     )
 
     for (const entry of productionEntries) {
       const shiftName = `LEDGER-${entry.lineNo}`
+      // Soft-validation: collect warnings, decide flag-vs-fail at the end.
+      const rowWarnings: string[] = []
+      if (entry.errorMessage && entry.status === "ANOMALY") {
+        rowWarnings.push(entry.errorMessage)
+      }
       try {
         await prisma.$transaction(async (tx) => {
           const group = await tx.shiftGroup.findUnique({
@@ -78,8 +87,35 @@ export async function POST(
               },
             },
           })
-          if (!group || !group.leader.isActive) {
-            throw new Error("Mapped shift group is missing or leader inactive")
+          // Defensive: if the group is missing or the leader is inactive, we
+          // can't credibly create a witnessed allocation. Save the row with
+          // ANOMALY + a tracked exception and move on, rather than blowing
+          // up the whole import.
+          if (!group) {
+            rowWarnings.push("Mapped shift group not found")
+            await tx.goldLedgerEntry.update({
+              where: { id: entry.id },
+              data: {
+                status: "ANOMALY",
+                errorMessage: rowWarnings.join(" · "),
+              },
+            })
+            await tx.goldException.create({
+              data: {
+                companyId,
+                siteId,
+                category: "NAME_UNMAPPED",
+                severity: "WARNING",
+                entityType: "GoldLedgerEntry",
+                entityId: entry.id,
+                description: `Ledger line ${entry.lineNo}: shift group ${entry.mappedShiftGroupId} not found`,
+                createdById: userId,
+              },
+            })
+            return
+          }
+          if (!group.leader.isActive) {
+            rowWarnings.push(`Group leader ${group.leader.name} is inactive`)
           }
 
           const presentEmployeeIds = new Set<string>([group.leader.id])
@@ -87,7 +123,7 @@ export async function POST(
             if (m.employee.isActive) presentEmployeeIds.add(m.employee.id)
           }
           if (presentEmployeeIds.size === 0) {
-            throw new Error("No active members in shift group")
+            rowWarnings.push("No active members in shift group")
           }
 
           // Create ShiftReport
@@ -129,14 +165,25 @@ export async function POST(
             ? JSON.parse(entry.expensesJson)
             : []
           const expenseTotal = expenses.reduce((s, e) => s + e.weight, 0)
-          const netWeight = +(totalWeight - expenseTotal).toFixed(4)
-          if (netWeight <= 0) {
-            throw new Error("Net weight must be positive after expenses")
+          const rawNetWeight = +(totalWeight - expenseTotal).toFixed(4)
+          let netWeight = rawNetWeight
+          if (rawNetWeight <= 0) {
+            rowWarnings.push(
+              `Expenses (${expenseTotal.toFixed(2)} g) ≥ gross (${totalWeight.toFixed(2)} g) — clamped net to 0.001 g`,
+            )
+            netWeight = 0.001
           }
 
           const boys = entry.boysGrams ?? netWeight / 2
-          const mdara = entry.mdaraGrams ?? netWeight - boys
-          // Slight rounding tolerance
+          const mdaraRaw = entry.mdaraGrams ?? netWeight - boys
+          // Don't allow negative company share — clamp to 0 with a warning.
+          const mdara = mdaraRaw < 0 ? 0 : mdaraRaw
+          if (mdaraRaw < 0) {
+            rowWarnings.push(
+              `Boys (${boys}) > net (${netWeight}) — Mdara share clamped to 0`,
+            )
+          }
+          // Override mode whenever Boys ≠ exactly half of net (small tolerance).
           const splitMode =
             Math.abs(boys - netWeight / 2) < 0.001 ? "DEFAULT_50_50" : "OVERRIDE_WORKER_WEIGHT"
 
@@ -196,6 +243,13 @@ export async function POST(
             include: { expenses: true, workerShares: true },
           })
 
+          // Witness rule: a pour needs at least two people present.
+          if (presentList.length < 2) {
+            rowWarnings.push(
+              `Only ${presentList.length} present employee — no auto-pour for this row`,
+            )
+          }
+
           // Auto-pour if witnesses available
           let createdPourId: string | null = null
           if (presentList.length >= 2) {
@@ -239,14 +293,37 @@ export async function POST(
             })
           }
 
+          // If we collected any warnings (parser-level or this-pass-level),
+          // the row is saved but flagged ANOMALY. Otherwise CREATED.
+          const isFlagged = rowWarnings.length > 0
+          const flaggedMessage = rowWarnings.join(" · ")
           await tx.goldLedgerEntry.update({
             where: { id: entry.id },
             data: {
               goldShiftAllocationId: allocation.id,
-              status: "CREATED",
-              errorMessage: null,
+              status: isFlagged ? "ANOMALY" : "CREATED",
+              errorMessage: isFlagged ? flaggedMessage : null,
             },
           })
+          if (isFlagged) {
+            await tx.goldException.create({
+              data: {
+                companyId,
+                siteId,
+                category: "EXPENSE_MISMATCH",
+                severity: "WARNING",
+                entityType: "GoldShiftAllocation",
+                entityId: allocation.id,
+                description: `Ledger line ${entry.lineNo} saved with warnings: ${flaggedMessage}`,
+                metadata: JSON.stringify({
+                  ledgerImportId: importRecord.id,
+                  ledgerEntryId: entry.id,
+                  warnings: rowWarnings,
+                }),
+                createdById: userId,
+              },
+            })
+          }
           allocationsCreated += 1
           if (createdPourId) poursCreated += 1
 
@@ -315,27 +392,25 @@ export async function POST(
             }
           }
 
-          if (presentList.length < 2) {
-            await tx.goldException.create({
-              data: {
-                companyId,
-                siteId,
-                category: "WITNESS_MISSING",
-                severity: "WARNING",
-                entityType: "GoldShiftAllocation",
-                entityId: allocation.id,
-                description: `No auto-pour for line ${entry.lineNo}: only ${presentList.length} present employee.`,
-                createdById: userId,
-              },
-            })
-          }
         })
-        rowsCreated += 1
+        // Tally: rowWarnings non-empty means the row was saved-with-flag
+        // (counts toward rowsAnomaly). Empty means clean save. The two
+        // counters never overlap on a single row.
+        if (rowWarnings.length > 0) rowsAnomaly += 1
+        else rowsCreated += 1
       } catch (rowError) {
-        const message = rowError instanceof Error ? rowError.message : String(rowError)
+        // Real DB-level failure (Prisma error, FK violation, unique
+        // conflict). Log the full stack so the operator can see it in the
+        // server logs; surface a concise message on the row itself.
+        const message =
+          rowError instanceof Error ? rowError.message : String(rowError)
+        console.error(
+          `[Import] Production row ${entry.lineNo} failed:`,
+          rowError,
+        )
         await prisma.goldLedgerEntry.update({
           where: { id: entry.id },
-          data: { status: "FAILED", errorMessage: message },
+          data: { status: "FAILED", errorMessage: message.slice(0, 500) },
         })
         rowsFailed += 1
       }
@@ -376,14 +451,24 @@ export async function POST(
               },
             })
           }
+          // Don't clobber an ANOMALY flag that the production pass put on
+          // this same row (e.g., parser warning on a row that's both
+          // production + sale). Promote PENDING/FAILED to CREATED only if
+          // FIFO fully covered the sale.
+          const currentEntry = await tx.goldLedgerEntry.findUnique({
+            where: { id: entry.id },
+            select: { status: true, errorMessage: true },
+          })
+          const stayAnomaly =
+            r.isAnomaly || currentEntry?.status === "ANOMALY"
           await tx.goldLedgerEntry.update({
             where: { id: entry.id },
             data: {
-              status: r.isAnomaly ? "ANOMALY" : "CREATED",
+              status: stayAnomaly ? "ANOMALY" : "CREATED",
               buyerReceiptId: r.receiptIds[0] ?? null,
               errorMessage: r.isAnomaly
                 ? `Inventory deficit ${r.remainingGrams.toFixed(3)} g`
-                : null,
+                : currentEntry?.errorMessage ?? null,
             },
           })
           return r
@@ -397,10 +482,15 @@ export async function POST(
           rowsCreated += 1
         }
       } catch (rowError) {
-        const message = rowError instanceof Error ? rowError.message : String(rowError)
+        const message =
+          rowError instanceof Error ? rowError.message : String(rowError)
+        console.error(
+          `[Import] Sale row ${entry.lineNo} failed:`,
+          rowError,
+        )
         await prisma.goldLedgerEntry.update({
           where: { id: entry.id },
-          data: { status: "FAILED", errorMessage: message },
+          data: { status: "FAILED", errorMessage: message.slice(0, 500) },
         })
         rowsFailed += 1
       }


### PR DESCRIPTION
Replaces #105 (which had merge conflicts after the first commit was squash-merged into main). All commits since then collapsed into one clean diff against current main.

## Why

After PR #105's first commit landed on main, you ran a commit and saw `0 created · 14 flagged · 14 failed`. Those 14 failures were the production pass throwing on conditions that shouldn't take a row down — the FIFO sales pass then had no pours to draw against, and every negative-Bal row anomalied with full deficit.

## What changed (`app/api/gold/imports/[id]/commit/route.ts`)

Three throws → flag-and-save:

| Condition | Old | New |
|---|---|---|
| Missing/invalid shift group | throw → row FAILED | row ANOMALY + ``NAME_UNMAPPED`` exception, no allocation |
| Inactive group leader | throw → row FAILED | warning collected, allocation still saved |
| `netWeight <= 0` (expenses ≥ gross) | throw → row FAILED | net clamped to 0.001 g, allocation saved with ledger Boys/Mdara split |
| `Boys > net` | unchecked | Mdara clamped to 0, row flagged |
| Only leader present | exception emitted but row marked CREATED | warning rolled into row's errorMessage, no auto-pour, row flagged |

All saved-with-warning paths funnel through a single ``rowWarnings`` collector that becomes the row's ``errorMessage`` and an exception pointing at the allocation. ``rowsCreated`` and ``rowsAnomaly`` are now a strict partition.

Re-commit support already in this file:
- Production filter accepts ``PENDING | ANOMALY | FAILED`` (so previously-failed rows get retried).
- Skips rows that already have ``goldShiftAllocationId`` (no double-create).
- Sales pass re-fetches the row's current status before update; promotes to CREATED only when FIFO succeeded AND the row wasn't already flagged.

Hard catch handler now ``console.error``s the full Error with the line number, and saves a truncated message on the row. So when something Prisma-level breaks for real, the operator can see why in the logs.

## Test plan

- [ ] Pull, restart Next dev server (the previous failure was on stale bundle).
- [ ] Hit Commit on the existing failed import. Expect production rows to now reprocess: most should land as CREATED, a handful as ANOMALY with a saved allocation. The FIFO sales pass should consume real pours and produce non-zero ``Sales (FIFO)`` in the wizard summary.
- [ ] Spot-check a flagged allocation in ``/gold/insights/allocations/[id]``. The ``GoldException`` should appear in the audit list.
- [ ] If anything still fails, the server console will print ``[Import] Production row N failed: <full error>`` — paste that and we can fix the next layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)