### PR TITLE
docs: add Corelith design system reference + install @corelithzw/react

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,22 @@ The Gold module is undergoing a structured rebuild. Every agent working in this 
 2. `docs/gold-module-review-2026-05-09.md` §15 — Plan-of-record refinements (current Jira epic adjustments)
 3. `AGENTS.md` — collaboration rules and DoR/DoD
 
+## Design system
+
+UI work targets the Corelith design system (`@corelithzw/react`, installed; site at design.corelith.co.zw).
+
+**Before any UI change, read `docs/design-system/README.md`** — it is a router that tells you which of the
+seven reference files to load. Do not read the whole folder, and do not scrape the website when the answer
+is in `node_modules/@corelithzw/react/dist/index.d.ts` or `styles.css`.
+
+Two things that will bite you immediately:
+- The package ships **no `"use client"`** — add it to every file importing from `@corelithzw/react`.
+- **`--space-8` and `--space-10` mean different sizes** in `app/globals.css` than in the DS. See
+  `docs/design-system/01-setup.md` before touching spacing or importing `styles.css` globally.
+
+DS migration must **not** ride along in Gold files (`app/gold/**`, `components/gold/**`) as drive-by work —
+those are reviewer-gated and mid-rebuild. Land it as its own ticket.
+
 ## Hard rules (Gold module)
 
 - **Append-only ledger.** Never `DELETE`/`UPDATE` from `GoldInventoryEvent`. Insert `REVERSAL` events instead. See §4.4 C-4.

--- a/docs/design-system/01-setup.md
+++ b/docs/design-system/01-setup.md
@@ -1,0 +1,110 @@
+# Setup & integration
+
+All facts below were verified against the installed package and this repo, not read off the website.
+
+## Installed state
+
+`@corelithzw/react@0.3.0` is in `package.json` dependencies. Nothing else is needed — do not copy
+`tokens.css` / `components.css` / `icons.js` off the website.
+
+| Fact | Value |
+|---|---|
+| Peer deps | `react ^18 \|\| ^19`, `react-dom ^18 \|\| ^19` — repo has React 19.2.3 ✓ |
+| Runtime deps | none |
+| Entry | ESM `dist/index.js`, CJS `dist/index.cjs`, types `dist/index.d.ts` |
+| Stylesheet | `@corelithzw/react/styles.css` — **the only import you need** |
+| Typecheck | Verified clean under this repo's TS 5.9 + React 19 + `moduleResolution: bundler` |
+
+### `styles.css` is self-sufficient — verified
+
+- It is a **superset** of the website's `components.css`: 635 class names vs the site's 586, with **zero**
+  classes present on the site but missing from the package. Same for tokens (identical, plus 5 internal ones).
+- `dist/react.css` also exists but is a **redundant subset** — its runtime overlay rules
+  (`.x-modal-overlay`, `.toast-stack`, `.lightbox-backdrop`, `.file-upload`, `.mobile-shell`,
+  `.date-picker-popover`, …) are already appended, minified, to `styles.css`. It is not in the package
+  `exports` map. **Do not import it.**
+- `styles.css` line 14 pulls Atkinson Hyperlegible Next + Mono from Google Fonts via `@import url(...)`.
+  Offline/CSP-restricted builds fall back to `-apple-system` and lose the intended metrics.
+
+## Two blocking gotchas
+
+### 1. No `"use client"` — you must add it
+
+The dist bundle contains **zero** `"use client"` directives but uses `useState`, `useEffect`, and `document`.
+Importing any DS component into a Next.js Server Component throws.
+
+Every file importing from `@corelithzw/react` needs `"use client"` at the top. If a Server Component needs
+DS markup, wrap it in a thin client child rather than adding `"use client"` up the tree.
+
+```tsx
+"use client";
+import { Button, DataTable } from "@corelithzw/react";
+```
+
+### 2. Token name collisions with `app/globals.css`
+
+39 of the DS's 157 tokens already exist in `app/globals.css` under the same names with **different values**.
+Importing `styles.css` after `globals.css` silently reflows existing UI. These are the ones that change size
+or shape — the dangerous set:
+
+| Token | This repo | Design system | Consequence |
+|---|---|---|---|
+| `--space-8` | 32px | **40px** | Scale divergence — see below |
+| `--space-10` | 40px | **64px** | Scale divergence — see below |
+| `--button-radius` | 11px | 8px | Every button gets squarer |
+| `--radius-sm` / `md` / `lg` / `xl` / `2xl` | `calc()` off `--radius` | 6 / 8 / 10 / 14 / 18px | Radius scale replaced |
+| `--button-height` / `--input-height` | `2.25rem` | `var(--h-control-md)` = 36px | Same size, different mechanism |
+| `--font-sans` | `var(--font-sans)` → "SS Huchu" | Atkinson Hyperlegible Next | **Whole-product typeface change** |
+| `--shadow-popover` | `0 8px 24px …` | `0 12px 32px -8px …` | Deeper popovers |
+
+**The spacing scale is the real trap.** This repo indexes roughly by 4×n; the DS indexes by step. They agree
+through `--space-6` and diverge after:
+
+| | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| repo | 4 | 8 | 12 | 16 | 20 | 24 | — | **32** | — | **40** | — | — | — |
+| DS | 4 | 8 | 12 | 16 | 20 | 24 | 32 | **40** | 48 | **64** | 80 | 96 | 128 |
+
+So repo `--space-8` (32px) is DS `--space-7`, and repo `--space-10` (40px) is DS `--space-8`. Any existing
+rule using `--space-8` or `--space-10` shifts if the DS values win.
+
+The remaining collisions (`--text-*`, `--border*`, `--action-*`, `--focus-ring`, `--surface-muted`) are
+indirection-only: the repo aliases its own palette, the DS uses literals. Resolved values are close, so they
+are low-risk — but they are the seam where the two colour systems meet.
+
+### Dark mode
+
+The DS ships **no** `prefers-color-scheme` or `.dark` block — verified, zero matches across all package CSS.
+`app/globals.css` has dark-mode handling. Any surface migrated to raw DS tokens loses dark mode.
+Options: keep the repo's dark overrides layered on top and re-map DS tokens inside them, or scope the DS to
+light-only surfaces. Do not assume the DS handles it. The site's colours page claims surfaces flip in dark
+mode; the shipped CSS does not implement that.
+
+## Recommended adoption order
+
+Scoped, reversible, and it keeps the collision surface small.
+
+1. **Do not** import `styles.css` globally into `app/layout.tsx` yet — that fires all 39 collisions at once.
+2. Add the DS's non-colliding tokens (118 of them) to `app/globals.css` under their own names. `--brand-*`,
+   `--tone-*`, `--type-*`, `--dur-*`, `--ease-*`, `--h-control-*`, `--gray-*`, `--space-7/9/11/12/13`,
+   `--sidebar-w`, `--gutter-x` — all safe, all additive.
+3. Migrate route-by-route. Import `styles.css` inside the migrated subtree, or accept it globally only once
+   the collision table above has been reconciled deliberately.
+4. Reconcile spacing before anything else: rename repo `--space-8` → `--space-7` and `--space-10` → `--space-8`
+   at every use site, then adopt the DS scale wholesale. Do this as one mechanical commit with no other changes.
+5. Decide the typeface explicitly. "SS Huchu" vs Atkinson Hyperlegible is a product decision, not a
+   refactor detail — flag it, don't silently switch it.
+6. Delete the local `components/ui/*` equivalent only after its DS replacement is proven at every call site.
+   See `07-repo-migration.md`.
+
+## Verified environment notes
+
+- Breakpoints in `styles.css` are `max-width`-first: 320, 380, 460, 480, 520, 560, 600, **720**, 760, 900,
+  1100, 1200px. 720px is the dominant phone/desktop split; 900/1100/1200 handle shell collapse.
+  These are **not** Tailwind's defaults — don't mix the two on one component.
+- The repo already carries `@base-ui/react`, six `@radix-ui/*` packages, `@rtcamp/frappe-ui-react`,
+  `@tanstack/react-table`, and `@visx/*`. The DS overlaps all of them. Migrating a component means
+  **removing** the old dependency's usage, not layering DS on top.
+- The DS's own charts (`Chart.Line|Bar|Donut|Sparkline`) are deliberately minimal SVG. The repo's `@visx/*`
+  charts are more capable. Do not downgrade a working visx chart to `Chart.*` without checking the
+  20 chart recipes in `06-reference-urls.md` for whether the needed form exists at all.

--- a/docs/design-system/02-tokens.md
+++ b/docs/design-system/02-tokens.md
@@ -1,0 +1,231 @@
+# Tokens
+
+157 CSS custom properties, all defined in one `:root` in `node_modules/@corelithzw/react/dist/styles.css`.
+Values below are the shipped literals. **Reference tokens, never literals** — if you are typing a hex, a px,
+or a ms into new code, stop and find the token here.
+
+```bash
+# authoritative dump
+awk '/^:root/,/^}/' node_modules/@corelithzw/react/dist/styles.css
+```
+
+## Colour
+
+Governing rule: **saturated colour means action or state, never decoration.** Pick the semantic role token;
+never reach past it to a raw `--gray-*`.
+
+### Surfaces & structure
+
+| Token | Value | Use |
+|---|---|---|
+| `--canvas` | `#F7F8FA` | Page background |
+| `--surface` | `#FFFFFF` | Raised panels, cards, inputs |
+| `--surface-muted` | `#F1F3F6` | Hover, grouped areas |
+| `--surface-sunken` | `#E8EBF0` | Deeper grouped areas |
+| `--surface-deep` | `#DDE1E7` | Skeletons, divider blocks |
+| `--border` | `#E5E8EE` | Default hairline — the workhorse |
+| `--border-strong` | `#D2D7E0` | Emphasised separation |
+| `--border-subtle` | `#EEF0F4` | Within-group rows |
+| `--border-hover` | `#BFB9A8` | Interactive surface hover, pre-focus |
+| `--hairline` | `rgba(22,24,29,.08)` | Translucent divider over unknown bg |
+
+`--gray-50 100 200 300 400 500 600 700 800 900 950` exist for when a literal swatch is genuinely needed
+(charts, illustrations). Not for text or surfaces — use the role tokens.
+
+### Text
+
+| Token | Value | Use |
+|---|---|---|
+| `--text-strong` | `#16181D` | Headings, primary values, emphasis |
+| `--text-body` | `#262A33` | Body copy — the default |
+| `--text-muted` | `#565C69` | Secondary explanatory text. **Never an action label** |
+| `--text-subtle` | `#5E6573` | Timestamps, counts, de-emphasised meta |
+| `--text-inverse` | `#FFFFFF` | On solid dark/brand fills |
+| `--text-link` | `#0944C2` | Inline links |
+| `--ink` / `--ink-soft` | `#16181D` / `#262A33` | Solid dark button fills, ink elements |
+
+Muted text on a button reads as disabled. Don't.
+
+### Brand — the only saturated colour
+
+| Token | Value | Use |
+|---|---|---|
+| `--brand` | `#0B5DF0` | Primary action, focus ring. **One per surface** |
+| `--brand-strong` | `#0944C2` | Hover |
+| `--brand-deeper` | `#08379C` | Pressed |
+| `--brand-soft` | `#E8EFFE` | Tinted backgrounds |
+| `--brand-tint` | `rgba(11,93,240,.08)` | Selection wash |
+| `--brand-50 …900` | scale | Charts, tinted borders |
+
+`--clay`, `--clay-strong`, `--clay-soft`, `--clay-tint` are **legacy aliases pointing at `--brand`**.
+They exist so old kit pages still render. Never use them in new code.
+
+### Actions
+
+| Token | Resolves to |
+|---|---|
+| `--action-primary-bg` / `-hover` / `-pressed` / `-fg` | `--brand` / `--brand-strong` / `--brand-deeper` / `#FFF` |
+| `--action-secondary-bg` / `-bg-h` / `-fg` | `--surface` / `--surface-muted` / `--text-strong` |
+| `--action-destructive-bg` / `-hover` / `-fg` | `#B83A2A` / `#A33324` / `#FFF` |
+| `--action-destructive-soft-bg` / `-hover` | `#6B655A` / `#57524A` |
+
+Use **soft destructive** (warm grey) for serious-but-reversible actions; reserve red for irreversible ones.
+
+### Semantic tones
+
+Each tone has `--tone-X` (foreground), `--tone-X-bg`, `--tone-X-bd`.
+
+| Tone | fg | bg | Meaning — do not blur these |
+|---|---|---|---|
+| `info` | `var(--brand)` | `#E8EFFE` | Neutral information |
+| `success` | `#5E8E54` | `#E7EFE0` | **Past tense.** Done, nothing pending |
+| `warn` | `#B07626` | `#F4E6C5` | **Operator input needed.** Nothing broken yet |
+| `danger` | `#B83A2A` | `#F6E2DD` | Destructive, or an error needing intervention |
+| `neutral` | `var(--text-muted)` | `var(--surface-muted)` | No state |
+
+`--tone-success-strong` `#2E5526` and `--tone-danger-strong` `#7A2419` are for **prose on a tinted
+background** — the base tones only clear 3.84:1, which is AA Large / UI-only (badges, icons). Use the
+strong variants for sentences.
+
+Status dots: `--dot-attention` and `--dot-progress` (both brand), `--dot-ok` (success), `--dot-idle` (subtle).
+
+### Focus
+
+`--focus-ring` = `--brand`; `--focus-ring-soft` = `rgba(11,93,240,.22)`.
+Rendered as 2px solid + 3px halo, on `:focus-visible` only.
+
+### Contrast floors
+
+Body text ≥ 4.5:1. Links and headings exceed 5:1. Never signal state by colour alone — pair with an icon
+and a text label.
+
+## Typography
+
+One family; **weight does the work**. `--font-display` and `--font-serif` are aliases of `--font-sans`.
+
+- `--font-sans` — Atkinson Hyperlegible Next, then `-apple-system`, Segoe UI, Helvetica Neue, Arial
+- `--font-mono` — Atkinson Hyperlegible Mono, then ui-monospace, SF Mono, JetBrains Mono, Menlo, Consolas
+
+Role tokens are complete `font:` shorthand — assign, don't decompose. Each has a matching `.t-*` utility class.
+
+| Token | Class | Value | Use |
+|---|---|---|---|
+| `--type-display` | `.t-display` | 700 56/1.04 | Marketing hero only |
+| `--type-display-sm` | `.t-display-sm` | 600 32/1.15 | Large stat hero |
+| `--type-page-title` | `.t-page-title` | 600 22/1.3 | Page `<h1>` |
+| `--type-section-title` | `.t-section` | 600 16/1.4 | Section + card titles |
+| `--type-body-lg` | `.t-body-lg` | 400 16/1.55 | Long-form prose |
+| `--type-body` | `.t-body` | 400 14/1.55 | **Default body** |
+| `--type-body-sm` | `.t-body-sm` | 400 13/1.5 | Dense rows |
+| `--type-label` | `.t-label` | 500 14/1.4 | Form labels |
+| `--type-label-sm` | `.t-label-sm` | 500 13/1.4 | Compact labels |
+| `--type-caption` | `.t-caption` | 400 12/1.45 | Helper, captions |
+| `--type-eyebrow` | `.t-eyebrow` | 500 12/1.3 | Section eyebrow — **not** all-caps |
+| `--type-table-head` | — | 500 12/1.3 | `<th>` |
+| `--type-mono` | `.t-mono` | 500 12/1.5 mono | IDs, timestamps, money |
+
+Also: `.t-strong` `.t-muted` `.t-subtle` `.t-brand` for colour-only shifts.
+
+Rules: sentence case for headings and buttons. ALL CAPS never, eyebrows included. Emphasise by moving
+500→600, never by switching family. **Set `font-variant-numeric: tabular-nums` anywhere a number can change**
+— live counters, table columns, totals.
+
+## Spacing — 4px base, 8px rhythm
+
+`--space-px` 1 · `-1` 4 · `-2` 8 · `-3` 12 · `-4` 16 · `-5` 20 · `-6` 24 · `-7` 32 · `-8` 40 · `-9` 48 ·
+`-10` 64 · `-11` 80 · `-12` 96 · `-13` 128
+
+> ⚠ This repo's `--space-8` is 32px and `--space-10` is 40px. Different scale. See `01-setup.md`.
+
+Also `--gutter-x` 24px (page gutter per side), `--row-y` 12px (list/table row padding).
+
+| Situation | Value |
+|---|---|
+| Sibling cards in a column, field rows | `--space-4` (16) |
+| Section → section | `--space-7` (32) tight, `--space-9` (48) default |
+| Field group internals | `--space-1` (4) |
+| Page gutter | ≤430px: 16 · 431–767: 20 · ≥768: 24 |
+
+Card padding mirrors the page gutter at that viewport.
+
+Principle: **generous air over hairline borders** — reach for space before adding a divider.
+
+## Radius
+
+`--radius-xs` 4 · `-sm` 6 · `-md` 8 · `-lg` 10 · `-xl` 14 · `-2xl` 18 · `-pill` 9999
+Semantic: `--button-radius` 8, `--card-radius` 12. Never 0 — nothing in this system has sharp corners.
+
+## Control heights
+
+`--h-control-xs` 24 · `-sm` 30 · `-md` 36 (default) · `-lg` 44 (mobile-primary)
+`--input-height` and `--button-height` both alias `--h-control-md`.
+
+36px clears the WCAG 24px floor. Mobile-primary surfaces use 44. Dense tables may drop to 30, or 24 with
+4px clear space around the target.
+
+## Shadows — earned, not decorative
+
+> "A border separates two surfaces at rest. A shadow only appears when something is floating."
+
+| Token | Surface |
+|---|---|
+| `--shadow-none` | **Cards and panels at rest.** Use `--border` instead |
+| `--shadow-rest` | `0 1px 0` — barely-there lift |
+| `--shadow-hover` | Interactive card hover |
+| `--shadow-popover` | Dropdowns, menus, date pickers, autocomplete |
+| `--shadow-modal` | Modal dialogs only |
+| `--shadow-bar-bottom` | Upward shadow — bottom tab bar, sticky save bar |
+| `--shadow-sheet-bottom` | Bottom sheet — deeper, longer throw than a bar |
+| `--shadow-inset-rest` / `-soft` | Active segmented-control / tab item |
+| `--shadow-thumb` | Switch knob |
+
+Never shadow several static cards — it flattens hierarchy instead of building it.
+
+## Motion
+
+| Token | ms | Use |
+|---|---|---|
+| `--dur-instant` | 80 | Tooltips, instant feedback |
+| `--dur-fast` | 140 | Hover, button press |
+| `--dur-base` | 200 | Popovers, modals |
+| `--dur-slow` | 320 | Side sheets, section reveals |
+| `--dur-slower` | 480 | Full-screen transitions |
+| `--dur-page` | 640 | Page-level orchestration |
+
+| Easing | Curve | Use |
+|---|---|---|
+| `--ease-out` | `cubic-bezier(.22,1,.36,1)` | Entrances |
+| `--ease-in-out` | `cubic-bezier(.65,0,.35,1)` | Bidirectional movement |
+| `--ease-spring` | `cubic-bezier(.5,1.8,.3,1)` | Deliberate overshoot |
+| `--ease-snap` | `cubic-bezier(.7,0,.3,1)` | Instant corrections |
+
+Utilities: `.anim-fade-in` `.anim-fade-up` `.anim-scale-in` `.anim-slide-right` `.anim-pulse`,
+staggered with `.anim-delay-1` … `.anim-delay-6`.
+
+Animate **`transform` and `opacity`** freely. With care: `filter`, `background-color` on small elements,
+`color` on text. **Never** `width`/`height`/`top`/`left`/`margin`, or large surface backgrounds.
+
+`prefers-reduced-motion: reduce` forces `animation-duration: 0.01ms !important`; entrances snap to their
+final frame. Do not defeat this.
+
+## Layout
+
+`--sidebar-w` 264 · `--sidebar-w-narrow` 240 · `--rail-w` 220 (settings rail) · `--content-max` 900
+(forms/settings column). Data-heavy pages go to 1300px.
+
+## Internal — do not use
+
+`--btn-loading-ink` `--fill` `--pct` `--size` `--track` are component internals with no `:root` default.
+
+## Icons
+
+Not a package — a hand-rolled Lucide-style set of ~100 icons.
+
+24×24 grid · 1.6px stroke · round caps and joins · no fill · `currentColor` only · default 16px, with
+slots at 14/16/18/22/28/40.
+
+The DS delivers them via an `icons.js` helper (`<span data-icon="name">`, inflated on `DOMContentLoaded`)
+that is **not part of the React package**. This repo uses `@phosphor-icons/react` instead. Keep Phosphor —
+it is React-native and SSR-safe — but constrain it to the spec above: `size={16}`, `currentColor`, and
+Phosphor's `regular` weight, which matches the 1.6px stroke most closely. Do not adopt the
+`DOMContentLoaded` helper in a Next.js app.

--- a/docs/design-system/03-components.md
+++ b/docs/design-system/03-components.md
@@ -1,0 +1,173 @@
+# Component catalogue
+
+The website documents 47 primitives. The React package exports **71 components + 16 hooks**. The two sets
+overlap but neither contains the other — some documented primitives are CSS-only, and some exports
+(`Stack`, `Checklist`, `KanbanBoard`, `Lightbox`, `I18nProvider`, `Meter`, `NavItem`, …) are not on the
+primitives page at all.
+
+**Read props from the type file. Never from here, never from memory:**
+
+```bash
+grep -B3 -A25 "interface <Name>Props" node_modules/@corelithzw/react/dist/index.d.ts
+```
+
+The `.d.ts` carries JSDoc, `@example` blocks, and per-prop notes for nearly every component. It is the API.
+
+## React exports
+
+All 71. Compound children are listed inline. "Gotchas" flags only what the type signature won't tell you.
+
+### Actions & input
+
+| Component | Shape | Gotchas |
+|---|---|---|
+| `Button` | `variant` primary\|secondary\|ghost · `tone` default\|success\|warn\|danger · `size` sm\|md\|lg · `loading` `icon` `iconRight` `fullWidth` | One `primary` per surface |
+| `Input` | `invalid` `leadingIcon` `trailingIcon` `trailingSlot` | `trailingSlot` takes non-icon content (e.g. `<Kbd>⌘K</Kbd>`). Covers the "input group" primitive |
+| `TextArea` | `invalid` | |
+| `Select` | `options?: SelectOption[]` or children · `placeholder` `invalid` | Styled **native** `<select>` |
+| `Combobox` | `items` `value` `onChange(value, item)` `emptyMessage` `footer` `defaultQuery` | Filterable **body only** — you supply the anchor/`Popover` |
+| `Checkbox` | `label` `indeterminate` | `indeterminate` is set as a DOM property via ref |
+| `Radio` / `RadioGroup` | `Radio` needs `value`; group owns `name` `value` `onChange(value)` | Always nest Radio in RadioGroup |
+| `Switch` | `label` | Applies immediately — no save step |
+| `InputOtp` | `length` `value` `onChange(value)` `invalid`; ref → `{focus()}` | Ref is `InputOtpHandle`, not an element |
+| `SegmentedControl<T>` | `options` `value`\|`defaultValue` `onChange(value, event?)` `size` sm\|md | Generic over `T extends string`. 2–4 segments |
+| `FilterChips<T>` | `options` (with `count`) `value`\|`defaultValue` `onChange` `role` radiogroup\|tablist\|group | Single-select |
+| `RoleSwitcher<T>` | `options` `value`\|`defaultValue` `onChange` | |
+| `Form` | `submitOnEnter` (default true) | |
+| `Field` + `.Label` `.Description` `.Error` | `label` `description` `error` `required` | Wires `id`/`aria-describedby` automatically. Read it via `useFieldContext()` |
+| `InlineEdit` | `value` `onSave` `onCancel` `editing` | Click-to-edit; not a form control |
+| `FileUpload` | `onFiles(File[])` `accept` `multiple` | Drop zone only — no progress. Pair with `useUpload()` |
+| `Grabber` | `ariaLabel` | Drag affordance only; no DnD logic |
+| `Calendar` | `value` `month` `onChange(date)` `min` `max` `disabledDates` `weekStartsOn` `locale` | Local-time `Date`. `disabledDates` compared Y-M-D |
+| `DatePicker` | `value` `onChange` `min` `max` `format` `icon` `id` | Composes Input + Popover + Calendar. Single date only — for ranges use `useDateRange()` |
+
+### Overlays
+
+All portal to `document.body` unless given `container`, and share one **global overlay stack** — Escape
+closes the innermost first, and focus returns to the trigger. Forwarded refs point at the `role="dialog"`
+element.
+
+| Component | Shape | Gotchas |
+|---|---|---|
+| `Modal` | `open` `onClose` `title` `subtitle` `footer` `size` sm\|md\|lg `dismissOnBackdrop` `dismissOnEscape` | Base for Dialog + AlertDialog |
+| `Dialog` | `extends ModalProps` + `confirmLabel` `cancelLabel` `onConfirm` `confirmDisabled` `destructive` | Modal with a prebuilt footer |
+| `AlertDialog` | `open` `onClose` `title` `description` `variant` default\|danger\|warning `onConfirm` `icon` | `onConfirm` may be async — the button shows loading until it resolves. Also `AlertDialog.confirm(opts) => Promise<boolean>` for imperative one-shots |
+| `Drawer` | `side` right\|left `title` `subtitle` `footer` | Collapses to a bottom sheet under 720px |
+| `BottomSheet` | `open` `onClose` `title` | Mobile-anchored |
+| `Popover` | `open` `onClose` `title` `arrow` `dismissOnOutside` `dismissOnEscape` | You position the anchor |
+| `CommandPalette` | `open` `onClose` `items: CommandItem[]` `placeholder` `emptyMessage` `footer` | Returns `ReactPortal \| null`. `CommandItem` has `group` `icon` `shortcut` `onSelect` |
+| `Lightbox` | `images` `index` `open` `onClose` `onChange` | Drive with `useGallery()` |
+| `Tooltip` | `content` `placement` top\|bottom\|left\|right `open` | `children` must be **one focusable element** |
+
+### Layout & shells
+
+| Component | Compound children | Notes |
+|---|---|---|
+| `AppShell` | `.Sidebar` (`collapsible` `onToggle`) · `.TopBar` / `.Topbar` · `.Main` · `.Brand` (`mark` `href`) | Root takes `collapsed`. Tab order: sidebar nav → top-bar → main |
+| `AuthShell` | `.Brand` (`logo` `product`) · `.Card` (`title` `subtitle` `footer`) | Split-pane sign-in. No AppShell |
+| `MobileShell` | `.Header` · `.Body` · `.BottomTabs` · `.Tab` · `.NavItem` | `.Tab` renders `null` — it is a config shape, not an element |
+| `Stack` | — | `as` `direction` vertical\|horizontal `gap` none\|xs\|sm\|md\|lg\|xl `align` `justify` `wrap` |
+| `Card` | `.Header` `.Title` `.Body` `.Footer` | Resting card: border, no shadow |
+| `NavGroup` / `NavItem` | — | `NavItem` uses **`to`** (mapped to `href`), plus `active` `icon` `badge`. Emits `aria-current="page"` |
+| `PageHeader` | — | `title` `onBack` `backLabel` `actions`. Exactly one per page |
+| `Tabs` | `.List` (`ariaLabel`) `.Tab` (`value`) `.Panel` (`value`) | `value`+`onValueChange` or `defaultValue`. Full WAI-ARIA tablist |
+| `BottomTabs<T>` | — | `items: BottomTabItem[]` (`icon` `badge` `href` `disabled`), `value` `onChange` |
+
+### Data & display
+
+| Component | Shape | Gotchas |
+|---|---|---|
+| `DataTable<Row>` | `columns` `rows` `getRowId` `selectable` `selected` `onSelectionChange` `sort` `onSortChange` `caption` `footer` `emptyState` | **Fully controlled** — sorting/selection state is yours; it does not sort rows. `DataTableSortState.column` is canonical; `columnId` is deprecated. Columns take `cell(row,i)` `numeric` `sortable` `width` |
+| `DataToolbar` | `.Search` `.Filters` `.Actions` | Layout only — wire behaviour yourself |
+| `Pagination` | `page` `pageCount` `onChange` `total` `pageSize` `pageSizeOptions` `onPageSizeChange` | |
+| `Chart` | `.Line` `.Bar` `.Donut` (`inner`) `.Sparkline` | Minimal SVG. `width` `height` `color` `legend` `axes`. `Line` takes `ChartPoint[]`; `Bar`/`Donut` take `ChartCategoricalDatum[]`; `Sparkline` takes `number[]` or points |
+| `KanbanBoard<T>` | `columns` `items` `onMove(id,from,to,toIndex)` `renderCard` `label` | Keyboard-accessible DnD. Pair with `useKanban()`. `KanbanColumnDef.limit` renders a WIP warn pill |
+| `DayList` | `rows: {label, value, tone}` | `tone` is up\|down\|neutral |
+| `RowCard` | `title` `sub` `value` `delta` `deltaTone` `meta` `leading` `trailing` `onClick` `href` | `deltaTone` positive\|negative\|neutral |
+| `StatCard` (alias `Stat`) | `label` `value` `unit` `delta` `deltaTone` `tone` | `deltaTone` up\|down\|neutral. Note: differs from RowCard's |
+| `StatHero` | `label` `value` `description` `secondaries[]` | |
+| `KpiGrid` | `minWidth` | **Deprecated** on the website — use `StatCard` children in a plain grid |
+| `Checklist` | `.Item` (`done` `title` `subtitle` `onToggle` `action`) | |
+| `CommentsThread` | `comments` `currentUser` `mentionable` `onAdd` `onEdit` `onResolve` `onReact` `showResolved` `onToggleShowResolved` | Flat `Comment[]`, **one** nesting level — deeper replies flatten with a "replying to X" prefix. Pair with `useComments()`. `DEFAULT_REACTIONS` = 👍 ❤️ 😄 🎉 🤔 👀 |
+| `NotificationMatrix` | `events` `channels` `value` (keyed `` `${eventId}:${channelId}` ``) `onChange` `masterPauseHours` `onMasterPause` | Real `<table>`. `MasterPause` = `0\|1\|4\|24\|'until-tomorrow'`. Pair with `usePreferences()` |
+
+### Status & feedback
+
+| Component | Shape | Gotchas |
+|---|---|---|
+| `Alert` | `tone` info\|success\|warn\|danger `title` `icon` | Inline, persistent |
+| `Badge` | `tone` neutral\|info\|success\|warn\|danger\|clay\|outline `icon` | `clay` is a legacy alias of brand — don't use it |
+| `Avatar` | `size` sm\|md\|lg `tone` default\|clay\|ink `name` `src` `alt` `initials` | Derives 1–2 initials from `name` |
+| `Kbd` | — | |
+| `EmptyState` | `icon` `title` `description` `action` `variant` full\|inline | `inline` renders `.p-empty-inline` — this **is** the "inline empty" primitive |
+| `Progress` | `value` 0..1 (or 0..max with `max`) `label` | `null`/`undefined` → indeterminate |
+| `Meter` | `value` `min` `max` `low` `high` `optimum` `tone` `label` | `role="meter"` — a gauge, not progress |
+| `Spinner` | `label` | |
+| `Skeleton` | `width` `height` `lines` `gap` | `lines > 1` stacks rows |
+| `Stepper` | `.Step` (`state` pending\|current\|done, `label`) | Root takes `total` `current` (1-based) `labelled`. `total` ignored when children given |
+| `SaveBar` | `dirty` `title` `summary` `onSave` `onDiscard` `saving` `saveLabel` `discardLabel` `actions` | Slides up on `dirty` |
+| `Toast` / `ToastProvider` | Provider: `defaultDuration` (0 = sticky) `container`. Emit via `useToast()` | Mount the provider once. `ToastInput` has `tone` `title` `message` `duration` `action{label,onClick}` |
+| `Menu` (alias `DropdownMenu`) | `.Item` (`icon` `shortcut` `destructive`) `.Label` `.Divider` / `.Separator` | Menu body only — you own the trigger and positioning |
+| `I18nProvider` | `locale` `setLocale` `locales` `messages` `fallbackMessages` | Read via `useI18n()` / `useT()` |
+| `LocalePicker` | `locales` `onChange(locale)` `label` | Reads `I18nProvider` unless overridden |
+
+### Hooks
+
+| Hook | Returns / purpose |
+|---|---|
+| `useToast()` | `{show(input) => id, dismiss(id)}` — needs `ToastProvider` |
+| `useComments(initial?)` | `{comments, add, edit, resolve, react, reply}` — **in-memory**; back it with real persistence |
+| `useKanban(initial)` | `{items, move, addCard, removeCard, setItems}` |
+| `usePreferences(initial?)` | `{prefs, set, pauseFor, pause, quietHours, setQuietHours}` — **in-memory** |
+| `useGallery(initial?, total?)` | `{open, index, show, close, next, prev, setIndex}` |
+| `useDateRange(initial?)` | `{from, to, setRange, preset(id), isPreset(id)}` — ISO `YYYY-MM-DD`; auto-swaps if `from > to`. Presets: today, yesterday, this-week, last-week, this-month, last-month, last-7-days, last-30-days, year-to-date |
+| `useUpload()` | `{upload(url, file\|FormData, opts?), cancel, reset, status, progress, error, response}` — XHR-backed, so real progress |
+| `useOptimistic(initial, apply)` | `{base, setBase, derived, queue, mutate(m) => {confirm, rollback}}` |
+| `useUrlState(key, default)` | `[value, set]` synced to `?key=` via `history.replaceState`. SSR-safe |
+| `usePersistedFlag(key, initial)` | `[value, set]` in `localStorage`. Survives sign-out |
+| `useMatchMedia(query)` (alias `useMediaQuery`) | `boolean`. Returns `false` during SSR **and on first client render** — deliberate, for hydration safety |
+| `useInterval(cb, delay, {paused})` | Always calls the latest `cb`. `delay: null` or `paused` stops it |
+| `useI18n()` / `useT()` | Full context / just `t(key, vars)` |
+| `useFieldContext()` | `{inputId, descId, errorId, invalid, describedBy} \| null` — for custom controls inside `Field` |
+
+## CSS-only — no React export
+
+Documented on the primitives page but **absent from `@corelithzw/react@0.3.0`**. Author markup by hand
+against the classes below, which are all verified present in `styles.css`. Grep before extending:
+
+```bash
+grep -n "^[^{]*\.<class>[^a-z0-9_-]" node_modules/@corelithzw/react/dist/styles.css
+```
+
+| Primitive | Real markup contract |
+|---|---|
+| **Accordion** | `.accordion` wrapping native `<details>` / `<summary>`, body in `.acc-body`. Open state is `<details open>` — the browser handles `aria-expanded` and keyboard. ⚠ The website documents `.accordion-item` / `.accordion-trigger` / `.accordion-content`; **those do not exist.** |
+| **Status indicator** | `.status-dot` + one of `.attention` `.ok` `.progress` `.idle` `.ring`. Dot drawn via `::before` |
+| **Chip** | `.chip`, with `.icon`/`svg` and `.caret` children; rows use `.chip-bar`. Filter variant `.fchip` |
+| **Tag** | `.tag` with a `.x` child as the remove button (needs a real `<button>` + `aria-label`) |
+| **Table** | `.table`; `<th>`/`<td class="num">` right-aligns numerics; `.table.quiet` for low-chrome; `.more` for the row overflow trigger. Use `DataTable` instead whenever the table sorts or selects |
+| **Numeric cell** | `.num` on `th`/`td`, plus `--type-mono` and `tabular-nums` |
+| **Item row** | `.list-item` with `.lead` `.title` (`.bold`) `.sub` `.meta` `.chev` `.body-text > .desc` |
+| **Mobile list** | `.list`, or `.list-plain` for no chrome, containing `.list-item` |
+| **Button group** | `.btn-split` — split buttons and toggle groups. ⚠ There is no `.btn-group` |
+| **Hover card** | `.hover-card`, which forwards to `.pop-card`. Legacy — prefer `Popover` |
+| **Attachment center** | `.upload-zone` (`.uz-ic` `.uz-title` `.uz-help` `.uz-actions`, `.dragover` state) plus `.file-row` / `.file-tile`. React `FileUpload` covers only the drop zone |
+| **Pill** | `.pill`, or `.erp-pill` for the denser ERP variant. Prefer `Badge` |
+| **Avatar group** | `.avatar-group` around stacked `Avatar`s |
+| **Tab strips** | `.tabstrip` `.seg-tabs` `.iconstrip` / `.iconstrip-tab` `.kit-tab`. Prefer `Tabs` — these have no keyboard contract |
+| **Toolbars** | `.page-toolbar` `.toolbar-group` |
+| **Sidebar internals** | `.sb-chrome` `.sb-nav` `.sb-section` `.sb-section-label` `.sb-item`. Prefer `AppShell.Sidebar` + `NavGroup`/`NavItem` |
+| **Settings layout** | `.settings-layout` `.settings-rail` `.settings-content` `.settings-section` `.settings-row` |
+| **Steps** | `.steps` with `.st` (`.current` `.done`), `.st-bubble` `.st-label` `.st-rail`. Prefer `Stepper` |
+| **Notification row** | `.notif` (`.unread`) with `.n-av` (`.brand` `.success` `.warn` `.danger`) `.n-body` `.n-dot` `.n-time` |
+| **Diff** | `.diff` / `.diff-line` — for the sync conflict view |
+
+**No styles ship at all** for these documented primitives: mobile action bar, scroll container, page section,
+export menu. This repo already has working local implementations
+(`components/ui/mobile-action-bar.tsx`, `scroll-container.tsx`, `page-section.tsx`, `export-menu.tsx`) —
+**keep them** and restyle with tokens. Do not delete them expecting a DS replacement.
+
+## Utilities in `styles.css`
+
+Layout: `.row` `.col` `.wrap` `.nowrap` `.grow` `.center` `.between` `.gap-1` `.gap-4` `.ml-auto` `.truncate`
+Type: `.t-*` (see `02-tokens.md`) · A11y: `.sr-only` `.ds-skip-link` · Motion: `.anim-*`

--- a/docs/design-system/04-composition.md
+++ b/docs/design-system/04-composition.md
@@ -1,0 +1,187 @@
+# Composition — blocks, patterns, shells, pages
+
+Use this when building or restructuring a whole surface. For a single control see `03-components.md`.
+
+## The six-step page recipe
+
+1. **Pick a shell.** `AppShell` for almost everything; settings shell for multi-section editors;
+   `AuthShell` for sign-in; `MobileShell` for portal/kiosk surfaces.
+2. **One page header.** `PageHeader` — title, lede, meta pills, **max 3 actions, exactly 1 primary.**
+3. **Pick one body block** by content type:
+   | Content | Body block |
+   |---|---|
+   | List of records | List page shell |
+   | One record | Detail page shell |
+   | Create / edit form | Form shell |
+   | Executive overview | KPI grid + module matrix |
+   | Reference data editor | Master data shell |
+4. **Wire the state surfaces** — empty, loading, error — **before shipping**, using `EmptyState`,
+   status state, and record-saved banner.
+5. **Place actions in exactly one place.** Page-level → header. Filters and bulk → toolbar.
+   Per-record → row menu. **Never duplicate an action across two locations.**
+6. **Wire keyboard + a11y.** Everything tab-reachable, `⌘K` palette available, `aria-label` on every
+   icon-only button. See `05-rules.md`.
+
+## Blocks (33)
+
+A block is several components in a fixed arrangement with **no behavioural contract**. Prefix `b-`.
+"React" means an export exists in `@corelithzw/react`; "CSS" means author markup yourself.
+
+### Page chrome
+| Block | Impl |
+|---|---|
+| Page header — title, lede, meta pills, actions | React `PageHeader` |
+| Page intro — eyebrow + headline + lede | CSS (`.t-eyebrow` + `.t-page-title` + `.lede`) |
+| List page shell — header + toolbar + table + pagination | CSS · compose `PageHeader` + `DataToolbar` + `DataTable` + `Pagination` |
+| Detail page shell — hero + 1.4fr/1fr body | CSS `.detail-page` (`.detail-grid` `.detail-card` `.detail-stats`) |
+| Form shell — header, sections, sticky action bar | CSS · compose `Form` + `Field` + `SaveBar` |
+
+### Executive surfaces
+| Block | Impl |
+|---|---|
+| Stat card — one number with delta | React `StatCard` / `Stat` |
+| KPI grid | React `KpiGrid` — **deprecated**, use `StatCard` children in a grid |
+| Module matrix — all active modules with status | CSS `.modules-grid` > `.module-card` (`.num` `.nm` `.ds` `.arrow`) |
+| Summary bar — one line of small metrics | CSS |
+| Critical strip — must-act-now items | CSS — ⚠ `.b-critical-strip` **has no styles**; see the gap note below |
+| Quick links — 4-up next-action tiles | CSS (`.nav-card`) |
+| Highlights — wins and anomalies | CSS |
+
+### Content
+| Block | Impl |
+|---|---|
+| Card & panel | React `Card` (+ `.card-soft` `.card-pad` `.card-sub`) |
+| Detail hero — title + key facts + primary action | CSS `.detail-hero` |
+| Activity feed — who / what / when | CSS `.activity-card` |
+| Comment thread | React `CommentsThread` + `useComments` |
+| Data toolbar — search, chips, count, bulk actions | React `DataToolbar` |
+| Callout — bordered notice with icon | CSS `.b-callout` |
+
+### Status & state — all four are required on every data surface
+| Block | Impl |
+|---|---|
+| Empty state — first-run / no-results / error | React `EmptyState` (`variant="inline"` for < 80px) |
+| Status state — whole-area loading / error / blocked | CSS · compose `Spinner` or `Skeleton` + `Alert` |
+| Record saved banner | CSS |
+| Export bar — recently-finished export | CSS |
+
+### Mobile portal
+| Block | Impl |
+|---|---|
+| Bottom tabs (3–5, phone only) | React `BottomTabs` · CSS `.b-bottom-tabs` |
+| Filter chips (horizontal scroll) | React `FilterChips` · CSS `.b-filter-chips` |
+| Row card (full-width tap target) | React `RowCard` · CSS `.b-row-card` |
+| Stat hero (brand-tinted) | React `StatHero` · CSS `.b-stat-hero` |
+| Day list (day-grouped events) | React `DayList` · CSS `.b-day-list` |
+
+### Marketing & offline
+| Block | Impl |
+|---|---|
+| Pricing grid / pricing card | CSS `.pricing-card` |
+| Offline banner — system-wide disconnection | CSS |
+| Sync panel — offline queue, retry, failures | CSS |
+| Conflict dialog — side-by-side sync diff | CSS `.diff` / `.diff-line` inside `Modal` |
+
+### ⚠ Documented blocks with no shipped CSS
+
+Verified absent from `styles.css`: `.b-critical-strip` `.b-page-header` `.b-page-intro` `.b-module-matrix`
+`.b-summary-bar` `.b-quick-links` `.b-highlights` `.b-status-state` `.b-record-saved-banner` `.b-export-bar`
+`.b-offline-banner` `.b-sync-panel` `.b-conflict-dialog` `.b-form-shell` `.b-list-page-shell`
+`.b-detail-page-shell` `.b-master-data-shell` `.b-stat-card` `.b-card` `.b-activity` `.b-comment`
+`.b-data-toolbar` `.b-empty-state` `.b-pricing`.
+
+Only **six** `.b-*` classes actually ship: `.b-bottom-tabs` `.b-callout` `.b-day-list` `.b-filter-chips`
+`.b-row-card` `.b-stat-hero`.
+
+For the rest, **compose from primitives and tokens** — using an unstyled `.b-*` class produces bare markup.
+Where the website names one (e.g. `.b-critical-strip`), keep it on the element as a semantic hook, but do
+not rely on it for appearance.
+
+**Critical strip spec** (compose by hand): a top-of-page banner **above** the page header — icon +
+one-line message + primary action. Tone follows the highest severity present. Max 4 items; at 5, link to a
+queue instead. Only render it when there is something the operator must act on this shift.
+Responsive: ≤720px the message wraps and the action becomes icon-only; ≥1024px full-width with the action
+right-aligned.
+
+## Patterns (20)
+
+A pattern owns a **state machine, URL convention, or keyboard contract**. Prefix `x-`.
+That contract — not complexity — is what makes something a pattern.
+
+| Pattern | Contract it owns | Primary components |
+|---|---|---|
+| App shell | Sidebar collapse, tab order, responsive rail | `AppShell` + `NavGroup`/`NavItem` |
+| Settings | 240px rail + 900px content, section routing | `.settings-layout` + `.settings-rail` |
+| Executive dashboard | Drill-down navigation | Critical strip + `StatCard` + module matrix + highlights |
+| Command palette | Global `⌘K`, fuzzy search, groups | `CommandPalette` |
+| Data table | Sticky header, bulk select, pagination, filter URL state | `DataTable` + `DataToolbar` + `Pagination` + `useUrlState` |
+| Detail view | Hero + body + context sidebar | `.detail-page` grid |
+| Detail tabs | Tab ↔ URL sync | `Tabs` + `useUrlState` |
+| Master data | Split pane, **saves on blur** | CSS |
+| Bulk edit | Toolbar swap on selection, undo window | `DataToolbar` + `useOptimistic` |
+| Import wizard | upload → map → preview → commit | `Stepper` + `FileUpload` + `DataTable` |
+| Audit view | Cross-module append-only log | `.activity-card` |
+| Modal & sheet | Overlay stack, focus trap, Escape order | `Modal` / `Drawer` |
+| Bottom sheet | Phone-anchored, drag dismiss | `BottomSheet` |
+| Approval flow | Approve / reject / delegate state machine | `AlertDialog` + `Stepper` |
+| Role gate | Permission-based rendering | conditional render — see `x-role-gate` |
+| Auth flow | sign-in → 2FA → reset | `AuthShell` + `InputOtp` |
+| Onboarding | Workspace setup, feature primers, progress | `Checklist` + `Stepper` |
+| Offline runtime | Queue, sync, conflict resolution | banner + sync panel + conflict dialog |
+| Notifications | Toast → popover → inbox escalation | `ToastProvider` + `useToast` + `.notif` |
+| Help center | In-product side panel | `Drawer` |
+
+## Shells (9 app + 4 page)
+
+| ID | Shell | Layout | Responsive |
+|---|---|---|---|
+| SHL·01 | Dashboard | 252px sidebar, org switcher, primary action, grouped nav | desktop → tablet rail → mobile sheet |
+| SHL·02 | Settings | 240px rail + 900px max content | desktop → mobile collapse |
+| SHL·03 | Data table | Full-bleed, sticky column headers | desktop, tablet |
+| SHL·04 | POS portal | Bottom tabs, keypad, category tiles | mobile → tablet side rail → desktop + customer pane. PWA |
+| SHL·05 | Parent portal | Mobile-first, fee balance | mobile → tablet. PWA |
+| SHL·06 | Student portal | Tablet-first, collapsible left rail | tablet → phone sheet |
+| SHL·07 | Teacher portal | Class/term-anchored nav | tablet → desktop → mobile |
+| SHL·08 | Staff portal | Desktop-first self-service, softer than dashboard | desktop. PWA |
+| SHL·09 | Admin control plane | Cross-tenant ops, **dark by default** | desktop only |
+| PG·01 | List page | Header + toolbar + table + pagination | — |
+| PG·02 | Detail page | **1.4fr / 1fr** body split | mobile stacks |
+| PG·03 | Form | Grouped field sections + sticky save bar | — |
+| PG·04 | Master data | Split list + editor, saves on blur | — |
+
+⚠ SHL·09 is "dark by default" but the package ships **no dark mode**. Building it means authoring the
+dark palette yourself. See `01-setup.md`.
+
+Note the sidebar-width discrepancy: SHL·01 says 252px, `--sidebar-w` is **264px**, `--sidebar-w-narrow`
+is 240px. Use the tokens.
+
+## Page templates (10)
+
+| Template | Purpose | Composition |
+|---|---|---|
+| `pg-overview` | Operations homepage | AppShell + KPI grid + critical strip + activity feed |
+| `pg-data` | Dense ERP lists (batches, journals, invoices) | AppShell + data table + data toolbar |
+| `pg-detail` | Record inspection | AppShell + detail view + detail tabs |
+| `pg-posting` | Posting rules: configure, simulate, replay | AppShell + data table + modal |
+| `pg-import` | CSV ingestion | AppShell + import wizard |
+| `pg-inventory` | Stock, alerts, transfers | AppShell + master data |
+| `pg-products` | Catalogue, grid + table views | AppShell + master data + filter chips |
+| `pg-customers` | Directory with credit + purchase history | AppShell + master data + detail view |
+| `pg-retail` | Retail module index | AppShell + module matrix |
+| `pg-signin` | Auth, 3 layout variants | **No AppShell** + auth flow |
+
+Full markup for each: `https://design.corelith.co.zw/system/<id>.html`.
+
+## Responsive contract
+
+Package breakpoints are `max-width`-first: **720px** is the main phone/desktop split; 900/1100/1200 handle
+shell collapse; 320–600 tune dense mobile.
+
+| Viewport | Gutter | Behaviour |
+|---|---|---|
+| ≤430px | 16px | Sidebar hidden behind hamburger → sheet. Controls 44px |
+| 431–767px | 20px | Sidebar collapses to icon rail |
+| 768–1199px | 24px | Full sidebar, narrowed content |
+| ≥1200px | 24px | Full sidebar (240–280px), content to 1300px on data pages |
+
+Do not mix these with Tailwind's `sm:`/`md:` scale inside one component — pick one system per component.

--- a/docs/design-system/05-rules.md
+++ b/docs/design-system/05-rules.md
@@ -1,0 +1,128 @@
+# Rules — accessibility, copy, layering
+
+These are contracts, not preferences. A change that violates one is a regression.
+
+## Accessibility
+
+### Focus
+- Focus ring on **`:focus-visible` only** — 2px solid `--focus-ring` + 3px `--focus-ring-soft` halo.
+  Never `outline: none` without an equivalent replacement.
+- Modals trap focus while open; Escape releases. Focus **returns to the trigger** on close.
+- The DS overlay stack handles nested overlays — Escape closes the innermost first. Don't hand-roll
+  Escape handlers on DS overlays; you'll fight it.
+
+### Keyboard
+- Every interactive element operable by keyboard alone.
+- Tab / Shift+Tab move · Enter / Space activate · Escape closes overlays.
+- Composite widgets (tabs, menus, listboxes) use **roving tabindex**: one tab stop, arrows navigate inside.
+  `Tabs`, `DataTable`, `Menu`, `KanbanBoard`, `NotificationMatrix` already implement this.
+- Table rows activate on Enter. Checkboxes toggle on Space.
+- `⌘K` opens the command palette from any surface.
+
+### Labels & ARIA
+- Every control needs `<label for>` or `aria-labelledby`. **Every icon-only button needs `aria-label`.**
+- Screen-reader-only text uses `.sr-only`.
+- Live regions: `aria-live="polite"` for toasts and confirmations, `aria-live="assertive"` for errors.
+  `role="status"` for progress, `role="alert"` for errors.
+- **Never signal state by colour alone.** Colour + icon + text label, always.
+
+### Touch targets
+36px default (`--h-control-md`), clearing the WCAG 24px floor. Mobile-primary surfaces use 44px
+(`--h-control-lg`). Dense tables may use 30px, or 24px with 4px clear space.
+
+### Contrast
+Body text ≥ 4.5:1. Links and headings > 5:1. `--tone-warn` / `--tone-success` on white are 3.84:1 —
+**AA Large / UI only** (badges, icons). For sentences on a tinted background use `--tone-success-strong`
+or `--tone-danger-strong`.
+
+### Motion
+`prefers-reduced-motion: reduce` forces `animation-duration: 0.01ms !important` and snaps entrances to
+their final frame. Do not override it. Never make motion load-bearing for meaning.
+
+## Voice & copy
+
+Tone: **confident, direct, quietly human.** No exclamation marks. No apologies. No marketing language.
+
+| Surface | Rule | Good | Bad |
+|---|---|---|---|
+| Button | Action verb, sentence case | "Approve" · "Post" · "Settle" | "Click here to approve" |
+| Confirmation | Past tense, name the object | "Receipt R-19281 printed" | "Yay! All done" |
+| Error | What broke + next step | "Couldn't reach refinery. Retry?" | "Oops! Something went wrong" |
+| Alert | Specific fact + timing | "Will sell out by 16:00" | "Low stock alert!" |
+| Empty state | What, why, next action | "No receipts yet — they'll appear here as cashiers ring up sales" | "No data" |
+| Loading | Name the action | "Fetching receipts…" | "Loading…" |
+| Toast | One sentence, **no end punctuation** | "Receipt R-19281 printed" | "Success!" |
+| Confirm dialog | Outcome + consequence | "Close shift. This locks the till until tomorrow" | "Are you sure?" |
+
+- **Destructive actions must name the specific object affected.** Not "Delete item" — "Delete batch B-4471".
+- **Warnings always carry a count or a next step.** Never a bare label.
+- Sentence case everywhere. ALL CAPS never, eyebrows included.
+
+### The five canonical status labels
+
+**Needs input · Running · Completed · Idle · Not started**
+
+Do not invent new ones. Do not synonym-drift ("In progress", "Pending", "Done", "Awaiting", "Queued" are
+all wrong). If a state genuinely doesn't fit, that's a design conversation, not a copy choice.
+
+### Value formatting
+
+| Type | Format | Example |
+|---|---|---|
+| Money | symbol + non-breaking space + 2 decimals | `$ 2,816.40` |
+| Time | 24-hour | `14:38` |
+| Date | day month year, no zero-padding | `3 June 2026` |
+| ID | mono, zero-padded | `R-19281` |
+| Range | en-dash with spaces | `07:30 – 19:00` |
+
+Anything numeric that can change gets `font-variant-numeric: tabular-nums`. IDs, timestamps, and monetary
+amounts get `--font-mono`.
+
+## Elevation & z-index
+
+> "A border separates two surfaces at rest. A shadow only appears when something is floating."
+
+Resting cards get `--border`, not a shadow. Shadowing several static cards destroys hierarchy.
+
+| Layer | z-index | Contents |
+|---|---|---|
+| Base | auto / 0 | Page content, cards, tables |
+| Local lift | 1–5 | Sticky headers, focus halos |
+| In-page sticky | 20–30 | Embedded toolbars, chrome |
+| Sidebar / rails | 44–55 | Navigation |
+| Top nav | 60 | Primary nav bar |
+| Drawer / sheet | 80–81 | Side drawers |
+| Popover / menu | 90 | Dropdowns, date pickers |
+| Modal | 100 | Modal dialogs |
+| Toast | 200 | **Intentionally above modals** |
+
+⚠ The package's own runtime overlay CSS uses **9998/9999** (and 1000 for `.lightbox-backdrop`), not this
+scale. So DS overlays sit above everything in this repo regardless. When mixing a DS overlay with a
+Radix/Base-UI overlay, the DS one wins — plan the interaction rather than fighting z-index.
+
+## Colour discipline
+
+1. Saturated colour = action or state. **Never decoration.**
+2. **One brand-blue element per surface.** Two competing primary buttons is a bug.
+3. Pick the role token; never bypass it to a raw `--gray-*`.
+4. Never hard-code a hex.
+5. `--text-muted` is for secondary prose, **never an action label** — it reads as disabled.
+6. Red for irreversible. `--action-destructive-soft-bg` (warm grey) for serious-but-reversible.
+7. Success copy is past tense and calm. No celebration.
+
+## Pre-merge checklist
+
+- [ ] Zero hard-coded hex / px / ms / font stacks
+- [ ] One primary action on the surface
+- [ ] Empty, loading, and error states all present
+- [ ] `aria-label` on every icon-only button
+- [ ] Keyboard-reachable and keyboard-operable end to end
+- [ ] Focus visible, trapped in overlays, returned on close
+- [ ] State conveyed by icon + text, not colour alone
+- [ ] Status labels drawn from the canonical five
+- [ ] Money / date / time / ID formatted per the table above
+- [ ] `tabular-nums` on every changing number
+- [ ] Resting surfaces bordered, not shadowed
+- [ ] `prefers-reduced-motion` respected
+- [ ] `"use client"` present on any file importing `@corelithzw/react`
+- [ ] No action duplicated across header + toolbar + row

--- a/docs/design-system/06-reference-urls.md
+++ b/docs/design-system/06-reference-urls.md
@@ -1,0 +1,152 @@
+# Worked examples — fetch on demand
+
+Base: `https://design.corelith.co.zw/`
+
+This file is an **index, not content.** Every entry is a live page with copy-pasteable code. Fetch the one
+page you need; never bulk-fetch. When a fetched page contradicts `index.d.ts` or `styles.css`,
+**the package wins** — see `README.md`.
+
+## URL patterns
+
+| Layer | Pattern |
+|---|---|
+| Primitive | `system/p-<name>.html` |
+| Block | `system/b-<name>.html` |
+| Pattern | `system/x-<name>.html` |
+| Page template | `system/pg-<name>.html` |
+| Foundation | `system/<colors\|typography\|spacing\|elevation\|motion\|iconography\|accessibility\|voice\|content\|tokens\|principles>.html` |
+| Guide | `system/guide-<name>.html` |
+| Cookbook recipe | `cookbook/<slug>.html` |
+| Chart recipe | `cookbook/charts/<slug>.html` |
+| Kit | `kits/<name>.html` |
+| Portal prototype | `portals/<name>/demo.html` |
+| Vertical | `verticals/<name>/index.html` |
+| Shared module | `shared/<stock\|hr\|maintenance\|cctv\|settings\|notifications>/index.html` |
+
+Also: `sitemap.html` (every page), `playground/index.html`, `system/changelog.html`,
+`system/audit-a11y.html`, `system/audit-reuse.html`, `system/roadmap.html`.
+
+## Cookbook — 61 recipes
+
+Real React using only `@corelithzw/react` plus state hooks — no other dependencies. Each opens with the
+primitives it needs and ends with a complete copyable component. **This is the best source for
+"how do I actually wire X".**
+
+`cookbook/<slug>.html`
+
+**Onboarding** · `onboarding-checklist` — empty state → first success
+
+**Auth** · `auth-signin-2fa` (password + 6-digit OTP, resend countdown) · `auth-forgot-password` ·
+`auth-signup-email-verify` · `auth-permission-gate`
+
+**Shells & navigation** · `shells-app-shell-sidebar` · `shells-mobile-bottom-tab` · `commands-cmd-k` ·
+`shells-multi-tenant-switcher` · `shells-deep-link-restore`
+
+**Forms** · `forms-multi-step-wizard` (validated + autosave) · `forms-autosave-drawer` ·
+`forms-inline-edit-row` · `forms-bulk-edit-with-undo` · `forms-file-upload` · `forms-date-range-picker`
+
+**Lists** · `lists-simple-list` · `lists-grid-list` · `lists-grouped-by-date` · `lists-grouped-by-section` ·
+`lists-virtualised-long` · `lists-history-feed` · `lists-filterable-data-table` · `lists-master-detail` ·
+`lists-activity-log` · `lists-kanban-board`
+
+**Tables** · `tables-server-paginated` · `tables-editable-cells` · `tables-heavy-with-everything` ·
+`tables-responsive-to-cards`
+
+**Views** · `views-print-friendly` · `views-image-gallery`
+
+**Dashboards** · `dashboards-operator-overview` · `dashboards-kpi-hero-drilldown`
+
+**States** · `states-empty-loading-error` · `states-optimistic-mutations` · `notifications-toasts`
+
+**Other** · `settings-notification-preferences` · `i18n-localized-app` (locale + currency) ·
+`communication-comments-thread` · `approvals-leave-request`
+
+### Charts — 20 recipes
+
+`cookbook/charts/<slug>.html` · index at `cookbook/charts/index.html`
+
+`line-simple` `line-multi` `area-stacked` `bar-vertical` `bar-horizontal` `bar-grouped` `bar-stacked`
+`donut` `pie` `progress-ring` `sparkline` `bullet` `heatmap` `funnel` `scatter` `radar` `treemap` `gauge`
+`waterfall` `candlestick`
+
+⚠ The React package's `Chart` namespace only ships **Line, Bar, Donut, Sparkline**. The other 16 recipes
+build on SVG or the CSS layer. Before replacing a working `@visx/*` chart in this repo, check the recipe —
+the DS may not have the form at all. See `01-setup.md`.
+
+## Kits — 10 full screens
+
+`kits/<name>.html` · Operator-facing back-office for multi-tenant ERP: approvals, reconciliation, daily ops.
+Ready-to-copy compositions of patterns + blocks.
+
+| Kit | Use case | Built from |
+|---|---|---|
+| `data-heavy` | Dense ERP operations | AppShell + data table + page header + data toolbar |
+| `lists` | Medium-density viewing | AppShell + data table + page header |
+| `posting-studio` | Define and test posting rules | AppShell + page header + heavy controls |
+| `journal-detail` | Single-record inspection | AppShell + detail view + page header |
+| `batch-detail` | Batch tracking and settlement | AppShell + detail view + page header |
+| `employee-detail` | Staff profile and payroll | AppShell + detail view + page header |
+| `import-ledger` | Upload and mapping workflow | AppShell + import wizard + page header |
+| `notifications` | Alerts and preferences | AppShell + notifications pattern |
+| `settings` | Workspace and account | AppShell + settings pattern + page header |
+| `signin` | Authentication | Auth flow (no AppShell) |
+
+Index: `kits/overview.html`
+
+## Portals — 10 built prototypes
+
+`portals/<name>/demo.html` · index at `portals/index.html`
+
+A portal is a role-scoped app exposing only what that role needs, tuned to their primary device.
+**These are the most complete end-to-end references** — use them when a whole role-specific surface is
+being built or restyled.
+
+| Portal | Audience | Device | Covers |
+|---|---|---|---|
+| `admin` | System operators | Desktop | Users, activity history, billing, integrations, backup |
+| `owner` | Business owners | Tablet / desktop | Cross-location metrics, cash, receivables/payables, profit, task alerts |
+| `pos` | Cashiers, field buyers | Tablet | Sales entry, payments, receipts, till reconciliation |
+| `staff` | Employees | Mobile / desktop | Payslips + deductions, leave, clock in/out, expenses, directory |
+| `gold` | Mine clerks | Tablet / desktop | Pour ledger, refinery batching, payments, regulatory forms |
+| `scrap` | Scrap yard workers | Mobile / tablet / desktop | Opening checks, load weighing, suppliers, batch shipments |
+| `parent` | Parents, guardians | Mobile | Fee balances, attendance, marks, news, payments |
+| `student` | Students | Mobile / tablet | Timetable, marks, homework, library, goals |
+| `teacher` | Teachers | Tablet / desktop | Attendance, grades, lesson plans, parent messaging |
+| `stash` | Individuals | Mobile | Spend tracking, budgets, savings goals, subscription alerts |
+
+**Directly relevant to this repo:** `gold`, `scrap`, `owner`, `staff`, `admin`.
+
+## Verticals — 13 industries, 68 surfaces
+
+`verticals/<name>/index.html` · index at `verticals/index.html`
+
+A vertical is an industry-specific implementation (pages, dashboards, forms) built from shared primitives.
+A portal is a role's access point; a vertical is a business domain's screens.
+
+| Vertical | Surfaces documented |
+|---|---|
+| `gold` | Pours, settlement, audit export, pricing |
+| `scrap` | Intake, stockpile, bulk sales, supplier ledger |
+| `accounting` | Ledgers, journals, reconciliation, financials |
+| `hr` | Employee database, payroll runs, compliance |
+| `retail` | Branch dashboard, products, Z-report |
+| `warehouses` | Stock register, receiving, stock take |
+| `multisite` | Group overview, site comparison, transfers |
+| `maintenance` | Asset register, preventive scheduling, breakdowns |
+| `compliance` | Permits, inspections, training, audit reports |
+| `cctv` | Live wall, playback search, incident logs |
+| `auto` | Sales pipeline, vehicle detail, workshop board |
+| `schools` | Student records, fees, attendance, marks, timetable |
+| `thrift` | Bale opening, lot inventory, sales tracking |
+
+**These map 1:1 onto this repo's route groups** — `app/gold`, `app/scrap-metal`, `app/accounting`,
+`app/human-resources`, `app/retail`, `app/stores`, `app/management`, `app/maintenance`, `app/compliance`,
+`app/cctv`, `app/car-sales`, `app/schools`, `app/thrift`. Fetch the matching vertical before restyling a
+route group; it is the intended target design for that exact surface.
+
+## Guides
+
+`system/guides.html` · `system/guide-compose-page.html` (six-step recipe — digested in `04-composition.md`) ·
+`system/guide-compose-pattern.html` · `system/guide-new-feature.html` ·
+`system/guide-block-vs-pattern.html` (decision tree — digested in `README.md`) ·
+`system/guide-mobile-adaptation.html`

--- a/docs/design-system/07-repo-migration.md
+++ b/docs/design-system/07-repo-migration.md
@@ -1,0 +1,216 @@
+# Repo migration map — `tate2301/huchu`
+
+The DS primitives page says its 47 components "mirror the live `tate2301/huchu` UI primitives". The local
+`components/ui/*` layer and the DS are **two implementations of the same intent**. Migration is
+convergence, not adoption from zero.
+
+## Blast radius — measured, use it to sequence work
+
+310 of 571 `.tsx` files under `app/` + `components/` import from `@/components/ui/`.
+
+| Local component | Importing files | Sequence |
+|---|---|---|
+| `button` | 212 | **Last.** Highest risk; do it as one mechanical pass |
+| `badge` | 142 | Late |
+| `input` | 140 | Late |
+| `select` | 111 | Late |
+| `data-table` | 99 | Mid — needs a behavioural decision, see below |
+| `dialog` | 64 | Mid |
+| `skeleton` | 62 | Mid |
+| `card` | 57 | Mid |
+| `sheet` | 33 | Mid |
+| `dropdown-menu` | 23 | Mid |
+| `table` | 10 | Early |
+| `sidebar` | 7 | Early |
+| `popover` | 5 | Early |
+| `dropdown/tabs/tooltip/status-dot/segmented-control/toast` | 1–2 each | **First.** Cheap, proves the pipeline |
+
+Migrate a **leaf first** (`tabs`, `tooltip`, `status-dot`) end to end — token wiring, `"use client"`,
+visual check — before touching anything above 50 files.
+
+## Current UI dependency surface
+
+The DS overlaps all of these. A migration that leaves the old package installed and imported hasn't
+migrated anything — it has added a third UI system.
+
+| Package | Version | Used by |
+|---|---|---|
+| `radix-ui` (unified) | ^1.4.3 | accordion, alert-dialog, avatar, button-group, collapsible, hover-card, item, menubar |
+| `@radix-ui/react-*` (10 scoped) | — | checkbox, dialog, dropdown-menu, popover, select, separator, slot, tabs, toast, tooltip |
+| `@base-ui/react` | ^1.1.0 | combobox, dialog |
+| `@tanstack/react-table` | ^8.21.3 | data-table, data-table-column-header |
+| `react-day-picker` | ^9.14.0 | calendar, date-picker |
+| `cmdk` | ^1.1.1 | command |
+| `input-otp` | ^1.4.2 | input-otp |
+| `@rtcamp/frappe-ui-react` | ^1.1.0 | scanned via `@source` in `globals.css` |
+| `@corelithzw/react` | ^0.3.0 | **the target** |
+
+Both `radix-ui` and 10 scoped `@radix-ui/*` packages are installed — the same primitives reachable by two
+import paths. Worth consolidating regardless of the DS work.
+
+## Component mapping
+
+`⇄` direct swap · `~` swap with behaviour change · `✎` keep local, restyle with tokens · `✖` no DS equivalent
+
+| `components/ui/*` | Currently built on | DS target | |
+|---|---|---|---|
+| `button.tsx` | `@radix-ui/react-slot` | `Button` | `~` Local uses `asChild` (3 sites); DS has no Slot. Keep a local `asChild` shim. **Variant axes differ — see below** |
+| `input.tsx` | native | `Input` | `⇄` DS adds `leadingIcon` / `trailingIcon` / `trailingSlot` |
+| `input-group.tsx` | native | `Input` props | `~` Fold into `Input`'s icon/slot props — no separate component |
+| `textarea.tsx` | native | `TextArea` | `⇄` |
+| `select.tsx` | `@radix-ui/react-select` | `Select` | `~` **DS `Select` is a styled native `<select>`.** Loses Radix portal/scroll/groups. For rich pickers use `Combobox` or keep Radix |
+| `searchable-select.tsx` | native | `Combobox` | `~` DS ships the body only — you supply the anchor |
+| `combobox.tsx` | `@base-ui/react` | `Combobox` | `~` Same caveat |
+| `checkbox.tsx` | `@radix-ui/react-checkbox` | `Checkbox` | `⇄` DS sets `indeterminate` via ref |
+| `segmented-control.tsx` | native | `SegmentedControl<T>` | `⇄` |
+| `input-otp.tsx` | `input-otp` | `InputOtp` | `⇄` Ref is `{focus()}`, not an element |
+| `calendar.tsx` | `react-day-picker` | `Calendar` | `⇄` Local-time `Date` |
+| `date-picker.tsx` | `react-day-picker` | `DatePicker` | `~` Single date only. Ranges → `useDateRange()` |
+| `label.tsx` | native | `Field` / `Field.Label` | `~` `Field` owns `id` + `aria-describedby` wiring |
+| `dialog.tsx` | `@base-ui/react/dialog` | `Modal` / `Dialog` | `~` DS has its own overlay stack — see the z-index warning below |
+| `alert-dialog.tsx` | `radix-ui` | `AlertDialog` | `⇄` Gains async `onConfirm` + imperative `AlertDialog.confirm()` |
+| `sheet.tsx` | `@radix-ui/react-dialog` | `Drawer` | `~` DS auto-collapses to a bottom sheet < 720px |
+| `popover.tsx` | `@radix-ui/react-popover` | `Popover` | `~` **DS does not position** — no floating-ui. Keep Radix where anchoring matters |
+| `hover-card.tsx` | `radix-ui` | `.hover-card` (CSS) | `✎` No React export. Prefer `Popover` |
+| `dropdown-menu.tsx` | `@radix-ui/react-dropdown-menu` | `Menu` / `DropdownMenu` | `~` DS is menu **body** only; you own trigger + positioning. Keep Radix for anchored menus |
+| `menubar.tsx` | `radix-ui` | — | `✖` Keep |
+| `command.tsx` | `cmdk` | `CommandPalette` | `⇄` Returns `ReactPortal \| null` |
+| `tabs.tsx` | `@radix-ui/react-tabs` | `Tabs` | `⇄` Full WAI-ARIA tablist. **Migrate first — only 2 files** |
+| `table.tsx` | custom | `.table` (CSS) | `✎` |
+| `data-table.tsx` | `@tanstack/react-table` | `DataTable<Row>` | `~` **Decide deliberately** — see below |
+| `data-table-column-header.tsx` | `@tanstack/react-table` | `DataTable` `columns[].sortable` | `~` |
+| `data-table-floating-actions.tsx` | custom | `DataToolbar` + `useOptimistic` | `~` Bulk-edit pattern |
+| `numeric-cell.tsx` | custom | `.num` + `--type-mono` | `✎` No DS component; keep and restyle |
+| `table-rail.tsx` | custom | — | `✖` Keep |
+| `vertical-data-views.tsx` | custom | — | `✖` Keep |
+| `badge.tsx` | custom | `Badge` | `⇄` Tones: neutral/info/success/warn/danger/outline. **Don't use `clay`** |
+| `status-chip.tsx` | custom | `Badge` or `.chip` | `~` Enforce the canonical five status labels here |
+| `status-dot.tsx` | custom | `.status-dot` + `.attention\|.ok\|.progress\|.idle\|.ring` | `✎` CSS-only |
+| `avatar.tsx` | `radix-ui` | `Avatar` | `⇄` Groups use `.avatar-group` |
+| `kbd.tsx` | custom | `Kbd` | `⇄` |
+| `tooltip.tsx` | `@radix-ui/react-tooltip` | `Tooltip` | `~` DS `children` must be one focusable element. **Migrate early — 2 files** |
+| `alert.tsx` | custom | `Alert` | `⇄` |
+| `progress.tsx` | custom | `Progress` / `Meter` | `~` `Meter` for bounded gauges, `Progress` for tasks |
+| `skeleton.tsx` | custom | `Skeleton` | `⇄` DS adds `lines` + `gap` |
+| `empty.tsx` | custom | `EmptyState` | `⇄` `variant="inline"` for < 80px |
+| `toast.tsx` / `toaster.tsx` / `use-toast.ts` | `@radix-ui/react-toast` | `ToastProvider` + `useToast` | `~` Mount provider once; delete the Radix stack |
+| `card.tsx` | custom | `Card` + `.Header/.Title/.Body/.Footer` | `⇄` |
+| `accordion.tsx` | `radix-ui` Accordion | `.accordion` > `<details>`/`<summary>` (CSS) | `✎` **No React export.** ⚠ Site docs the wrong class names — see `03-components.md` |
+| `collapsible.tsx` | `radix-ui` | `<details>` | `✎` |
+| `separator.tsx` | `@radix-ui/react-separator` | `.hr` | `✎` |
+| `item.tsx` | `radix-ui` | `.list-item` (+ `.lead .title .sub .meta .chev`) | `✎` |
+| `mobile-list.tsx` | `@radix-ui/react-slot` | `.list` / `.list-plain` + `RowCard` | `~` |
+| `mobile-action-bar.tsx` | custom | — | `✖` **No DS CSS ships.** Keep, restyle with `--shadow-bar-bottom` |
+| `scroll-container.tsx` | custom | — | `✖` No DS CSS. Keep |
+| `page-section.tsx` | custom | — | `✖` No DS CSS. Keep, use `--type-section-title` |
+| `export-menu.tsx` | custom | — | `✖` No DS CSS. Keep |
+| `attachment-center.tsx` | custom | `.upload-zone` + `.file-row`/`.file-tile`; `FileUpload` for the drop zone | `~` `FileUpload` has no progress — add `useUpload()` |
+| `button-group.tsx` | `radix-ui` | `.btn-split` | `✎` ⚠ There is no `.btn-group` |
+| `split-button.tsx` | custom | `.btn-split` | `✎` |
+| `sidebar.tsx` | `@radix-ui/react-slot` | `AppShell.Sidebar` + `NavGroup` + `NavItem` | `~` `NavItem` uses **`to`**, not `href` |
+| `step-progress.tsx` / `workflow-step.tsx` | custom | `Stepper` + `Stepper.Step` | `⇄` `current` is **1-based** |
+| `client-date.tsx` | custom | — | `✖` Keep. Apply the date format from `05-rules.md` |
+
+### New capability the DS adds — no local equivalent
+
+`Stack` · `Checklist` · `KanbanBoard` + `useKanban` · `Lightbox` + `useGallery` · `CommentsThread` +
+`useComments` · `NotificationMatrix` + `usePreferences` · `I18nProvider` / `LocalePicker` / `useT` ·
+`SaveBar` · `InlineEdit` · `RoleSwitcher` · `FilterChips` · `RowCard` · `StatCard` / `StatHero` · `DayList` ·
+`Grabber` · `BottomSheet` · `BottomTabs` · `MobileShell` · `AuthShell` · `PageHeader` · `Pagination` ·
+`Chart` · `useOptimistic` · `useUrlState` · `usePersistedFlag` · `useUpload` · `useInterval` ·
+`useMatchMedia` · `useDateRange`
+
+Reach for these on new work rather than hand-rolling.
+
+### Button variant mapping — the axes differ
+
+Local `button.tsx` puts everything on one `variant` axis. The DS splits it into `variant` (shape) ×
+`tone` (semantics), and adds `loading` / `icon` / `iconRight` / `fullWidth`.
+
+| Local `variant` | DS equivalent |
+|---|---|
+| `default` | `variant="primary"` |
+| `secondary` | `variant="secondary"` |
+| `outline` | `variant="secondary"` — DS has no separate outline; secondary already carries the border |
+| `ghost` | `variant="ghost"` |
+| `destructive` | `variant="primary" tone="danger"` |
+| `link` | ✖ no DS variant. Use `.btn-link` (CSS) or an anchor with `--text-link` |
+| `size` `default` / `sm` / `lg` | `size="md"` / `"sm"` / `"lg"` |
+| `size` `icon` / `icon-sm` / `icon-lg` | ✖ no DS icon size. Pass `icon` with no children, or keep the local shim — **and keep `aria-label`** |
+
+Local `destructive` currently renders `--status-error-bg` (a *tinted* background), while DS
+`tone="danger"` is a **solid** `#B83A2A` fill. That is a visible change, not a like-for-like swap.
+Also decide `--action-destructive-soft-bg` (warm grey) for serious-but-reversible actions —
+see rule 6 in `05-rules.md`.
+
+## Two decisions to make before bulk migration
+
+### 1. `DataTable`: DS vs `@tanstack/react-table`
+
+`DataTable` is **fully controlled and does not sort rows** — it renders sort affordances and calls
+`onSortChange`; you own the comparator, pagination, and filtering. TanStack does that work for you.
+
+99 files depend on the local `data-table`. Realistic split: keep TanStack for the heavy ERP grids
+(gold batches, journals, imports) and use DS `DataTable` for simple lists. If you do migrate,
+`DataTableSortState.column` is canonical — `columnId` is deprecated and slated for removal in v1.0.
+
+### 2. Overlay ownership: DS stack vs Radix/Base-UI
+
+The DS ships its own overlay stack — global Escape ordering, focus trap, focus return — at
+**z-index 9998/9999**, well above this repo's Radix overlays. Mixing them means the DS overlay always wins.
+Pick one owner per surface. Do not nest a Radix `Dialog` inside a DS `Modal`.
+
+The DS `Popover` and `Menu` also have **no positioning engine** (no floating-ui). Radix keeps anchoring,
+collision detection, and scroll locking. Keep Radix wherever a floating element must track an anchor;
+use DS `Popover`/`Menu` only where you position it yourself.
+
+## Route-group → vertical mapping
+
+Fetch the matching vertical before restyling a route group — it is the intended target design for that
+exact surface. `https://design.corelith.co.zw/verticals/<name>/index.html`
+
+| Route | Vertical | Also see portal |
+|---|---|---|
+| `app/gold` | `gold` | `portals/gold/demo.html` |
+| `app/scrap-metal` | `scrap` | `portals/scrap/demo.html` |
+| `app/accounting` | `accounting` | — |
+| `app/human-resources`, `app/attendance` | `hr` | `portals/staff/demo.html` |
+| `app/retail` | `retail` | `portals/pos/demo.html` |
+| `app/stores` | `warehouses` | — |
+| `app/management`, `app/reports` | `multisite` | `portals/owner/demo.html` |
+| `app/maintenance` | `maintenance` | — |
+| `app/compliance` | `compliance` | — |
+| `app/cctv` | `cctv` | — |
+| `app/car-sales` | `auto` | — |
+| `app/schools` | `schools` | `portals/{parent,student,teacher}/demo.html` |
+| `app/thrift` | `thrift` | — |
+| `app/admin`, `app/user-management` | — | `portals/admin/demo.html` |
+| `app/login` | — | `kits/signin.html`, `system/pg-signin.html` |
+| `app/settings` | — | `kits/settings.html`, `system/x-settings.html` |
+| `app/dashboard`, `app/home` | — | `system/pg-overview.html`, `kits/data-heavy.html` |
+| `app/offline` | — | `system/x-offline-runtime.html` |
+| `app/notifications` | — | `kits/notifications.html` |
+
+## Gold module constraint
+
+`CLAUDE.md` puts the Gold module under a structured rebuild: **Epic 0 and Epic 5a are the only active work,
+and `gold-reviewer` must sign off before any Gold change merges to `main`.**
+
+Do **not** fold design-system migration into Gold files (`app/gold/**`, `components/gold/**`) as
+opportunistic drive-by work. Either land it as its own reviewed ticket, or wait for the rebuild to reach a
+UI epic. Migrate non-Gold route groups first — they carry no reviewer gate and give the shared
+`components/ui/*` layer a safe place to stabilise.
+
+## Per-file procedure
+
+1. Read the current file. Note every prop its call sites use.
+2. Check `03-components.md` for the DS target and its implementation status.
+3. Read the real props: `grep -A25 "interface <Name>Props" node_modules/@corelithzw/react/dist/index.d.ts`.
+4. If a needed prop is missing, do **not** fork the DS component — wrap it locally in `components/ui/`,
+   keeping the existing import path so call sites don't churn.
+5. Add `"use client"` if the file lacks it.
+6. Replace hard-coded values with tokens (`02-tokens.md`).
+7. Update every call site. `grep -rl "components/ui/<name>\"" --include=*.tsx app components`.
+8. Verify: `npx tsc --noEmit` then `npx eslint <files>`.
+9. Walk the checklist in `05-rules.md`.
+10. Remove the superseded dependency from `package.json` **only** once no file imports it.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,70 @@
+# Corelith Design System — AI reference
+
+Audience: AI agents refactoring `tate2301/huchu` onto the Corelith DS. No human maintains this folder.
+Written against `@corelithzw/react@0.3.0`, installed in this repo. Site: <https://design.corelith.co.zw>.
+
+## Source-of-truth order
+
+Resolve every question in this order. Higher wins on conflict — the website prose is aspirational in places and has been observed to be wrong.
+
+| Rank | Source | Use it for |
+|---|---|---|
+| 1 | `node_modules/@corelithzw/react/dist/index.d.ts` | Exact React API: names, props, generics, compound slots |
+| 2 | `node_modules/@corelithzw/react/dist/styles.css` | Exact tokens, class names, real markup contracts, breakpoints |
+| 3 | This folder | Verified digest, migration mapping, invariants, what does/doesn't exist |
+| 4 | `https://design.corelith.co.zw/**` | Composition guidance, worked recipes, prototypes — fetch on demand |
+
+**Never restate a prop signature from memory.** Read it:
+
+```bash
+# props for one component
+grep -A25 "interface ButtonProps" node_modules/@corelithzw/react/dist/index.d.ts
+# does a class exist, and what does it require?
+grep -n "\.status-dot" node_modules/@corelithzw/react/dist/styles.css
+```
+
+Observed conflict, as an example of why rank matters: the site's `p-accordion` page documents
+`.accordion-item` / `.accordion-trigger` / `.accordion-content`. **None of those exist.** The shipped
+`.accordion` styles native `<details>`/`<summary>`. Grep before you trust prose.
+
+## Which file to load
+
+Load only what the task needs. Do not read this folder end to end.
+
+| File | Load when |
+|---|---|
+| `01-setup.md` | Wiring the package in, importing CSS, touching `app/globals.css`, hitting an RSC/hydration error |
+| `02-tokens.md` | Choosing a colour, size, font, radius, shadow, duration, or breakpoint |
+| `03-components.md` | Picking a component; checking whether one exists as React or CSS-only |
+| `04-composition.md` | Building or restructuring a whole page, layout, or shell |
+| `05-rules.md` | Writing copy, formatting values, a11y, z-index, motion — the merge-blocking contract |
+| `06-reference-urls.md` | You want a worked example (61 recipes, 20 charts, 10 kits, 10 portals, 13 verticals) |
+| `07-repo-migration.md` | Migrating a specific file under `components/`, `components/ui/`, or `app/` |
+
+## Invariants — never violate
+
+1. **No hard-coded values.** No hex, px, ms, or font stacks in new code. Token or nothing (`02-tokens.md`).
+2. **One primary action per surface.** One `Button variant="primary"` / brand-blue element per page.
+3. **Brand blue is action + focus only.** Never decoration.
+4. **Borders at rest, shadows only when floating.** Resting cards get `--border`, never a shadow.
+5. **Every DS component import needs `"use client"`.** The package ships no client directive; see `01-setup.md`.
+6. **Never invent a class name.** Grep `styles.css` first; if absent, compose from primitives that do exist.
+7. **Never invent a status label.** Exactly five: Needs input, Running, Completed, Idle, Not started.
+8. **Ship the empty, loading, and error state** with every new data surface.
+9. **`--space-8` and `--space-10` mean different sizes in this repo than in the DS.** Read the collision table in `01-setup.md` before touching spacing.
+10. **The DS has no dark mode.** This repo does. Read `01-setup.md` before assuming either.
+
+## Layer model
+
+Four layers, prefix-coded. Pick the lowest that fits.
+
+```
+p-  primitive   one component                      → 03-components.md
+b-  block       several components, fixed arrangement, no behavioural contract
+x-  pattern     whole surface owning a state machine / URL scheme / keyboard contract
+pg- page        fills the entire content area       → 04-composition.md
+```
+
+Decision tree: fills the content area → page. Else owns a state machine, URL convention, or keyboard
+contract → pattern. Else more than one component in a specific arrangement → block. Else primitive.
+When uncertain, build a block; promote to pattern only when a second use site needs the same contract.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",
     "@base-ui/react": "^1.1.0",
+    "@corelithzw/react": "^0.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@prisma/adapter-pg": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@corelithzw/react':
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
@@ -883,6 +886,13 @@ packages:
   '@chevrotain/utils@10.5.0':
     resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
 
+  '@corelithzw/react@0.3.0':
+    resolution: {integrity: sha512-bNN+c5216XA+01uVSXIz7MAo8Gn5ivrycoQ5UydTHaXFSWldjpQ5j0sXaCa7nSBdyvrxnXw206uYWCb7ao6g6g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -1219,89 +1229,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1375,24 +1401,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -2329,66 +2359,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2559,24 +2602,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3064,41 +3111,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4709,24 +4764,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7067,6 +7126,11 @@ snapshots:
   '@chevrotain/types@10.5.0': {}
 
   '@chevrotain/utils@10.5.0': {}
+
+  '@corelithzw/react@0.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
Adds `@corelithzw/react@0.3.0` and an AI-targeted reference folder at `docs/design-system/` for migrating the existing UI onto the design system at design.corelith.co.zw. **No application code changes.**

## What's in the folder

A router (`README.md`) plus six focused files, so a refactor loads ~2–5k tokens instead of the whole catalogue.

| File | Covers |
|---|---|
| `README.md` | Source-of-truth order, which file to load, 10 invariants, layer model |
| `01-setup.md` | Install, CSS import, `"use client"`, token collisions, adoption order |
| `02-tokens.md` | All 157 tokens + which one to use for what |
| `03-components.md` | 71 components + 16 hooks; CSS-only primitives with real markup contracts |
| `04-composition.md` | 33 blocks, 20 patterns, 13 shells, 10 page templates, six-step page recipe |
| `05-rules.md` | a11y, voice/copy, value formatting, z-index — plus a pre-merge checklist |
| `06-reference-urls.md` | On-demand index: 61 recipes, 20 charts, 10 kits, 10 portals, 13 verticals |
| `07-repo-migration.md` | Per-file map for `components/ui/*`, blast radius, route→vertical mapping |

## Design decisions

**The docs don't restate prop signatures.** The installed `index.d.ts` and `styles.css` are the API; the docs point at them with grep commands. That keeps the folder small and makes drift impossible.

**Site prose is ranked last.** Everything here was verified against the installed package, and the ranking earned its place — see below.

**Deep detail stays on the website.** The 61 recipes and 10 portals are indexed by URL, not inlined.

## Verified findings worth flagging

- `styles.css` is a **superset** of the site CSS (635 classes vs 586, zero missing) — no assets need copying. `dist/react.css` is a redundant subset and is not in the `exports` map.
- The package ships **no `"use client"`** but uses hooks and `document` — every importing file needs the directive under the App Router.
- **`--space-8` and `--space-10` denote different sizes** here than in the DS. The scales agree only through `--space-6`; repo `--space-8` (32px) is DS `--space-7`, repo `--space-10` (40px) is DS `--space-8`. 39 tokens collide by name in total.
- Only **6 of the 33** documented `.b-*` block classes actually ship.
- The DS has **no dark mode** (zero `prefers-color-scheme` matches); this repo does. SHL·09 is specified "dark by default" with nothing to implement it.
- The site's `p-accordion` page documents `.accordion-item` / `.accordion-trigger` / `.accordion-content` — **none exist**. `.accordion` styles native `&lt;details&gt;` / `&lt;summary&gt;` elements.
- DS `Select` is a styled **native** `&lt;select&gt;`, and DS `Popover` / `Menu` have no positioning engine — so some Radix usage should stay. Called out in the migration map rather than assumed away.
- DS overlays run at z-index 9998/9999, above this repo's Radix overlays, regardless of the documented 100/200 scale.

## Verification

- `@corelithzw/react` typechecks clean against this repo's TS 5.9 / React 19.2.3 / `moduleResolution: bundler` (smoke component exercising `AppShell`, generic `DataTable`, `Card`, `PageHeader`, `Stack`, `useToast`).
- Full-repo `npx tsc --noEmit` is at **0 errors** after `npx prisma generate`. Worth noting for anyone reproducing: without the generate step it reports ~1357 pre-existing errors from the ungenerated Prisma client, none related to this change.
- Every `.class` and component/hook name asserted in the docs is machine-checked against `styles.css` and the package's runtime exports.
- Both Vercel preview deployments build green with the new dependency installed.

## Notes for review

- `CLAUDE.md` gains a short Design system section pointing at the router and the two gotchas that bite immediately.
- The migration map states that DS work must **not** ride along in Gold files as drive-by work, since those are reviewer-gated and mid-rebuild.
- Two decisions are flagged rather than made: DS `DataTable` vs `@tanstack/react-table` (99 files), and overlay ownership (DS stack vs Radix/Base-UI).