### PR TITLE
feat(retail): harden, redesign and design-system-align the retail + P…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ next-env.d.ts
 .env
 /worktrees
 /.worktrees/
+
+.vercel

--- a/app/api/v2/retail/_helpers.ts
+++ b/app/api/v2/retail/_helpers.ts
@@ -22,11 +22,34 @@ export async function requireRetailSession(request: NextRequest) {
   return { response: null, session: sessionResult.session as RetailSession };
 }
 
-const RETAIL_MANAGER_ROLES: UserRole[] = ["SUPERADMIN", "MANAGER", "SHOP_MANAGER"];
+export const RETAIL_MANAGER_ROLES: UserRole[] = ["SUPERADMIN", "MANAGER", "SHOP_MANAGER"];
+export const RETAIL_STOCK_ROLES: UserRole[] = [...RETAIL_MANAGER_ROLES, "STOCK_CLERK"];
+export const RETAIL_POS_ROLES: UserRole[] = [...RETAIL_MANAGER_ROLES, "CASHIER"];
 const POS_SUPPORTED_PROMOTION_TYPES = ["PERCENT", "AMOUNT"] as const;
 
 export function canManageRetailTransactions(role: string | null | undefined) {
   return hasRole(role, RETAIL_MANAGER_ROLES);
+}
+
+export function requireRetailManager(session: RetailSession): NextResponse | null {
+  if (!hasRole(session.user.role, RETAIL_MANAGER_ROLES)) {
+    return errorResponse("Insufficient permissions", 403);
+  }
+  return null;
+}
+
+export function requireRetailStock(session: RetailSession): NextResponse | null {
+  if (!hasRole(session.user.role, RETAIL_STOCK_ROLES)) {
+    return errorResponse("Insufficient permissions", 403);
+  }
+  return null;
+}
+
+export function requireRetailPos(session: RetailSession): NextResponse | null {
+  if (!hasRole(session.user.role, RETAIL_POS_ROLES)) {
+    return errorResponse("Insufficient permissions", 403);
+  }
+  return null;
 }
 
 export function isPosSupportedPromotionType(type: string | null | undefined) {
@@ -100,7 +123,10 @@ export function normalizeRetailPostingPayments(input: {
     .filter((payment) => payment.amount > 0);
 }
 
-export async function postRetailJournal(input: Parameters<typeof createJournalEntryFromSource>[0]) {
+export async function postRetailJournal(
+  input: Parameters<typeof createJournalEntryFromSource>[0],
+  options: { throwOnFail?: boolean } = {},
+) {
   const result = await createJournalEntryFromSource(input);
   if (result.entryId || result.skipped) {
     return {
@@ -111,8 +137,13 @@ export async function postRetailJournal(input: Parameters<typeof createJournalEn
     } satisfies RetailAccountingResult;
   }
 
+  const isPending = RETAIL_PENDING_POSTING_CODES.has(result.code ?? "");
+  if (!isPending && options.throwOnFail === true) {
+    throw new Error(result.error ?? "Accounting posting failed");
+  }
+
   return {
-    accountingStatus: RETAIL_PENDING_POSTING_CODES.has(result.code ?? "") ? "PENDING" : "FAILED",
+    accountingStatus: isPending ? "PENDING" : "FAILED",
     accountingError: result.error ?? "Accounting posting failed",
     accountingCode: result.code ?? null,
     journalEntryId: null,

--- a/app/api/v2/retail/catalog/[id]/route.ts
+++ b/app/api/v2/retail/catalog/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { ensureInventoryItemAccess, requireRetailSession } from "../../_helpers";
+import { ensureInventoryItemAccess, requireRetailManager, requireRetailSession } from "../../_helpers";
 
 const patchSchema = z.object({
   inventoryItemId: z.string().uuid().optional(),
@@ -67,6 +67,9 @@ export async function PATCH(
     return response as NextResponse;
   }
 
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
+
   try {
     const { id } = await params;
     const existing = await getCatalogItem(session.user.companyId, id);
@@ -125,6 +128,9 @@ export async function DELETE(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   const { id } = await params;
   const existing = await getCatalogItem(session.user.companyId, id);

--- a/app/api/v2/retail/catalog/route.ts
+++ b/app/api/v2/retail/catalog/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
 import { prisma } from "@/lib/prisma";
-import { ensureInventoryItemAccess, requireRetailSession } from "../_helpers";
+import { ensureInventoryItemAccess, requireRetailManager, requireRetailSession } from "../_helpers";
 
 const catalogItemSchema = z.object({
   catalogCode: z.string().min(1).max(50).optional(),
@@ -95,6 +95,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/customers/route.ts
+++ b/app/api/v2/retail/customers/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../_helpers";
+import { requireRetailPos, requireRetailSession } from "../_helpers";
 
 function getLoyaltyTier(points: number) {
   if (points >= 2_000) return "GOLD";
@@ -131,6 +131,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/pos/held-carts/[id]/recall/route.ts
+++ b/app/api/v2/retail/pos/held-carts/[id]/recall/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../../../../_helpers";
+import { requireRetailPos, requireRetailSession } from "../../../../_helpers";
 
 export async function POST(
   request: NextRequest,
@@ -11,6 +11,9 @@ export async function POST(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   const { id } = await params;
   const cart = await prisma.retailHeldCart.findFirst({

--- a/app/api/v2/retail/pos/held-carts/route.ts
+++ b/app/api/v2/retail/pos/held-carts/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../../_helpers";
+import { requireRetailPos, requireRetailSession } from "../../_helpers";
 
 const heldCartSchema = z.object({
   holdNo: z.string().min(1).max(50).optional(),
@@ -43,6 +43,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/pos/sales/[id]/refund/route.ts
+++ b/app/api/v2/retail/pos/sales/[id]/refund/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import {
+  requireRetailPos,
   requireRetailSession,
 } from "../../../../_helpers";
 import { refundRetailSaleTransaction } from "../../../../_services";
@@ -34,6 +35,9 @@ export async function POST(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const { id } = await params;

--- a/app/api/v2/retail/pos/sales/[id]/void/route.ts
+++ b/app/api/v2/retail/pos/sales/[id]/void/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import {
+  requireRetailPos,
   requireRetailSession,
 } from "../../../../_helpers";
 import { voidRetailSaleTransaction } from "../../../../_services";
@@ -21,6 +22,9 @@ export async function POST(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const { id } = await params;

--- a/app/api/v2/retail/pos/sales/route.ts
+++ b/app/api/v2/retail/pos/sales/route.ts
@@ -18,6 +18,7 @@ import {
   ensureSiteAccess,
   getPosSupportedPromotionTypes,
   isPosSupportedPromotionType,
+  requireRetailPos,
   requireRetailSession,
 } from "../../_helpers";
 import { createRetailSaleTransaction } from "../../_services";
@@ -288,6 +289,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/pos/sync/route.ts
+++ b/app/api/v2/retail/pos/sync/route.ts
@@ -21,6 +21,7 @@ import { errorResponse, successResponse } from "@/lib/api-utils";
 import { reserveIdentifier } from "@/lib/id-generator";
 import { prisma } from "@/lib/prisma";
 import {
+  requireRetailPos,
   requireRetailSession,
 } from "../../_helpers";
 import {
@@ -772,6 +773,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/promotions/[id]/route.ts
+++ b/app/api/v2/retail/promotions/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../../_helpers";
+import { requireRetailManager, requireRetailSession } from "../../_helpers";
 
 const patchSchema = z.object({
   name: z.string().min(1).max(200).optional(),
@@ -28,6 +28,9 @@ export async function PATCH(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const { id } = await params;
@@ -70,6 +73,9 @@ export async function DELETE(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   const { id } = await params;
   const existing = await getPromotion(session.user.companyId, id);

--- a/app/api/v2/retail/promotions/route.ts
+++ b/app/api/v2/retail/promotions/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../_helpers";
+import { requireRetailManager, requireRetailSession } from "../_helpers";
 
 const promotionSchema = z.object({
   promoCode: z.string().min(1).max(50).optional(),
@@ -56,6 +56,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/purchasing/orders/[id]/route.ts
+++ b/app/api/v2/retail/purchasing/orders/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { ensureInventoryItemAccess, ensureSiteAccess, requireRetailSession } from "../../../_helpers";
+import { ensureInventoryItemAccess, ensureSiteAccess, requireRetailManager, requireRetailStock, requireRetailSession } from "../../../_helpers";
 
 const lineSchema = z.object({
   inventoryItemId: z.string().uuid().optional().nullable(),
@@ -35,6 +35,9 @@ export async function PATCH(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailStock(session);
+  if (gate) return gate;
 
   try {
     const { id } = await params;
@@ -130,6 +133,9 @@ export async function DELETE(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   const { id } = await params;
   const existing = await getOrder(session.user.companyId, id);

--- a/app/api/v2/retail/purchasing/orders/route.ts
+++ b/app/api/v2/retail/purchasing/orders/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { normalizeProvidedId, reserveIdentifier } from "@/lib/id-generator";
 import { prisma } from "@/lib/prisma";
-import { ensureInventoryItemAccess, ensureSiteAccess, requireRetailSession } from "../../_helpers";
+import { ensureInventoryItemAccess, ensureSiteAccess, requireRetailManager, requireRetailStock, requireRetailSession } from "../../_helpers";
 
 const lineSchema = z.object({
   inventoryItemId: z.string().uuid().optional().nullable(),
@@ -72,6 +72,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailStock(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/purchasing/receipts/route.ts
+++ b/app/api/v2/retail/purchasing/receipts/route.ts
@@ -10,6 +10,7 @@ import {
   ensureSiteAccess,
   postRetailJournal,
   recordRetailInventoryMovement,
+  requireRetailStock,
   requireRetailSession,
 } from "../../_helpers";
 
@@ -78,6 +79,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailStock(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/setup/operations/route.ts
+++ b/app/api/v2/retail/setup/operations/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import {
   ensureRetailRegisterAccess,
+  requireRetailManager,
   requireRetailSession,
   ensureSiteAccess,
   upsertRetailRegister,
@@ -51,9 +52,8 @@ export async function PUT(request: NextRequest) {
     return response as NextResponse;
   }
 
-  if (!["SUPERADMIN", "MANAGER", "SHOP_MANAGER"].includes(session.user.role ?? "")) {
-    return errorResponse("Only managers can update retail operations setup", 403);
-  }
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/setup/pos-policy/route.ts
+++ b/app/api/v2/retail/setup/pos-policy/route.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
-import { requireRetailSession } from "../../_helpers";
+import { requireRetailManager, requireRetailSession } from "../../_helpers";
 import {
   DEFAULT_RETAIL_POS_POLICY,
   getRetailPosPolicy,
@@ -50,9 +50,8 @@ export async function PUT(request: NextRequest) {
     return response as NextResponse;
   }
 
-  if (!["SUPERADMIN", "MANAGER", "SHOP_MANAGER"].includes(session.user.role ?? "")) {
-    return errorResponse("Only managers can update POS policy", 403);
-  }
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/setup/tender-policy/route.ts
+++ b/app/api/v2/retail/setup/tender-policy/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
-import { requireRetailSession } from "../../_helpers";
+import { requireRetailManager, requireRetailSession } from "../../_helpers";
 import {
   DEFAULT_RETAIL_TENDER_POLICY,
   getRetailTenderPolicy,
@@ -32,9 +32,8 @@ export async function PUT(request: NextRequest) {
     return response as NextResponse;
   }
 
-  if (!["SUPERADMIN", "MANAGER", "SHOP_MANAGER"].includes(session.user.role ?? "")) {
-    return errorResponse("Only managers can update tender policy", 403);
-  }
+  const gate = requireRetailManager(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/shifts/[id]/close/route.ts
+++ b/app/api/v2/retail/shifts/[id]/close/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
-import { requireRetailSession } from "../../../_helpers";
+import { requireRetailPos, requireRetailSession } from "../../../_helpers";
 import { closeRetailShiftTransaction } from "../../../_services";
 
 const closeShiftSchema = z.object({
@@ -18,6 +18,9 @@ export async function POST(
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const { id } = await params;

--- a/app/api/v2/retail/shifts/route.ts
+++ b/app/api/v2/retail/shifts/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { errorResponse, successResponse } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
 import {
+  requireRetailPos,
   requireRetailSession,
 } from "../_helpers";
 import { openRetailShiftTransaction } from "../_services";
@@ -64,6 +65,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailPos(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/stock/count/route.ts
+++ b/app/api/v2/retail/stock/count/route.ts
@@ -6,6 +6,7 @@ import {
   ensureSiteAccess,
   postRetailJournal,
   recordRetailInventoryMovement,
+  requireRetailStock,
   requireRetailSession,
 } from "../../_helpers";
 
@@ -22,6 +23,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailStock(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();

--- a/app/api/v2/retail/stock/transfers/route.ts
+++ b/app/api/v2/retail/stock/transfers/route.ts
@@ -7,6 +7,7 @@ import {
   ensureLocationAccess,
   ensureSiteAccess,
   recordRetailInventoryMovement,
+  requireRetailStock,
   requireRetailSession,
 } from "../../_helpers";
 
@@ -23,6 +24,9 @@ export async function POST(request: NextRequest) {
   if (response || !session) {
     return response as NextResponse;
   }
+
+  const gate = requireRetailStock(session);
+  if (gate) return gate;
 
   try {
     const body = await request.json();
@@ -87,7 +91,7 @@ export async function POST(request: NextRequest) {
         movementType: "TRANSFER",
       },
       createdById: session.user.id,
-      status: "IGNORED",
+      status: "POSTED",
     });
 
     return successResponse(

--- a/app/globals.css
+++ b/app/globals.css
@@ -110,6 +110,10 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+
+  /* POS-specific breakpoints */
+  --breakpoint-ms: 520px;
+  --breakpoint-3xl: 1920px;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -822,5 +826,131 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 @keyframes shimmer {
   100% {
     transform: translateX(100%);
+  }
+}
+
+/* ── POS Terminal Theme ─────────────────────────────────────────────────── */
+
+.pos-terminal {
+  /* Navigation rail */
+  --pos-rail-bg: #0c1015;
+  --pos-rail-border: rgba(255,255,255,0.07);
+  --pos-rail-text-idle: rgba(255,255,255,0.36);
+  --pos-rail-text-active: #ffffff;
+  --pos-rail-active-bg: rgba(47,107,255,0.18);
+  --pos-rail-active-ring: rgba(47,107,255,0.42);
+  --pos-rail-workspace-shadow: 0 8px 28px rgba(0,0,0,0.5);
+
+  /* Dark instrument panel (dialog headers, amount display, table headers) */
+  --pos-amount-bg: #090e18;
+  --pos-amount-surface: #111827;
+  --pos-amount-text: #f0f9ff;
+  --pos-amount-label: rgba(240,249,255,0.42);
+  --pos-amount-border: rgba(255,255,255,0.07);
+  --pos-amount-pill-bg: rgba(255,255,255,0.07);
+  --pos-amount-pill-text: rgba(255,255,255,0.6);
+  --pos-amount-pill-hover-bg: rgba(255,255,255,0.12);
+  --pos-amount-pill-active-bg: rgba(47,107,255,0.22);
+  --pos-amount-pill-active-text: #93b4ff;
+  --pos-amount-pill-active-ring: rgba(47,107,255,0.45);
+  --pos-change-bg: rgba(34,197,94,0.14);
+  --pos-change-text: #4ade80;
+  --pos-due-bg: rgba(245,158,11,0.14);
+  --pos-due-text: #fbbf24;
+
+  /* Physical keypad */
+  --pos-key-bg: #ffffff;
+  --pos-key-border: #cdd5df;
+  --pos-key-shadow: #96a5b5;
+  --pos-key-text: #0f172a;
+  --pos-key-hover-bg: #f8fafc;
+  --pos-key-preset-bg: #f0fdf4;
+  --pos-key-preset-border: #bbf7d0;
+  --pos-key-preset-shadow: #86efac;
+  --pos-key-preset-text: #15803d;
+  --pos-key-back-bg: #f8fafc;
+  --pos-key-back-border: #e2e8f0;
+  --pos-key-back-shadow: #94a3b8;
+  --pos-key-back-text: #475569;
+  --pos-key-clear-bg: #fff1f2;
+  --pos-key-clear-border: #fecdd3;
+  --pos-key-clear-shadow: #fca5a5;
+  --pos-key-clear-text: #be123c;
+
+  /* Flat ringed status banners */
+  --pos-status-success-bg: rgba(34,197,94,0.08);
+  --pos-status-success-ring: rgba(34,197,94,0.25);
+  --pos-status-success-text: #15803d;
+  --pos-status-warning-bg: rgba(245,158,11,0.08);
+  --pos-status-warning-ring: rgba(245,158,11,0.25);
+  --pos-status-warning-text: #92400e;
+  --pos-status-danger-bg: rgba(239,68,68,0.08);
+  --pos-status-danger-ring: rgba(239,68,68,0.25);
+  --pos-status-danger-text: #b91c1c;
+  --pos-status-info-bg: rgba(47,107,255,0.08);
+  --pos-status-info-ring: rgba(47,107,255,0.25);
+  --pos-status-info-text: #1f46c4;
+
+  /* Primary CTA */
+  --pos-cta-bg: #2f6bff;
+  --pos-cta-text: #ffffff;
+  --pos-cta-shadow: #1f46c4;
+
+  /* Tender buttons */
+  --pos-tender-idle-bg: #ffffff;
+  --pos-tender-idle-border: #cdd5df;
+  --pos-tender-idle-shadow: #96a5b5;
+  --pos-tender-idle-text: #475569;
+  --pos-tender-cash-bg: #15803d;
+  --pos-tender-cash-shadow: #14532d;
+  --pos-tender-card-bg: #2563eb;
+  --pos-tender-card-shadow: #1e40af;
+  --pos-tender-mobile-bg: #ea580c;
+  --pos-tender-mobile-shadow: #9a3412;
+  --pos-tender-transfer-bg: #7c3aed;
+  --pos-tender-transfer-shadow: #5b21b6;
+  --pos-tender-voucher-bg: #d97706;
+  --pos-tender-voucher-shadow: #92400e;
+
+  /* LCD numeric input */
+  --pos-lcd-bg: #f0f4f8;
+  --pos-lcd-bg-active: #e0eaf5;
+  --pos-lcd-border: #cdd5df;
+  --pos-lcd-text: #0f172a;
+  --pos-lcd-text-active: var(--action-primary-bg);
+  --pos-lcd-label: #64748b;
+
+  /* Shadow utilities */
+  --shadow-card: 0 1px 3px rgba(15,23,42,0.06), 0 8px 24px rgba(15,23,42,0.06);
+  --shadow-popover: 0 4px 6px -1px rgba(15,23,42,0.1), 0 2px 4px -2px rgba(15,23,42,0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  .pos-terminal {
+    --pos-lcd-bg: #1a2030;
+    --pos-lcd-bg-active: #1e2a40;
+    --pos-lcd-border: rgba(255,255,255,0.10);
+    --pos-lcd-text: #f0f9ff;
+    --pos-lcd-label: rgba(240,249,255,0.55);
+    --pos-key-bg: #1f2632;
+    --pos-key-border: rgba(255,255,255,0.10);
+    --pos-key-shadow: #0a0d14;
+    --pos-key-text: #f0f9ff;
+    --pos-tender-idle-bg: #1f2632;
+    --pos-tender-idle-border: rgba(255,255,255,0.10);
+    --pos-tender-idle-shadow: #0a0d14;
+    --pos-tender-idle-text: rgba(240,249,255,0.78);
+    --pos-status-success-bg: rgba(34,197,94,0.14);
+    --pos-status-success-ring: rgba(34,197,94,0.42);
+    --pos-status-success-text: #4ade80;
+    --pos-status-warning-bg: rgba(245,158,11,0.14);
+    --pos-status-warning-ring: rgba(245,158,11,0.42);
+    --pos-status-warning-text: #fbbf24;
+    --pos-status-danger-bg: rgba(239,68,68,0.14);
+    --pos-status-danger-ring: rgba(239,68,68,0.42);
+    --pos-status-danger-text: #fca5a5;
+    --pos-status-info-bg: rgba(47,107,255,0.18);
+    --pos-status-info-ring: rgba(47,107,255,0.45);
+    --pos-status-info-text: #93b4ff;
   }
 }

--- a/app/portal/pos/login/client.tsx
+++ b/app/portal/pos/login/client.tsx
@@ -15,15 +15,17 @@ export function PosPortalLoginClient({
   rememberMeEnabled?: boolean;
 }) {
   return (
-    <PortalLoginForm
-      portalTitle="Point of Sale"
-      portalDescription="Sign in to continue."
-      portalIcon={<ReceiptLong className="h-7 w-7" />}
-      companyLabel={companyLabel}
-      redirectTo={redirectTo}
-      callbackUrl={callbackUrl}
-      rememberMeEnabled={rememberMeEnabled}
-      helpText="Use your standard company account."
-    />
+    <div className="pos-terminal flex min-h-[100dvh] items-center justify-center p-4" style={{ background: "var(--surface-canvas)" }}>
+      <PortalLoginForm
+        portalTitle="Point of Sale"
+        portalDescription="Sign in to continue."
+        portalIcon={<ReceiptLong className="h-7 w-7" />}
+        companyLabel={companyLabel}
+        redirectTo={redirectTo}
+        callbackUrl={callbackUrl}
+        rememberMeEnabled={rememberMeEnabled}
+        helpText="Use your standard company account."
+      />
+    </div>
   );
 }

--- a/app/retail/catalog/page.tsx
+++ b/app/retail/catalog/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import type { SearchableOption } from "@/components/ui/searchable-select";
 import { RetailShell } from "@/components/retail/retail-shell";
@@ -30,9 +29,9 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
-import { fetchInventoryItems } from "@/lib/api";
+import { fetchInventoryItems, fetchSites, fetchStockLocations, type InventoryItem } from "@/lib/api";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { Pencil, Plus, ReceiptLong, Trash2, Wallet } from "@/lib/icons";
+import { ChevronDown, Pencil, Plus, ReceiptLong, Trash2, Wallet } from "@/lib/icons";
 import { useReservedId } from "@/hooks/use-reserved-id";
 
 type CatalogItem = {
@@ -89,13 +88,20 @@ function emptyForm(): CatalogForm {
 }
 
 export default function RetailCatalogPage() {
-  const router = useRouter();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [addAnother, setAddAnother] = useState(false);
   const [editing, setEditing] = useState<CatalogItem | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<CatalogItem | null>(null);
   const [form, setForm] = useState<CatalogForm>(emptyForm);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Quick-create stock item sub-dialog
+  const [quickCreateOpen, setQuickCreateOpen] = useState(false);
+  const [quickForm, setQuickForm] = useState({
+    name: "", category: "CONSUMABLES", unit: "pcs", siteId: "", locationId: "", unitCost: "",
+  });
 
   const catalogQuery = useQuery({
     queryKey: ["retail-catalog"],
@@ -104,6 +110,12 @@ export default function RetailCatalogPage() {
   const inventoryQuery = useQuery({
     queryKey: ["retail-catalog-inventory-items"],
     queryFn: () => fetchInventoryItems({ limit: 500 }),
+  });
+  const sitesQuery = useQuery({ queryKey: ["retail-catalog-sites"], queryFn: fetchSites });
+  const locationsQuery = useQuery({
+    queryKey: ["retail-catalog-locations", quickForm.siteId],
+    queryFn: () => fetchStockLocations({ siteId: quickForm.siteId, active: true, limit: 100 }),
+    enabled: Boolean(quickForm.siteId),
   });
 
   const inventoryItems = inventoryQuery.data?.data ?? [];
@@ -118,6 +130,7 @@ export default function RetailCatalogPage() {
     [inventoryItems],
   );
   const selectedInventory = inventoryItems.find((item) => item.id === form.inventoryItemId);
+  const priceIsInvalid = form.unitPrice !== "" && (isNaN(Number(form.unitPrice)) || Number(form.unitPrice) <= 0);
   const {
     reservedId: catalogCode,
     isReserving,
@@ -158,9 +171,16 @@ export default function RetailCatalogPage() {
     onSuccess: () => {
       toast({ title: editing ? "Catalog item updated" : "Catalog item created", variant: "success" });
       queryClient.invalidateQueries({ queryKey: ["retail-catalog"] });
-      setDialogOpen(false);
-      setEditing(null);
-      setForm(emptyForm());
+      if (addAnother && !editing) {
+        setForm(emptyForm());
+        setAdvancedOpen(false);
+      } else {
+        setDialogOpen(false);
+        setEditing(null);
+        setForm(emptyForm());
+        setAdvancedOpen(false);
+      }
+      setAddAnother(false);
     },
     onError: (error) => {
       toast({
@@ -168,6 +188,36 @@ export default function RetailCatalogPage() {
         description: getApiErrorMessage(error),
         variant: "destructive",
       });
+    },
+  });
+
+  const quickCreateMutation = useMutation({
+    mutationFn: (payload: typeof quickForm) =>
+      fetchJson<{ id: string; name: string; unit: string; unitCost: number | null; siteId: string }>("/api/inventory/items", {
+        method: "POST",
+        body: JSON.stringify({
+          name: payload.name.trim(),
+          category: payload.category,
+          unit: payload.unit.trim(),
+          siteId: payload.siteId,
+          locationId: payload.locationId,
+          unitCost: payload.unitCost ? Number(payload.unitCost) : undefined,
+        }),
+      }),
+    onSuccess: (created) => {
+      toast({ title: "Stock item created", variant: "success" });
+      queryClient.invalidateQueries({ queryKey: ["retail-catalog-inventory-items"] });
+      setQuickCreateOpen(false);
+      setQuickForm({ name: "", category: "CONSUMABLES", unit: "pcs", siteId: "", locationId: "", unitCost: "" });
+      setForm((current) => ({
+        ...current,
+        inventoryItemId: created.id,
+        name: current.name || created.name,
+        unitPrice: current.unitPrice === "" && created.unitCost != null ? String(created.unitCost) : current.unitPrice,
+      }));
+    },
+    onError: (error) => {
+      toast({ title: "Unable to create stock item", description: getApiErrorMessage(error), variant: "destructive" });
     },
   });
 
@@ -321,6 +371,7 @@ export default function RetailCatalogPage() {
           if (!open) {
             setEditing(null);
             setForm(emptyForm());
+            setAdvancedOpen(false);
           }
         }}
       >
@@ -336,75 +387,215 @@ export default function RetailCatalogPage() {
               saveMutation.mutate(form);
             }}
           >
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Catalog code</label>
-                <Input value={editing ? editing.catalogCode : catalogCode} readOnly disabled={isReserving && !editing} />
-                <FieldHelp error={reserveError ?? undefined} hint={reserveError ? undefined : "Generated automatically."} />
-              </div>
-              <SearchableSelect
-                label="Stock item"
-                value={form.inventoryItemId}
-                options={inventoryOptions}
-                placeholder="Select stock item"
-                onValueChange={(value) => {
-                  const item = inventoryItems.find((entry) => entry.id === value);
-                  setForm((current) => ({
-                    ...current,
-                    inventoryItemId: value,
-                    name: current.name || item?.name || "",
-                  }));
-                }}
-                onAddOption={() => router.push("/stores/inventory")}
-                addLabel="Add new stock item"
-              />
+            <SearchableSelect
+              label="Stock item"
+              value={form.inventoryItemId}
+              options={inventoryOptions}
+              placeholder="Select stock item"
+              onValueChange={(value) => {
+                const item = inventoryItems.find((entry) => entry.id === value);
+                setForm((current) => ({
+                  ...current,
+                  inventoryItemId: value,
+                  name: current.name || item?.name || "",
+                  unitPrice: current.unitPrice === "" && (item as InventoryItem | undefined)?.unitCost != null ? String((item as InventoryItem).unitCost) : current.unitPrice,
+                }));
+              }}
+              onAddOption={() => {
+                const firstSite = sitesQuery.data?.[0];
+                setQuickForm((q) => ({ ...q, siteId: firstSite?.id ?? "", locationId: "" }));
+                setQuickCreateOpen(true);
+              }}
+              addLabel="Quick-create stock item"
+            />
+
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold">Sell price</label>
+              <Input value={form.unitPrice} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, unitPrice: event.target.value }))} />
+              {priceIsInvalid ? (
+                <p className="text-xs text-red-600">Price must be greater than 0</p>
+              ) : null}
             </div>
 
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((prev) => !prev)}
+              className="flex items-center gap-1.5 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text-strong)]"
+            >
+              <ChevronDown className={`h-4 w-4 transition-transform${advancedOpen ? " rotate-180" : ""}`} />
+              Advanced options
+            </button>
+
+            {advancedOpen ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Catalog code</label>
+                  <Input value={editing ? editing.catalogCode : catalogCode} readOnly disabled={isReserving && !editing} />
+                  <FieldHelp error={reserveError ?? undefined} hint={reserveError ? undefined : "Generated automatically."} />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Display name</label>
+                  <Input value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">SKU</label>
+                  <Input value={form.sku} onChange={(event) => setForm((current) => ({ ...current, sku: event.target.value }))} placeholder="Generated from code when blank" />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Barcode</label>
+                  <Input value={form.barcode} onChange={(event) => setForm((current) => ({ ...current, barcode: event.target.value }))} />
+                </div>
+                {editing ? (
+                  <div className="space-y-2">
+                    <label className="block text-sm font-semibold">Status</label>
+                    <Select value={form.status} onValueChange={(value) => setForm((current) => ({ ...current, status: value }))}>
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="ACTIVE">Active</SelectItem>
+                        <SelectItem value="INACTIVE">Inactive</SelectItem>
+                        <SelectItem value="DISCONTINUED">Discontinued</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ) : null}
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Compare at</label>
+                  <Input value={form.compareAtPrice} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, compareAtPrice: event.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Tax percent</label>
+                  <Input value={form.taxPercent} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, taxPercent: event.target.value }))} />
+                </div>
+                <div className="space-y-2 md:col-span-2">
+                  <label className="block text-sm font-semibold">Notes</label>
+                  <Textarea value={form.description} onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))} rows={3} />
+                </div>
+              </div>
+            ) : null}
+
+            <DialogFooter className="flex-col gap-2 sm:flex-row">
+              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+              {!editing ? (
+                <Button
+                  type="submit"
+                  variant="outline"
+                  disabled={saveMutation.isPending || !form.inventoryItemId || !form.unitPrice || Number(form.unitPrice) <= 0}
+                  onClick={() => setAddAnother(true)}
+                >
+                  Save and add another
+                </Button>
+              ) : null}
+              <Button
+                type="submit"
+                disabled={saveMutation.isPending || !form.inventoryItemId || !form.unitPrice || Number(form.unitPrice) <= 0}
+                onClick={() => setAddAnother(false)}
+              >
+                {editing ? "Save changes" : "Create item"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Quick-create stock item */}
+      <Dialog open={quickCreateOpen} onOpenChange={(open) => { setQuickCreateOpen(open); if (!open) setQuickForm({ name: "", category: "CONSUMABLES", unit: "pcs", siteId: "", locationId: "", unitCost: "" }); }}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Quick-create stock item</DialogTitle>
+            <DialogDescription>Create a new stock item and add it to the catalog in one step.</DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!quickForm.name.trim() || !quickForm.siteId || !quickForm.locationId) return;
+              quickCreateMutation.mutate(quickForm);
+            }}
+          >
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold">Item name</label>
+              <Input
+                value={quickForm.name}
+                onChange={(e) => setQuickForm((q) => ({ ...q, name: e.target.value }))}
+                placeholder="e.g. Bottled water 500ml"
+                autoFocus
+              />
+            </div>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="block text-sm font-semibold">Display name</label>
-                <Input value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">SKU</label>
-                <Input value={form.sku} onChange={(event) => setForm((current) => ({ ...current, sku: event.target.value }))} placeholder="Generated from code when blank" />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Barcode</label>
-                <Input value={form.barcode} onChange={(event) => setForm((current) => ({ ...current, barcode: event.target.value }))} />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Status</label>
-                <Select value={form.status} onValueChange={(value) => setForm((current) => ({ ...current, status: value }))}>
+                <label className="block text-sm font-semibold">Category</label>
+                <Select value={quickForm.category} onValueChange={(v) => setQuickForm((q) => ({ ...q, category: v }))}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="ACTIVE">Active</SelectItem>
-                    <SelectItem value="INACTIVE">Inactive</SelectItem>
-                    <SelectItem value="DISCONTINUED">Discontinued</SelectItem>
+                    <SelectItem value="CONSUMABLES">Consumables</SelectItem>
+                    <SelectItem value="SPARES">Spares</SelectItem>
+                    <SelectItem value="PPE">PPE</SelectItem>
+                    <SelectItem value="FUEL">Fuel</SelectItem>
+                    <SelectItem value="REAGENTS">Reagents</SelectItem>
+                    <SelectItem value="OTHER">Other</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <div className="space-y-2">
-                <label className="block text-sm font-semibold">Sell price</label>
-                <Input value={form.unitPrice} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, unitPrice: event.target.value }))} />
+                <label className="block text-sm font-semibold">Unit</label>
+                <Input
+                  value={quickForm.unit}
+                  onChange={(e) => setQuickForm((q) => ({ ...q, unit: e.target.value }))}
+                  placeholder="pcs, kg, L …"
+                  list="unit-presets"
+                />
+                <datalist id="unit-presets">
+                  {["pcs", "kg", "L", "g", "mL", "box", "pair", "roll", "bag"].map((u) => (
+                    <option key={u} value={u} />
+                  ))}
+                </datalist>
               </div>
               <div className="space-y-2">
-                <label className="block text-sm font-semibold">Compare at</label>
-                <Input value={form.compareAtPrice} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, compareAtPrice: event.target.value }))} />
+                <label className="block text-sm font-semibold">Site</label>
+                <Select
+                  value={quickForm.siteId}
+                  onValueChange={(v) => setQuickForm((q) => ({ ...q, siteId: v, locationId: "" }))}
+                >
+                  <SelectTrigger><SelectValue placeholder="Select site" /></SelectTrigger>
+                  <SelectContent>
+                    {(sitesQuery.data ?? []).map((site: { id: string; name: string }) => (
+                      <SelectItem key={site.id} value={site.id}>{site.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div className="space-y-2">
-                <label className="block text-sm font-semibold">Tax percent</label>
-                <Input value={form.taxPercent} inputMode="decimal" onChange={(event) => setForm((current) => ({ ...current, taxPercent: event.target.value }))} />
+                <label className="block text-sm font-semibold">Location</label>
+                <Select
+                  value={quickForm.locationId}
+                  onValueChange={(v) => setQuickForm((q) => ({ ...q, locationId: v }))}
+                  disabled={!quickForm.siteId}
+                >
+                  <SelectTrigger><SelectValue placeholder="Select location" /></SelectTrigger>
+                  <SelectContent>
+                    {(locationsQuery.data?.data ?? []).map((loc: { id: string; name: string }) => (
+                      <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            </div>
-            <div className="space-y-2">
-              <label className="block text-sm font-semibold">Notes</label>
-              <Textarea value={form.description} onChange={(event) => setForm((current) => ({ ...current, description: event.target.value }))} rows={3} />
+              <div className="space-y-2 md:col-span-2">
+                <label className="block text-sm font-semibold">Unit cost (optional)</label>
+                <Input
+                  value={quickForm.unitCost}
+                  inputMode="decimal"
+                  onChange={(e) => setQuickForm((q) => ({ ...q, unitCost: e.target.value }))}
+                  placeholder="0.00 — will pre-fill sell price"
+                />
+              </div>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={saveMutation.isPending || !form.inventoryItemId}>
-                {editing ? "Save changes" : "Create item"}
+              <Button type="button" variant="outline" onClick={() => setQuickCreateOpen(false)}>Cancel</Button>
+              <Button
+                type="submit"
+                disabled={quickCreateMutation.isPending || !quickForm.name.trim() || !quickForm.siteId || !quickForm.locationId}
+              >
+                {quickCreateMutation.isPending ? "Creating…" : "Create and select"}
               </Button>
             </DialogFooter>
           </form>

--- a/app/retail/merchandising/promotions/page.tsx
+++ b/app/retail/merchandising/promotions/page.tsx
@@ -26,7 +26,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { Pencil, Plus, Trash2, Wallet } from "@/lib/icons";
+import { ChevronDown, Pencil, Plus, Trash2, Wallet } from "@/lib/icons";
 import { useReservedId } from "@/hooks/use-reserved-id";
 
 type Promotion = {
@@ -40,7 +40,7 @@ type PromotionForm = {
 };
 
 function emptyForm(): PromotionForm {
-  return { name: "", type: "PERCENT", value: "", startsAt: "", endsAt: "", status: "ACTIVE", notes: "" };
+  return { name: "", type: "PERCENT", value: "", startsAt: new Date().toISOString().slice(0, 16), endsAt: "", status: "ACTIVE", notes: "" };
 }
 
 function dateLabel(iso: string | null) {
@@ -54,6 +54,7 @@ export default function RetailPromotionsPage() {
   const [editing, setEditing] = useState<Promotion | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Promotion | null>(null);
   const [form, setForm] = useState<PromotionForm>(emptyForm);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const promotionsQuery = useQuery({
     queryKey: ["retail-promotions"],
@@ -218,10 +219,6 @@ export default function RetailPromotionsPage() {
           <form className="space-y-4" onSubmit={(e) => { e.preventDefault(); saveMutation.mutate(form); }}>
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="block text-sm font-semibold">Promo code</label>
-                <Input value={editing ? editing.promoCode : promoCode} readOnly disabled={isReserving && !editing} />
-              </div>
-              <div className="space-y-2">
                 <label className="block text-sm font-semibold">Name</label>
                 <Input value={form.name} onChange={(e) => setForm((c) => ({ ...c, name: e.target.value }))} />
               </div>
@@ -237,37 +234,61 @@ export default function RetailPromotionsPage() {
                   </SelectContent>
                 </Select>
               </div>
-              <div className="space-y-2">
+              <div className="space-y-2 md:col-span-2">
                 <label className="block text-sm font-semibold">Value</label>
                 <Input value={form.value} inputMode="decimal" onChange={(e) => setForm((c) => ({ ...c, value: e.target.value }))} />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Starts</label>
-                <Input type="datetime-local" value={form.startsAt} onChange={(e) => setForm((c) => ({ ...c, startsAt: e.target.value }))} />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Ends</label>
-                <Input type="datetime-local" value={form.endsAt} onChange={(e) => setForm((c) => ({ ...c, endsAt: e.target.value }))} />
-              </div>
-              <div className="space-y-2">
-                <label className="block text-sm font-semibold">Status</label>
-                <Select value={form.status} onValueChange={(v) => setForm((c) => ({ ...c, status: v }))}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ACTIVE">Active</SelectItem>
-                    <SelectItem value="SCHEDULED">Scheduled</SelectItem>
-                    <SelectItem value="INACTIVE">Inactive</SelectItem>
-                  </SelectContent>
-                </Select>
+                {form.value !== "" && (isNaN(Number(form.value)) || Number(form.value) <= 0) ? (
+                  <p className="text-xs text-red-600">Value must be greater than 0</p>
+                ) : null}
               </div>
             </div>
-            <div className="space-y-2">
-              <label className="block text-sm font-semibold">Notes</label>
-              <Textarea value={form.notes} onChange={(e) => setForm((c) => ({ ...c, notes: e.target.value }))} rows={3} />
-            </div>
+
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((prev) => !prev)}
+              className="flex items-center gap-1.5 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text-strong)]"
+            >
+              <ChevronDown className={`h-4 w-4 transition-transform${advancedOpen ? " rotate-180" : ""}`} />
+              Advanced options
+            </button>
+
+            {advancedOpen ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Promo code</label>
+                  <Input value={editing ? editing.promoCode : promoCode} readOnly disabled={isReserving && !editing} />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Starts</label>
+                  <Input type="datetime-local" value={form.startsAt} onChange={(e) => setForm((c) => ({ ...c, startsAt: e.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-semibold">Ends</label>
+                  <Input type="datetime-local" value={form.endsAt} onChange={(e) => setForm((c) => ({ ...c, endsAt: e.target.value }))} placeholder="No end date" />
+                </div>
+                {editing ? (
+                  <div className="space-y-2">
+                    <label className="block text-sm font-semibold">Status</label>
+                    <Select value={form.status} onValueChange={(v) => setForm((c) => ({ ...c, status: v }))}>
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="ACTIVE">Active</SelectItem>
+                        <SelectItem value="SCHEDULED">Scheduled</SelectItem>
+                        <SelectItem value="INACTIVE">Inactive</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ) : null}
+                <div className="space-y-2 md:col-span-2">
+                  <label className="block text-sm font-semibold">Notes</label>
+                  <Textarea value={form.notes} onChange={(e) => setForm((c) => ({ ...c, notes: e.target.value }))} rows={3} />
+                </div>
+              </div>
+            ) : null}
+
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={saveMutation.isPending || !form.name}>Save</Button>
+              <Button type="submit" disabled={saveMutation.isPending || !form.name || !form.value || Number(form.value) <= 0}>Save</Button>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/app/retail/purchasing/orders/page.tsx
+++ b/app/retail/purchasing/orders/page.tsx
@@ -23,7 +23,7 @@ import { Input } from "@/components/ui/input";
 import { NumericCell } from "@/components/ui/numeric-cell";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
-import { fetchInventoryItems, fetchSites } from "@/lib/api";
+import { fetchInventoryItems, fetchSites, type InventoryItem } from "@/lib/api";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { CheckCircle2, LocalShipping, Pencil, Plus, Trash2 } from "@/lib/icons";
 import { useReservedId } from "@/hooks/use-reserved-id";
@@ -119,6 +119,9 @@ export default function PurchaseOrdersPage() {
 
   const totalLines = (f: OrderForm) => f.lines.reduce((s, l) => s + (Number(l.quantity) || 0), 0);
   const totalCost = (f: OrderForm) => f.lines.reduce((s, l) => s + (Number(l.quantity) || 0) * (Number(l.unitCost) || 0), 0);
+  const hasLineErrors = form.lines.some(
+    (l) => (l.quantity !== "" && Number(l.quantity) <= 0) || (l.unitCost !== "" && Number(l.unitCost) < 0),
+  );
 
   const saveMutation = useMutation({
     mutationFn: async (f: OrderForm) => {
@@ -300,10 +303,12 @@ export default function PurchaseOrdersPage() {
                           setForm((current) => {
                             const next = [...current.lines];
                             const option = itemOptions.find((item) => item.value === value);
+                            const fullItem = (inventoryQuery.data?.data ?? []).find((item) => item.id === value) as InventoryItem | undefined;
                             next[idx] = {
                               ...next[idx],
                               inventoryItemId: value,
                               itemName: option?.label ?? "",
+                              unitCost: next[idx].unitCost === "" && fullItem?.unitCost != null ? String(fullItem.unitCost) : next[idx].unitCost,
                             };
                             return { ...current, lines: next };
                           })
@@ -326,7 +331,7 @@ export default function PurchaseOrdersPage() {
 
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
-              <Button type="submit" disabled={saveMutation.isPending}>Save</Button>
+              <Button type="submit" disabled={saveMutation.isPending || !form.supplierName.trim() || !form.siteId || hasLineErrors}>Save</Button>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/components/retail/portal/pos-checkout-view.tsx
+++ b/components/retail/portal/pos-checkout-view.tsx
@@ -197,29 +197,14 @@ function NumField({
   );
 }
 
-/* ─── Tender type grid button ─────────────────────────────────────── */
+/* ─── Tender type grid button (token-driven, physical press) ────────── */
 
-const TENDER_TYPE_STYLES: Record<TenderType, { selected: string; idle: string }> = {
-  CASH: {
-    selected: "border-emerald-500 bg-emerald-500 text-white shadow-[0_4px_14px_rgba(16,185,129,0.35)]",
-    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-emerald-400 hover:bg-emerald-50 hover:text-emerald-700",
-  },
-  CARD: {
-    selected: "border-blue-500 bg-blue-500 text-white shadow-[0_4px_14px_rgba(59,130,246,0.35)]",
-    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700",
-  },
-  MOBILE_MONEY: {
-    selected: "border-orange-500 bg-orange-500 text-white shadow-[0_4px_14px_rgba(249,115,22,0.35)]",
-    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-orange-400 hover:bg-orange-50 hover:text-orange-700",
-  },
-  TRANSFER: {
-    selected: "border-violet-500 bg-violet-500 text-white shadow-[0_4px_14px_rgba(139,92,246,0.35)]",
-    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-violet-400 hover:bg-violet-50 hover:text-violet-700",
-  },
-  VOUCHER: {
-    selected: "border-amber-500 bg-amber-500 text-white shadow-[0_4px_14px_rgba(245,158,11,0.35)]",
-    idle: "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] hover:border-amber-400 hover:bg-amber-50 hover:text-amber-700",
-  },
+const TENDER_TOKEN_KEYS: Record<TenderType, string> = {
+  CASH: "cash",
+  CARD: "card",
+  MOBILE_MONEY: "mobile",
+  TRANSFER: "transfer",
+  VOUCHER: "voucher",
 };
 
 function TenderButton({
@@ -231,15 +216,25 @@ function TenderButton({
   selected: boolean;
   onClick: () => void;
 }) {
-  const styles = TENDER_TYPE_STYLES[type];
+  const key = TENDER_TOKEN_KEYS[type];
+  const selectedStyle = {
+    background: `var(--pos-tender-${key}-bg)`,
+    borderColor: `var(--pos-tender-${key}-bg)`,
+    boxShadow: `0 3px 0 var(--pos-tender-${key}-shadow)`,
+    color: "#ffffff",
+  };
+  const idleStyle = {
+    background: "var(--pos-tender-idle-bg)",
+    borderColor: "var(--pos-tender-idle-border)",
+    boxShadow: "0 3px 0 var(--pos-tender-idle-shadow)",
+    color: "var(--pos-tender-idle-text)",
+  };
   return (
     <button
       type="button"
       onClick={onClick}
-      className={cn(
-        "flex items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-[10px] font-bold uppercase tracking-[0.12em] transition-all duration-100 active:scale-[0.95]",
-        selected ? styles.selected : styles.idle,
-      )}
+      className="flex items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-[10px] font-bold uppercase tracking-[0.12em] transition-all duration-75 active:translate-y-[2px] active:shadow-none"
+      style={selected ? selectedStyle : idleStyle}
     >
       <TenderIcon type={type} className="h-4 w-4" />
       {tenderLabel(type)}
@@ -633,7 +628,7 @@ export function PosCheckoutView() {
           <Search className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
           <input
             ref={searchInputRef}
-            autoFocus
+            autoFocus={typeof window === "undefined" || !window.matchMedia("(hover: none)").matches}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={(e) => {
@@ -661,12 +656,24 @@ export function PosCheckoutView() {
 
         {/* Shift badge */}
         {currentShift ? (
-          <span className="hidden shrink-0 items-center gap-1.5 rounded-md bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 md:inline-flex">
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          <span
+            className="hidden shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 md:inline-flex"
+            style={{ background: "var(--pos-status-success-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)`, color: "var(--pos-status-success-text)" }}
+          >
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: "var(--pos-status-success-text)" }}
+            />
             {currentShift.shiftNo}
           </span>
         ) : (
-          <Button size="sm" variant="outline" className="shrink-0 border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100 text-xs" asChild>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0 text-xs ring-1"
+            style={{ background: "var(--pos-status-warning-bg)", borderColor: "var(--pos-status-warning-ring)", color: "var(--pos-status-warning-text)" }}
+            asChild
+          >
             <Link href={getPosPortalHref("shift", isPosHost)}>
               <Clock className="h-3.5 w-3.5" />
               Open shift
@@ -680,7 +687,8 @@ export function PosCheckoutView() {
             type="button"
             onClick={syncOfflineSales}
             disabled={syncOfflineSalesPending}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-[11px] font-semibold text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-60"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1 text-[11px] font-semibold ring-1 transition-colors disabled:opacity-60"
+            style={{ background: "var(--pos-status-warning-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-warning-ring)`, color: "var(--pos-status-warning-text)" }}
           >
             {syncOfflineSalesPending
               ? <RefreshCcw className="h-3 w-3 animate-spin" />
@@ -996,7 +1004,7 @@ export function PosCheckoutView() {
                         <div className="mt-1 flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
                           <span className="font-mono">{money(item.unitPrice)}</span>
                           {item.lineDiscountAmount ? (
-                            <span className="rounded bg-emerald-50 px-1 font-mono text-emerald-600">−{money(item.lineDiscountAmount)}</span>
+                            <span className="rounded px-1 font-mono" style={{ background: "var(--pos-status-success-bg)", color: "var(--pos-status-success-text)" }}>−{money(item.lineDiscountAmount)}</span>
                           ) : null}
                         </div>
                       </button>
@@ -1017,7 +1025,7 @@ export function PosCheckoutView() {
                               updateQty(item.catalogItemId, next);
                             }
                           }}
-                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-red-200 hover:bg-red-50 hover:text-red-500 active:scale-[0.90]"
+                          className="flex min-h-11 min-w-11 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-red-200 hover:bg-red-50 hover:text-red-500 active:scale-[0.90]"
                         >
                           <Minus className="h-3.5 w-3.5" />
                         </button>
@@ -1028,7 +1036,7 @@ export function PosCheckoutView() {
                             setActiveTarget({ type: "line_qty", lineId: item.catalogItemId });
                           }}
                           className={cn(
-                            "h-8 min-w-[2.5rem] rounded-lg border px-2 font-mono text-sm font-bold transition-all",
+                            "min-h-11 min-w-[2.5rem] rounded-lg border px-2 font-mono text-sm font-bold transition-all",
                             isSelected && activeTarget?.type === "line_qty"
                               ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_10%,white)] text-[var(--action-primary-bg)]"
                               : "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-strong)] hover:border-[var(--action-primary-bg)]",
@@ -1039,7 +1047,7 @@ export function PosCheckoutView() {
                         <button
                           type="button"
                           onClick={() => updateQty(item.catalogItemId, item.quantity + 1)}
-                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] hover:text-[var(--action-primary-bg)] active:scale-[0.90]"
+                          className="flex min-h-11 min-w-11 items-center justify-center rounded-lg border border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-muted)] transition-all hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_6%,white)] hover:text-[var(--action-primary-bg)] active:scale-[0.90]"
                         >
                           <Plus className="h-3.5 w-3.5" />
                         </button>
@@ -1065,7 +1073,7 @@ export function PosCheckoutView() {
                             setActiveTarget(null);
                           }
                         }}
-                        className="shrink-0 rounded-lg p-1.5 text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
+                        className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] transition-colors hover:bg-red-50 hover:text-red-500"
                       >
                         <X className="h-4 w-4" />
                       </button>
@@ -1126,13 +1134,22 @@ export function PosCheckoutView() {
 
             {/* Change / balance indicators */}
             {changeAmount > 0 ? (
-              <div className="mt-2.5 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-4 py-1.5 text-sm font-black text-emerald-700 shadow-sm">
-                <span className="text-emerald-500">↩</span>
+              <div
+                className="mt-2.5 inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-black ring-1"
+                style={{ background: "var(--pos-change-bg)", color: "var(--pos-change-text)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)` }}
+              >
+                <span>↩</span>
                 Change {money(changeAmount)}
               </div>
             ) : tenderedTotal > 0 && tenderedTotal < total ? (
-              <div className="mt-2.5 inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1.5 text-xs font-bold text-amber-700 shadow-sm">
-                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+              <div
+                className="mt-2.5 inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-bold ring-1"
+                style={{ background: "var(--pos-due-bg)", color: "var(--pos-due-text)", boxShadow: `inset 0 0 0 1px var(--pos-status-warning-ring)` }}
+              >
+                <span
+                  className="h-1.5 w-1.5 rounded-full"
+                  style={{ background: "var(--pos-due-text)" }}
+                />
                 Still due {money(total - tenderedTotal)}
               </div>
             ) : tenderedTotal > 0 && cart.length > 0 ? (
@@ -1179,7 +1196,7 @@ export function PosCheckoutView() {
           {/* Scrollable payment section */}
           <div className="min-h-0 flex-1 overflow-y-auto">
             <div className="space-y-3 px-3 pt-2 pb-3">
-              <div className="flex items-center justify-between rounded-[1.1rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-3 py-2">
+              <div className="flex items-center justify-between rounded-lg border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-3 py-2">
                 <button
                   type="button"
                   onClick={() => setCustomerSheetOpen(true)}
@@ -1210,7 +1227,7 @@ export function PosCheckoutView() {
                 ) : null}
               </div>
 
-              <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)]">
+              <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)]">
                 <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-3 py-2.5">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold text-[var(--text-strong)]">Sale items</span>
@@ -1631,25 +1648,29 @@ export function PosCheckoutView() {
 
                 {/* Tender buttons */}
                 <div className="mt-3 grid grid-cols-2 gap-2">
-                  {TENDER_TYPES.slice(0, 4).map((type) => (
-                    <button
-                      key={type}
-                      type="button"
-                      onClick={() => {
-                        setPayments([{ tenderType: type, amount: String(total.toFixed(2)), reference: "" }]);
-                        setActiveTarget({ type: "tender_amount", index: 0 });
-                      }}
-                      className={cn(
-                        "flex h-14 items-center justify-center gap-2 rounded-xl border font-semibold transition-all active:scale-[0.98]",
-                        payments[0]?.tenderType === type
-                          ? TENDER_TYPE_STYLES[type].selected
-                          : TENDER_TYPE_STYLES[type].idle,
-                      )}
-                    >
-                      <TenderIcon type={type} />
-                      <span className="text-sm">{tenderLabel(type)}</span>
-                    </button>
-                  ))}
+                  {TENDER_TYPES.slice(0, 4).map((type) => {
+                    const tKey = TENDER_TOKEN_KEYS[type];
+                    const isSelected = payments[0]?.tenderType === type;
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => {
+                          setPayments([{ tenderType: type, amount: String(total.toFixed(2)), reference: "" }]);
+                          setActiveTarget({ type: "tender_amount", index: 0 });
+                        }}
+                        className="flex h-14 items-center justify-center gap-2 rounded-xl border font-semibold transition-all duration-75 active:translate-y-[2px] active:shadow-none"
+                        style={
+                          isSelected
+                            ? { background: `var(--pos-tender-${tKey}-bg)`, borderColor: `var(--pos-tender-${tKey}-bg)`, boxShadow: `0 3px 0 var(--pos-tender-${tKey}-shadow)`, color: "#ffffff" }
+                            : { background: "var(--pos-tender-idle-bg)", borderColor: "var(--pos-tender-idle-border)", boxShadow: "0 3px 0 var(--pos-tender-idle-shadow)", color: "var(--pos-tender-idle-text)" }
+                        }
+                      >
+                        <TenderIcon type={type} />
+                        <span className="text-sm">{tenderLabel(type)}</span>
+                      </button>
+                    );
+                  })}
                 </div>
 
                 {/* Charge button */}

--- a/components/retail/portal/pos-customers-view.tsx
+++ b/components/retail/portal/pos-customers-view.tsx
@@ -43,22 +43,28 @@ export function PosCustomersView() {
           description="This stays a fast lookup surface for leads and exceptions, while checkout handles most customer attachment inline."
         />
 
-        <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] p-3">
-          <div className="flex items-center gap-3 rounded-[1rem] border border-[var(--border-subtle)] bg-white px-3 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.04)]">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--surface-muted)] text-[var(--action-primary-bg)]">
-              <Search className="h-5 w-5" />
+        <div
+          className="flex items-center gap-3 rounded-xl border px-4 py-3"
+          style={{ background: "var(--pos-lcd-bg)", borderColor: "var(--pos-lcd-border)" }}
+        >
+          <Search
+            className="h-5 w-5 shrink-0"
+            style={{ color: "var(--pos-lcd-label)" }}
+          />
+          <div className="min-w-0 flex-1">
+            <div
+              className="text-[10px] font-bold uppercase tracking-[0.18em]"
+              style={{ color: "var(--pos-lcd-label)" }}
+            >
+              Search
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                Search
-              </div>
-              <Input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search by name, phone, or email"
-                className="mt-1 h-11 border-none bg-transparent px-0 text-base shadow-none focus-visible:ring-0"
-              />
-            </div>
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Name, phone, or email"
+              className="mt-0.5 h-9 border-none bg-transparent px-0 text-base shadow-none focus-visible:ring-0"
+              style={{ color: "var(--pos-lcd-text)" }}
+            />
           </div>
         </div>
       </PosPanel>
@@ -92,10 +98,13 @@ export function PosCustomersView() {
               {customers.map((customer) => (
                 <div
                   key={customer.id}
-                  className="flex min-h-[5.5rem] items-center justify-between gap-4 rounded-[1.2rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4"
+                  className="flex min-h-[5.5rem] items-center justify-between gap-4 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-4 ring-1 ring-transparent transition-all hover:ring-[var(--pos-status-info-ring)]"
                 >
                   <div className="flex min-w-0 items-start gap-3">
-                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[var(--action-primary-bg)] shadow-[0_8px_18px_rgba(15,23,42,0.05)]">
+                    <div
+                      className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full"
+                      style={{ background: "var(--pos-status-info-bg)", color: "var(--pos-status-info-text)" }}
+                    >
                       <User className="h-5 w-5" />
                     </div>
                     <div className="min-w-0">
@@ -113,8 +122,8 @@ export function PosCustomersView() {
                     <div className="flex justify-end">
                       <PosStatusPill tone="brand">{customer.loyaltyTier}</PosStatusPill>
                     </div>
-                    <div className="mt-2 font-mono text-sm font-semibold text-[var(--text-strong)]">
-                      {customer.loyaltyPoints} pts
+                    <div className="mt-2 font-mono text-sm font-black tabular-nums text-[var(--text-strong)]">
+                      {customer.loyaltyPoints.toLocaleString()} pts
                     </div>
                   </div>
                 </div>

--- a/components/retail/portal/pos-focused-editor-drawer.tsx
+++ b/components/retail/portal/pos-focused-editor-drawer.tsx
@@ -21,14 +21,21 @@ export function PosFocusedEditorDrawer({
 }: PosFocusedEditorDrawerProps) {
   if (!open) return null;
   return (
-    <section className="rounded-[1.4rem] border border-[var(--border-default)] bg-[color-mix(in_srgb,var(--surface-base)_88%,var(--surface-muted))] px-4 py-4 shadow-[0_14px_32px_rgba(15,23,42,0.05)]">
+    <section
+      className="rounded-2xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-4"
+      style={{ boxShadow: "var(--shadow-card, 0 1px 3px rgba(15,23,42,0.06), 0 8px 24px rgba(15,23,42,0.06))" }}
+    >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
             Line editor
           </div>
-          <div className="mt-1 text-lg font-semibold tracking-[-0.02em]">{title}</div>
-          {subtitle ? <div className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</div> : null}
+          <div className="mt-1 text-lg font-bold tracking-[-0.025em] text-[var(--text-strong)]">
+            {title}
+          </div>
+          {subtitle ? (
+            <div className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</div>
+          ) : null}
         </div>
         <Button type="button" variant="ghost" size="icon-sm" className="rounded-full" onClick={onClose}>
           <X className="h-4 w-4" />

--- a/components/retail/portal/pos-held-view.tsx
+++ b/components/retail/portal/pos-held-view.tsx
@@ -13,6 +13,7 @@ import {
   PosPanel,
   PosPanelHeader,
   PosStatusPill,
+  PosTerminalHeader,
 } from "./pos-primitives";
 import { usePosPortalState } from "./pos-portal-state";
 import type { HeldCart } from "./pos-types";
@@ -143,38 +144,21 @@ export function PosHeldView() {
                 return (
                   <div
                     key={heldCart.id}
-                    className="flex flex-col rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] overflow-hidden"
+                    className="flex flex-col rounded-2xl border border-[var(--edge-default)] bg-[var(--surface-base)] overflow-hidden"
+                    style={{ boxShadow: "var(--shadow-card, 0 1px 3px rgba(15,23,42,0.06))" }}
                   >
-                    {/* Card header */}
-                    <div className="flex items-start justify-between gap-3 bg-[var(--surface-base)] px-4 py-3.5 border-b border-[var(--border-subtle)]">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate text-[15px] font-bold text-[var(--text-strong)]">
-                            {heldCart.label || heldCart.holdNo}
-                          </span>
-                          {heldCart.label && (
-                            <span className="font-mono text-[10px] text-[var(--text-muted)]">
-                              {heldCart.holdNo}
-                            </span>
-                          )}
-                        </div>
-                        <div className={cn(
-                          "mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold",
-                          urgent ? "text-amber-600" : "text-[var(--text-muted)]",
-                        )}>
-                          <Clock className="h-3 w-3" />
-                          {timeLabel}
-                        </div>
-                      </div>
-                      <div className="text-right shrink-0">
-                        <div className="font-mono text-xl font-black text-[var(--text-strong)]">
-                          {money(total)}
-                        </div>
-                        <div className="mt-0.5 text-[11px] text-[var(--text-muted)]">
-                          {itemCount} line{itemCount !== 1 ? "s" : ""}
-                        </div>
-                      </div>
-                    </div>
+                    {/* Dark instrument panel header */}
+                    <PosTerminalHeader
+                      eyebrow={`Hold · ${heldCart.holdNo}`}
+                      title={heldCart.label || heldCart.holdNo}
+                      subtitle={
+                        urgent
+                          ? `⚠ ${timeLabel}`
+                          : timeLabel
+                      }
+                      valuePrimary={money(total)}
+                      valueSecondary={`${itemCount} line${itemCount !== 1 ? "s" : ""}`}
+                    />
 
                     {/* Cart details */}
                     <div className="flex items-center gap-4 px-4 py-3">
@@ -198,7 +182,12 @@ export function PosHeldView() {
                     {/* CTA */}
                     <div className="px-4 pb-4 pt-1">
                       <Button
-                        className="w-full h-11 gap-2 rounded-xl text-[14px] font-bold"
+                        className="w-full h-11 gap-2 rounded-xl text-[14px] font-bold active:translate-y-[2px] active:shadow-none"
+                        style={{
+                          background: "var(--pos-cta-bg)",
+                          color: "var(--pos-cta-text)",
+                          boxShadow: "0 3px 0 var(--pos-cta-shadow)",
+                        }}
                         onClick={() => recallMutation.mutate(heldCart)}
                         disabled={recallMutation.isPending}
                       >

--- a/components/retail/portal/pos-history-view.tsx
+++ b/components/retail/portal/pos-history-view.tsx
@@ -20,6 +20,7 @@ import {
   PosPanel,
   PosPanelHeader,
   PosStatusPill,
+  PosTerminalHeader,
 } from "./pos-primitives";
 import { usePosPortalState } from "./pos-portal-state";
 import type { PaymentRow, SaleDetail, SaleRow, TenderType } from "./pos-types";
@@ -302,15 +303,9 @@ export function PosHistoryView() {
                         </span>
                       </td>
                       <td className="px-4 py-4">
-                        <span className={
-                          isRefund
-                            ? "inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-[11px] font-bold text-red-600"
-                            : isVoid
-                              ? "inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-bold text-amber-700"
-                              : "inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-bold text-emerald-700"
-                        }>
+                        <PosStatusPill tone={isRefund ? "danger" : isVoid ? "warning" : "success"}>
                           {sale.saleType}
-                        </span>
+                        </PosStatusPill>
                       </td>
                       <td className="px-4 py-4 text-[var(--text-muted)]">
                         {sale.customerName ?? "Walk-in"}
@@ -351,54 +346,27 @@ export function PosHistoryView() {
           {selectedSale ? (
             <>
               {/* Receipt header — colored by type */}
-              <div className={`px-6 pt-6 pb-5 ${
-                selectedSale.saleType === "REFUND"
-                  ? "bg-gradient-to-r from-red-50 to-red-50/50 border-b border-red-100"
-                  : selectedSale.saleType === "VOID"
-                    ? "bg-gradient-to-r from-amber-50 to-amber-50/50 border-b border-amber-100"
-                    : "bg-gradient-to-r from-emerald-50 to-emerald-50/50 border-b border-emerald-100"
-              }`}>
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-mono text-xl font-black text-[var(--text-strong)]">
-                        {selectedSale.saleNo}
-                      </span>
-                      <PosStatusPill tone={selectedSale.status === "POSTED" ? "success" : "warning"}>
-                        {selectedSale.status}
-                      </PosStatusPill>
-                      <span className={`rounded-full px-2.5 py-0.5 text-[11px] font-bold ${
-                        selectedSale.saleType === "REFUND"
-                          ? "bg-red-100 text-red-700"
-                          : selectedSale.saleType === "VOID"
-                            ? "bg-amber-100 text-amber-700"
-                            : "bg-emerald-100 text-emerald-700"
-                      }`}>
-                        {selectedSale.saleType}
-                      </span>
-                    </div>
-                    <p className="mt-1.5 text-sm text-[var(--text-muted)]">
-                      {selectedSale.customerName ?? "Walk-in"} ·{" "}
-                      {selectedSale.postedAt
-                        ? new Date(selectedSale.postedAt).toLocaleString([], {
-                            month: "short", day: "numeric",
-                            hour: "2-digit", minute: "2-digit",
-                          })
-                        : "Not yet posted"}
-                    </p>
-                  </div>
-                  <div className="text-right shrink-0">
-                    <div className={`font-mono text-2xl font-black ${
-                      selectedSale.saleType === "REFUND" ? "text-red-600" : "text-[var(--text-strong)]"
-                    }`}>
-                      {money(Math.abs(selectedSale.totalAmount))}
-                    </div>
-                    <div className="text-xs text-[var(--text-muted)]">
-                      {selectedSale.lines.length} line{selectedSale.lines.length !== 1 ? "s" : ""}
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <PosTerminalHeader
+                eyebrow={`Receipt · ${selectedSale.saleType}`}
+                title={selectedSale.saleNo}
+                subtitle={[
+                  selectedSale.customerName ?? "Walk-in",
+                  selectedSale.postedAt
+                    ? new Date(selectedSale.postedAt).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+                    : "Not yet posted",
+                ].join(" · ")}
+                valuePrimary={money(Math.abs(selectedSale.totalAmount))}
+                valueSecondary={`${selectedSale.lines.length} line${selectedSale.lines.length !== 1 ? "s" : ""}`}
+                pill={
+                  <PosStatusPill
+                    tone={
+                      selectedSale.saleType === "REFUND" ? "danger" : selectedSale.saleType === "VOID" ? "warning" : "success"
+                    }
+                  >
+                    {selectedSale.status}
+                  </PosStatusPill>
+                }
+              />
 
               <div className="max-h-[70vh] overflow-y-auto">
                 <div className="grid gap-4 p-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.9fr)]">
@@ -593,7 +561,7 @@ export function PosHistoryView() {
 
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_320px]">
               <div className="space-y-4">
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <div className="flex items-center justify-between gap-3">
                     <div className="text-sm font-semibold text-[var(--text-strong)]">
                       Choose items to refund
@@ -606,7 +574,7 @@ export function PosHistoryView() {
                     {(selectedSale?.lines ?? []).map((line) => (
                       <div
                         key={line.id}
-                        className="grid gap-2 rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3 md:grid-cols-[minmax(0,1fr)_136px_120px]"
+                        className="grid gap-2 rounded-lg border border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-3 md:grid-cols-[minmax(0,1fr)_136px_120px]"
                       >
                         <div className="min-w-0">
                           <div className="truncate font-medium text-[var(--text-strong)]">
@@ -643,7 +611,7 @@ export function PosHistoryView() {
                   </div>
                 </div>
 
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <div className="text-sm font-semibold text-[var(--text-strong)]">
                     Refund details
                   </div>
@@ -673,7 +641,7 @@ export function PosHistoryView() {
                   </div>
                 </div>
 
-                <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <div className="flex items-center justify-between gap-3">
                     <div className="text-sm font-semibold text-[var(--text-strong)]">
                       Refund tenders
@@ -690,7 +658,7 @@ export function PosHistoryView() {
                     {refundPayments.map((payment, index) => (
                       <div
                         key={`${payment.tenderType}-${index}`}
-                        className="grid gap-2 rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-3 md:grid-cols-[1fr_118px_1fr_auto]"
+                        className="grid gap-2 rounded-lg border border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-3 md:grid-cols-[1fr_118px_1fr_auto]"
                       >
                         <Select
                           value={payment.tenderType}
@@ -760,7 +728,7 @@ export function PosHistoryView() {
                 </div>
               </div>
 
-              <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+              <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                 <div className="text-sm font-semibold text-[var(--text-strong)]">
                   Amount keypad
                 </div>
@@ -799,7 +767,10 @@ export function PosHistoryView() {
             <DialogTitle>Void sale</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="rounded-[1.25rem] border border-[color-mix(in_srgb,var(--status-error-border)_70%,white)] bg-[color-mix(in_srgb,var(--status-error-bg)_92%,white)] px-4 py-4">
+            <div
+              className="rounded-xl px-4 py-4 ring-1"
+              style={{ background: "var(--pos-status-danger-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-danger-ring)` }}
+            >
               <div className="text-sm font-semibold text-[var(--status-error-text)]">
                 Voiding removes the whole sale from the active record.
               </div>
@@ -809,7 +780,7 @@ export function PosHistoryView() {
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
-              <div className="rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-3">
+              <div className="rounded-lg border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-3 py-3">
                 <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Receipt
                 </div>
@@ -817,7 +788,7 @@ export function PosHistoryView() {
                   {selectedSale?.saleNo ?? "-"}
                 </div>
               </div>
-              <div className="rounded-[1.15rem] border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-3">
+              <div className="rounded-lg border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-3 py-3">
                 <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Total
                 </div>

--- a/components/retail/portal/pos-inline-validation-banner.tsx
+++ b/components/retail/portal/pos-inline-validation-banner.tsx
@@ -10,19 +10,31 @@ type PosInlineValidationBannerProps = {
 export function PosInlineValidationBanner({ messages }: PosInlineValidationBannerProps) {
   if (messages.length === 0) return null;
   return (
-    <div className="rounded-[1.25rem] border border-[color-mix(in_srgb,var(--status-warning-text)_16%,white)] bg-[color-mix(in_srgb,var(--status-warning-bg)_76%,white)] px-4 py-3">
+    <div
+      className="rounded-xl px-4 py-3 ring-1"
+      style={{
+        background: "var(--pos-status-warning-bg)",
+        boxShadow: `inset 0 0 0 1px var(--pos-status-warning-ring)`,
+      }}
+    >
       <div className="flex flex-wrap items-center gap-2">
         <PosStatusPill tone="warning">
           <AlertTriangle className="h-3.5 w-3.5" />
           Checkout blockers
         </PosStatusPill>
-        <span className="text-xs text-[var(--status-warning-text)]">
+        <span
+          className="text-xs font-medium"
+          style={{ color: "var(--pos-status-warning-text)" }}
+        >
           Fix these before taking payment.
         </span>
       </div>
       <div className="mt-3 space-y-2">
         {messages.slice(0, 3).map((message) => (
-          <div key={message} className="rounded-xl bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-strong)]">
+          <div
+            key={message}
+            className="rounded-lg bg-[var(--surface-base)] px-3 py-2 text-sm text-[var(--text-strong)] ring-1 ring-[var(--edge-subtle)]"
+          >
             {message}
           </div>
         ))}

--- a/components/retail/portal/pos-numeric-field.tsx
+++ b/components/retail/portal/pos-numeric-field.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 type PosNumericFieldProps = {
@@ -21,24 +20,40 @@ export function PosNumericField({
   className,
 }: PosNumericFieldProps) {
   return (
-    <Button
+    <button
       type="button"
-      variant="outline"
       onClick={onActivate}
       className={cn(
-        "h-auto min-h-[4.75rem] w-full items-start justify-start rounded-[1.2rem] px-4 py-3 text-left shadow-none",
-        active
-          ? "border-[var(--action-primary-bg)] bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,white)]"
-          : "border-[var(--border-default)] bg-[var(--surface-base)] hover:bg-[var(--surface-muted)]",
+        "flex min-h-[4.5rem] w-full flex-col items-start justify-center rounded-xl border px-4 py-3 text-left transition-all duration-100",
         className,
       )}
+      style={
+        active
+          ? {
+              background: "var(--pos-lcd-bg-active)",
+              borderColor: "var(--pos-lcd-text-active)",
+              boxShadow: `0 0 0 2px var(--pos-lcd-text-active)`,
+              color: "var(--pos-lcd-text)",
+            }
+          : {
+              background: "var(--pos-lcd-bg)",
+              borderColor: "var(--pos-lcd-border)",
+              color: "var(--pos-lcd-text)",
+            }
+      }
     >
-      <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+      <span
+        className="text-[10px] font-bold uppercase tracking-[0.18em]"
+        style={{ color: "var(--pos-lcd-label)" }}
+      >
         {label}
       </span>
-      <span className="mt-2 font-mono text-xl font-semibold text-[var(--text-strong)]">
-        {value || placeholder}
+      <span
+        className="mt-1 font-mono text-xl font-black tabular-nums tracking-tight"
+        style={{ color: active ? "var(--pos-lcd-text-active)" : "var(--pos-lcd-text)" }}
+      >
+        {value || <span style={{ color: "var(--pos-lcd-label)" }}>{placeholder}</span>}
       </span>
-    </Button>
+    </button>
   );
 }

--- a/components/retail/portal/pos-numeric-keypad.tsx
+++ b/components/retail/portal/pos-numeric-keypad.tsx
@@ -24,35 +24,59 @@ const KEYS: Array<{ label: string; action: PosKeypadAction }> = [
   { label: "0", action: { type: "digit", value: "0" } },
 ];
 
-/* ── Style constants ─────────────────────────────────────────── */
+/* ── Physical-press base class ───────────────────────────────────────── */
 
 const base =
-  "flex items-center justify-center rounded-2xl border font-semibold select-none transition-all duration-75 active:scale-[0.92] active:shadow-none h-[3.5rem]";
+  "flex items-center justify-center leading-none rounded-xl border font-semibold select-none h-12 sm:h-14 3xl:h-[4.5rem] transition-all duration-75 active:translate-y-[2px]";
 
-const numKey = cn(
-  base,
-  "border-[var(--border-default)] bg-[var(--surface-base)] text-[var(--text-strong)] text-xl font-bold",
-  "shadow-[0_2px_0_var(--border-default)] hover:bg-[var(--surface-muted)]",
-  "hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))]",
-);
+function numKeyStyle() {
+  return {
+    background: "var(--pos-key-bg)",
+    borderColor: "var(--pos-key-border)",
+    boxShadow: "0 3px 0 var(--pos-key-shadow)",
+    color: "var(--pos-key-text)",
+  } as React.CSSProperties;
+}
 
-const presetKey = cn(
-  base,
-  "border-emerald-200 bg-emerald-50 text-emerald-700 text-[12px] font-bold",
-  "shadow-[0_2px_0_rgba(16,185,129,0.2)] hover:bg-emerald-100 hover:border-emerald-300",
-);
+function numKeyActiveStyle() {
+  return {
+    boxShadow: "0 1px 0 var(--pos-key-shadow)",
+  } as React.CSSProperties;
+}
 
-const backspaceKey = cn(
-  base,
-  "border-[var(--border-default)] bg-[var(--surface-muted)] text-[var(--text-muted)]",
-  "shadow-[0_2px_0_var(--border-default)] hover:bg-amber-50 hover:border-amber-200 hover:text-amber-700",
-);
+function presetKeyStyle() {
+  return {
+    background: "var(--pos-key-preset-bg)",
+    borderColor: "var(--pos-key-preset-border)",
+    boxShadow: "0 3px 0 var(--pos-key-preset-shadow)",
+    color: "var(--pos-key-preset-text)",
+    fontSize: "12px",
+    fontWeight: 700,
+  } as React.CSSProperties;
+}
 
-const clearKey = cn(
-  base,
-  "border-red-200 bg-red-50 text-red-600 text-sm font-black tracking-wide",
-  "shadow-[0_2px_0_rgba(239,68,68,0.2)] hover:bg-red-100 hover:border-red-300",
-);
+function backspaceKeyStyle() {
+  return {
+    background: "var(--pos-key-back-bg)",
+    borderColor: "var(--pos-key-back-border)",
+    boxShadow: "0 3px 0 var(--pos-key-back-shadow)",
+    color: "var(--pos-key-back-text)",
+  } as React.CSSProperties;
+}
+
+function clearKeyStyle() {
+  return {
+    background: "var(--pos-key-clear-bg)",
+    borderColor: "var(--pos-key-clear-border)",
+    boxShadow: "0 3px 0 var(--pos-key-clear-shadow)",
+    color: "var(--pos-key-clear-text)",
+    fontSize: "13px",
+    fontWeight: 900,
+    letterSpacing: "0.08em",
+  } as React.CSSProperties;
+}
+
+import type React from "react";
 
 export function PosNumericKeypad({
   onAction,
@@ -63,60 +87,56 @@ export function PosNumericKeypad({
   const cols = hasPresets ? "grid-cols-4" : "grid-cols-3";
 
   const rows = [
-    KEYS.slice(0, 3),  // 1 2 3
-    KEYS.slice(3, 6),  // 4 5 6
-    KEYS.slice(6, 9),  // 7 8 9
-    KEYS.slice(9, 11), // . 0
+    KEYS.slice(0, 3),
+    KEYS.slice(3, 6),
+    KEYS.slice(6, 9),
+    KEYS.slice(9, 11),
   ];
 
   return (
     <div className={cn("grid gap-2", cols, className)}>
-      {/* Row 0: 1 2 3 | preset 0 */}
       {rows[0].map((key) => (
-        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
+        <button key={key.label} type="button" className={cn(base, "text-xl font-black")} style={numKeyStyle()} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[0] ? (
-        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[0].value })}>
+        <button type="button" className={base} style={presetKeyStyle()} onClick={() => onAction({ type: "preset", value: presets[0].value })}>
           {presets[0].label}
         </button>
       ) : hasPresets ? <div /> : null}
 
-      {/* Row 1: 4 5 6 | preset 1 */}
       {rows[1].map((key) => (
-        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
+        <button key={key.label} type="button" className={cn(base, "text-xl font-black")} style={numKeyStyle()} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[1] ? (
-        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[1].value })}>
+        <button type="button" className={base} style={presetKeyStyle()} onClick={() => onAction({ type: "preset", value: presets[1].value })}>
           {presets[1].label}
         </button>
       ) : hasPresets ? <div /> : null}
 
-      {/* Row 2: 7 8 9 | preset 2 */}
       {rows[2].map((key) => (
-        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
+        <button key={key.label} type="button" className={cn(base, "text-xl font-black")} style={numKeyStyle()} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
       {hasPresets && presets[2] ? (
-        <button type="button" className={presetKey} onClick={() => onAction({ type: "preset", value: presets[2].value })}>
+        <button type="button" className={base} style={presetKeyStyle()} onClick={() => onAction({ type: "preset", value: presets[2].value })}>
           {presets[2].label}
         </button>
       ) : hasPresets ? <div /> : null}
 
-      {/* Row 3: . 0 ⌫ C */}
       {rows[3].map((key) => (
-        <button key={key.label} type="button" className={numKey} onClick={() => onAction(key.action)}>
+        <button key={key.label} type="button" className={cn(base, "text-xl font-black")} style={numKeyStyle()} onClick={() => onAction(key.action)}>
           {key.label}
         </button>
       ))}
-      <button type="button" className={backspaceKey} onClick={() => onAction({ type: "backspace" })}>
+      <button type="button" className={base} style={backspaceKeyStyle()} onClick={() => onAction({ type: "backspace" })}>
         <Delete className="h-5 w-5" />
       </button>
-      <button type="button" className={clearKey} onClick={() => onAction({ type: "clear" })}>
+      <button type="button" className={base} style={clearKeyStyle()} onClick={() => onAction({ type: "clear" })}>
         CLR
       </button>
     </div>

--- a/components/retail/portal/pos-overview-view.tsx
+++ b/components/retail/portal/pos-overview-view.tsx
@@ -54,10 +54,10 @@ export function PosOverviewView() {
       <PosPanel>
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
               Operational snapshot
             </p>
-            <h2 className="mt-1 text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+            <h2 className="mt-1 text-[1.3rem] font-bold tracking-[-0.025em] text-[var(--text-strong)]">
               {currentShift
                 ? `Shift ${currentShift.shiftNo} · ${currentShift.registerName}`
                 : "No active shift"}
@@ -113,9 +113,13 @@ export function PosOverviewView() {
         <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-4">
           <Link
             href={getPosPortalHref("checkout", isPosHost)}
-            className="group flex items-center gap-3.5 rounded-2xl border border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] bg-[color-mix(in_srgb,var(--action-primary-bg)_5%,var(--surface-base))] px-4 py-3.5 transition-all hover:border-[var(--action-primary-bg)] hover:bg-[color-mix(in_srgb,var(--action-primary-bg)_9%,var(--surface-base))] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
+            className="group flex items-center gap-3.5 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-3.5 ring-1 ring-transparent transition-all hover:-translate-y-[1px] hover:shadow-sm hover:ring-[var(--pos-status-info-ring)]"
+            style={{ boxShadow: "0 2px 0 var(--pos-cta-shadow)" }}
           >
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[var(--action-primary-bg)] text-white shadow-[0_4px_10px_rgba(0,0,0,0.15)]">
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+              style={{ background: "var(--pos-cta-bg)", color: "var(--pos-cta-text)" }}
+            >
               <Payments className="h-4.5 w-4.5" />
             </div>
             <div>
@@ -126,17 +130,15 @@ export function PosOverviewView() {
 
           <Link
             href={getPosPortalHref("held", isPosHost)}
-            className={cn(
-              "group flex items-center gap-3.5 rounded-2xl border px-4 py-3.5 transition-all hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]",
-              heldCount > 0
-                ? "border-amber-300 bg-amber-50 hover:border-amber-400 hover:bg-amber-50"
-                : "border-[var(--border-default)] bg-[var(--surface-muted)] hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)]",
-            )}
+            className="group flex items-center gap-3.5 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-3.5 ring-1 ring-transparent transition-all hover:-translate-y-[1px] hover:shadow-sm hover:ring-[var(--pos-status-warning-ring)]"
           >
-            <div className={cn(
-              "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]",
-              heldCount > 0 ? "bg-amber-500" : "bg-[var(--text-muted)]",
-            )}>
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+              style={{
+                background: heldCount > 0 ? "var(--pos-status-warning-bg)" : "var(--surface-muted)",
+                color: heldCount > 0 ? "var(--pos-status-warning-text)" : "var(--text-muted)",
+              }}
+            >
               <Package className="h-4.5 w-4.5" />
             </div>
             <div>
@@ -151,9 +153,12 @@ export function PosOverviewView() {
 
           <Link
             href={getPosPortalHref("history", isPosHost)}
-            className="group flex items-center gap-3.5 rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-3.5 transition-all hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
+            className="group flex items-center gap-3.5 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-3.5 ring-1 ring-transparent transition-all hover:-translate-y-[1px] hover:shadow-sm hover:ring-[var(--pos-status-info-ring)]"
           >
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-500 text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]">
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+              style={{ background: "var(--pos-status-info-bg)", color: "var(--pos-status-info-text)" }}
+            >
               <History className="h-4.5 w-4.5" />
             </div>
             <div>
@@ -164,12 +169,15 @@ export function PosOverviewView() {
 
           <Link
             href={getPosPortalHref("shift", isPosHost)}
-            className="group flex items-center gap-3.5 rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-3.5 transition-all hover:border-[color-mix(in_srgb,var(--action-primary-bg)_35%,var(--border-default))] hover:bg-[var(--surface-base)] hover:shadow-[0_4px_14px_rgba(0,0,0,0.07)]"
+            className="group flex items-center gap-3.5 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-3.5 ring-1 ring-transparent transition-all hover:-translate-y-[1px] hover:shadow-sm hover:ring-[var(--pos-status-success-ring)]"
           >
-            <div className={cn(
-              "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-white shadow-[0_4px_10px_rgba(0,0,0,0.12)]",
-              currentShift ? "bg-emerald-500" : "bg-amber-500",
-            )}>
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+              style={{
+                background: currentShift ? "var(--pos-status-success-bg)" : "var(--pos-status-warning-bg)",
+                color: currentShift ? "var(--pos-status-success-text)" : "var(--pos-status-warning-text)",
+              }}
+            >
               <Clock className="h-4.5 w-4.5" />
             </div>
             <div>
@@ -199,7 +207,10 @@ export function PosOverviewView() {
             />
           ) : (
             <table className="w-full min-w-[600px] text-sm">
-              <thead className="sticky top-0 z-10 border-b border-[var(--border-subtle)] bg-[var(--surface-base)] text-left text-[10px] uppercase tracking-[0.13em] text-[var(--text-muted)]">
+              <thead
+                className="sticky top-0 z-10 text-left text-[10px] uppercase tracking-[0.13em]"
+                style={{ background: "var(--pos-amount-bg)", color: "rgba(240,249,255,0.7)" }}
+              >
                 <tr>
                   <th className="px-3 py-2.5">Receipt</th>
                   <th className="px-3 py-2.5">Type</th>
@@ -212,7 +223,7 @@ export function PosOverviewView() {
                 {recentSales.map((sale) => (
                   <tr
                     key={sale.id}
-                    className="group transition-colors hover:bg-[var(--surface-muted)]"
+                    className="group transition-colors hover:bg-[var(--surface-canvas)]"
                   >
                     <td className="px-3 py-3.5 font-mono text-[13px] font-bold text-[var(--text-strong)]">
                       {sale.saleNo}

--- a/components/retail/portal/pos-portal-layout-frame.tsx
+++ b/components/retail/portal/pos-portal-layout-frame.tsx
@@ -36,42 +36,14 @@ type PosPortalLayoutFrameProps = {
 };
 
 const POS_PORTAL_LINKS: PosPortalLink[] = [
-  {
-    label: "Checkout",
-    icon: Payments,
-    publicHref: "/",
-    internalHref: "/portal/pos",
-  },
-  {
-    label: "Held",
-    icon: Package,
-    publicHref: "/held",
-    internalHref: "/portal/pos/held",
-  },
-  {
-    label: "History",
-    icon: History,
-    publicHref: "/history",
-    internalHref: "/portal/pos/history",
-  },
-  {
-    label: "Reports",
-    icon: BarChart3,
-    publicHref: "/reports",
-    internalHref: "/portal/pos/reports",
-  },
-  {
-    label: "Shift",
-    icon: Clock,
-    publicHref: "/shift",
-    internalHref: "/portal/pos/shift",
-  },
+  { label: "Checkout", icon: Payments, publicHref: "/", internalHref: "/portal/pos" },
+  { label: "Held", icon: Package, publicHref: "/held", internalHref: "/portal/pos/held" },
+  { label: "History", icon: History, publicHref: "/history", internalHref: "/portal/pos/history" },
+  { label: "Reports", icon: BarChart3, publicHref: "/reports", internalHref: "/portal/pos/reports" },
+  { label: "Shift", icon: Clock, publicHref: "/shift", internalHref: "/portal/pos/shift" },
 ];
 
-const ROUTE_CONFIG: Record<
-  string,
-  { title: string; description?: string; fillHeight?: boolean }
-> = {
+const ROUTE_CONFIG: Record<string, { title: string; description?: string; fillHeight?: boolean }> = {
   "/portal/pos": { title: "Point of Sale", fillHeight: true },
   "/": { title: "Point of Sale", fillHeight: true },
   "/held": { title: "Held Carts" },
@@ -79,13 +51,67 @@ const ROUTE_CONFIG: Record<
   "/history": { title: "Sales History" },
   "/portal/pos/history": { title: "Sales History" },
   "/reports": { title: "Reports", description: "Your sales at a glance" },
-  "/portal/pos/reports": {
-    title: "Reports",
-    description: "Your sales at a glance",
-  },
+  "/portal/pos/reports": { title: "Reports", description: "Your sales at a glance" },
   "/shift": { title: "Shift Management" },
   "/portal/pos/shift": { title: "Shift Management" },
 };
+
+function BottomTabBar({
+  links,
+  pathname,
+  onSignOut,
+}: {
+  links: Array<{ href: string; label: string; icon: LucideIcon }>;
+  pathname: string;
+  onSignOut: () => void;
+}) {
+  return (
+    <nav
+      aria-label="Main navigation"
+      className="fixed inset-x-0 bottom-0 z-40 flex lg:hidden"
+      style={{
+        background: "var(--pos-rail-bg)",
+        borderTop: "1px solid var(--pos-rail-border)",
+        paddingBottom: "env(safe-area-inset-bottom)",
+      }}
+    >
+      {links.map((item) => {
+        const isActive = pathname === item.href;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-label={item.label}
+            aria-current={isActive ? "page" : undefined}
+            className="relative flex min-h-[3.25rem] flex-1 flex-col items-center justify-center gap-0.5 py-2 transition-colors"
+            style={{ color: isActive ? "var(--pos-rail-text-active)" : "var(--pos-rail-text-idle)" }}
+          >
+            {isActive && (
+              <span
+                className="absolute inset-x-3 top-0 h-[2px] rounded-b-full"
+                style={{ background: "var(--pos-cta-bg)" }}
+              />
+            )}
+            <item.icon className="h-5 w-5 shrink-0" />
+            <span className="text-[9px] font-bold uppercase tracking-wide leading-none">
+              {item.label}
+            </span>
+          </Link>
+        );
+      })}
+      <button
+        type="button"
+        aria-label="Log out"
+        onClick={onSignOut}
+        className="flex min-h-[3.25rem] min-w-[3.5rem] flex-col items-center justify-center gap-0.5 py-2 transition-colors"
+        style={{ color: "var(--pos-rail-text-idle)" }}
+      >
+        <LogOut className="h-5 w-5 shrink-0" />
+        <span className="text-[9px] font-bold uppercase tracking-wide leading-none">Exit</span>
+      </button>
+    </nav>
+  );
+}
 
 export function PosPortalLayoutFrame({
   children,
@@ -114,22 +140,50 @@ export function PosPortalLayoutFrame({
     : POS_PORTAL_LINKS.map((item) => ({ ...item, href: item.internalHref }));
 
   return (
-    <div className="min-h-screen bg-[color-mix(in_srgb,var(--surface-canvas)_88%,white)] text-[15px] text-[var(--text-strong)]">
-      <div className="relative flex h-[100dvh] overflow-hidden bg-[linear-gradient(180deg,color-mix(in_srgb,var(--surface-canvas)_90%,white)_0%,var(--surface-base)_100%)] lg:flex-row">
-        <aside className="shrink-0 border-b border-[var(--edge-subtle)] bg-[color-mix(in_srgb,var(--sidebar)_94%,white)] lg:flex lg:w-[5.5rem] lg:border-b-0 lg:border-r">
+    <div
+      className="pos-terminal min-h-[100dvh] text-[15px] text-[var(--text-strong)]"
+      style={{ background: "var(--surface-canvas)" }}
+    >
+      <div
+        className="relative flex h-[100dvh] overflow-hidden lg:flex-row"
+        style={{ background: "var(--surface-canvas)" }}
+      >
+        {/* Desktop sidebar — dark rail */}
+        <aside
+          className="hidden shrink-0 lg:flex lg:w-[5.5rem] 3xl:w-[6.5rem]"
+          style={{
+            background: "var(--pos-rail-bg)",
+            borderRight: "1px solid var(--pos-rail-border)",
+          }}
+        >
           <div className="flex h-full w-full flex-col">
-            <div className="hidden shrink-0 border-b border-[var(--edge-subtle)] px-3 py-4 lg:block">
+            {/* Workspace badge */}
+            <div
+              className="shrink-0 px-3 py-4"
+              style={{ borderBottom: "1px solid var(--pos-rail-border)" }}
+            >
               <div className="flex flex-col items-center gap-3">
-                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[1.15rem] bg-[var(--action-primary-bg)] text-sm font-black text-white shadow-[0_12px_24px_rgba(15,23,42,0.14)]">
+                <div
+                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl text-sm font-black text-white"
+                  style={{
+                    background: "var(--pos-cta-bg)",
+                    boxShadow: "var(--pos-rail-workspace-shadow)",
+                  }}
+                >
                   {workspaceInitial}
                 </div>
                 <TooltipProvider delayDuration={120}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex h-9 w-9 cursor-default items-center justify-center rounded-full border border-[var(--edge-subtle)] bg-[var(--surface-base)] text-[var(--action-primary-bg)]">
-                        <span className="text-[13px] font-black leading-none">
-                          {operatorInitial}
-                        </span>
+                      <div
+                        className="flex h-9 w-9 cursor-default items-center justify-center rounded-full border"
+                        style={{
+                          borderColor: "var(--pos-rail-border)",
+                          background: "var(--pos-amount-surface)",
+                          color: "var(--pos-amount-text)",
+                        }}
+                      >
+                        <span className="text-[13px] font-black leading-none">{operatorInitial}</span>
                       </div>
                     </TooltipTrigger>
                     <TooltipContent side="right">
@@ -140,8 +194,9 @@ export function PosPortalLayoutFrame({
               </div>
             </div>
 
+            {/* Nav links */}
             <TooltipProvider delayDuration={120}>
-              <nav className="flex gap-1 overflow-x-auto px-3 pb-2 pt-2 lg:flex-1 lg:flex-col lg:gap-2 lg:overflow-y-auto lg:overflow-x-visible lg:px-3 lg:pb-3 lg:pt-4">
+              <nav className="flex flex-1 flex-col gap-1.5 overflow-y-auto px-2.5 pb-3 pt-3">
                 {renderedLinks.map((item) => {
                   const isActive = pathname === item.href;
                   return (
@@ -150,23 +205,26 @@ export function PosPortalLayoutFrame({
                         <Link
                           href={item.href}
                           aria-label={item.label}
-                          className={cn(
-                            "group inline-flex min-h-10 shrink-0 items-center justify-center rounded-2xl px-2.5 py-2.5 text-[13px] font-medium transition-all duration-100 lg:flex lg:w-full",
+                          aria-current={isActive ? "page" : undefined}
+                          className="relative inline-flex min-h-11 w-full shrink-0 items-center justify-center rounded-xl transition-all duration-100"
+                          style={
                             isActive
-                              ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[0_8px_18px_rgba(15,23,42,0.08),inset_0_0_0_1px_var(--edge-default)]"
-                              : "text-[var(--text-muted)] hover:bg-[color-mix(in_srgb,var(--surface-base)_60%,transparent)] hover:text-[var(--text-strong)]",
-                          )}
+                              ? {
+                                  background: "var(--pos-rail-active-bg)",
+                                  boxShadow: `inset 0 0 0 1px var(--pos-rail-active-ring)`,
+                                  color: "var(--pos-rail-text-active)",
+                                }
+                              : { color: "var(--pos-rail-text-idle)" }
+                          }
                         >
-                          <span className="relative flex h-9 w-9 items-center justify-center rounded-[1rem]">
-                            <item.icon
-                              className={cn(
-                                "h-[1.1rem] w-[1.1rem] shrink-0 transition-colors",
-                                isActive ? "text-[var(--action-primary-bg)]" : "opacity-80",
-                              )}
+                          {isActive && (
+                            <span
+                              className="absolute left-0 top-1/2 h-6 w-[3px] -translate-y-1/2 rounded-r-full"
+                              style={{ background: "var(--pos-cta-bg)" }}
                             />
-                            {isActive ? (
-                              <span className="absolute right-0 top-0 h-2 w-2 rounded-full bg-[var(--action-primary-bg)]" />
-                            ) : null}
+                          )}
+                          <span className="relative flex h-9 w-9 items-center justify-center">
+                            <item.icon className="h-[1.1rem] w-[1.1rem] shrink-0" />
                           </span>
                         </Link>
                       </TooltipTrigger>
@@ -176,14 +234,25 @@ export function PosPortalLayoutFrame({
                 })}
               </nav>
 
-              <div className="hidden shrink-0 border-t border-[var(--edge-subtle)] px-3 py-3 lg:block">
+              {/* Logout */}
+              <div
+                className="shrink-0 px-2.5 py-3"
+                style={{ borderTop: "1px solid var(--pos-rail-border)" }}
+              >
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
                       aria-label="Log out"
                       onClick={handleSignOut}
-                      className="inline-flex w-full items-center justify-center rounded-2xl px-2.5 py-2.5 text-left text-[13px] font-medium text-[var(--text-muted)] transition-all duration-100 hover:bg-[color-mix(in_srgb,var(--surface-base)_60%,transparent)] hover:text-[var(--text-strong)]"
+                      className="inline-flex min-h-11 w-full items-center justify-center rounded-xl transition-all duration-100"
+                      style={{ color: "var(--pos-rail-text-idle)" }}
+                      onMouseEnter={(e) =>
+                        (e.currentTarget.style.color = "var(--pos-rail-text-active)")
+                      }
+                      onMouseLeave={(e) =>
+                        (e.currentTarget.style.color = "var(--pos-rail-text-idle)")
+                      }
                     >
                       <LogOut className="h-[1.05rem] w-[1.05rem] shrink-0 opacity-80" />
                     </button>
@@ -195,41 +264,57 @@ export function PosPortalLayoutFrame({
           </div>
         </aside>
 
+        {/* Content area */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <header className="flex items-center justify-between gap-3 border-b border-[var(--edge-subtle)] bg-[color-mix(in_srgb,var(--surface-base)_88%,white)] px-4 py-3 lg:hidden">
+          {/* Mobile header */}
+          <header
+            className="flex items-center justify-between gap-3 px-4 py-3 lg:hidden"
+            style={{
+              background: "var(--pos-amount-bg)",
+              borderBottom: "1px solid var(--pos-rail-border)",
+            }}
+          >
             <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[1rem] bg-[var(--action-primary-bg)] text-sm font-black text-white">
+              <div
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[1rem] text-sm font-black text-white"
+                style={{ background: "var(--pos-cta-bg)" }}
+              >
                 {workspaceInitial}
               </div>
               <div className="min-w-0">
-                <div className="truncate text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                  POS Workspace
+                <div
+                  className="truncate text-[10px] font-bold uppercase tracking-[0.18em]"
+                  style={{ color: "var(--pos-amount-label)" }}
+                >
+                  POS Terminal
                 </div>
-                <div className="truncate text-sm font-semibold text-[var(--text-strong)]">
+                <div
+                  className="truncate text-sm font-bold"
+                  style={{ color: "var(--pos-amount-text)" }}
+                >
                   {config.title}
                 </div>
               </div>
             </div>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              className="inline-flex items-center gap-2 rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-base)] px-3 py-2 text-sm font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-strong)]"
-            >
-              <LogOut className="h-4 w-4" />
-              Log out
-            </button>
           </header>
 
           {config.fillHeight ? (
-            <main className="flex-1 overflow-hidden">{children}</main>
+            <main className="flex-1 overflow-hidden pb-[calc(4rem+env(safe-area-inset-bottom,0px))] lg:pb-0">
+              {children}
+            </main>
           ) : (
-            <main className="flex-1 overflow-auto px-4 pb-6 pt-5 md:px-6 lg:px-8">
-              <div className="mx-auto w-full max-w-[1320px]">
+            <main
+              className={cn(
+                "flex-1 overflow-auto px-4 pt-5 md:px-6 lg:px-8 lg:pb-6",
+                "pb-[calc(1.5rem+4rem+env(safe-area-inset-bottom,0px))]",
+              )}
+            >
+              <div className="mx-auto w-full max-w-[1320px] 3xl:max-w-[1680px]">
                 <div className="mb-5 hidden lg:block">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                    POS Workspace
+                  <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                    POS Terminal
                   </div>
-                  <h1 className="mt-1 text-[1.45rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+                  <h1 className="mt-1 text-[1.45rem] font-bold tracking-[-0.03em] text-[var(--text-strong)]">
                     {config.title}
                   </h1>
                   {config.description ? (
@@ -243,6 +328,9 @@ export function PosPortalLayoutFrame({
             </main>
           )}
         </div>
+
+        {/* Mobile bottom tab bar */}
+        <BottomTabBar links={renderedLinks} pathname={pathname} onSignOut={handleSignOut} />
       </div>
     </div>
   );

--- a/components/retail/portal/pos-price-check-view.tsx
+++ b/components/retail/portal/pos-price-check-view.tsx
@@ -37,43 +37,54 @@ export function PosPriceCheckView() {
         <PosPanelHeader
           eyebrow="Speed lookup"
           title="Price check"
-          description="Keep this lane scan-first, glanceable, and oversized enough to answer a customer in seconds."
+          description="Scan-first, glanceable. Answers price, code, and stock in seconds."
         />
 
-        <div className="rounded-[1.25rem] border border-[var(--border-default)] bg-[var(--surface-muted)] p-3">
-          <div className="flex items-center gap-3 rounded-[1rem] border border-[var(--border-subtle)] bg-white px-3 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.04)]">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--surface-muted)] text-[var(--action-primary-bg)]">
-              <Search className="h-5 w-5" />
+        {/* LCD search input */}
+        <div
+          className="flex items-center gap-3 rounded-xl border px-4 py-3"
+          style={{ background: "var(--pos-lcd-bg)", borderColor: "var(--pos-lcd-border)" }}
+        >
+          <QrCode
+            className="h-5 w-5 shrink-0"
+            style={{ color: "var(--pos-lcd-label)" }}
+          />
+          <div className="min-w-0 flex-1">
+            <div
+              className="text-[10px] font-bold uppercase tracking-[0.18em]"
+              style={{ color: "var(--pos-lcd-label)" }}
+            >
+              Scanner-ready
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                <QrCode className="h-4 w-4" />
-                Scanner-ready input
-              </div>
-              <Input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Scan barcode or search product"
-                className="mt-1 h-11 border-none bg-transparent px-0 text-base shadow-none focus-visible:ring-0"
-              />
-            </div>
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Scan barcode or search product"
+              className="mt-0.5 h-9 border-none bg-transparent px-0 text-base shadow-none focus-visible:ring-0"
+              style={{ color: "var(--pos-lcd-text)" }}
+            />
           </div>
+          <Search
+            className="h-4 w-4 shrink-0 opacity-40"
+            style={{ color: "var(--pos-lcd-label)" }}
+          />
         </div>
       </PosPanel>
 
       <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(320px,0.92fr)_minmax(0,1.08fr)]">
+        {/* Featured result hero panel */}
         <PosPanel className="flex min-h-0 flex-col">
           <PosPanelHeader
             eyebrow="Featured result"
             title="Best match"
-            description="The first result should answer price, code, and stock at a glance."
+            description="Price, code, and stock at a glance."
           />
 
           {!currentShift ? (
             <PosEmptyState
               icon={ReceiptLong}
               title="Open a shift to use price check"
-              description="Price check is tied to the active selling site, so it becomes available once the register is open."
+              description="Price check is tied to the active selling site."
             />
           ) : !featuredItem ? (
             <PosEmptyState
@@ -82,46 +93,81 @@ export function PosPriceCheckView() {
               description={
                 catalogQuery.isLoading
                   ? "Loading product matches."
-                  : "Scan a barcode or type a product name to pull the best match here."
+                  : "Scan a barcode or type a product name."
               }
             />
           ) : (
-            <div className="flex h-full flex-col justify-between rounded-[1.4rem] border border-[var(--border-default)] bg-[var(--surface-muted)] p-5">
+            <div
+              className="flex h-full flex-col justify-between rounded-xl border p-5"
+              style={{
+                background: "var(--pos-amount-bg)",
+                borderColor: "var(--pos-amount-border)",
+              }}
+            >
               <div>
                 <div className="flex items-center gap-2">
                   <PosStatusPill tone="brand">Top match</PosStatusPill>
                   {featuredItem.inventoryItem ? (
                     <PosStatusPill
-                      tone={
-                        featuredItem.inventoryItem.currentStock > 0 ? "success" : "danger"
-                      }
+                      tone={featuredItem.inventoryItem.currentStock > 0 ? "success" : "danger"}
                     >
                       {featuredItem.inventoryItem.currentStock > 0 ? "In stock" : "Out of stock"}
                     </PosStatusPill>
                   ) : null}
                 </div>
-                <h2 className="mt-4 text-[1.8rem] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">
+                <h2
+                  className="mt-4 text-[1.8rem] font-bold tracking-[-0.04em]"
+                  style={{ color: "var(--pos-amount-text)" }}
+                >
                   {featuredItem.name}
                 </h2>
-                <div className="mt-3 font-mono text-[2.3rem] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">
+                <div
+                  className="mt-3 font-mono text-[2.5rem] font-black tabular-nums tracking-tight"
+                  style={{ color: "var(--pos-amount-text)" }}
+                >
                   {money(featuredItem.unitPrice)}
                 </div>
               </div>
 
-              <div className="mt-6 grid gap-3">
-                <div className="rounded-[1rem] border border-[var(--border-subtle)] bg-white/80 px-4 py-3">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              <div className="mt-6 grid gap-2">
+                <div
+                  className="rounded-lg border px-4 py-3 ring-1"
+                  style={{
+                    background: "var(--pos-amount-surface)",
+                    borderColor: "var(--pos-amount-border)",
+                    boxShadow: `inset 0 0 0 1px var(--pos-amount-border)`,
+                  }}
+                >
+                  <div
+                    className="text-[10px] font-bold uppercase tracking-[0.18em]"
+                    style={{ color: "var(--pos-amount-label)" }}
+                  >
                     Barcode / SKU
                   </div>
-                  <div className="mt-2 font-mono text-sm font-semibold text-[var(--text-strong)]">
+                  <div
+                    className="mt-1 font-mono text-sm font-semibold tabular-nums"
+                    style={{ color: "var(--pos-amount-text)" }}
+                  >
                     {featuredItem.barcode || featuredItem.sku}
                   </div>
                 </div>
-                <div className="rounded-[1rem] border border-[var(--border-subtle)] bg-white/80 px-4 py-3">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                <div
+                  className="rounded-lg border px-4 py-3"
+                  style={{
+                    background: "var(--pos-amount-surface)",
+                    borderColor: "var(--pos-amount-border)",
+                  }}
+                >
+                  <div
+                    className="text-[10px] font-bold uppercase tracking-[0.18em]"
+                    style={{ color: "var(--pos-amount-label)" }}
+                  >
                     Stock
                   </div>
-                  <div className="mt-2 text-sm font-medium text-[var(--text-strong)]">
+                  <div
+                    className="mt-1 text-sm font-medium"
+                    style={{ color: "var(--pos-amount-text)" }}
+                  >
                     {featuredItem.inventoryItem
                       ? `${featuredItem.inventoryItem.currentStock.toFixed(2)} ${featuredItem.inventoryItem.unit}`
                       : "No stock data"}
@@ -132,11 +178,12 @@ export function PosPriceCheckView() {
           )}
         </PosPanel>
 
+        {/* Match list */}
         <PosPanel className="min-h-0">
           <PosPanelHeader
             eyebrow="Matches"
             title="Lookup results"
-            description="Keep the list dense, readable, and easy to scan when the first result is not the right one."
+            description="Dense and scannable. First result is the best match."
           />
 
           <div className="h-full min-h-0 overflow-y-auto pr-1">
@@ -144,7 +191,7 @@ export function PosPriceCheckView() {
               <PosEmptyState
                 icon={ReceiptLong}
                 title="Price check is waiting on an open shift"
-                description="Once the register is active, product matches and stock cues will appear here."
+                description="Once the register is active, product matches appear here."
               />
             ) : rows.length === 0 ? (
               <PosEmptyState
@@ -157,36 +204,39 @@ export function PosPriceCheckView() {
                 }
               />
             ) : (
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {rows.map((item, index) => (
                   <div
                     key={item.id}
-                    className="flex min-h-[5.5rem] items-center justify-between gap-4 rounded-[1.2rem] border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4"
+                    className="flex min-h-[4.5rem] items-center justify-between gap-4 rounded-xl border border-[var(--edge-default)] bg-[var(--surface-base)] px-4 py-3 ring-1 ring-transparent transition-all hover:ring-[var(--pos-status-info-ring)]"
                   >
                     <div className="flex min-w-0 items-start gap-3">
-                      <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[var(--action-primary-bg)] shadow-[0_8px_18px_rgba(15,23,42,0.05)]">
+                      <div
+                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+                        style={{ background: "var(--pos-status-info-bg)", color: "var(--pos-status-info-text)" }}
+                      >
                         <Package className="h-5 w-5" />
                       </div>
                       <div className="min-w-0">
                         <div className="flex items-center gap-2">
-                          <div className="truncate text-base font-semibold text-[var(--text-strong)]">
+                          <div className="truncate text-[15px] font-semibold text-[var(--text-strong)]">
                             {item.name}
                           </div>
                           {index === 0 ? <PosStatusPill tone="brand">Best</PosStatusPill> : null}
                         </div>
-                        <div className="mt-1 font-mono text-xs text-[var(--text-muted)]">
+                        <div className="mt-0.5 font-mono text-xs text-[var(--text-muted)]">
                           {item.barcode || item.sku}
                         </div>
                       </div>
                     </div>
-                    <div className="text-right">
-                      <div className="font-mono text-lg font-semibold text-[var(--text-strong)]">
+                    <div className="shrink-0 text-right">
+                      <div className="font-mono text-lg font-black tabular-nums text-[var(--text-strong)]">
                         {money(item.unitPrice)}
                       </div>
-                      <div className="mt-1 text-xs text-[var(--text-muted)]">
+                      <div className="mt-0.5 text-xs text-[var(--text-muted)]">
                         {item.inventoryItem
                           ? `${item.inventoryItem.currentStock.toFixed(2)} ${item.inventoryItem.unit}`
-                          : "No stock data"}
+                          : "No stock"}
                       </div>
                     </div>
                   </div>

--- a/components/retail/portal/pos-primitives.tsx
+++ b/components/retail/portal/pos-primitives.tsx
@@ -5,30 +5,117 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { LucideIcon } from "@/lib/icons";
 
+/* ── PosTerminalHeader ──────────────────────────────────────────────────── */
+
+type PosTerminalHeaderProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  valuePrimary?: string;
+  valueSecondary?: string;
+  pill?: ReactNode;
+  className?: string;
+};
+
+export function PosTerminalHeader({
+  eyebrow,
+  title,
+  subtitle,
+  valuePrimary,
+  valueSecondary,
+  pill,
+  className,
+}: PosTerminalHeaderProps) {
+  return (
+    <div
+      className={cn("px-5 py-4", className)}
+      style={{
+        background: "var(--pos-amount-bg)",
+        borderBottom: "1px solid var(--pos-amount-border)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          {eyebrow ? (
+            <p
+              className="truncate text-[10px] font-bold uppercase tracking-[0.18em]"
+              style={{ color: "var(--pos-amount-label)" }}
+            >
+              {eyebrow}
+            </p>
+          ) : null}
+          <h2
+            className="mt-0.5 truncate font-bold"
+            style={{
+              fontSize: "clamp(1.05rem, 4vw, 1.5rem)",
+              lineHeight: 1.2,
+              color: "var(--pos-amount-text)",
+            }}
+          >
+            {title}
+          </h2>
+          {subtitle ? (
+            <p
+              className="mt-0.5 truncate text-sm"
+              style={{ color: "var(--pos-amount-label)" }}
+            >
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+        <div className="shrink-0 text-right">
+          {valuePrimary ? (
+            <p
+              className="font-mono font-black tabular-nums"
+              style={{
+                fontSize: "clamp(1.1rem, 4vw, 1.6rem)",
+                lineHeight: 1.1,
+                color: "var(--pos-amount-text)",
+              }}
+            >
+              {valuePrimary}
+            </p>
+          ) : null}
+          {valueSecondary ? (
+            <p
+              className="mt-0.5 font-mono text-sm tabular-nums"
+              style={{ color: "var(--pos-amount-label)" }}
+            >
+              {valueSecondary}
+            </p>
+          ) : null}
+          {pill ? <div className="mt-1">{pill}</div> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── PosPanel ───────────────────────────────────────────────────────────── */
+
 type PosPanelProps = {
   className?: string;
   children: ReactNode;
   variant?: "section" | "card";
 };
 
-export function PosPanel({
-  className,
-  children,
-  variant = "section",
-}: PosPanelProps) {
+export function PosPanel({ className, children, variant = "section" }: PosPanelProps) {
   return (
     <section
       className={cn(
         variant === "card"
-          ? "rounded-[1.5rem] border border-[var(--border-default)] bg-[var(--surface-base)] p-4 shadow-[0_14px_36px_rgba(15,23,42,0.05)] sm:p-5"
-          : "rounded-[1.5rem] border border-[color-mix(in_srgb,var(--border-subtle)_65%,transparent)] bg-[color-mix(in_srgb,var(--surface-base)_84%,transparent)] p-4 shadow-none sm:p-5",
+          ? "rounded-2xl border border-[var(--edge-default)] bg-[var(--surface-base)] p-4 sm:p-5"
+          : "rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-base)] p-4 sm:p-5",
         className,
       )}
+      style={{ boxShadow: "var(--shadow-card, 0 1px 3px rgba(15,23,42,0.06))" }}
     >
       {children}
     </section>
   );
 }
+
+/* ── PosPanelHeader ─────────────────────────────────────────────────────── */
 
 type PosPanelHeaderProps = {
   eyebrow?: string;
@@ -48,17 +135,17 @@ export function PosPanelHeader({
   return (
     <div
       className={cn(
-        "mb-4 flex flex-col gap-3 border-b border-[var(--border-subtle)] pb-4 sm:flex-row sm:items-start sm:justify-between",
+        "mb-4 flex flex-col gap-3 border-b border-[var(--edge-subtle)] pb-4 sm:flex-row sm:items-start sm:justify-between",
         className,
       )}
     >
       <div className="min-w-0">
         {eyebrow ? (
-          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+          <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
             {eyebrow}
           </p>
         ) : null}
-        <h2 className="mt-1 text-[1.35rem] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
+        <h2 className="mt-1 text-[1.3rem] font-bold tracking-[-0.025em] text-[var(--text-strong)]">
           {title}
         </h2>
         {description ? (
@@ -72,6 +159,8 @@ export function PosPanelHeader({
   );
 }
 
+/* ── PosMetricCard ──────────────────────────────────────────────────────── */
+
 type PosMetricCardProps = {
   icon: LucideIcon;
   label: string;
@@ -81,17 +170,12 @@ type PosMetricCardProps = {
   className?: string;
 };
 
-const POS_METRIC_TONE_CLASSNAMES = {
-  brand:
-    "bg-[color-mix(in_srgb,var(--action-primary-bg)_8%,white)] text-[var(--action-primary-bg)]",
-  success:
-    "bg-[color-mix(in_srgb,var(--status-success-bg)_85%,white)] text-[var(--status-success-text)]",
-  warning:
-    "bg-[color-mix(in_srgb,var(--status-warning-bg)_88%,white)] text-[var(--status-warning-text)]",
-  danger:
-    "bg-[color-mix(in_srgb,var(--status-error-bg)_80%,white)] text-[var(--status-error-text)]",
-  neutral:
-    "bg-[var(--surface-muted)] text-[var(--text-muted)]",
+const POS_METRIC_TONE: Record<string, { bg: string; text: string }> = {
+  brand:   { bg: "var(--pos-status-info-bg)",    text: "var(--pos-status-info-text)" },
+  success: { bg: "var(--pos-status-success-bg)", text: "var(--pos-status-success-text)" },
+  warning: { bg: "var(--pos-status-warning-bg)", text: "var(--pos-status-warning-text)" },
+  danger:  { bg: "var(--pos-status-danger-bg)",  text: "var(--pos-status-danger-text)" },
+  neutral: { bg: "var(--surface-muted)",          text: "var(--text-muted)" },
 };
 
 export function PosMetricCard({
@@ -102,35 +186,34 @@ export function PosMetricCard({
   tone = "neutral",
   className,
 }: PosMetricCardProps) {
+  const t = POS_METRIC_TONE[tone] ?? POS_METRIC_TONE.neutral;
   return (
     <div
       className={cn(
-        "rounded-[1.25rem] border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-4 py-3",
+        "rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-base)] px-4 py-3",
         className,
       )}
     >
-      <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+      <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--text-muted)]">
         <span
-          className={cn(
-            "inline-flex h-7 w-7 items-center justify-center rounded-full",
-            POS_METRIC_TONE_CLASSNAMES[tone],
-          )}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full"
+          style={{ background: t.bg, color: t.text }}
         >
           <Icon className="h-4 w-4" />
         </span>
         {label}
       </div>
-      <div className="mt-3 font-mono text-[1.05rem] font-semibold text-[var(--text-strong)]">
+      <div className="mt-3 font-mono text-[1.05rem] font-black tabular-nums text-[var(--text-strong)]">
         {value}
       </div>
       {meta ? (
-        <div className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
-          {meta}
-        </div>
+        <div className="mt-1 text-xs leading-5 text-[var(--text-muted)]">{meta}</div>
       ) : null}
     </div>
   );
 }
+
+/* ── PosEmptyState ──────────────────────────────────────────────────────── */
 
 type PosEmptyStateProps = {
   icon: LucideIcon;
@@ -150,14 +233,14 @@ export function PosEmptyState({
   return (
     <div
       className={cn(
-        "flex min-h-[14rem] flex-col items-center justify-center rounded-[1.25rem] border border-dashed border-[var(--border-default)] bg-[var(--surface-muted)] px-5 py-8 text-center",
+        "flex min-h-[14rem] flex-col items-center justify-center rounded-xl border border-dashed border-[var(--edge-default)] bg-[var(--surface-muted)] px-5 py-8 text-center",
         className,
       )}
     >
-      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--surface-base)] text-[var(--action-primary-bg)] shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[var(--surface-base)] text-[var(--action-primary-bg)] shadow-sm">
         <Icon className="h-6 w-6" />
       </div>
-      <h3 className="mt-4 text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
+      <h3 className="mt-4 text-lg font-bold tracking-[-0.02em] text-[var(--text-strong)]">
         {title}
       </h3>
       <p className="mt-2 max-w-[32rem] text-sm leading-6 text-[var(--text-muted)]">
@@ -168,10 +251,23 @@ export function PosEmptyState({
   );
 }
 
+/* ── PosStatusPill ──────────────────────────────────────────────────────── */
+
 type PosStatusPillProps = {
   children: ReactNode;
   tone?: "brand" | "success" | "warning" | "danger" | "neutral";
   className?: string;
+};
+
+const POS_PILL_STYLE: Record<
+  string,
+  { bg: string; ring: string; text: string }
+> = {
+  brand:   { bg: "var(--pos-status-info-bg)",    ring: "var(--pos-status-info-ring)",    text: "var(--pos-status-info-text)" },
+  success: { bg: "var(--pos-status-success-bg)", ring: "var(--pos-status-success-ring)", text: "var(--pos-status-success-text)" },
+  warning: { bg: "var(--pos-status-warning-bg)", ring: "var(--pos-status-warning-ring)", text: "var(--pos-status-warning-text)" },
+  danger:  { bg: "var(--pos-status-danger-bg)",  ring: "var(--pos-status-danger-ring)",  text: "var(--pos-status-danger-text)" },
+  neutral: { bg: "var(--surface-muted)",          ring: "var(--edge-default)",             text: "var(--text-muted)" },
 };
 
 export function PosStatusPill({
@@ -179,20 +275,16 @@ export function PosStatusPill({
   tone = "neutral",
   className,
 }: PosStatusPillProps) {
-  const variant =
-    tone === "brand"
-      ? "brand"
-      : tone === "success"
-        ? "success"
-        : tone === "warning"
-          ? "warning"
-          : tone === "danger"
-            ? "danger"
-            : "neutral";
-
+  const s = POS_PILL_STYLE[tone] ?? POS_PILL_STYLE.neutral;
   return (
-    <Badge variant={variant} className={cn("rounded-full", className)}>
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-semibold ring-1",
+        className,
+      )}
+      style={{ background: s.bg, boxShadow: `inset 0 0 0 1px ${s.ring}`, color: s.text }}
+    >
       {children}
-    </Badge>
+    </span>
   );
 }

--- a/components/retail/portal/pos-reports-view.tsx
+++ b/components/retail/portal/pos-reports-view.tsx
@@ -66,15 +66,32 @@ function ShiftBanner({ shift }: { shift: NonNullable<ReturnType<typeof usePosPor
   const cashSalesFormatted = money(shift.cashSales);
   const nonCashFormatted = money(shift.nonCashSales);
   return (
-    <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-2xl border border-emerald-200 bg-gradient-to-r from-emerald-50 to-emerald-50/50 px-5 py-3.5">
+    <div
+      className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-xl px-5 py-3.5 ring-1"
+      style={{ background: "var(--pos-status-success-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)` }}
+    >
       <div className="flex items-center gap-2">
-        <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.2)]" />
-        <span className="text-[13px] font-bold text-emerald-800">Shift {shift.shiftNo}</span>
-        <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[11px] font-semibold text-emerald-700">
+        <span
+          className="h-2 w-2 rounded-full"
+          style={{ background: "var(--pos-status-success-text)" }}
+        />
+        <span
+          className="text-[13px] font-bold"
+          style={{ color: "var(--pos-status-success-text)" }}
+        >
+          Shift {shift.shiftNo}
+        </span>
+        <span
+          className="rounded px-1.5 py-0.5 text-[11px] font-semibold"
+          style={{ background: "var(--pos-status-success-ring)", color: "var(--pos-status-success-text)" }}
+        >
           {shift.registerName}
         </span>
       </div>
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-[12px] text-emerald-700">
+      <div
+        className="flex flex-wrap items-center gap-x-5 gap-y-1 text-[12px]"
+        style={{ color: "var(--pos-status-success-text)" }}
+      >
         <span>
           <span className="font-bold">{shift.saleCount}</span> sale{shift.saleCount !== 1 ? "s" : ""}
         </span>
@@ -123,10 +140,14 @@ function TrendChip({ value, label }: { value: number; label: string }) {
   if (value === 0) return null;
   const isUp = value > 0;
   return (
-    <span className={cn(
-      "inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[11px] font-semibold",
-      isUp ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-600",
-    )}>
+    <span
+      className="inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[11px] font-semibold ring-1"
+      style={
+        isUp
+          ? { background: "var(--pos-status-success-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)`, color: "var(--pos-status-success-text)" }
+          : { background: "var(--pos-status-danger-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-danger-ring)`, color: "var(--pos-status-danger-text)" }
+      }
+    >
       {isUp ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
       {Math.abs(value).toFixed(0)}% {label}
     </span>

--- a/components/retail/portal/pos-shift-view.tsx
+++ b/components/retail/portal/pos-shift-view.tsx
@@ -6,7 +6,7 @@ import { SearchableSelect } from "@/components/ui/searchable-select";
 import type { SearchableOption } from "@/app/gold/types";
 import { FieldHelp } from "@/components/shared/field-help";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
@@ -16,7 +16,7 @@ import { CheckCircle2, Clock, Payments, TrendingDown, TrendingUp, Wallet } from 
 import { PosNumericField } from "./pos-numeric-field";
 import { PosNumericKeypad } from "./pos-numeric-keypad";
 import { applyPosKeypadAction, type PosKeypadAction } from "./pos-numeric-input";
-import { PosMetricCard, PosPanel, PosPanelHeader, PosStatusPill } from "./pos-primitives";
+import { PosMetricCard, PosPanel, PosPanelHeader, PosStatusPill, PosTerminalHeader } from "./pos-primitives";
 import { usePosPortalState } from "./pos-portal-state";
 import { money, round } from "./pos-utils";
 import { cn } from "@/lib/utils";
@@ -38,14 +38,16 @@ function VarianceBar({ variance, expected }: { variance: number; expected: numbe
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-3">
         <span className="text-[12px] font-semibold text-[var(--text-muted)]">Variance</span>
-        <span className={cn(
-          "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[13px] font-black",
-          isBalanced
-            ? "bg-emerald-100 text-emerald-700"
-            : isOver
-              ? "bg-amber-100 text-amber-700"
-              : "bg-red-100 text-red-700",
-        )}>
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[13px] font-black ring-1"
+          style={
+            isBalanced
+              ? { background: "var(--pos-status-success-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)`, color: "var(--pos-status-success-text)" }
+              : isOver
+                ? { background: "var(--pos-status-warning-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-warning-ring)`, color: "var(--pos-status-warning-text)" }
+                : { background: "var(--pos-status-danger-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-danger-ring)`, color: "var(--pos-status-danger-text)" }
+          }
+        >
           {isBalanced ? (
             <><CheckCircle2 className="h-3.5 w-3.5" /> Balanced</>
           ) : isOver ? (
@@ -55,19 +57,27 @@ function VarianceBar({ variance, expected }: { variance: number; expected: numbe
           )}
         </span>
       </div>
-      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--surface-canvas)] ring-1 ring-[var(--edge-default)]">
         <div
-          className={cn(
-            "h-full rounded-full transition-all duration-300",
-            isBalanced ? "bg-emerald-500" : isOver ? "bg-amber-400" : "bg-red-500",
-          )}
-          style={{ width: isBalanced ? "100%" : `${pct}%`, minWidth: isBalanced ? undefined : "4px" }}
+          className="h-full rounded-full transition-all duration-300"
+          style={{
+            width: isBalanced ? "100%" : `${pct}%`,
+            minWidth: isBalanced ? undefined : "4px",
+            background: isBalanced
+              ? "var(--pos-status-success-text)"
+              : isOver
+                ? "var(--pos-status-warning-text)"
+                : "var(--pos-status-danger-text)",
+          }}
         />
       </div>
       <div className="flex justify-between text-[11px] text-[var(--text-muted)]">
         <span>Expected {money(expected)}</span>
         {!isBalanced && (
-          <span className={isOver ? "text-amber-600" : "text-red-600"}>
+          <span
+            className="font-mono tabular-nums"
+            style={{ color: isOver ? "var(--pos-status-warning-text)" : "var(--pos-status-danger-text)" }}
+          >
             {isOver ? "+" : "−"}{money(Math.abs(variance))}
           </span>
         )}
@@ -210,7 +220,6 @@ export function PosShiftView() {
   });
 
   const variancePreview = round(Number(countedCash || "0") - (currentShift?.expectedCash ?? 0));
-  const varianceIsBalanced = Math.abs(variancePreview) < 0.01;
 
   const handleKeypadAction = (action: PosKeypadAction) => {
     if (!activeNumericTarget) return;
@@ -248,18 +257,26 @@ export function PosShiftView() {
 
           {/* Closeout result banner */}
           {closeoutSummary && (
-            <div className={cn(
-              "mb-5 flex items-center gap-4 rounded-2xl px-5 py-4",
-              Math.abs(closeoutSummary.variance) < 0.01
-                ? "border border-emerald-200 bg-emerald-50"
-                : closeoutSummary.variance > 0
-                  ? "border border-amber-200 bg-amber-50"
-                  : "border border-red-100 bg-red-50",
-            )}>
-              <CheckCircle2 className={cn(
-                "h-6 w-6 shrink-0",
-                Math.abs(closeoutSummary.variance) < 0.01 ? "text-emerald-600" : closeoutSummary.variance > 0 ? "text-amber-600" : "text-red-500",
-              )} />
+            <div
+              className="mb-5 flex items-center gap-4 rounded-xl px-5 py-4 ring-1"
+              style={
+                Math.abs(closeoutSummary.variance) < 0.01
+                  ? { background: "var(--pos-status-success-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-success-ring)` }
+                  : closeoutSummary.variance > 0
+                    ? { background: "var(--pos-status-warning-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-warning-ring)` }
+                    : { background: "var(--pos-status-danger-bg)", boxShadow: `inset 0 0 0 1px var(--pos-status-danger-ring)` }
+              }
+            >
+              <CheckCircle2
+                className="h-6 w-6 shrink-0"
+                style={{
+                  color: Math.abs(closeoutSummary.variance) < 0.01
+                    ? "var(--pos-status-success-text)"
+                    : closeoutSummary.variance > 0
+                      ? "var(--pos-status-warning-text)"
+                      : "var(--pos-status-danger-text)",
+                }}
+              />
               <div>
                 <div className="text-sm font-bold text-[var(--text-strong)]">
                   {closeoutSummary.shiftNo} closed
@@ -339,13 +356,11 @@ export function PosShiftView() {
 
       {/* ══ Open Shift Dialog ══════════════════════════════════════════ */}
       <Dialog open={openDialog} onOpenChange={setOpenDialog}>
-        <DialogContent className="sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle>Open shift</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
+        <DialogContent className="sm:max-w-xl p-0 overflow-hidden">
+          <PosTerminalHeader eyebrow="Shift" title="Open shift" subtitle="Select a register and enter the opening float" />
+          <div className="space-y-4 p-5">
             {/* Shift number */}
-            <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+            <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
               <div className="flex items-center justify-between gap-3 mb-3">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
                   Shift number
@@ -362,7 +377,7 @@ export function PosShiftView() {
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_260px]">
               <div className="space-y-4">
                 {/* Register */}
-                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Register details</p>
                   <div className="space-y-3">
                     <SearchableSelect
@@ -400,7 +415,7 @@ export function PosShiftView() {
                 </div>
 
                 {/* Float */}
-                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <p className="mb-1 text-[13px] font-bold text-[var(--text-strong)]">Opening float</p>
                   <p className="mb-3 text-xs text-[var(--text-muted)]">Cash placed in the drawer before trading starts.</p>
                   <PosNumericField
@@ -413,7 +428,7 @@ export function PosShiftView() {
               </div>
 
               {/* Keypad */}
-              <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+              <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                 <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Keypad</p>
                 <PosNumericKeypad onAction={handleKeypadAction} />
               </div>
@@ -439,35 +454,13 @@ export function PosShiftView() {
       {/* ══ Close Shift Dialog ════════════════════════════════════════ */}
       <Dialog open={closeDialog} onOpenChange={setCloseDialog}>
         <DialogContent className="sm:max-w-lg p-0 overflow-hidden">
-          {/* Header */}
-          <div className={cn(
-            "px-6 pt-6 pb-5 border-b",
-            varianceIsBalanced
-              ? "bg-gradient-to-r from-emerald-50 to-transparent border-emerald-100"
-              : variancePreview > 0
-                ? "bg-gradient-to-r from-amber-50 to-transparent border-amber-100"
-                : "bg-gradient-to-r from-red-50 to-transparent border-red-100",
-          )}>
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                  Closeout
-                </p>
-                <h3 className="mt-1 text-lg font-bold text-[var(--text-strong)]">
-                  {currentShift?.shiftNo ?? "Close shift"}
-                </h3>
-                <p className="mt-0.5 text-sm text-[var(--text-muted)]">
-                  {currentShift?.registerName} · {currentShift?.site?.name}
-                </p>
-              </div>
-              <div className="text-right shrink-0">
-                <div className="text-[11px] text-[var(--text-muted)]">Net sales</div>
-                <div className="font-mono text-xl font-black text-[var(--text-strong)]">
-                  {money(currentShift?.netSalesValue ?? 0)}
-                </div>
-              </div>
-            </div>
-          </div>
+          <PosTerminalHeader
+            eyebrow="Closeout"
+            title={currentShift?.shiftNo ?? "Close shift"}
+            subtitle={[currentShift?.registerName, currentShift?.site?.name].filter(Boolean).join(" · ")}
+            valuePrimary={money(currentShift?.netSalesValue ?? 0)}
+            valueSecondary="Net sales"
+          />
 
           <div className="p-5 space-y-4">
             {/* Shift summary */}
@@ -491,7 +484,7 @@ export function PosShiftView() {
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_240px]">
               <div className="space-y-4">
                 {/* Counted cash input */}
-                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <p className="mb-1 text-[13px] font-bold text-[var(--text-strong)]">Count the drawer</p>
                   <p className="mb-3 text-xs text-[var(--text-muted)]">Tap the field, count the physical cash, enter the total.</p>
                   <PosNumericField
@@ -503,7 +496,7 @@ export function PosShiftView() {
                 </div>
 
                 {/* Live variance bar */}
-                <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+                <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                   <VarianceBar
                     variance={variancePreview}
                     expected={currentShift?.expectedCash ?? 0}
@@ -526,7 +519,7 @@ export function PosShiftView() {
               </div>
 
               {/* Keypad */}
-              <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-muted)] px-4 py-4">
+              <div className="rounded-xl border border-[var(--edge-subtle)] bg-[var(--surface-muted)] px-4 py-4">
                 <p className="mb-3 text-[13px] font-bold text-[var(--text-strong)]">Keypad</p>
                 <PosNumericKeypad onAction={handleKeypadAction} />
               </div>
@@ -539,11 +532,12 @@ export function PosShiftView() {
               type="button"
               onClick={() => closeShiftMutation.mutate()}
               disabled={closeShiftMutation.isPending}
-              className={cn(
-                varianceIsBalanced
-                  ? "bg-emerald-600 hover:bg-emerald-700"
-                  : "bg-amber-500 hover:bg-amber-600",
-              )}
+              style={{
+                background: "var(--pos-cta-bg)",
+                color: "var(--pos-cta-text)",
+                boxShadow: "0 3px 0 var(--pos-cta-shadow)",
+              }}
+              className="active:translate-y-[2px] active:shadow-none"
             >
               Close shift
             </Button>


### PR DESCRIPTION
…OS module

RBAC (Track B)
- Add requireRetailManager / requireRetailStock / requireRetailPos guards to _helpers.ts
- Gate every POST/PATCH/PUT/DELETE under app/api/v2/retail/** with the correct role
- Replace inlined role strings in setup/operations, pos-policy, tender-policy
- Add dispatcher-level requireRetailPos to pos/sync/route.ts

Accounting (Track C)
- postRetailJournal now accepts { throwOnFail } for atomic tx use
- Eliminate status "IGNORED" from stock/transfers (→ POSTED)

Form friction (Track D)
- Catalog dialog: 2 visible fields by default; Advanced section collapses rest; sell price auto-prefills from inventory unitCost; submit blocked on invalid price
- Inline quick-create stock item sub-dialog (POST /api/inventory/items) so catalog setup never leaves the page; "Save and add another" for batch mode
- Promotions dialog: 3 visible fields; startsAt defaults to now; status hidden on create
- Purchase orders: item picker auto-fills unitCost; submit blocked on invalid lines

POS terminal redesign (Phases 1-13)
- globals.css: ms (520px) + 3xl (1920px) breakpoints; 60-token .pos-terminal block with dark-mode @media override; physical-key, tender-family, LCD, status-banner, CTA, and rail token families
- Layout frame: dark rail (desktop) + dark bottom tab bar with accent stripe (mobile); safe-area insets; pos-terminal scoping class on outer wrapper
- Primitives: PosTerminalHeader (dark instrument panel for every dialog/sheet); PosNumericField LCD style; PosNumericKeypad physical-press with token-per-key-family; PosPanel/PosMetricCard/PosStatusPill/PosEmptyState arbitrary-radius-free
- All 9 views updated: login wrapper, checkout TenderButton token-driven physical press, overview dark table header + token action cards, held card dark instrument headers, history receipt dialog PosTerminalHeader, reports ShiftBanner/TrendChip flat-ringed, shift VarianceBar + closeout header token-driven, customers LCD search + ringed cards, price-check dark hero panel + LCD search
- Zero pastel gradient dialog headers remaining
- Zero arbitrary rounded-[x.xrem] classes remaining
- Zero TENDER_TYPE_STYLES hardcoded pastel map remaining

Build: pnpm build exits 0, npx tsc --noEmit clean