### PR TITLE
feat(auth): redesign sign-in page to Corelith split layout

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -3,18 +3,18 @@
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { normalizeCallbackUrl } from "@/lib/auth-redirect";
-import { Shield, AlertCircle } from "@/lib/icons";
+import {
+  AlertCircle,
+  Eye,
+  EyeOff,
+  Hexagon,
+  Lock,
+  Mail,
+} from "@/lib/icons";
 
 type LoginFormProps = {
   companyLabel: string;
@@ -81,6 +81,7 @@ export function LoginForm({
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [rememberMe, setRememberMe] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const resolvedCallbackUrl = normalizeCallbackUrl(callbackUrl, "/");
@@ -119,93 +120,271 @@ export function LoginForm({
   };
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-6">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center space-y-2">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-md bg-primary/10 text-primary">
-            <Shield className="h-6 w-6" />
+    <div className="min-h-svh grid grid-cols-1 md:grid-cols-[520px_1fr] bg-[var(--surface-canvas)]">
+      <aside className="relative hidden md:flex flex-col overflow-hidden bg-[var(--primary)] px-11 py-12 text-white">
+        <div
+          aria-hidden
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 18% 20%, rgba(255,255,255,0.18), transparent 40%), radial-gradient(circle at 82% 78%, rgba(8,55,156,0.45), transparent 50%)",
+          }}
+        />
+        <div
+          aria-hidden
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)",
+            backgroundSize: "32px 32px",
+            maskImage:
+              "radial-gradient(ellipse 110% 70% at 50% 30%, black, transparent 80%)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 110% 70% at 50% 30%, black, transparent 80%)",
+          }}
+        />
+        <div className="relative flex h-full flex-col">
+          <span className="inline-flex items-center gap-3 text-[22px] font-semibold tracking-tight text-white">
+            <Hexagon className="size-[22px] text-white" weight="fill" />
+            Huchu
+          </span>
+          <h2 className="mt-auto mb-6 max-w-[16ch] text-[44px] font-semibold leading-[1.05] tracking-tight text-balance text-white">
+            The operating layer for the companies that actually move things.
+          </h2>
+          <p className="mb-8 max-w-[38ch] text-base leading-relaxed text-white/75">
+            One ledger. One workflow. One audit trail across every site, every
+            shift, every reconciliation.
+          </p>
+          <div className="flex items-center gap-4 text-xs text-white/60">
+            <span>SOC 2 Type II</span>
+            <span className="size-1.5 rounded-full bg-white/40" aria-hidden />
+            <span>ISO 27001</span>
+            <span className="size-1.5 rounded-full bg-white/40" aria-hidden />
+            <span>POPIA-ready</span>
           </div>
-          <h1 className="text-2xl font-semibold">{companyLabel}</h1>
-          {productLabel ? (
-            <p className="text-sm text-muted-foreground">{productLabel}</p>
-          ) : null}
+        </div>
+      </aside>
+
+      <main className="flex flex-col px-6 py-10 md:px-14 md:py-12">
+        <div className="hidden md:flex items-center justify-between text-sm text-[var(--text-muted)]">
+          <span>
+            Need help?{" "}
+            <a
+              href="#"
+              data-stub
+              className="font-medium text-[var(--primary-700)] hover:underline"
+            >
+              Contact support
+            </a>
+          </span>
+          <span>
+            No account?{" "}
+            <a
+              href="#"
+              data-stub
+              className="font-medium text-[var(--primary-700)] hover:underline"
+            >
+              Request a workspace
+            </a>
+          </span>
         </div>
 
-        <Card>
-          <CardHeader className="space-y-1 text-center">
-            <CardTitle>Sign In</CardTitle>
-            <CardDescription>
-              Secure access for authorized personnel only
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              {error && (
-                <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3">
-                  <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
-                  <p className="text-sm text-destructive">{error}</p>
-                </div>
-              )}
+        <div className="my-auto w-full max-w-[380px] pt-10 md:pt-0">
+          <div className="md:hidden mb-8 flex items-center gap-3 text-[18px] font-semibold tracking-tight text-[var(--text-strong)]">
+            <span className="grid size-9 place-items-center rounded-md bg-[var(--primary)] text-white">
+              <Hexagon className="size-5" weight="fill" />
+            </span>
+            Huchu
+          </div>
 
-              <div className="space-y-2">
-                <label htmlFor="email" className="text-sm font-semibold">
-                  Email
-                </label>
+          <h1 className="text-[30px] font-semibold tracking-tight leading-tight text-[var(--text-strong)]">
+            Sign in to {productLabel ?? companyLabel}
+          </h1>
+          <p className="mt-2 mb-8 text-sm text-[var(--text-muted)]">
+            Welcome back. Pick up where you left off.
+          </p>
+
+          {error ? (
+            <div
+              role="alert"
+              className="mb-5 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3"
+            >
+              <AlertCircle className="mt-0.5 size-5 shrink-0 text-destructive" />
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-3 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled
+              title="Coming soon"
+              aria-label="Sign in with Google (coming soon)"
+              className="h-10 gap-1.5 px-2 text-[13px] font-medium"
+            >
+              <span className="font-bold text-[#4285F4]">G</span>
+              Google
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled
+              title="Coming soon"
+              aria-label="Sign in with Microsoft (coming soon)"
+              className="h-10 gap-1.5 px-2 text-[13px] font-medium"
+            >
+              <span
+                aria-hidden
+                className="inline-grid grid-cols-2 gap-[1px]"
+                style={{ width: 12, height: 12 }}
+              >
+                <span style={{ background: "#F25022" }} />
+                <span style={{ background: "#7FBA00" }} />
+                <span style={{ background: "#00A4EF" }} />
+                <span style={{ background: "#FFB900" }} />
+              </span>
+              Microsoft
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled
+              title="Coming soon"
+              aria-label="Sign in with SAML SSO (coming soon)"
+              className="h-10 gap-1.5 px-2 text-[13px] font-medium"
+            >
+              <Lock className="size-3.5" />
+              SAML SSO
+            </Button>
+          </div>
+
+          <div className="my-4 flex items-center gap-3 text-xs text-[var(--text-subtle)]">
+            <span className="h-px flex-1 bg-[var(--border-default)]" />
+            or with email
+            <span className="h-px flex-1 bg-[var(--border-default)]" />
+          </div>
+
+          <form onSubmit={handleSubmit} className="grid gap-3.5">
+            <div className="grid gap-1.5">
+              <label
+                htmlFor="login-email"
+                className="text-[13px] font-medium text-[var(--text-strong)]"
+              >
+                Work email
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-[var(--text-subtle)]" />
                 <Input
-                  id="email"
+                  id="login-email"
                   type="email"
-                  placeholder="name@example.com"
+                  autoComplete="email"
+                  placeholder={`you@${companyLabel
+                    .toLowerCase()
+                    .replace(/\s+/g, "")}.com`}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
                   disabled={loading}
+                  className="h-10 pl-10"
                 />
               </div>
+            </div>
 
-              <div className="space-y-2">
-                <label htmlFor="password" className="text-sm font-semibold">
+            <div className="grid gap-1.5">
+              <div className="flex items-baseline justify-between">
+                <label
+                  htmlFor="login-password"
+                  className="text-[13px] font-medium text-[var(--text-strong)]"
+                >
                   Password
                 </label>
+                <a
+                  href="#"
+                  data-stub
+                  className="text-xs font-medium text-[var(--primary-700)] hover:underline"
+                >
+                  Forgot?
+                </a>
+              </div>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-[var(--text-subtle)]" />
                 <Input
-                  id="password"
-                  type="password"
-                  placeholder="********"
+                  id="login-password"
+                  type={showPassword ? "text" : "password"}
+                  autoComplete="current-password"
+                  placeholder="••••••••••••"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   disabled={loading}
+                  className="h-10 pl-10 pr-10"
                 />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-subtle)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                  aria-label={
+                    showPassword ? "Hide password" : "Show password"
+                  }
+                >
+                  {showPassword ? (
+                    <EyeOff className="size-4" />
+                  ) : (
+                    <Eye className="size-4" />
+                  )}
+                </button>
               </div>
-
-              {rememberMeEnabled ? (
-                <label className="flex items-center gap-3 rounded-md border border-border/60 px-3 py-2 text-sm">
-                  <Checkbox
-                    checked={rememberMe}
-                    onCheckedChange={(checked) => setRememberMe(checked === true)}
-                    disabled={loading}
-                  />
-                  <span>Remember me on this device</span>
-                </label>
-              ) : null}
-
-              <Button
-                type="submit"
-                className="w-full"
-                size="lg"
-                disabled={loading}
-              >
-                {loading ? "Signing in..." : "Sign In"}
-              </Button>
-            </form>
-
-            <div className="mt-6 pt-6 border-t">
-              <p className="text-xs text-center text-muted-foreground">
-                Contact your administrator if you need access
-              </p>
             </div>
-          </CardContent>
-        </Card>
-      </div>
+
+            {rememberMeEnabled ? (
+              <label
+                htmlFor="login-remember"
+                className="mt-1 flex items-center gap-2 text-sm text-[var(--text-body)] cursor-pointer"
+              >
+                <Checkbox
+                  id="login-remember"
+                  checked={rememberMe}
+                  onCheckedChange={(checked) =>
+                    setRememberMe(checked === true)
+                  }
+                  disabled={loading}
+                />
+                <span>Keep me signed in on this device</span>
+              </label>
+            ) : null}
+
+            <Button
+              type="submit"
+              size="lg"
+              className="mt-3 h-11 w-full text-[15px]"
+              disabled={loading}
+            >
+              {loading ? "Signing in…" : "Sign in"}
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-xs text-[var(--text-muted)]">
+            By continuing you agree to the{" "}
+            <a
+              href="#"
+              data-stub
+              className="font-medium text-[var(--primary-700)] hover:underline"
+            >
+              Terms
+            </a>{" "}
+            and{" "}
+            <a
+              href="#"
+              data-stub
+              className="font-medium text-[var(--primary-700)] hover:underline"
+            >
+              Privacy Policy
+            </a>
+            .
+          </p>
+        </div>
+      </main>
     </div>
   );
 }

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -233,6 +233,9 @@ export const Download = createPhosphorIcon("DownloadSimple", "Download");
 export const EditSquare = createPhosphorIcon("NotePencil", "EditSquare");
 export const EventNote = createPhosphorIcon("Note", "EventNote");
 export const Eye = createPhosphorIcon("Eye", "Eye");
+export const EyeOff = createPhosphorIcon("EyeSlash", "EyeOff");
+export const Mail = createPhosphorIcon("Envelope", "Mail");
+export const Hexagon = createPhosphorIcon("Hexagon", "Hexagon");
 export const ExternalLink = createPhosphorIcon(
   "ArrowSquareOut",
   "ExternalLink",


### PR DESCRIPTION
Replace the centered shadcn Card with a brand-panel-left, form-right split layout (SI.01 from the Corelith design kit). Adds a disabled SSO row (Google/Microsoft/SAML — "Coming soon"), inline leading icons on email/password, password show/hide toggle, and a mobile-collapsed brand header. All existing auth wiring (precheck, signIn, error mapping, rememberMe, props surface) is preserved.