### PR TITLE
feat(admin): rework per-user feature access management

### DIFF
--- a/app/api/users/access/reset/route.ts
+++ b/app/api/users/access/reset/route.ts
@@ -5,11 +5,7 @@ import { errorResponse, successResponse, validateSession } from "@/lib/api-utils
 import { prisma } from "@/lib/prisma";
 import { clearUserFeatureOverrides } from "@/lib/platform/user-entitlements";
 
-import {
-  appendUserManagementEvent,
-  canMutateUserManagement,
-  isManagedRole,
-} from "../../_helpers";
+import { appendUserManagementEvent, canMutateUserManagement } from "../../_helpers";
 
 const resetFeatureAccessSchema = z.object({
   userId: z.string().uuid(),
@@ -42,9 +38,6 @@ export async function POST(request: NextRequest) {
 
     if (!user || user.companyId !== session.user.companyId) {
       return errorResponse("User not found for this organization.", 404);
-    }
-    if (!isManagedRole(session, user.role)) {
-      return errorResponse("Only SUPERADMIN, MANAGER, and OPERATOR accounts can be managed here.", 403);
     }
 
     await clearUserFeatureOverrides(user.id);

--- a/app/api/users/access/route.ts
+++ b/app/api/users/access/route.ts
@@ -3,26 +3,19 @@ import { z } from "zod";
 
 import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
+import { normalizeFeatureKey } from "@/lib/platform/gating/catalog-utils";
 import {
   getManagedUserFeatureAccessEntries,
   setManagedUserFeatureOverride,
 } from "@/lib/platform/user-entitlements";
 
-import {
-  appendUserManagementEvent,
-  canMutateUserManagement,
-  isManagedRole,
-} from "../_helpers";
+import { appendUserManagementEvent, canMutateUserManagement } from "../_helpers";
 
 const setFeatureAccessSchema = z.object({
   userId: z.string().uuid(),
   featureKey: z.string().trim().min(1).max(200),
   isEnabled: z.boolean(),
 });
-
-function normalizeFeatureKey(value: string): string {
-  return value.trim().toLowerCase();
-}
 
 async function getManagedUserForCompany(userId: string, companyId: string) {
   const user = await prisma.user.findUnique({
@@ -64,9 +57,6 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return errorResponse("User not found for this organization.", 404);
     }
-    if (!isManagedRole(session, user.role)) {
-      return errorResponse("Only SUPERADMIN, MANAGER, and OPERATOR accounts can be managed here.", 403);
-    }
 
     const features = await getManagedUserFeatureAccessEntries({
       companyId: session.user.companyId,
@@ -107,9 +97,6 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return errorResponse("User not found for this organization.", 404);
     }
-    if (!isManagedRole(session, user.role)) {
-      return errorResponse("Only SUPERADMIN, MANAGER, and OPERATOR accounts can be managed here.", 403);
-    }
 
     try {
       await setManagedUserFeatureOverride({
@@ -123,9 +110,6 @@ export async function POST(request: NextRequest) {
       const message = error instanceof Error ? error.message : "";
       if (message === "FEATURE_NOT_ENABLED_FOR_COMPANY") {
         return errorResponse("Feature is not enabled for this company.", 400);
-      }
-      if (message === "FEATURE_BLOCKED_BY_TEMPLATE") {
-        return errorResponse("Feature is blocked by the selected role template.", 400);
       }
       throw error;
     }

--- a/components/user-management/feature-access-dialog.tsx
+++ b/components/user-management/feature-access-dialog.tsx
@@ -22,6 +22,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { getApiErrorMessage } from "@/lib/api-client";
 import {
   fetchManagedUserFeatureAccess,
+  fetchManagedUsers,
   resetManagedUserFeatureAccess,
   setManagedUserFeatureAccess,
   type ManagedUserFeatureAccessEntry,
@@ -58,6 +59,7 @@ export function FeatureAccessDialog({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const targetUserId = target?.userId || "";
+  const [userSearch, setUserSearch] = React.useState("");
   const [search, setSearch] = React.useState("");
   const [pendingKeys, setPendingKeys] = React.useState<Set<string>>(new Set());
 
@@ -65,6 +67,23 @@ export function FeatureAccessDialog({
     setSearch("");
     setPendingKeys(new Set());
   }, [targetUserId]);
+
+  React.useEffect(() => {
+    if (!target) setUserSearch("");
+  }, [target]);
+
+  const normalizedUserSearch = userSearch.trim();
+  const pickerUsersQuery = useQuery({
+    queryKey: ["managed-user-picker", normalizedUserSearch],
+    queryFn: () =>
+      fetchManagedUsers({
+        search: normalizedUserSearch || undefined,
+        page: 1,
+        limit: 50,
+      }),
+    enabled: Boolean(target),
+    staleTime: 30_000,
+  });
 
   const featureAccessQuery = useQuery({
     queryKey: featureAccessQueryKey(targetUserId),
@@ -77,6 +96,29 @@ export function FeatureAccessDialog({
     () => featureAccessQuery.data?.features ?? [],
     [featureAccessQuery.data?.features],
   );
+  const targetUserSummary = React.useMemo<ManagedUserSummary | null>(
+    () =>
+      targetUser
+        ? {
+            id: targetUser.id,
+            name: targetUser.name,
+            email: targetUser.email,
+            role: targetUser.role,
+            isActive: targetUser.isActive,
+          }
+        : null,
+    [targetUser],
+  );
+  const pickerUsers = React.useMemo(() => {
+    const merged = new Map<string, ManagedUserSummary>();
+    for (const user of users) merged.set(user.id, user);
+    for (const user of pickerUsersQuery.data?.data ?? []) merged.set(user.id, user);
+    if (targetUserSummary) merged.set(targetUserSummary.id, targetUserSummary);
+    return [...merged.values()].sort((a, b) => {
+      const nameOrder = a.name.localeCompare(b.name);
+      return nameOrder === 0 ? a.email.localeCompare(b.email) : nameOrder;
+    });
+  }, [pickerUsersQuery.data?.data, targetUserSummary, users]);
 
   const normalizedSearch = search.trim().toLowerCase();
   const groupedFeatures = React.useMemo(() => {
@@ -192,12 +234,19 @@ export function FeatureAccessDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-3 lg:grid-cols-3">
+            <Input
+              value={userSearch}
+              onChange={(event) => setUserSearch(event.target.value)}
+              placeholder="Search users by name or email"
+              disabled={!target}
+            />
+
             <Select
               value={targetUserId || "__none"}
               onValueChange={(value) => {
-                if (value === "__none") return;
-                const selected = users.find((user) => user.id === value);
+                if (value.startsWith("__")) return;
+                const selected = pickerUsers.find((user) => user.id === value);
                 if (!selected) return;
                 onTargetChange({ userId: selected.id, userEmail: selected.email });
               }}
@@ -207,7 +256,17 @@ export function FeatureAccessDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="__none">Select user</SelectItem>
-                {users.map((user) => (
+                {pickerUsersQuery.isLoading ? (
+                  <SelectItem value="__loading" disabled>
+                    Loading users...
+                  </SelectItem>
+                ) : null}
+                {!pickerUsersQuery.isLoading && pickerUsers.length === 0 ? (
+                  <SelectItem value="__empty" disabled>
+                    No users found
+                  </SelectItem>
+                ) : null}
+                {pickerUsers.map((user) => (
                   <SelectItem key={user.id} value={user.id}>
                     {`${user.name} (${user.email})`}
                   </SelectItem>

--- a/components/user-management/feature-access-dialog.tsx
+++ b/components/user-management/feature-access-dialog.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import { getApiErrorMessage } from "@/lib/api-client";
+import {
+  fetchManagedUserFeatureAccess,
+  resetManagedUserFeatureAccess,
+  setManagedUserFeatureAccess,
+  type ManagedUserFeatureAccessEntry,
+  type ManagedUserFeatureAccessResponse,
+  type ManagedUserSummary,
+} from "@/lib/user-management-api";
+
+export type FeatureAccessTarget = {
+  userId: string;
+  userEmail: string;
+};
+
+function featureAccessQueryKey(userId: string | undefined) {
+  return ["managed-user-feature-access", userId] as const;
+}
+
+function matchesSearch(entry: ManagedUserFeatureAccessEntry, search: string): boolean {
+  if (!search) return true;
+  const haystack = `${entry.name} ${entry.featureKey} ${entry.description}`.toLowerCase();
+  return haystack.includes(search);
+}
+
+export function FeatureAccessDialog({
+  target,
+  users,
+  onTargetChange,
+  onClose,
+}: {
+  target: FeatureAccessTarget | null;
+  users: ManagedUserSummary[];
+  onTargetChange: (target: FeatureAccessTarget) => void;
+  onClose: () => void;
+}) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const targetUserId = target?.userId || "";
+  const [search, setSearch] = React.useState("");
+  const [pendingKeys, setPendingKeys] = React.useState<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    setSearch("");
+    setPendingKeys(new Set());
+  }, [targetUserId]);
+
+  const featureAccessQuery = useQuery({
+    queryKey: featureAccessQueryKey(targetUserId),
+    queryFn: () => fetchManagedUserFeatureAccess(targetUserId),
+    enabled: Boolean(targetUserId),
+  });
+
+  const targetUser = featureAccessQuery.data?.user;
+  const features = React.useMemo(
+    () => featureAccessQuery.data?.features ?? [],
+    [featureAccessQuery.data?.features],
+  );
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const groupedFeatures = React.useMemo(() => {
+    const groups = new Map<string, ManagedUserFeatureAccessEntry[]>();
+    for (const entry of features) {
+      if (!matchesSearch(entry, normalizedSearch)) continue;
+      const group = groups.get(entry.domain);
+      if (group) {
+        group.push(entry);
+      } else {
+        groups.set(entry.domain, [entry]);
+      }
+    }
+    return [...groups.entries()];
+  }, [features, normalizedSearch]);
+
+  const enabledCount = React.useMemo(
+    () => features.filter((entry) => entry.isEnabled).length,
+    [features],
+  );
+  const overrideCount = React.useMemo(
+    () => features.filter((entry) => entry.hasOverride).length,
+    [features],
+  );
+
+  const toggleMutation = useMutation({
+    mutationFn: setManagedUserFeatureAccess,
+    onMutate: async (input) => {
+      const queryKey = featureAccessQueryKey(input.userId);
+      setPendingKeys((current) => new Set(current).add(input.featureKey));
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ManagedUserFeatureAccessResponse>(queryKey);
+      queryClient.setQueryData<ManagedUserFeatureAccessResponse>(queryKey, (current) =>
+        current
+          ? {
+              ...current,
+              features: current.features.map((entry) =>
+                entry.featureKey === input.featureKey
+                  ? {
+                      ...entry,
+                      isEnabled: input.isEnabled,
+                      hasOverride: input.isEnabled !== entry.roleDefault,
+                    }
+                  : entry,
+              ),
+            }
+          : current,
+      );
+      return { previous };
+    },
+    onError: (error, input, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(featureAccessQueryKey(input.userId), context.previous);
+      }
+      toast({
+        title: "Unable to update feature access",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: (_data, _error, input) => {
+      setPendingKeys((current) => {
+        const next = new Set(current);
+        next.delete(input.featureKey);
+        return next;
+      });
+      queryClient.invalidateQueries({ queryKey: featureAccessQueryKey(input.userId) });
+    },
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: resetManagedUserFeatureAccess,
+    onSuccess: (_data, input) => {
+      toast({
+        title: "Feature access reset",
+        description: "All overrides were removed. Role defaults now apply.",
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: featureAccessQueryKey(input.userId) });
+    },
+    onError: (error) => {
+      toast({
+        title: "Unable to reset feature access",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleToggle = (entry: ManagedUserFeatureAccessEntry, nextEnabled: boolean) => {
+    if (!targetUserId) return;
+    toggleMutation.mutate({
+      userId: targetUserId,
+      featureKey: entry.featureKey,
+      isEnabled: nextEnabled,
+    });
+  };
+
+  return (
+    <Dialog
+      open={Boolean(target)}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Manage Feature Access</DialogTitle>
+          <DialogDescription>
+            Toggle the features this user can access. Features not provisioned for the company are
+            not listed. Changes take effect on the user&apos;s next session refresh.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Select
+              value={targetUserId || "__none"}
+              onValueChange={(value) => {
+                if (value === "__none") return;
+                const selected = users.find((user) => user.id === value);
+                if (!selected) return;
+                onTargetChange({ userId: selected.id, userEmail: selected.email });
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select user" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">Select user</SelectItem>
+                {users.map((user) => (
+                  <SelectItem key={user.id} value={user.id}>
+                    {`${user.name} (${user.email})`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search features by name or key"
+              disabled={!targetUserId}
+            />
+          </div>
+
+          {!targetUserId ? (
+            <div className="rounded-lg border border-dashed border-[var(--edge-subtle)] p-6 text-center text-sm text-muted-foreground">
+              Select a user to manage their feature access.
+            </div>
+          ) : featureAccessQuery.error ? (
+            <Alert variant="destructive">
+              <AlertTitle>Unable to load feature access</AlertTitle>
+              <AlertDescription>{getApiErrorMessage(featureAccessQuery.error)}</AlertDescription>
+            </Alert>
+          ) : featureAccessQuery.isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  {targetUser ? (
+                    <Badge variant="outline">{targetUser.role}</Badge>
+                  ) : null}
+                  <span>
+                    {enabledCount} of {features.length} features enabled
+                  </span>
+                  {overrideCount > 0 ? (
+                    <Badge variant="secondary">
+                      {overrideCount} {overrideCount === 1 ? "override" : "overrides"}
+                    </Badge>
+                  ) : null}
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={overrideCount === 0 || resetMutation.isPending}
+                  onClick={() => resetMutation.mutate({ userId: targetUserId })}
+                >
+                  {resetMutation.isPending ? "Resetting..." : "Reset to Role Defaults"}
+                </Button>
+              </div>
+
+              <div className="max-h-[50vh] space-y-4 overflow-y-auto pr-1">
+                {groupedFeatures.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-[var(--edge-subtle)] p-6 text-center text-sm text-muted-foreground">
+                    {features.length === 0
+                      ? "No features are provisioned for this company."
+                      : "No features match this search."}
+                  </div>
+                ) : (
+                  groupedFeatures.map(([domain, entries]) => (
+                    <div key={domain} className="space-y-2">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {domain}
+                      </div>
+                      <div className="space-y-1.5">
+                        {entries.map((entry) => {
+                          const pending = pendingKeys.has(entry.featureKey);
+                          return (
+                            <div
+                              key={entry.featureKey}
+                              className="flex items-center gap-3 rounded-lg border border-[var(--edge-subtle)] px-3 py-2"
+                            >
+                              <Checkbox
+                                checked={entry.isEnabled}
+                                disabled={pending}
+                                onCheckedChange={(value) => handleToggle(entry, value === true)}
+                                aria-label={`Toggle ${entry.name}`}
+                              />
+                              <div className="min-w-0 flex-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="text-sm font-medium">{entry.name}</span>
+                                  {entry.hasOverride ? (
+                                    <Badge variant="secondary">
+                                      {entry.isEnabled ? "Granted" : "Revoked"}
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                                <div className="truncate font-mono text-xs text-muted-foreground">
+                                  {entry.featureKey}
+                                </div>
+                              </div>
+                              {entry.hasOverride ? (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="ghost"
+                                  className="shrink-0 text-xs text-muted-foreground"
+                                  disabled={pending}
+                                  onClick={() => handleToggle(entry, entry.roleDefault)}
+                                >
+                                  Use role default
+                                </Button>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/user-management/user-management-console.tsx
+++ b/components/user-management/user-management-console.tsx
@@ -29,13 +29,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/components/ui/use-toast";
 import {
+  FeatureAccessDialog,
+  type FeatureAccessTarget,
+} from "@/components/user-management/feature-access-dialog";
+import {
   changeManagedUserRole,
   createManagedUser,
-  fetchManagedUserFeatureAccess,
   fetchManagedUsers,
-  resetManagedUserFeatureAccess,
-  setManagedUserFeatureAccess,
-  type ManagedUserFeatureAccessEntry,
   type ManagedUserSummary,
   resetManagedUserPassword,
   setManagedUserStatus,
@@ -64,7 +64,6 @@ export type UserManagementMode =
 
 type RoleFilter = "ALL" | ManagedUserRole;
 type StatusFilter = "ALL" | "ACTIVE" | "INACTIVE";
-type FeatureAccessBlockedReason = "COMPANY_DISABLED" | "TEMPLATE_BLOCKED";
 type ManagedUserTargetBase = {
   userId: string;
   userEmail: string;
@@ -116,12 +115,6 @@ function toManagedRole(
   return null;
 }
 
-function getBlockedFeatureLabel(reason: FeatureAccessBlockedReason | null): string {
-  if (reason === "COMPANY_DISABLED") return "Company Disabled";
-  if (reason === "TEMPLATE_BLOCKED") return "Template Blocked";
-  return "Unavailable";
-}
-
 export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -164,12 +157,6 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
   });
   const [roleFilter, setRoleFilter] = React.useState<RoleFilter>("ALL");
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("ALL");
-  const [featureQueryState, setFeatureQueryState] = React.useState<DataTableQueryState>({
-    mode: "paginated",
-    page: 1,
-    pageSize: 20,
-    search: "",
-  });
 
   const [createOpen, setCreateOpen] = React.useState(false);
   const [createDraft, setCreateDraft] = React.useState({
@@ -194,11 +181,7 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
       role: ManagedUserRole;
     }) | null
   >(null);
-  const [featureTarget, setFeatureTarget] = React.useState<
-    (ManagedUserTargetBase & {
-      role: ManagedUserRole;
-    }) | null
-  >(null);
+  const [featureTarget, setFeatureTarget] = React.useState<FeatureAccessTarget | null>(null);
 
   React.useEffect(() => {
     if (mode === "create" && canMutate) {
@@ -214,18 +197,6 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
       }));
     }
   }, [createDraft.role, managedRoles, mode]);
-
-  const featureTargetUserId = featureTarget?.userId;
-
-  React.useEffect(() => {
-    if (!featureTargetUserId) return;
-    setFeatureQueryState({
-      mode: "paginated",
-      page: 1,
-      pageSize: 20,
-      search: "",
-    });
-  }, [featureTargetUserId]);
 
   const usersQuery = useQuery({
     queryKey: [
@@ -256,14 +227,8 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
     [users],
   );
 
-  const featureAccessQuery = useQuery({
-    queryKey: ["managed-user-feature-access", featureTarget?.userId],
-    queryFn: () => fetchManagedUserFeatureAccess(featureTarget!.userId),
-    enabled: Boolean(featureTarget?.userId) && canManageFeatureAccess,
-  });
-  const featureRows = featureAccessQuery.data?.features ?? [];
-  const totalRows = usersQuery.data?.pagination.total ?? users.length;
-  const totalPages = usersQuery.data?.pagination.pages ?? 1;
+  const totalRows = usersQuery.data?.pagination?.total ?? users.length;
+  const totalPages = usersQuery.data?.pagination?.pages ?? 1;
 
   const refreshUsers = React.useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["managed-users"] });
@@ -354,118 +319,6 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
       });
     },
   });
-
-  const setFeatureAccessMutation = useMutation({
-    mutationFn: setManagedUserFeatureAccess,
-    onSuccess: () => {
-      toast({
-        title: "Feature access updated",
-        description: "Per-user feature access was updated successfully.",
-        variant: "success",
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["managed-user-feature-access", featureTarget?.userId],
-      });
-    },
-    onError: (error) => {
-      toast({
-        title: "Unable to update feature access",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
-    },
-  });
-
-  const resetFeatureAccessMutation = useMutation({
-    mutationFn: resetManagedUserFeatureAccess,
-    onSuccess: () => {
-      toast({
-        title: "Feature access reset",
-        description: "User feature access was reset to role defaults.",
-        variant: "success",
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["managed-user-feature-access", featureTarget?.userId],
-      });
-    },
-    onError: (error) => {
-      toast({
-        title: "Unable to reset feature access",
-        description: getApiErrorMessage(error),
-        variant: "destructive",
-      });
-    },
-  });
-
-  const featureColumns: ColumnDef<ManagedUserFeatureAccessEntry>[] = [
-    {
-      id: "feature",
-      header: "Feature",
-      cell: ({ row }) => (
-        <div className="space-y-1">
-          <div className="font-medium">{row.original.name}</div>
-          <div className="font-mono text-xs text-muted-foreground">
-            {row.original.featureKey}
-          </div>
-        </div>
-      ),
-    },
-    {
-      id: "domain",
-      header: "Domain",
-      cell: ({ row }) => (
-        <Badge variant="outline" className="uppercase">
-          {row.original.domain}
-        </Badge>
-      ),
-    },
-    {
-      id: "availability",
-      header: "Availability",
-      cell: ({ row }) => {
-        if (row.original.available) {
-          return <Badge variant="secondary">Available</Badge>;
-        }
-        return (
-          <Badge variant="destructive">
-            {getBlockedFeatureLabel(
-              row.original.blockedReason as FeatureAccessBlockedReason | null,
-            )}
-          </Badge>
-        );
-      },
-    },
-    {
-      id: "access",
-      header: "Access",
-      cell: ({ row }) => {
-        const entry = row.original;
-        if (!entry.available) {
-          return <Badge variant="outline">Not Assignable</Badge>;
-        }
-
-        const nextEnabled = !entry.isEnabled;
-        return (
-          <Button
-            type="button"
-            size="sm"
-            variant={entry.isEnabled ? "outline" : "default"}
-            disabled={setFeatureAccessMutation.isPending || !featureTarget?.userId}
-            onClick={() => {
-              if (!featureTarget?.userId) return;
-              setFeatureAccessMutation.mutate({
-                userId: featureTarget.userId,
-                featureKey: entry.featureKey,
-                isEnabled: nextEnabled,
-              });
-            }}
-          >
-            {entry.isEnabled ? "Enabled" : "Disabled"}
-          </Button>
-        );
-      },
-    },
-  ];
 
   const columns = React.useMemo<ColumnDef<ManagedUserSummary>[]>(
     () => {
@@ -571,7 +424,7 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
               });
             }
 
-            if (actionsVisible.featureAccess && managedRole) {
+            if (actionsVisible.featureAccess) {
               rowActions.push({
                 key: "feature",
                 label: "Feature Access",
@@ -580,7 +433,6 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
                   setFeatureTarget({
                     userId: row.original.id,
                     userEmail: row.original.email,
-                    role: managedRole,
                   }),
               });
             }
@@ -646,16 +498,6 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
   );
 
   const heading = modeMeta[mode];
-  const openFeatureAccessFromFirstManagedUser = React.useCallback(() => {
-    const firstManagedUser = users.find((user) => toManagedRole(user.role, managedRoles));
-    const managedRole = toManagedRole(firstManagedUser?.role, managedRoles);
-    if (!firstManagedUser || !managedRole) return;
-    setFeatureTarget({
-      userId: firstManagedUser.id,
-      userEmail: firstManagedUser.email,
-      role: managedRole,
-    });
-  }, [managedRoles, users]);
 
   const showHeaderActions = canMutate && (mode === "directory" || mode === "create");
   const headerActions = showHeaderActions ? (
@@ -707,7 +549,13 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
               <span>Change Role</span>
             </DropdownMenuItem>
             {actionsVisible.featureAccess ? (
-              <DropdownMenuItem disabled={users.length === 0} onClick={openFeatureAccessFromFirstManagedUser}>
+              <DropdownMenuItem
+                onClick={() =>
+                  setFeatureTarget({
+                    userId: "",
+                    userEmail: "",
+                  })}
+              >
                 <ShieldCheck className="h-4 w-4" />
                 <span>Manage Feature Access</span>
               </DropdownMenuItem>
@@ -1201,81 +1049,14 @@ export function UserManagementConsole({ mode }: { mode: UserManagementMode }) {
         </DialogContent>
       </Dialog>
 
-      <Dialog
-        open={Boolean(featureTarget)}
-        onOpenChange={(open) => {
-          if (!open) setFeatureTarget(null);
-        }}
-      >
-        <DialogContent size="lg">
-          <DialogHeader>
-            <DialogTitle>Manage Feature Access</DialogTitle>
-            <DialogDescription>
-              {featureTarget?.userEmail
-                ? `Set feature access for ${featureTarget.userEmail}. Effective access is company access ∩ role template ∩ user overrides.`
-                : "Select a managed user and configure feature access."}
-            </DialogDescription>
-          </DialogHeader>
-
-          {featureAccessQuery.error ? (
-            <Alert variant="destructive">
-              <AlertTitle>Unable to load feature access</AlertTitle>
-              <AlertDescription>{getApiErrorMessage(featureAccessQuery.error)}</AlertDescription>
-            </Alert>
-          ) : null}
-
-          {featureAccessQuery.isLoading ? (
-            <Skeleton className="h-16 w-full" />
-          ) : (
-            <DataTable
-              data={featureRows}
-              columns={featureColumns}
-              queryState={featureQueryState}
-              onQueryStateChange={(next) =>
-                setFeatureQueryState((current) => ({
-                  ...current,
-                  ...next,
-                }))
-              }
-              features={{ sorting: false, globalFilter: true, pagination: true }}
-              searchPlaceholder="Search by feature name or key"
-              searchSubmitLabel="Search"
-              tableClassName="text-sm"
-              noResultsText="No features found for current filters."
-              toolbar={
-                <>
-                  <Badge variant="outline">
-                    {featureRows.filter((entry) => entry.isEnabled).length} Enabled
-                  </Badge>
-                  <Badge variant="outline">
-                    {featureRows.filter((entry) => entry.available).length} Assignable
-                  </Badge>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={!featureTarget?.userId || resetFeatureAccessMutation.isPending}
-                    onClick={() => {
-                      if (!featureTarget?.userId) return;
-                      resetFeatureAccessMutation.mutate({
-                        userId: featureTarget.userId,
-                      });
-                    }}
-                  >
-                    {resetFeatureAccessMutation.isPending ? "Resetting..." : "Reset to Role Default"}
-                  </Button>
-                </>
-              }
-            />
-          )}
-
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setFeatureTarget(null)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {canManageFeatureAccess ? (
+        <FeatureAccessDialog
+          target={featureTarget}
+          users={users}
+          onTargetChange={setFeatureTarget}
+          onClose={() => setFeatureTarget(null)}
+        />
+      ) : null}
     </ManagementShell>
   );
 }

--- a/lib/platform/user-entitlements.test.ts
+++ b/lib/platform/user-entitlements.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockGetCompanyFeatureMap,
+  mockUserFeatureFlagFindMany,
+  mockUserFeatureFlagDeleteMany,
+  mockUserFeatureFlagUpsert,
+  mockPlatformFeatureUpsert,
+} = vi.hoisted(() => ({
+  mockGetCompanyFeatureMap: vi.fn(),
+  mockUserFeatureFlagFindMany: vi.fn(),
+  mockUserFeatureFlagDeleteMany: vi.fn(),
+  mockUserFeatureFlagUpsert: vi.fn(),
+  mockPlatformFeatureUpsert: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    userFeatureFlag: {
+      findMany: mockUserFeatureFlagFindMany,
+      deleteMany: mockUserFeatureFlagDeleteMany,
+      upsert: mockUserFeatureFlagUpsert,
+    },
+    platformFeature: {
+      upsert: mockPlatformFeatureUpsert,
+    },
+  },
+}));
+
+vi.mock("@/lib/platform/entitlements", () => ({
+  getCompanyFeatureMap: mockGetCompanyFeatureMap,
+}));
+
+import {
+  getEffectiveFeaturesForUser,
+  getManagedUserFeatureAccessEntries,
+  setManagedUserFeatureOverride,
+} from "./user-entitlements";
+
+const COMPANY_ID = "company-1";
+const USER_ID = "user-1";
+
+// gold.home is outside the OPERATOR prefix allowlist; stores.inventory is inside it.
+const GOLD_KEY = "gold.home";
+const STORES_KEY = "stores.inventory";
+
+function setupCompanyMap(map: Record<string, boolean>) {
+  mockGetCompanyFeatureMap.mockResolvedValue(map);
+}
+
+function setupOverrides(rows: Array<{ key: string; isEnabled: boolean }>) {
+  mockUserFeatureFlagFindMany.mockResolvedValue(
+    rows.map((row) => ({ isEnabled: row.isEnabled, feature: { key: row.key } })),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPlatformFeatureUpsert.mockResolvedValue({ id: "feature-1" });
+  mockUserFeatureFlagDeleteMany.mockResolvedValue({ count: 0 });
+  mockUserFeatureFlagUpsert.mockResolvedValue({ id: "flag-1" });
+});
+
+describe("getEffectiveFeaturesForUser", () => {
+  it("excludes features blocked by the role template when there is no override", async () => {
+    setupCompanyMap({ [GOLD_KEY]: true, [STORES_KEY]: true });
+    setupOverrides([]);
+
+    const features = await getEffectiveFeaturesForUser({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    expect(features).toContain(STORES_KEY);
+    expect(features).not.toContain(GOLD_KEY);
+  });
+
+  it("grants a template-blocked feature when an enable override exists", async () => {
+    setupCompanyMap({ [GOLD_KEY]: true, [STORES_KEY]: true });
+    setupOverrides([{ key: GOLD_KEY, isEnabled: true }]);
+
+    const features = await getEffectiveFeaturesForUser({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    expect(features).toContain(GOLD_KEY);
+  });
+
+  it("revokes a template-allowed feature when a disable override exists", async () => {
+    setupCompanyMap({ [STORES_KEY]: true });
+    setupOverrides([{ key: STORES_KEY, isEnabled: false }]);
+
+    const features = await getEffectiveFeaturesForUser({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    expect(features).not.toContain(STORES_KEY);
+  });
+
+  it("never grants a company-disabled feature, even with an enable override", async () => {
+    setupCompanyMap({ [GOLD_KEY]: false });
+    setupOverrides([{ key: GOLD_KEY, isEnabled: true }]);
+
+    const features = await getEffectiveFeaturesForUser({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    expect(features).not.toContain(GOLD_KEY);
+  });
+
+  it("applies disable overrides to roles outside the managed role list", async () => {
+    setupCompanyMap({ [STORES_KEY]: true });
+    setupOverrides([{ key: STORES_KEY, isEnabled: false }]);
+
+    const features = await getEffectiveFeaturesForUser({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "LEGACY_ROLE",
+    });
+
+    expect(features).not.toContain(STORES_KEY);
+  });
+});
+
+describe("getManagedUserFeatureAccessEntries", () => {
+  it("only returns company-enabled features", async () => {
+    setupCompanyMap({ [GOLD_KEY]: true, [STORES_KEY]: false });
+    setupOverrides([]);
+
+    const entries = await getManagedUserFeatureAccessEntries({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    const keys = entries.map((entry) => entry.featureKey);
+    expect(keys).toContain(GOLD_KEY);
+    expect(keys).not.toContain(STORES_KEY);
+  });
+
+  it("reports role default, effective state, and override presence", async () => {
+    setupCompanyMap({ [GOLD_KEY]: true, [STORES_KEY]: true });
+    setupOverrides([{ key: GOLD_KEY, isEnabled: true }]);
+
+    const entries = await getManagedUserFeatureAccessEntries({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+    });
+
+    const gold = entries.find((entry) => entry.featureKey === GOLD_KEY);
+    expect(gold).toMatchObject({
+      roleDefault: false,
+      isEnabled: true,
+      hasOverride: true,
+    });
+
+    const stores = entries.find((entry) => entry.featureKey === STORES_KEY);
+    expect(stores).toMatchObject({
+      roleDefault: true,
+      isEnabled: true,
+      hasOverride: false,
+    });
+  });
+});
+
+describe("setManagedUserFeatureOverride", () => {
+  it("throws when the feature is not enabled for the company", async () => {
+    setupCompanyMap({ [GOLD_KEY]: false });
+
+    await expect(
+      setManagedUserFeatureOverride({
+        companyId: COMPANY_ID,
+        userId: USER_ID,
+        role: "OPERATOR",
+        featureKey: GOLD_KEY,
+        isEnabled: true,
+      }),
+    ).rejects.toThrow("FEATURE_NOT_ENABLED_FOR_COMPANY");
+  });
+
+  it("stores an enable override for a template-blocked feature", async () => {
+    setupCompanyMap({ [GOLD_KEY]: true });
+
+    await setManagedUserFeatureOverride({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+      featureKey: GOLD_KEY,
+      isEnabled: true,
+    });
+
+    expect(mockUserFeatureFlagUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { isEnabled: true },
+        create: expect.objectContaining({ isEnabled: true }),
+      }),
+    );
+    expect(mockUserFeatureFlagDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("stores a disable override for a template-allowed feature", async () => {
+    setupCompanyMap({ [STORES_KEY]: true });
+
+    await setManagedUserFeatureOverride({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+      featureKey: STORES_KEY,
+      isEnabled: false,
+    });
+
+    expect(mockUserFeatureFlagUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { isEnabled: false },
+      }),
+    );
+  });
+
+  it("removes the override when the requested state matches the role default", async () => {
+    setupCompanyMap({ [STORES_KEY]: true });
+
+    await setManagedUserFeatureOverride({
+      companyId: COMPANY_ID,
+      userId: USER_ID,
+      role: "OPERATOR",
+      featureKey: STORES_KEY,
+      isEnabled: true,
+    });
+
+    expect(mockUserFeatureFlagDeleteMany).toHaveBeenCalled();
+    expect(mockUserFeatureFlagUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/lib/platform/user-entitlements.ts
+++ b/lib/platform/user-entitlements.ts
@@ -203,21 +203,14 @@ export type ManagedUserRole =
   | "SHOP_MANAGER"
   | "CASHIER"
   | "STOCK_CLERK";
-export type ManagedUserFeatureBlockedReason =
-  | "COMPANY_DISABLED"
-  | "TEMPLATE_BLOCKED";
-
 export type ManagedUserFeatureAccessEntry = {
   featureKey: string;
   name: string;
   description: string;
   domain: string;
-  companyEnabled: boolean;
-  templateAllowed: boolean;
-  available: boolean;
+  roleDefault: boolean;
   isEnabled: boolean;
   hasOverride: boolean;
-  blockedReason: ManagedUserFeatureBlockedReason | null;
 };
 
 function isManagedUserRole(role: string): role is ManagedUserRole {
@@ -297,6 +290,11 @@ export function isTemplateAllowedForRole(role: string, featureKey: string): bool
   return true;
 }
 
+function getRoleDefaultForFeature(templateRole: string, featureKey: string): boolean {
+  if (!isManagedUserRole(templateRole)) return true;
+  return isTemplateAllowedForRole(templateRole, featureKey);
+}
+
 export async function getUserFeatureOverrideMap(userId: string): Promise<Map<string, boolean>> {
   const normalizedUserId = userId.trim();
   if (!normalizedUserId) return new Map();
@@ -338,23 +336,21 @@ export async function getEffectiveFeaturesForUser(input: {
   const companyEnabled = getAllCompanyEnabledFeatureKeys(companyMap);
   const templateRole = resolveTemplateRoleForCompany(role, companyMap);
 
-  if (!userId || !isManagedUserRole(templateRole)) {
-    return companyEnabled;
-  }
+  const overrideMap = userId
+    ? await getUserFeatureOverrideMap(userId)
+    : new Map<string, boolean>();
 
-  const overrideMap = await getUserFeatureOverrideMap(userId);
   return companyEnabled.filter((featureKey) => {
-    if (!isTemplateAllowedForRole(templateRole, featureKey)) return false;
     const override = overrideMap.get(featureKey);
-    if (override === false) return false;
-    return true;
+    if (override !== undefined) return override;
+    return getRoleDefaultForFeature(templateRole, featureKey);
   });
 }
 
 export async function getManagedUserFeatureAccessEntries(input: {
   companyId: string;
   userId: string;
-  role: ManagedUserRole;
+  role: string;
 }): Promise<ManagedUserFeatureAccessEntry[]> {
   const companyId = input.companyId.trim();
   const userId = input.userId.trim();
@@ -366,27 +362,11 @@ export async function getManagedUserFeatureAccessEntries(input: {
   ]);
   const templateRole = resolveTemplateRoleForCompany(input.role, companyMap);
 
-  const keys = new Set<string>([
-    ...FEATURE_CATALOG.map((feature) => normalizeFeatureKey(feature.key)),
-    ...Object.keys(companyMap).map((key) => normalizeFeatureKey(key)),
-    ...overrideMap.keys(),
-  ]);
-
   const entries: ManagedUserFeatureAccessEntry[] = [];
-  for (const featureKey of keys) {
+  for (const featureKey of getAllCompanyEnabledFeatureKeys(companyMap)) {
     const catalog = CATALOG_BY_KEY.get(featureKey);
-    const companyEnabled = isCompanyFeatureEnabled(featureKey, companyMap);
-    const templateAllowed = isTemplateAllowedForRole(templateRole, featureKey);
-    const available = companyEnabled && templateAllowed;
+    const roleDefault = getRoleDefaultForFeature(templateRole, featureKey);
     const override = overrideMap.get(featureKey);
-    const hasOverride = override !== undefined;
-
-    let blockedReason: ManagedUserFeatureBlockedReason | null = null;
-    if (!companyEnabled) {
-      blockedReason = "COMPANY_DISABLED";
-    } else if (!templateAllowed) {
-      blockedReason = "TEMPLATE_BLOCKED";
-    }
 
     entries.push({
       featureKey,
@@ -394,12 +374,9 @@ export async function getManagedUserFeatureAccessEntries(input: {
       description:
         catalog?.description ?? "Custom feature flag managed at platform level.",
       domain: catalog?.domain ?? "custom",
-      companyEnabled,
-      templateAllowed,
-      available,
-      isEnabled: available && (override ?? true),
-      hasOverride,
-      blockedReason,
+      roleDefault,
+      isEnabled: override ?? roleDefault,
+      hasOverride: override !== undefined,
     });
   }
 
@@ -413,7 +390,7 @@ export async function getManagedUserFeatureAccessEntries(input: {
 export async function setManagedUserFeatureOverride(input: {
   companyId: string;
   userId: string;
-  role: ManagedUserRole;
+  role: string;
   featureKey: string;
   isEnabled: boolean;
 }): Promise<void> {
@@ -424,21 +401,11 @@ export async function setManagedUserFeatureOverride(input: {
   if (!isCompanyFeatureEnabled(normalizedFeatureKey, companyMap)) {
     throw new Error("FEATURE_NOT_ENABLED_FOR_COMPANY");
   }
-  if (!isTemplateAllowedForRole(templateRole, normalizedFeatureKey)) {
-    throw new Error("FEATURE_BLOCKED_BY_TEMPLATE");
-  }
 
   const catalog = CATALOG_BY_KEY.get(normalizedFeatureKey);
   const feature = await prisma.platformFeature.upsert({
     where: { key: catalog?.key ?? normalizedFeatureKey },
     update: {
-      name: catalog?.name ?? normalizedFeatureKey,
-      description:
-        catalog?.description ?? `Feature flag for ${normalizedFeatureKey}`,
-      domain: catalog?.domain ?? null,
-      defaultEnabled: catalog?.defaultEnabled ?? false,
-      isBillable: catalog?.isBillable ?? false,
-      monthlyPrice: catalog?.monthlyPrice ?? null,
       isActive: true,
     },
     create: {
@@ -455,7 +422,10 @@ export async function setManagedUserFeatureOverride(input: {
     select: { id: true },
   });
 
-  if (input.isEnabled) {
+  const roleDefault = getRoleDefaultForFeature(templateRole, normalizedFeatureKey);
+
+  if (input.isEnabled === roleDefault) {
+    // Matches the role default, so no override is needed.
     await prisma.userFeatureFlag.deleteMany({
       where: {
         userId: input.userId.trim(),
@@ -473,12 +443,12 @@ export async function setManagedUserFeatureOverride(input: {
       },
     },
     update: {
-      isEnabled: false,
+      isEnabled: input.isEnabled,
     },
     create: {
       userId: input.userId.trim(),
       featureId: feature.id,
-      isEnabled: false,
+      isEnabled: input.isEnabled,
     },
   });
 }

--- a/lib/user-management-api.ts
+++ b/lib/user-management-api.ts
@@ -54,21 +54,14 @@ export type ChangeManagedUserRoleInput = {
   role: ManagedUserRole;
 };
 
-export type ManagedUserFeatureBlockedReason =
-  | "COMPANY_DISABLED"
-  | "TEMPLATE_BLOCKED";
-
 export type ManagedUserFeatureAccessEntry = {
   featureKey: string;
   name: string;
   description: string;
   domain: string;
-  companyEnabled: boolean;
-  templateAllowed: boolean;
-  available: boolean;
+  roleDefault: boolean;
   isEnabled: boolean;
   hasOverride: boolean;
-  blockedReason: ManagedUserFeatureBlockedReason | null;
 };
 
 export type ManagedUserFeatureAccessResponse = {
@@ -76,7 +69,7 @@ export type ManagedUserFeatureAccessResponse = {
     id: string;
     name: string;
     email: string;
-    role: ManagedUserRole;
+    role: string;
     isActive: boolean;
   };
   features: ManagedUserFeatureAccessEntry[];


### PR DESCRIPTION
## Summary

Reworks the per-user feature access management in the admin user directory. Previously the dialog listed the entire ~140-entry feature catalog (including features the company never provisioned), could not grant a feature past a role template (overrides were a pure deny-list), crashed on unsafe property access, and its header entry point silently targeted the first user on the page.

## Changes

### Entitlements engine (`lib/platform/user-entitlements.ts`)
- **Overrides are now two-directional.** An explicit per-user override wins over the role template in both directions, so a superadmin can grant a feature that the target's role template blocks. Company provisioning remains a hard cap — a feature disabled for the company can never be granted per-user.
- **Minimal persistence.** An override row is stored only when the requested state differs from the role default, and deleted when set back to the default. Existing deny rows (`isEnabled: false`) keep their exact meaning, so no data migration is needed.
- The admin view (`getManagedUserFeatureAccessEntries`) now only emits **company-enabled features**, each reporting `roleDefault`, `isEnabled` (effective), and `hasOverride`.
- Disable overrides now also apply to users whose role isn't in the managed-role list (previously such users bypassed all filtering and received the full company feature set).
- Toggling a feature no longer rewrites catalog fields (name, price, billable flag, etc.) on the global `PlatformFeature` row.

### API (`/api/users/access`, `/api/users/access/reset`)
- Responses now use the alias-aware feature-key normalizer, so toggling an aliased key (e.g. `thrift.core`) resolves the updated entry instead of returning `feature: null`.
- Removed the workspace-managed-role gate on target users, which returned 403 for users carrying legacy roles outside the current workspace's role list. Targets are still restricted to the session's company, and both endpoints remain SUPERADMIN-only plus feature-gated by `admin.user-management.feature-access`.
- Removed the now-impossible "blocked by role template" error path.

### UI
- New `components/user-management/feature-access-dialog.tsx` replaces the inline dialog: user picker (so the header "Manage Feature Access" entry works properly), search, features grouped by domain, per-row checkbox toggles with **optimistic updates** and per-row pending state, "Granted"/"Revoked" badges on overridden rows with a one-click "Use role default" revert, enabled/override summary counts, and a reset-to-role-defaults action.
- Header menu entry now opens the dialog with an empty picker instead of auto-picking the first user on the current page.
- Fixed the crash-prone `usersQuery.data?.pagination.total` / `.pages` accesses (now optional-chained through `pagination`).
- The row action is no longer hidden for users whose role isn't in the workspace's managed-role list.

### Tests
- New `lib/platform/user-entitlements.test.ts` (11 tests) covering: template-blocked exclusion, grant-past-template, deny-of-allowed, company-disabled hard cap, override handling for unmanaged roles, company-enabled-only listing, entry state reporting, and the store/delete override persistence rules.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npx vitest run lib/platform/user-entitlements.test.ts` — 11/11 pass
- Full suite: only pre-existing failures in Gold DB-integration tests that require a live Postgres (unavailable in the sandbox); all other tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xhZBREk8qCjiLUcLmn7oU

---
_Generated by [Claude Code](https://claude.ai/code/session_019xhZBREk8qCjiLUcLmn7oU)_