### PR TITLE
fix(workspaces): stop mining features leaking into non-mining workspaces

### DIFF
--- a/components/admin-portal/pages/client-data.ts
+++ b/components/admin-portal/pages/client-data.ts
@@ -15,11 +15,14 @@ export type EnrichedClient = CompanyWorkspace & {
 };
 
 const STATUS_ORDER: ClientStatus[] = ["ACTIVE", "EXPIRING_SOON", "IN_GRACE", "PAST_DUE", "CANCELED"];
+// Placeholder enrichment rotation for the demo client list. Only
+// cross-vertical bundles belong here: rotating vertical suites (gold,
+// schools, autos, retail, scrap) onto arbitrary companies implies a
+// workspace vertical the company does not have.
 const ADDON_ROTATION: FeatureBundleDefinition["code"][] = [
   "ADDON_CUSTOM_BRANDING",
   "ADDON_CCTV_SUITE",
   "ADDON_ADVANCED_PAYROLL",
-  "ADDON_GOLD_ADVANCED",
   "ADDON_COMPLIANCE_PRO",
   "ADDON_MAINTENANCE_PRO",
   "ADDON_USER_MANAGEMENT_PRO",
@@ -27,11 +30,7 @@ const ADDON_ROTATION: FeatureBundleDefinition["code"][] = [
   "ADDON_ACCOUNTING_CORE",
   "ADDON_ACCOUNTING_ADVANCED",
   "ADDON_ZIMRA_FISCAL",
-  "ADDON_SCHOOLS_SUITE",
-  "ADDON_AUTOS_SUITE",
-  "ADDON_RETAIL_SUITE",
   "ADDON_PORTAL_SUITE",
-  "ADDON_SCRAP_METAL_SUITE",
 ];
 
 export function computeMonthlyTotal(tier: TierDefinition, addonCodes: string[], activeSites: number) {

--- a/components/admin-portal/pages/templates-page.tsx
+++ b/components/admin-portal/pages/templates-page.tsx
@@ -3,17 +3,23 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { CLIENT_BUNDLE_TEMPLATES, getClientTemplateBundleCodes } from "@/lib/platform/client-templates";
+import { getBundleDefinition, getTierDefinition } from "@/lib/platform/feature-catalog";
 
-const templates = [
-  { name: "Core Starter", tier: "Basic", bundles: ["Custom Branding"], highlights: ["Shift reports", "Attendance", "Inventory"] },
-  { name: "Gold Mine", tier: "Standard", bundles: ["Gold Advanced", "Analytics Pro"], highlights: ["Gold chain of custody", "Exceptions", "Audit trail"] },
-  { name: "Small Business Security", tier: "Standard", bundles: ["CCTV Suite", "User Management Pro"], highlights: ["Live view", "Playback", "User onboarding"] },
-  { name: "Tech Workshop", tier: "Standard", bundles: ["Maintenance Pro", "Analytics Pro"], highlights: ["Work orders", "Preventive schedule", "Downtime analytics"] },
-  { name: "Schools", tier: "Enterprise", bundles: ["Schools Suite", "Portal Suite"], highlights: ["Admissions", "Results", "Parent/Student portals"] },
-  { name: "Car Sales", tier: "Standard", bundles: ["Auto Sales Suite", "Portal Suite"], highlights: ["Inventory", "Leads", "Deals"] },
-  { name: "Retail", tier: "Standard", bundles: ["Retail Suite", "Portal Suite"], highlights: ["POS", "Catalog", "Cash-up"] },
-  { name: "All Features", tier: "Enterprise", bundles: ["All bundles"], highlights: ["Everything on"] },
-];
+// Derived from the canonical template catalog so admin copy can never drift
+// from what a template actually provisions.
+const templates = CLIENT_BUNDLE_TEMPLATES.map((template) => ({
+  code: template.code,
+  name: template.label,
+  description: template.description,
+  tier: getTierDefinition(template.recommendedTierCode)?.name ?? template.recommendedTierCode,
+  bundles: template.includeAllFeatures
+    ? ["All bundles"]
+    : getClientTemplateBundleCodes(template.code).map(
+        (bundleCode) => getBundleDefinition(bundleCode)?.name ?? bundleCode,
+      ),
+  highlights: template.targetClients,
+}));
 
 export function TemplatesPage() {
   return (
@@ -25,7 +31,7 @@ export function TemplatesPage() {
 
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
         {templates.map((template) => (
-          <Card key={template.name} className="border-[var(--border)]">
+          <Card key={template.code} className="border-[var(--border)]">
             <CardHeader className="space-y-1">
               <CardTitle className="text-base">{template.name}</CardTitle>
               <CardDescription>Tier: {template.tier}</CardDescription>
@@ -36,6 +42,7 @@ export function TemplatesPage() {
               </div>
             </CardHeader>
             <CardContent className="space-y-3">
+              <p className="text-sm text-[var(--text-muted)]">{template.description}</p>
               <ul className="list-disc space-y-1 pl-5 text-sm text-[var(--text-muted)]">
                 {template.highlights.map((item) => (
                   <li key={item}>{item}</li>

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -60,14 +60,6 @@ export type NavSection = {
   items: NavItem[];
 };
 
-export type QuickAction = {
-  href: string;
-  label: string;
-  description: string;
-  icon: LucideIcon;
-  roles?: UserRole[];
-};
-
 export const navSections: NavSection[] = [
   {
     id: "overview",
@@ -79,8 +71,8 @@ export const navSections: NavSection[] = [
   },
   {
     id: "daily",
-    title: "Quick Actions",
-    description: "Daily forms and stock tasks",
+    title: "Daily Operations",
+    description: "Mining shift, attendance, and plant capture",
     items: [
       {
         href: "/shift-report",
@@ -96,18 +88,6 @@ export const navSections: NavSection[] = [
         href: "/plant-report",
         icon: Factory,
         label: "Submit Plant Report",
-      },
-      { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
-      { href: "/stores/issue", icon: ArrowUpward, label: "Issue Stock" },
-      {
-        href: "/gold/intake/pours/new",
-        icon: Dataset,
-        label: "Log Gold Output",
-      },
-      {
-        href: "/gold/intake/purchases/new",
-        icon: Payments,
-        label: "Record Gold Purchase",
       },
     ],
   },
@@ -418,47 +398,6 @@ export const navSections: NavSection[] = [
   },
 ];
 
-const quickActions: QuickAction[] = [
-  {
-    href: "/shift-report",
-    label: "Shift Report",
-    description: "Submit today's shift output",
-    icon: NoteAdd,
-  },
-  {
-    href: "/attendance",
-    label: "Attendance",
-    description: "Mark today's crew attendance",
-    icon: UserCheck,
-  },
-  {
-    href: "/stores/receive",
-    label: "Receive Stock",
-    description: "Log incoming stock",
-    icon: ArrowDownward,
-  },
-  {
-    href: "/stores/issue",
-    label: "Issue Stock",
-    description: "Record stock issue",
-    icon: ArrowUpward,
-  },
-  {
-    href: "/gold/intake/pours/new",
-    label: "Log Gold Output",
-    description: "Record gold produced for the shift",
-    icon: Dataset,
-    roles: ["SUPERADMIN", "MANAGER"],
-  },
-  {
-    href: "/gold/intake/purchases/new",
-    label: "Record Purchase",
-    description: "Capture gold bought from walk-in sellers",
-    icon: Payments,
-    roles: ["SUPERADMIN", "MANAGER"],
-  },
-];
-
 export function getNavSectionsForRole(role: string | null | undefined) {
   return navSections
     .map((section) => ({
@@ -468,10 +407,4 @@ export function getNavSectionsForRole(role: string | null | undefined) {
       ),
     }))
     .filter((section) => section.items.length > 0);
-}
-
-export function getQuickActionsForRole(role: string | null | undefined) {
-  return quickActions.filter((action) =>
-    action.roles ? hasRole(role, action.roles) : true,
-  );
 }

--- a/lib/platform/client-templates.ts
+++ b/lib/platform/client-templates.ts
@@ -20,6 +20,19 @@ export interface ClientBundleTemplateDefinition {
 
 const allBundleCodes = FEATURE_BUNDLES.map((bundle) => bundle.code);
 
+// Mining-only daily capture surfaces. These began life as the original
+// mine-focused build and must never reach non-mining verticals, so every
+// non-mining template disables them explicitly even though none of their
+// bundles grant them anymore.
+const MINE_DAILY_OPS_FEATURE_KEYS = [
+  "ops.shift-report.submit",
+  "ops.attendance.mark",
+  "ops.plant-report.submit",
+  "reports.shift",
+  "reports.attendance",
+  "reports.plant",
+] as const;
+
 export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
   {
     code: "TEMPLATE_CORE_STARTER",
@@ -30,6 +43,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     bundleCodes: ["ADDON_OPERATIONS_CORE", "ADDON_STORES_CORE", "ADDON_WORKFORCE_CORE"],
     featureKeys: [],
     verticalProductId: "general-business",
+    disabledFeatureKeys: [...MINE_DAILY_OPS_FEATURE_KEYS],
   },
   {
     code: "TEMPLATE_GOLD_MINE",
@@ -39,6 +53,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     recommendedTierCode: "ENTERPRISE",
     bundleCodes: [
       "ADDON_OPERATIONS_CORE",
+      "ADDON_MINE_DAILY_OPS",
       "ADDON_STORES_CORE",
       "ADDON_WORKFORCE_CORE",
       "ADDON_GOLD_CORE",
@@ -65,6 +80,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     ],
     featureKeys: [],
     verticalProductId: "multi-site-operations",
+    disabledFeatureKeys: [...MINE_DAILY_OPS_FEATURE_KEYS],
   },
   {
     code: "TEMPLATE_TECH_WORKSHOP",
@@ -81,6 +97,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     ],
     featureKeys: [],
     verticalProductId: "service-workshop",
+    disabledFeatureKeys: [...MINE_DAILY_OPS_FEATURE_KEYS],
   },
   {
     code: "TEMPLATE_SCRAP_METAL",
@@ -92,6 +109,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     featureKeys: [],
     verticalProductId: "scrap-recycling",
     disabledFeatureKeys: [
+      ...MINE_DAILY_OPS_FEATURE_KEYS,
       "stores.fuel-ledger",
       "maintenance.dashboard",
       "maintenance.equipment",
@@ -211,7 +229,13 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     bundleCodes: ["ADDON_AUTOS_SUITE", "ADDON_PORTAL_SUITE"],
     featureKeys: [],
     verticalProductId: "auto-sales",
-    disabledFeatureKeys: ["schools.core", "retail.core", "portal.schools", "portal.pos"],
+    disabledFeatureKeys: [
+      ...MINE_DAILY_OPS_FEATURE_KEYS,
+      "schools.core",
+      "retail.core",
+      "portal.schools",
+      "portal.pos",
+    ],
   },
   {
     code: "TEMPLATE_RETAIL",
@@ -230,6 +254,7 @@ export const CLIENT_BUNDLE_TEMPLATES: ClientBundleTemplateDefinition[] = [
     featureKeys: [],
     verticalProductId: "retail-operations",
     disabledFeatureKeys: [
+      ...MINE_DAILY_OPS_FEATURE_KEYS,
       "stores.fuel-ledger",
       "schools.core",
       "autos.core",
@@ -387,6 +412,8 @@ export function getClientTemplateWorkspaceProfile(code: string | null | undefine
     case "TEMPLATE_RETAIL":
       return "RETAIL";
     case "TEMPLATE_CORE_STARTER":
+    case "TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK":
+    case "TEMPLATE_TECH_WORKSHOP":
     case "TEMPLATE_ALL_FEATURES":
       return "GENERAL";
     default:

--- a/lib/platform/entitlements.ts
+++ b/lib/platform/entitlements.ts
@@ -155,12 +155,14 @@ export async function syncEntitlementCatalog(): Promise<{
         select: { id: true },
       });
 
+      const bundleFeatureIds: string[] = [];
       for (const featureKey of bundle.features) {
         const feature = await tx.platformFeature.findUnique({
           where: { key: featureKey },
           select: { id: true },
         });
         if (!feature) continue;
+        bundleFeatureIds.push(feature.id);
         await tx.featureBundleItem.upsert({
           where: {
             bundleId_featureId: {
@@ -175,6 +177,16 @@ export async function syncEntitlementCatalog(): Promise<{
           },
         });
       }
+
+      // Prune items removed from the in-code bundle definition so DB-backed
+      // entitlement resolution can never re-grant features a bundle no longer
+      // includes (e.g. mining ops capture removed from ADDON_OPERATIONS_CORE).
+      await tx.featureBundleItem.deleteMany({
+        where: {
+          bundleId: saved.id,
+          featureId: { notIn: bundleFeatureIds },
+        },
+      });
     }
 
     for (const tier of TIERS) {

--- a/lib/platform/feature-catalog.ts
+++ b/lib/platform/feature-catalog.ts
@@ -200,18 +200,27 @@ export const FEATURE_BUNDLES: FeatureBundleDefinition[] = [
   {
     code: "ADDON_OPERATIONS_CORE",
     name: "Operations Core",
-    description: "Daily operations capture and operational reporting.",
+    description: "Operational reporting home and site/section administration.",
+    monthlyPrice: 0,
+    additionalSiteMonthlyPrice: 0,
+    features: [
+      "reports.dashboard",
+      "admin.sites-sections",
+    ],
+  },
+  {
+    code: "ADDON_MINE_DAILY_OPS",
+    name: "Mine Daily Operations",
+    description: "Mining shift, crew attendance, and plant capture with matching reports.",
     monthlyPrice: 0,
     additionalSiteMonthlyPrice: 0,
     features: [
       "ops.shift-report.submit",
       "ops.attendance.mark",
       "ops.plant-report.submit",
-      "reports.dashboard",
       "reports.shift",
       "reports.attendance",
       "reports.plant",
-      "admin.sites-sections",
     ],
   },
   {

--- a/lib/platform/gating/route-registry.ts
+++ b/lib/platform/gating/route-registry.ts
@@ -169,6 +169,10 @@ export const PAGE_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "page", prefix: "/attendance", featureKey: "ops.attendance.mark" },
   { scope: "page", prefix: "/shift-report", featureKey: "ops.shift-report.submit" },
   { scope: "page", prefix: "/plant-report", featureKey: "ops.plant-report.submit" },
+  // The production dashboard is built entirely on plant reports; gate it with
+  // the same mining reporting feature so it never fail-opens into non-mining
+  // workspaces.
+  { scope: "page", prefix: "/dashboard", featureKey: "reports.plant" },
 
   { scope: "page", prefix: "/reports/cctv-events", featureKey: "reports.cctv-events" },
   { scope: "page", prefix: "/reports/compliance-incidents", featureKey: "reports.compliance-incidents" },

--- a/lib/primary-actions.ts
+++ b/lib/primary-actions.ts
@@ -2,8 +2,13 @@ import type { NavItem } from "@/lib/navigation";
 import { hasRole } from "@/lib/roles";
 import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 import {
+  resolveWorkspaceVerticalProductBundle,
+  type VerticalProductId,
+} from "@/lib/workspace-products";
+import {
   BarChart3,
   ArrowDownward,
+  ArrowUpward,
   Building2,
   Calendar,
   ClipboardList,
@@ -14,8 +19,11 @@ import {
   Package,
   Payments,
   ReceiptLong,
+  ReportProblem,
   Users,
+  Video,
   Wallet,
+  Wrench,
 } from "@/lib/icons";
 
 type PrimaryActionsArgs = {
@@ -24,54 +32,12 @@ type PrimaryActionsArgs = {
   enabledFeatures: string[] | undefined;
 };
 
-type WorkspaceProfileKey =
-  | "GOLD_MINE"
-  | "SCRAP_METAL"
-  | "SCHOOLS"
-  | "AUTOS"
-  | "RETAIL"
-  | "GENERAL";
-
-function normalizeWorkspaceProfile(value: string | null | undefined): WorkspaceProfileKey {
-  const normalized = String(value || "").trim().toUpperCase();
-
-  if (normalized === "SCRAP" || normalized === "SCRAP-METAL" || normalized === "SCRAPMETAL" || normalized === "SCRAP_METAL") {
-    return "SCRAP_METAL";
-  }
-  if (normalized === "GOLD" || normalized === "GOLD-MINE" || normalized === "GOLDMINE" || normalized === "GOLD_MINE") {
-    return "GOLD_MINE";
-  }
-  if (normalized === "SCHOOL" || normalized === "SCHOOLS") {
-    return "SCHOOLS";
-  }
-  if (
-    normalized === "AUTO" ||
-    normalized === "CAR_SALES" ||
-    normalized === "CAR-SALES" ||
-    normalized === "CARSALES" ||
-    normalized === "AUTOS"
-  ) {
-    return "AUTOS";
-  }
-  if (normalized === "RETAIL" || normalized === "THRIFT") {
-    return "RETAIL";
-  }
-
-  return "GENERAL";
-}
-
-const GENERAL_PRIMARY_ACTIONS: NavItem[] = [
-  { href: "/shift-report", icon: Dataset, label: "Shift Report" },
-  { href: "/attendance", icon: Calendar, label: "Attendance" },
-  { href: "/plant-report", icon: Factory, label: "Plant Report" },
-  { href: "/stores/receive", icon: LocalShipping, label: "Receive Stock" },
-  { href: "/stores/issue", icon: Package, label: "Issue Stock" },
-  { href: "/gold/intake/pours/new", icon: Coins, label: "Log Gold Output" },
-  { href: "/gold/intake/purchases/new", icon: Payments, label: "Record Purchase" },
-];
-
-const PROFILE_PRIMARY_ACTIONS: Record<Exclude<WorkspaceProfileKey, "GENERAL">, NavItem[]> = {
-  GOLD_MINE: [
+// Quick-create actions are keyed by the resolved vertical product so every
+// workspace only ever offers actions native to its own modules. Items are
+// additionally filtered by role and by the tenant's enabled features (via the
+// route registry), so an action never renders for a feature the tenant lacks.
+const PRODUCT_PRIMARY_ACTIONS: Record<VerticalProductId, NavItem[]> = {
+  "gold-operations": [
     { href: "/shift-report", icon: Dataset, label: "Shift Report" },
     { href: "/attendance", icon: Calendar, label: "Attendance" },
     { href: "/plant-report", icon: Factory, label: "Plant Report" },
@@ -80,24 +46,24 @@ const PROFILE_PRIMARY_ACTIONS: Record<Exclude<WorkspaceProfileKey, "GENERAL">, N
     { href: "/gold/transit/dispatches/new", icon: LocalShipping, label: "Record Dispatch" },
     { href: "/gold/settlement/receipts/new", icon: ReceiptLong, label: "Record Receipt" },
   ],
-  SCRAP_METAL: [
+  "scrap-recycling": [
     { href: "/scrap-metal/tickets", icon: Payments, label: "New Inbound Ticket" },
     { href: "/scrap-metal/batches", icon: Package, label: "Open Lot", roles: ["SUPERADMIN", "MANAGER"] },
     { href: "/scrap-metal/sales", icon: ReceiptLong, label: "New Outbound Ticket", roles: ["SUPERADMIN", "MANAGER"] },
     { href: "/scrap-metal/tickets/held", icon: Wallet, label: "Held Tickets" },
     { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
   ],
-  SCHOOLS: [
+  "school-operations": [
     { href: "/schools/admissions", icon: Building2, label: "Admissions" },
     { href: "/schools/attendance", icon: Calendar, label: "Attendance" },
     { href: "/schools/finance", icon: ReceiptLong, label: "Finance" },
   ],
-  AUTOS: [
+  "auto-sales": [
     { href: "/car-sales/leads", icon: Users, label: "Leads" },
     { href: "/car-sales/inventory", icon: Package, label: "Inventory" },
     { href: "/car-sales/deals", icon: Wallet, label: "Deals" },
   ],
-  RETAIL: [
+  "retail-operations": [
     { href: "/portal/pos", icon: Payments, label: "Open POS", roles: ["CASHIER"] },
     { href: "/retail/sales", icon: ClipboardList, label: "Sales" },
     { href: "/retail/stock", icon: Package, label: "Stock" },
@@ -113,6 +79,27 @@ const PROFILE_PRIMARY_ACTIONS: Record<Exclude<WorkspaceProfileKey, "GENERAL">, N
     { href: "/retail/reports", icon: BarChart3, label: "Insights" },
     { href: "/retail/setup", icon: Building2, label: "Setup" },
   ],
+  "service-workshop": [
+    { href: "/maintenance/breakdown", icon: ReportProblem, label: "Log Breakdown" },
+    { href: "/maintenance/work-orders", icon: Wrench, label: "Work Orders" },
+    { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
+    { href: "/stores/issue", icon: ArrowUpward, label: "Issue Stock" },
+    { href: "/human-resources", icon: Users, label: "Employees" },
+  ],
+  "multi-site-operations": [
+    { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
+    { href: "/stores/issue", icon: ArrowUpward, label: "Issue Stock" },
+    { href: "/stores/inventory", icon: Package, label: "Stock on Hand" },
+    { href: "/cctv/live", icon: Video, label: "Live Monitor", roles: ["SUPERADMIN", "MANAGER"] },
+    { href: "/human-resources", icon: Users, label: "Employees" },
+  ],
+  "general-business": [
+    { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
+    { href: "/stores/issue", icon: ArrowUpward, label: "Issue Stock" },
+    { href: "/stores/inventory", icon: Package, label: "Stock on Hand" },
+    { href: "/human-resources", icon: Users, label: "Employees" },
+    { href: "/reports", icon: BarChart3, label: "Reports" },
+  ],
 };
 
 export function getPrimaryQuickActions({
@@ -120,11 +107,11 @@ export function getPrimaryQuickActions({
   role,
   enabledFeatures,
 }: PrimaryActionsArgs): NavItem[] {
-  const profile = normalizeWorkspaceProfile(workspaceProfile);
-  const actions =
-    profile === "GENERAL"
-      ? GENERAL_PRIMARY_ACTIONS
-      : PROFILE_PRIMARY_ACTIONS[profile];
+  const verticalProduct = resolveWorkspaceVerticalProductBundle({
+    workspaceProfile,
+    enabledFeatures,
+  });
+  const actions = PRODUCT_PRIMARY_ACTIONS[verticalProduct.id] ?? [];
 
   return filterHrefItemsByEnabledFeatures(
     actions.filter((item) => (item.roles ? hasRole(role, item.roles) : true)),

--- a/lib/workspace-feature-resolution.test.ts
+++ b/lib/workspace-feature-resolution.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression tests for workspace / feature resolution.
+ *
+ * The platform started as a gold-mine product and was later made modular.
+ * These tests pin the boundary: mining-only surfaces (shift report, crew
+ * attendance, plant report, gold intake) must never resolve into non-mining
+ * workspaces — not from templates, not from bundles, and not from the
+ * presentation layer (quick actions, sidebar, route gating) even when a
+ * legacy tenant still carries leaked feature flags.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  CLIENT_BUNDLE_TEMPLATES,
+  getClientTemplateFeatureKeys,
+  getClientTemplateWorkspaceProfile,
+} from "@/lib/platform/client-templates";
+import { FEATURE_BUNDLES } from "@/lib/platform/feature-catalog";
+import { resolveFeatureKeyForPath } from "@/lib/platform/gating/route-registry";
+import { getPrimaryQuickActions } from "@/lib/primary-actions";
+import { resolveWorkspaceVerticalProductBundle } from "@/lib/workspace-products";
+import { getWorkspaceSidebarModel } from "@/lib/workspaces";
+
+const MINE_DAILY_OPS_FEATURE_KEYS = [
+  "ops.shift-report.submit",
+  "ops.attendance.mark",
+  "ops.plant-report.submit",
+  "reports.shift",
+  "reports.attendance",
+  "reports.plant",
+];
+
+const MINING_PAGE_HREFS = ["/shift-report", "/attendance", "/plant-report"];
+
+const MINING_TEMPLATE_CODES = new Set(["TEMPLATE_GOLD_MINE", "TEMPLATE_ALL_FEATURES"]);
+
+function templateFeatures(code: string): string[] {
+  return getClientTemplateFeatureKeys(code);
+}
+
+function isMiningHref(href: string): boolean {
+  return MINING_PAGE_HREFS.includes(href) || href.startsWith("/gold");
+}
+
+describe("feature catalog bundles", () => {
+  it("keeps mining daily ops out of ADDON_OPERATIONS_CORE", () => {
+    const operationsCore = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_OPERATIONS_CORE");
+    expect(operationsCore).toBeDefined();
+    for (const key of MINE_DAILY_OPS_FEATURE_KEYS) {
+      expect(operationsCore?.features).not.toContain(key);
+    }
+  });
+
+  it("collects mining daily ops in ADDON_MINE_DAILY_OPS", () => {
+    const mineOps = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_MINE_DAILY_OPS");
+    expect(mineOps?.features.slice().sort()).toEqual(MINE_DAILY_OPS_FEATURE_KEYS.slice().sort());
+  });
+});
+
+describe("client templates", () => {
+  const nonMiningTemplates = CLIENT_BUNDLE_TEMPLATES.filter(
+    (template) => !MINING_TEMPLATE_CODES.has(template.code),
+  );
+
+  it.each(nonMiningTemplates.map((template) => [template.code] as const))(
+    "%s grants no mining ops or gold features",
+    (code) => {
+      const keys = templateFeatures(code);
+      for (const key of MINE_DAILY_OPS_FEATURE_KEYS) {
+        expect(keys).not.toContain(key);
+      }
+      expect(keys.some((key) => key.startsWith("gold."))).toBe(false);
+    },
+  );
+
+  it("TEMPLATE_GOLD_MINE still grants mining daily ops and gold features", () => {
+    const keys = templateFeatures("TEMPLATE_GOLD_MINE");
+    for (const key of MINE_DAILY_OPS_FEATURE_KEYS) {
+      expect(keys).toContain(key);
+    }
+    expect(keys).toContain("gold.home");
+  });
+
+  it("resolves a workspace profile for every template", () => {
+    for (const template of CLIENT_BUNDLE_TEMPLATES) {
+      expect(getClientTemplateWorkspaceProfile(template.code)).not.toBeNull();
+    }
+  });
+});
+
+describe("vertical product resolution", () => {
+  it("resolves multi-site operations from the multi-site template features", () => {
+    const bundle = resolveWorkspaceVerticalProductBundle({
+      workspaceProfile: "GENERAL",
+      enabledFeatures: templateFeatures("TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK"),
+    });
+    expect(bundle.id).toBe("multi-site-operations");
+  });
+
+  it("resolves service workshop from the workshop template features", () => {
+    const bundle = resolveWorkspaceVerticalProductBundle({
+      workspaceProfile: "GENERAL",
+      enabledFeatures: templateFeatures("TEMPLATE_TECH_WORKSHOP"),
+    });
+    expect(bundle.id).toBe("service-workshop");
+  });
+});
+
+describe("primary quick actions", () => {
+  const nonMiningCases: Array<[string, string | null]> = [
+    ["TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK", "GENERAL"],
+    ["TEMPLATE_TECH_WORKSHOP", "GENERAL"],
+    ["TEMPLATE_CORE_STARTER", "GENERAL"],
+    ["TEMPLATE_SCHOOLS", "SCHOOLS"],
+    ["TEMPLATE_CAR_SALES", "AUTOS"],
+    ["TEMPLATE_RETAIL", "RETAIL"],
+    ["TEMPLATE_SCRAP_METAL", "SCRAP_METAL"],
+  ];
+
+  it.each(nonMiningCases)("%s offers no mining quick actions", (code, profile) => {
+    const actions = getPrimaryQuickActions({
+      workspaceProfile: profile,
+      role: "MANAGER",
+      enabledFeatures: templateFeatures(code),
+    });
+    expect(actions.filter((action) => isMiningHref(action.href))).toEqual([]);
+  });
+
+  it("multi-site offers stores actions", () => {
+    const actions = getPrimaryQuickActions({
+      workspaceProfile: "GENERAL",
+      role: "MANAGER",
+      enabledFeatures: templateFeatures("TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK"),
+    });
+    expect(actions.map((action) => action.href)).toContain("/stores/receive");
+  });
+
+  it("service workshop offers maintenance actions", () => {
+    const actions = getPrimaryQuickActions({
+      workspaceProfile: "GENERAL",
+      role: "MANAGER",
+      enabledFeatures: templateFeatures("TEMPLATE_TECH_WORKSHOP"),
+    });
+    expect(actions.map((action) => action.href)).toContain("/maintenance/breakdown");
+  });
+
+  it("gold mine keeps its mining quick actions", () => {
+    const actions = getPrimaryQuickActions({
+      workspaceProfile: "GOLD_MINE",
+      role: "MANAGER",
+      enabledFeatures: templateFeatures("TEMPLATE_GOLD_MINE"),
+    });
+    const hrefs = actions.map((action) => action.href);
+    expect(hrefs).toContain("/shift-report");
+    expect(hrefs).toContain("/gold/intake/pours/new");
+  });
+
+  it("legacy multi-site tenants with leaked mining flags still see no mining quick actions", () => {
+    const leakedFeatures = [
+      ...templateFeatures("TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK"),
+      ...MINE_DAILY_OPS_FEATURE_KEYS,
+    ];
+    const actions = getPrimaryQuickActions({
+      workspaceProfile: "GENERAL",
+      role: "MANAGER",
+      enabledFeatures: leakedFeatures,
+    });
+    expect(actions.filter((action) => isMiningHref(action.href))).toEqual([]);
+  });
+});
+
+describe("workspace sidebar model", () => {
+  it("multi-site sidebar contains no mining hrefs anywhere", () => {
+    const model = getWorkspaceSidebarModel({
+      role: "MANAGER",
+      enabledFeatures: templateFeatures("TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK"),
+      workspaceProfile: "GENERAL",
+    });
+    const hrefs = [
+      ...model.quickActions.map((item) => item.href),
+      ...model.sections.flatMap((section) => section.items.map((item) => item.href)),
+    ];
+    expect(hrefs.filter(isMiningHref)).toEqual([]);
+    expect(model.homeHref.startsWith("/gold")).toBe(false);
+  });
+
+  it("schools sidebar contains no mining hrefs anywhere", () => {
+    const model = getWorkspaceSidebarModel({
+      role: "MANAGER",
+      enabledFeatures: templateFeatures("TEMPLATE_SCHOOLS"),
+      workspaceProfile: "SCHOOLS",
+    });
+    const hrefs = [
+      ...model.quickActions.map((item) => item.href),
+      ...model.sections.flatMap((section) => section.items.map((item) => item.href)),
+    ];
+    expect(hrefs.filter(isMiningHref)).toEqual([]);
+  });
+});
+
+describe("route gating", () => {
+  it("gates the production dashboard behind plant reporting", () => {
+    expect(resolveFeatureKeyForPath("/dashboard")).toBe("reports.plant");
+  });
+
+  it("gates mining capture pages behind mining ops features", () => {
+    expect(resolveFeatureKeyForPath("/shift-report")).toBe("ops.shift-report.submit");
+    expect(resolveFeatureKeyForPath("/attendance")).toBe("ops.attendance.mark");
+    expect(resolveFeatureKeyForPath("/plant-report")).toBe("ops.plant-report.submit");
+  });
+});

--- a/lib/workspace-products.ts
+++ b/lib/workspace-products.ts
@@ -349,6 +349,7 @@ export function normalizeWorkspaceProfileInput(
   if (normalized === "SCRAP" || normalized === "SCRAP-METAL" || normalized === "SCRAPMETAL") return "SCRAP_METAL";
   if (normalized === "GOLD" || normalized === "GOLD-MINE" || normalized === "GOLDMINE") return "GOLD_MINE";
   if (normalized === "SCHOOL" || normalized === "SCHOOLS") return "SCHOOLS";
+  if (normalized === "THRIFT") return "RETAIL";
   if (
     normalized === "AUTO" ||
     normalized === "CAR_SALES" ||

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -6,9 +6,9 @@ import { normalizeFeatureKey } from "@/lib/platform/gating/catalog-utils";
 import { filterNavSectionsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 import { getPrimaryQuickActions } from "@/lib/primary-actions";
 import { canAccessPosPortal } from "@/lib/retail/pos-host";
-import type { UserRole } from "@/lib/roles";
 import {
   inferWorkspaceProfileFromEnabledFeatures,
+  normalizeWorkspaceProfileInput,
   resolveWorkspaceVerticalProductBundle,
   type VerticalProductBundleDefinition,
   WORKSPACE_PROFILES,
@@ -21,7 +21,6 @@ import {
   Dashboard,
   Gem,
   Building2,
-  Calendar,
   BarChart3,
   Coins,
   FileText,
@@ -91,7 +90,6 @@ type WorkspaceProfileSectionSpec = {
 type WorkspaceProfileRecipe = {
   label: string;
   preferredHomeHref: string | null;
-  quickActions: NavItem[];
   nativeModules: WorkspaceModuleId[];
   sections: WorkspaceProfileSectionSpec[];
 };
@@ -134,15 +132,6 @@ const WORKSPACE_MODULE_ORDER: readonly WorkspaceModuleId[] = [
 const SUPPORT_ITEMS: NavItem[] = [
   { href: "/help", icon: FileText, label: "Quick Tips" },
 ];
-
-function roleItem(
-  href: string,
-  label: string,
-  icon: LucideIcon,
-  roles?: UserRole[],
-): NavItem {
-  return { href, label, icon, roles };
-}
 
 function createSectionModule(args: {
   id: WorkspaceModuleId;
@@ -329,12 +318,6 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   GOLD_MINE: {
     label: "Gold Operations",
     preferredHomeHref: "/gold",
-    quickActions: [
-      roleItem("/gold/intake/pours/new", "Log Gold Output", Payments, ["SUPERADMIN", "MANAGER"]),
-      roleItem("/gold/intake/purchases/new", "Record Purchase", Coins, ["SUPERADMIN", "MANAGER"]),
-      roleItem("/gold/transit/dispatches/new", "Record Dispatch", LocalShipping, ["SUPERADMIN", "MANAGER"]),
-      roleItem("/gold/settlement/receipts/new", "Record Receipt", ReceiptLong, ["SUPERADMIN", "MANAGER"]),
-    ],
     nativeModules: ["gold", "reporting"],
     sections: [
       {
@@ -368,13 +351,6 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   SCRAP_METAL: {
     label: "Scrap & Recycling",
     preferredHomeHref: "/scrap-metal",
-    quickActions: [
-      roleItem("/scrap-metal/tickets", "New Inbound Ticket", Payments),
-      roleItem("/scrap-metal/batches", "Open Lot", Package),
-      roleItem("/scrap-metal/sales", "New Outbound Ticket", ReceiptLong),
-      roleItem("/scrap-metal/tickets/held", "Held Tickets", Wallet),
-      roleItem("/stores/receive", "Receive Stock", ArrowDownward),
-    ],
     nativeModules: ["scrap-metal", "reporting"],
     sections: [
       {
@@ -410,11 +386,6 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   SCHOOLS: {
     label: "School Operations",
     preferredHomeHref: "/schools",
-    quickActions: [
-      roleItem("/schools/admissions", "Admissions", Building2),
-      roleItem("/schools/attendance", "Attendance", Calendar),
-      roleItem("/schools/finance", "Finance", ReceiptLong),
-    ],
     nativeModules: ["schools"],
     sections: [
       {
@@ -452,11 +423,6 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   AUTOS: {
     label: "Auto Sales",
     preferredHomeHref: "/car-sales",
-    quickActions: [
-      roleItem("/car-sales/leads", "Leads", Users),
-      roleItem("/car-sales/inventory", "Inventory", Package),
-      roleItem("/car-sales/deals", "Deals", Wallet),
-    ],
     nativeModules: ["car-sales"],
     sections: [
       {
@@ -481,14 +447,6 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   RETAIL: {
     label: "Retail",
     preferredHomeHref: "/retail",
-    quickActions: [
-      roleItem("/portal/pos", "Open POS", Payments, ["CASHIER"]),
-      roleItem("/retail/sales", "Sales", ReceiptLong),
-      roleItem("/retail/stock/count", "Stock Count", Package),
-      roleItem("/retail/purchasing/receipts", "Receive Stock", LocalShipping),
-      roleItem("/retail/customers", "Customers", Users),
-      roleItem("/retail/setup", "Setup", Building2),
-    ],
     nativeModules: ["retail", "reporting"],
     sections: [
       {
@@ -539,35 +497,13 @@ const WORKSPACE_PROFILE_RECIPES: Record<WorkspaceProfile, WorkspaceProfileRecipe
   GENERAL: {
     label: "General Business",
     preferredHomeHref: null,
-    quickActions: [],
     nativeModules: [...WORKSPACE_MODULE_ORDER],
     sections: [],
   },
 };
 
 export function normalizeWorkspaceProfile(value: string | null | undefined): WorkspaceProfile {
-  const normalized = String(value || "").trim().toUpperCase();
-
-  if (normalized === "SCRAP" || normalized === "SCRAP-METAL" || normalized === "SCRAPMETAL") {
-    return "SCRAP_METAL";
-  }
-  if (normalized === "GOLD" || normalized === "GOLD-MINE" || normalized === "GOLDMINE") {
-    return "GOLD_MINE";
-  }
-  if (normalized === "SCHOOL" || normalized === "SCHOOLS") {
-    return "SCHOOLS";
-  }
-  if (
-    normalized === "AUTO" ||
-    normalized === "CAR_SALES" ||
-    normalized === "CAR-SALES" ||
-    normalized === "CARSALES" ||
-    normalized === "AUTOS"
-  ) {
-    return "AUTOS";
-  }
-
-  return WORKSPACE_PROFILES.find((profile) => profile === normalized) ?? DEFAULT_WORKSPACE_PROFILE;
+  return normalizeWorkspaceProfileInput(value) ?? DEFAULT_WORKSPACE_PROFILE;
 }
 
 export function getWorkspaceProfileForTemplate(code: string | null | undefined): WorkspaceProfile | null {

--- a/scripts/backfill-mining-ops-feature-flags.ts
+++ b/scripts/backfill-mining-ops-feature-flags.ts
@@ -1,0 +1,112 @@
+/**
+ * Repair mining ops feature flags leaked into non-mining companies.
+ *
+ * The original mine-focused build shipped ops.shift-report.submit,
+ * ops.attendance.mark, ops.plant-report.submit (and their reports.* pages)
+ * inside ADDON_OPERATIONS_CORE, which every generic template also bundled.
+ * The bundle has since been split (ADDON_MINE_DAILY_OPS is gold-mine only),
+ * but companies provisioned before the split still carry explicit
+ * CompanyFeatureFlag enables for those keys.
+ *
+ * A company keeps the mining flags only when it is actually a mine:
+ *   - workspaceProfile is GOLD_MINE, or
+ *   - it has an enabled gold.* feature flag, or
+ *   - it has an enabled ADDON_GOLD_CORE / ADDON_MINE_DAILY_OPS addon.
+ * Every other company gets the six mining flags flipped to disabled.
+ *
+ *   npx tsx scripts/backfill-mining-ops-feature-flags.ts          # report only
+ *   npx tsx scripts/backfill-mining-ops-feature-flags.ts --apply  # write rows
+ *
+ * Idempotent: rows are updated in place; re-running is safe.
+ */
+import "dotenv/config";
+
+import { prisma } from "@/lib/prisma";
+
+const APPLY = process.argv.includes("--apply");
+
+const MINE_DAILY_OPS_FEATURE_KEYS = [
+  "ops.shift-report.submit",
+  "ops.attendance.mark",
+  "ops.plant-report.submit",
+  "reports.shift",
+  "reports.attendance",
+  "reports.plant",
+];
+
+const MINING_BUNDLE_CODES = ["ADDON_GOLD_CORE", "ADDON_MINE_DAILY_OPS"];
+
+async function main() {
+  console.log(`[backfill] mode=${APPLY ? "APPLY" : "DRY-RUN"}`);
+
+  const companies = await prisma.company.findMany({
+    select: { id: true, name: true, slug: true, workspaceProfile: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const [goldFlagRows, miningAddonRows] = await Promise.all([
+    prisma.companyFeatureFlag.findMany({
+      where: { isEnabled: true, feature: { key: { startsWith: "gold." } } },
+      select: { companyId: true },
+    }),
+    prisma.companySubscriptionAddon.findMany({
+      where: { isEnabled: true, bundle: { code: { in: MINING_BUNDLE_CODES } } },
+      select: { companyId: true },
+    }),
+  ]);
+
+  const miningCompanyIds = new Set<string>([
+    ...goldFlagRows.map((row) => row.companyId),
+    ...miningAddonRows.map((row) => row.companyId),
+  ]);
+
+  let scanned = 0;
+  let repaired = 0;
+
+  for (const company of companies) {
+    const isMine =
+      company.workspaceProfile === "GOLD_MINE" || miningCompanyIds.has(company.id);
+    if (isMine) continue;
+
+    const leakedFlags = await prisma.companyFeatureFlag.findMany({
+      where: {
+        companyId: company.id,
+        isEnabled: true,
+        feature: { key: { in: MINE_DAILY_OPS_FEATURE_KEYS } },
+      },
+      select: { id: true, feature: { select: { key: true } } },
+    });
+    scanned += 1;
+    if (leakedFlags.length === 0) continue;
+
+    console.log(
+      `[backfill] ${company.slug ?? company.id} (${company.name}): disabling ${leakedFlags
+        .map((flag) => flag.feature.key)
+        .join(", ")}`,
+    );
+
+    if (APPLY) {
+      await prisma.companyFeatureFlag.updateMany({
+        where: { id: { in: leakedFlags.map((flag) => flag.id) } },
+        data: {
+          isEnabled: false,
+          reason: "Mining daily ops removed from non-mining workspaces (bundle split backfill)",
+        },
+      });
+    }
+    repaired += 1;
+  }
+
+  console.log(
+    `[backfill] done. companies scanned=${scanned}, companies ${APPLY ? "repaired" : "needing repair"}=${repaired}`,
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error("[backfill] failed:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/platform/domain/commercial-service.ts
+++ b/scripts/platform/domain/commercial-service.ts
@@ -166,10 +166,20 @@ export async function syncCommercialCatalog(): Promise<CatalogSyncResult> {
           bundleId,
           featureId: feature.id,
         }));
-      if (itemRows.length === 0) continue;
-      await tx.featureBundleItem.createMany({
-        data: itemRows,
-        skipDuplicates: true,
+      if (itemRows.length > 0) {
+        await tx.featureBundleItem.createMany({
+          data: itemRows,
+          skipDuplicates: true,
+        });
+      }
+      // Prune items removed from the in-code bundle definition so DB-backed
+      // entitlement resolution can never re-grant features a bundle no longer
+      // includes (e.g. mining ops capture removed from ADDON_OPERATIONS_CORE).
+      await tx.featureBundleItem.deleteMany({
+        where: {
+          bundleId,
+          featureId: { notIn: itemRows.map((row) => row.featureId) },
+        },
       });
     }
 

--- a/scripts/platform/services.ts
+++ b/scripts/platform/services.ts
@@ -1949,6 +1949,31 @@ async function applyClientTemplate(input: ApplySubscriptionTemplateInput): Promi
     }
   }
 
+  if (applyMode === "REPLACE") {
+    // Feature-level sync: REPLACE means the company ends up with exactly the
+    // template's feature set. Without this, stale explicit flags (e.g. mining
+    // ops capture granted by an older bundle definition) survive re-apply.
+    const templateFeatureSet = new Set(featureKeys.map((key) => key.trim().toLowerCase()));
+    const staleFlags = await prisma.companyFeatureFlag.findMany({
+      where: { companyId: input.companyId, isEnabled: true },
+      select: { feature: { select: { key: true } } },
+    });
+    for (const flag of staleFlags) {
+      const flagKey = flag.feature.key.trim().toLowerCase();
+      if (templateFeatureSet.has(flagKey)) continue;
+      const result = await setFeature({
+        companyId: input.companyId,
+        featureKey: flag.feature.key,
+        enabled: false,
+        actor: input.actor,
+        reason: input.reason ?? `Template ${template.code} replace mode`,
+      });
+      if (!result.enabled) {
+        disabledFeatures.push(result.feature);
+      }
+    }
+  }
+
   if (workspaceProfile) {
     await prisma.company.update({
       where: { id: input.companyId },


### PR DESCRIPTION
## Problem

The platform started as a mine-only build. When it went modular, mining daily-ops surfaces (Shift Report, Attendance, Plant Report, gold intake) kept leaking into unrelated workspaces — most visibly the **Multi-Site Operations** quick-create menu, which showed Shift Report / Attendance / Plant Report.

Root causes found in the audit:

1. **`ADDON_OPERATIONS_CORE` bundled the mining capture features** (`ops.shift-report.submit`, `ops.attendance.mark`, `ops.plant-report.submit`, `reports.shift/attendance/plant`) and was handed to every generic template (Core Starter, Multi-Site, Tech Workshop) — so the feature gate legitimately passed them through.
2. **`GENERAL_PRIMARY_ACTIONS` hard-coded a mining action list** for every GENERAL-profile workspace (which Multi-Site and Workshop tenants resolve to).
3. **`/dashboard` (Production Dashboard — plant reports, gold recovered) had no route-registry entry**, so it fail-opened into every workspace's nav and was the home fallback for GENERAL profiles.
4. **Catalog sync never pruned removed bundle items**, so DB-backed entitlement resolution would keep re-granting features removed from a bundle in code.
5. **REPLACE-mode template re-apply only synced bundles, not feature flags**, so stale mining flags survived re-provisioning.
6. Admin Templates page hard-coded drifting mining copy ("Shift reports, Attendance" for Core Starter); demo client list rotated `ADDON_GOLD_ADVANCED` onto arbitrary companies.

## Fix (three layers, so it stays stable)

**Provisioning / catalog**
- New gold-mine-only bundle `ADDON_MINE_DAILY_OPS` carries the six mining daily-ops keys; `ADDON_OPERATIONS_CORE` keeps only `reports.dashboard` + `admin.sites-sections`. `TEMPLATE_GOLD_MINE` picks up the new bundle.
- All non-mining templates now explicitly denylist the mining keys via `disabledFeatureKeys`.
- Both catalog syncs (`lib/platform/entitlements.ts` and the admin control plane's `syncCommercialCatalog`) now delete stale `FeatureBundleItem` rows.
- `TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK` / `TEMPLATE_TECH_WORKSHOP` now resolve an explicit `GENERAL` workspace profile.

**Presentation (safe even for tenants still carrying leaked flags)**
- `lib/primary-actions.ts` rewritten: quick-create actions are keyed by the resolved **vertical product** (`multi-site-operations`, `service-workshop`, `general-business`, …) instead of one mining-flavored GENERAL list. Multi-site now offers Receive/Issue Stock, Stock on Hand, Live Monitor, Employees; Workshop offers Breakdown/Work Orders/etc. Mining actions exist only on `gold-operations`. Role + feature filtering unchanged.
- Removed the two dead duplicate quick-action sources (`recipe.quickActions` in `lib/workspaces.ts`, legacy `quickActions` in `lib/navigation.ts`); the nav "daily" section now carries only the feature-gated mining capture forms.
- `/dashboard` is gated by `reports.plant` in the route registry.
- Workspace-profile normalization consolidated into `normalizeWorkspaceProfileInput` (was three divergent copies; `THRIFT` alias preserved).

**Admin side + repair for existing tenants**
- `applyClientTemplate` REPLACE mode now does a feature-level sync — enabled flags outside the template's feature set are disabled, making template re-apply a real repair path.
- `scripts/backfill-mining-ops-feature-flags.ts` (dry-run by default, `--apply` to write) disables leaked mining flags for every company that isn't actually a mine (checked via workspace profile, gold flags, and mining addons).
- Admin Templates page now derives cards from `CLIENT_BUNDLE_TEMPLATES`; demo addon rotation no longer assigns vertical suites to arbitrary companies.

## Tests

- New `lib/workspace-feature-resolution.test.ts` — 28 tests pinning the boundary: bundle split, per-template feature grants, vertical-product resolution, quick actions per template (including a legacy-leaked-flags case), full sidebar model for multi-site and schools, and route gating. All pass.
- `npx tsc --noEmit` clean; `eslint` clean on all touched files.
- Full `vitest run`: pre-existing failures only (gold DB-integration tests that need a local Postgres, unrelated to this change).

## Post-merge operational steps

1. Run the catalog sync (admin control plane) so DB bundle rows drop the mining items.
2. Run `npx tsx scripts/backfill-mining-ops-feature-flags.ts` (dry-run, review output) then with `--apply` against the production DB to repair already-provisioned tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XYrUgQS8sBtnczfw12ond

---
_Generated by [Claude Code](https://claude.ai/code/session_013XYrUgQS8sBtnczfw12ond)_