### PR TITLE
feat: add CRM catalog and sales role registration

### DIFF
--- a/app/api/platform-admin/companies/route.ts
+++ b/app/api/platform-admin/companies/route.ts
@@ -17,6 +17,8 @@ export async function GET(request: Request) {
       id: row.id,
       name: row.name,
       slug: row.slug,
+      workspaceProfile: row.workspaceProfile,
+      enabledFeatures: row.enabledFeatures,
       status: row.status,
       updatedAt: row.updatedAt,
     }));

--- a/app/api/users/role-change/route.ts
+++ b/app/api/users/role-change/route.ts
@@ -51,7 +51,7 @@ async function applyRoleChange(request: NextRequest) {
   }
 
   if (!isManagedRole(session, existing.role)) {
-    return errorResponse("Only SUPERADMIN, MANAGER, and OPERATOR accounts can be managed here.", 403);
+    return errorResponse("This user's current role is not available for this workspace.", 403);
   }
 
   const updated = await prisma.user.update({

--- a/app/retail/page.tsx
+++ b/app/retail/page.tsx
@@ -36,6 +36,7 @@ import {
   Users,
   Wallet,
 } from "@/lib/icons";
+import { hasTokenFeature } from "@/lib/platform/gating/token-check";
 import { canAccessPosPortal } from "@/lib/retail/pos-host";
 
 type RetailDashboardPayload = {
@@ -202,7 +203,9 @@ function SectionCard({
 
 export default function RetailOverviewPage() {
   const { data: session } = useSession();
+  const enabledFeatures = (session?.user as { enabledFeatures?: string[] } | undefined)?.enabledFeatures;
   const canOpenPos = canAccessPosPortal(session?.user?.role);
+  const canOpenCustomers = hasTokenFeature(enabledFeatures, "crm.customers");
   const { data, isLoading, error } = useQuery({
     queryKey: ["retail-dashboard-owner-overview"],
     queryFn: () => fetchJson<RetailDashboardPayload>("/api/v2/retail"),
@@ -310,11 +313,13 @@ export default function RetailOverviewPage() {
                   <LocalShipping className="h-4 w-4" /> Buy
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href="/retail/customers" className="flex items-center gap-2">
-                  <Users className="h-4 w-4" /> Customers
-                </Link>
-              </DropdownMenuItem>
+              {canOpenCustomers ? (
+                <DropdownMenuItem asChild>
+                  <Link href="/retail/customers" className="flex items-center gap-2">
+                    <Users className="h-4 w-4" /> Customers
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
               <DropdownMenuItem asChild>
                 <Link href="/retail/reports" className="flex items-center gap-2">
                   <BarChart3 className="h-4 w-4" /> Reports

--- a/components/admin-portal/pages/identity-hub-page.tsx
+++ b/components/admin-portal/pages/identity-hub-page.tsx
@@ -213,6 +213,10 @@ export function IdentityHubPage({ companyId }: { companyId?: string }) {
   const scopeLabel = companyId
     ? `${activeCompany?.name ?? "Workspace"} identity`
     : "Identity";
+  const companyById = useMemo(
+    () => new Map(companies.map((company) => [company.id, company])),
+    [companies],
+  );
   const activeAdmins =
     data?.admins.filter((admin) => admin.isActive).length ?? 0;
   const activeUsers = data?.users.filter((user) => user.isActive).length ?? 0;
@@ -894,6 +898,7 @@ export function IdentityHubPage({ companyId }: { companyId?: string }) {
                             <UserRoleDialog
                               actorEmail={actorEmail}
                               user={user}
+                              company={companyById.get(user.companyId) ?? null}
                               triggerLabel="Change role"
                               onCompleted={refresh}
                             />

--- a/components/admin-portal/types.ts
+++ b/components/admin-portal/types.ts
@@ -6,6 +6,8 @@ export type CompanyWorkspace = {
   id: string;
   name: string;
   slug?: string | null;
+  workspaceProfile?: string | null;
+  enabledFeatures?: string[];
   status?: string | null;
   updatedAt?: string | null;
 };

--- a/components/admin-portal/wizards/identity-hub-wizards.tsx
+++ b/components/admin-portal/wizards/identity-hub-wizards.tsx
@@ -1,13 +1,14 @@
 ﻿"use client";
 
 import type { ComponentProps, ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { AdminSummary, SiteSummary, SupportAccessRequestRecord, SupportSessionRecord, UserSummary } from "@/scripts/platform/types";
 import type { SearchableOption } from "@/app/gold/types";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import type { CompanyWorkspace } from "@/components/admin-portal/types";
 import { executeOperation } from "@/components/admin-portal/api";
-import { ROLES, type UserRole } from "@/lib/roles";
+import type { UserRole } from "@/lib/roles";
+import { getAllowedUserRoleOptionsForWorkspace } from "@/lib/platform/vertical-roles";
 import { USER_ROLE_LABELS } from "@/lib/platform/vertical-role-registry";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -74,10 +75,31 @@ function toRoleLabel(role: UserRole): string {
     .join(" ");
 }
 
-const USER_ROLE_OPTIONS = ROLES.map((role) => ({
-  value: role,
-  label: toRoleLabel(role),
-}));
+function getCompanyRoleOptions(company: CompanyWorkspace | null | undefined) {
+  return getAllowedUserRoleOptionsForWorkspace({
+    workspaceProfile: company?.workspaceProfile,
+    enabledFeatures: company?.enabledFeatures,
+  })
+    .filter((option) => option.value !== "SUPERADMIN")
+    .map((option) => ({
+      value: option.value,
+      label: option.label || toRoleLabel(option.value),
+    }));
+}
+
+function getSelectedCompany(
+  companies: CompanyWorkspace[],
+  fixedCompanyId: string | undefined,
+  companyId: string,
+) {
+  const selectedCompanyId = fixedCompanyId ?? companyId;
+  return companies.find((company) => company.id === selectedCompanyId) ?? null;
+}
+
+function getDefaultUserRole(options: Array<{ value: UserRole }>, fallback: UserRole): UserRole {
+  if (options.some((option) => option.value === fallback)) return fallback;
+  return options[0]?.value ?? fallback;
+}
 
 function ConfirmDialog({
   title,
@@ -274,6 +296,21 @@ export function CreateUserDialog({
   const [role, setRole] = useState<UserRole>("CLERK");
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+  const selectedCompany = useMemo(
+    () => getSelectedCompany(companies, fixedCompanyId, companyId),
+    [companies, companyId, fixedCompanyId],
+  );
+  const roleOptions = useMemo(
+    () => getCompanyRoleOptions(selectedCompany),
+    [selectedCompany],
+  );
+
+  useEffect(() => {
+    const nextRole = getDefaultUserRole(roleOptions, role);
+    if (nextRole !== role) {
+      setRole(nextRole);
+    }
+  }, [role, roleOptions]);
 
   const run = async () => {
     setRunning(true);
@@ -340,7 +377,7 @@ export function CreateUserDialog({
                 <Select value={role} onValueChange={(value) => setRole(value as UserRole)}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
-                    {USER_ROLE_OPTIONS.map((option) => (
+                    {roleOptions.map((option) => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
                       </SelectItem>
@@ -506,6 +543,7 @@ export function PasswordResetDialog({
 export function UserRoleDialog({
   actorEmail,
   user,
+  company,
   onCompleted,
   triggerLabel,
   buttonVariant = "outline",
@@ -513,6 +551,7 @@ export function UserRoleDialog({
 }: {
   actorEmail: string;
   user: UserSummary;
+  company?: CompanyWorkspace | null;
   onCompleted?: () => void;
 } & TriggerProps) {
   const [open, setOpen] = useState(false);
@@ -520,6 +559,17 @@ export function UserRoleDialog({
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+  const roleOptions = useMemo(
+    () => getCompanyRoleOptions(company),
+    [company],
+  );
+
+  useEffect(() => {
+    const nextRole = getDefaultUserRole(roleOptions, role);
+    if (nextRole !== role) {
+      setRole(nextRole);
+    }
+  }, [role, roleOptions]);
 
   const run = async () => {
     setRunning(true);
@@ -563,7 +613,7 @@ export function UserRoleDialog({
               <Select value={role} onValueChange={(value) => setRole(value as UserRole)}>
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {USER_ROLE_OPTIONS.map((option) => (
+                  {roleOptions.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       {option.label}
                     </SelectItem>

--- a/docs/platform-pricing-feature-flags-and-modules.md
+++ b/docs/platform-pricing-feature-flags-and-modules.md
@@ -38,14 +38,15 @@ Defined in `lib/platform/feature-catalog.ts` (`TIERS`).
 
 | Tier | Base / Month | Included Sites | Additional Site / Month | Warning Days | Grace Days |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `BASIC` | 450 | 1 | 90 | 14 | 7 |
-| `STANDARD` | 900 | 3 | 140 | 14 | 7 |
-| `ENTERPRISE` | 1800 | 8 | 220 | 21 | 14 |
+| `BASIC` | 29 | 1 | 19 | 14 | 7 |
+| `STANDARD` | 79 | 3 | 29 | 14 | 7 |
+| `MEDIUM` | 189 | 8 | 39 | 14 | 7 |
+| `ENTERPRISE` | 449 | 25 | 39 | 21 | 14 |
 
 Notes:
 
-- `ENTERPRISE` includes `ADDON_ANALYTICS_PRO` by default.
-- User management is add-on-only. No tier includes `ADDON_USER_MANAGEMENT_PRO` or `admin.user-management.*` by default.
+- Tier inclusions are code-defined in `TIERS`; do not change plan defaults directly in the database.
+- Higher tiers include selected add-ons at no extra charge through `includedBundles`.
 - Tier assignment and health enforcement are handled in platform services and TUI wizards.
 
 ## Add-on Bundles
@@ -57,38 +58,43 @@ The catalog includes both sellable add-ons and zero-priced foundation bundles us
 | Bundle Code | Name | Base / Month | Additional Site / Month |
 | --- | --- | ---: | ---: |
 | `ADDON_OPERATIONS_CORE` | Operations Core | 0 | 0 |
+| `ADDON_MINE_DAILY_OPS` | Mine Daily Operations | 0 | 0 |
 | `ADDON_STORES_CORE` | Stores Core | 0 | 0 |
 | `ADDON_WORKFORCE_CORE` | Workforce Core | 0 | 0 |
-| `ADDON_GOLD_CORE` | Gold Core | 0 | 0 |
-| `ADDON_CUSTOM_BRANDING` | Custom Branding | 120 | 0 |
-| `ADDON_CCTV_SUITE` | CCTV Suite | 300 | 40 |
-| `ADDON_ADVANCED_PAYROLL` | Advanced Payroll | 250 | 30 |
-| `ADDON_GOLD_ADVANCED` | Gold Advanced Controls | 220 | 25 |
-| `ADDON_COMPLIANCE_PRO` | Compliance Pro | 200 | 25 |
-| `ADDON_MAINTENANCE_PRO` | Maintenance Pro | 180 | 20 |
-| `ADDON_USER_MANAGEMENT_PRO` | User Management Pro | 180 | 20 |
-| `ADDON_ANALYTICS_PRO` | Analytics Pro | 160 | 15 |
-| `ADDON_ACCOUNTING_CORE` | Accounting Core | 250 | 30 |
-| `ADDON_ACCOUNTING_ADVANCED` | Accounting Advanced | 350 | 40 |
-| `ADDON_ZIMRA_FISCAL` | ZIMRA Tax & Fiscalisation | 120 | 15 |
-| `ADDON_SCHOOLS_SUITE` | Schools Suite | 320 | 35 |
-| `ADDON_AUTOS_SUITE` | Auto Sales Suite | 210 | 25 |
-| `ADDON_RETAIL_SUITE` | Retail Suite | 180 | 20 |
-| `ADDON_PORTAL_SUITE` | Client Portal Suite | 110 | 10 |
-| `ADDON_SCRAP_METAL_SUITE` | Scrap Metal Suite | 150 | 20 |
+| `ADDON_GOLD_CORE` | Gold Operations | 69 | 15 |
+| `ADDON_CUSTOM_BRANDING` | Custom Branding | 29 | 0 |
+| `ADDON_CCTV_SUITE` | CCTV Suite | 99 | 15 |
+| `ADDON_ADVANCED_PAYROLL` | Advanced Payroll | 49 | 10 |
+| `ADDON_GOLD_ADVANCED` | Gold Advanced Controls | 79 | 10 |
+| `ADDON_COMPLIANCE_PRO` | Compliance Pro | 49 | 10 |
+| `ADDON_MAINTENANCE_PRO` | Maintenance Pro | 39 | 10 |
+| `ADDON_USER_MANAGEMENT_PRO` | User Management Pro | 19 | 5 |
+| `ADDON_ANALYTICS_PRO` | Analytics Pro | 29 | 5 |
+| `ADDON_ACCOUNTING_CORE` | Accounting Core | 39 | 10 |
+| `ADDON_ACCOUNTING_ADVANCED` | Accounting Advanced | 49 | 10 |
+| `ADDON_ZIMRA_FISCAL` | ZIMRA Tax & Fiscalisation | 19 | 5 |
+| `ADDON_SCHOOLS_SUITE` | Schools Suite | 129 | 29 |
+| `ADDON_AUTOS_SUITE` | Auto Sales Suite | 59 | 10 |
+| `ADDON_RETAIL_SUITE` | Retail Suite | 39 | 10 |
+| `ADDON_CRM_CORE` | CRM Core | 19 | 5 |
+| `ADDON_PORTAL_SUITE` | Client Portal Suite | 19 | 5 |
+| `ADDON_SCRAP_METAL_SUITE` | Scrap Metal Suite | 39 | 10 |
 
 ### Bundle Feature Mapping
 
 `ADDON_OPERATIONS_CORE`
 
+- `reports.dashboard`
+- `admin.sites-sections`
+
+`ADDON_MINE_DAILY_OPS`
+
 - `ops.shift-report.submit`
 - `ops.attendance.mark`
 - `ops.plant-report.submit`
-- `reports.dashboard`
 - `reports.shift`
 - `reports.attendance`
 - `reports.plant`
-- `admin.sites-sections`
 
 `ADDON_STORES_CORE`
 
@@ -136,7 +142,7 @@ The catalog includes both sellable add-ons and zero-priced foundation bundles us
 - `hr.disciplinary-actions`
 - `hr.salaries`
 - `hr.approvals-history`
-- `hr.gold-payouts`
+- `hr.settlements`
 - `admin.payroll-config`
 
 `ADDON_GOLD_ADVANCED`
@@ -239,7 +245,12 @@ The catalog includes both sellable add-ons and zero-priced foundation bundles us
 - `retail.promotions`
 - `retail.shifts`
 - `retail.reports`
+- `crm.customers`
 - `portal.pos`
+
+`ADDON_CRM_CORE`
+
+- `crm.customers`
 
 `ADDON_PORTAL_SUITE`
 
@@ -261,13 +272,27 @@ The catalog includes both sellable add-ons and zero-priced foundation bundles us
 - `stores.issue`
 - `stores.receive`
 
+### Why a Bundle May Not Show After Sync
+
+`Sync Catalog` is an upsert from code-defined catalog rows into the database. It does not discover modules from `app/` routes, navigation labels, page headings, or custom UI text.
+
+If a bundle is missing after sync, check these in order:
+
+1. The bundle exists in `FEATURE_BUNDLES` in `lib/platform/feature-catalog.ts`.
+2. Every feature listed by that bundle exists in `FEATURE_CATALOG`.
+3. New page/API routes map to those feature keys in `lib/platform/gating/route-registry.ts`.
+4. The route mapping is more specific than broad fallbacks such as `/retail`, `/portal`, or `/api/v2/retail`.
+5. The bundle was not created only as a custom database row; custom rows can be useful operationally, but system bundles must be represented in code.
+
+The CRM issue came from this exact gap: customer screens existed under `/retail/customers`, and the UI labelled charts as `CRM`, but there was no `crm` domain, no `crm.customers` feature key, and no `ADDON_CRM_CORE` entry in `FEATURE_BUNDLES`. Catalog sync could not create a bundle that was absent from the source catalog, so the route fell through to `retail.core` and CRM never appeared in the bundle catalog.
+
 ### Bundle Behavior in TUI
 
 - Enabling an add-on now auto-enables feature flags for every feature in that bundle.
 - Disabling an add-on now auto-disables only bundle features that are no longer entitled by tier/other enabled bundles.
 - This keeps bundle provisioning aligned with effective feature access.
 - Add-on-only features should use `defaultEnabled: false` so they remain disabled until enabled by entitled tier/add-on access.
-- Bundle dependencies are enforced in `lib/platform/feature-catalog.ts` (`BUNDLE_DEPENDENCIES`). Accounting add-ons require `ADDON_ACCOUNTING_CORE`.
+- Bundle dependencies are enforced in `lib/platform/feature-catalog.ts` (`BUNDLE_DEPENDENCIES`). Advanced accounting and ZIMRA require `ADDON_ACCOUNTING_CORE`; Gold Advanced requires `ADDON_GOLD_CORE`.
 
 ## Client Template Bundles
 
@@ -354,7 +379,7 @@ Relevant files:
 
 ### Source of Truth
 
-Feature definitions and routing map live in:
+Feature definitions live in:
 
 - `lib/platform/feature-catalog.ts`
 
@@ -363,6 +388,15 @@ This file defines:
 - `FEATURE_CATALOG` for feature metadata and default billable values
 - `FEATURE_BUNDLES` for grouped features
 - `TIERS` for tier-included features and bundles
+
+Route mappings live in:
+
+- `lib/platform/gating/route-registry.ts`
+
+This file defines:
+
+- `PAGE_FEATURE_ROUTES` for page route prefixes
+- `API_FEATURE_ROUTES` for API route prefixes
 - `resolveFeatureKeyForPath(pathname)` for page/API feature resolution
 
 ### Runtime Resolution and Enforcement
@@ -389,14 +423,58 @@ Auth/session token enrichment with enabled features:
 - `lib/auth.ts`
 - `types/next-auth.d.ts`
 
-### How to Gate a New Route
+### How to Add a New Feature, Module, or Bundle
 
-1. Add feature key metadata to `FEATURE_CATALOG` in `lib/platform/feature-catalog.ts`.
-2. Add page/API prefix mapping in `PAGE_FEATURE_ROUTES` or `API_FEATURE_ROUTES` in `lib/platform/gating/route-registry.ts`.
-3. Include it in tier/bundle defaults if needed.
-4. Run TUI `Sync Catalog` action to materialize catalog to DB.
-5. For API handlers using `validateSession`, gating is automatic via path resolution.
-6. For extra server checks, use `hasFeature(companyId, "feature.key")` from `lib/platform/features.ts`.
+Use this checklist before running `Sync Catalog`.
+
+1. Decide the commercial unit.
+   - New feature only: add a key to `FEATURE_CATALOG`.
+   - New sellable bundle: add a code to `FEATURE_BUNDLES`.
+   - New workspace module: add feature keys, routes, navigation, and workspace presentation together.
+2. If the module has a new domain, add it to `FeatureDomain` in `lib/platform/feature-catalog.ts`.
+3. Add feature metadata to `FEATURE_CATALOG`.
+   - Use stable dot keys such as `crm.customers`.
+   - Keep billable add-on features `defaultEnabled: false`.
+   - Put pricing on bundles unless the feature is sold standalone.
+4. Add or update `FEATURE_BUNDLES`.
+   - A system bundle only appears in the bundle catalog if it is listed here.
+   - If an existing suite should continue to grant the feature, include the feature in both the new bundle and the existing suite. Example: `crm.customers` is in `ADDON_CRM_CORE` and `ADDON_RETAIL_SUITE`.
+   - Add required parent bundles in `BUNDLE_DEPENDENCIES` when needed.
+5. Add page and API mappings in `lib/platform/gating/route-registry.ts`.
+   - Add the most-specific prefixes first conceptually, even though the resolver sorts by prefix length.
+   - Always map child routes before broad fallbacks like `/retail`, `/portal`, `/api/retail`, and `/api/v2/retail`.
+   - Map both app pages and API endpoints. API handlers using `validateSession` are gated through the path resolver.
+6. Add navigation and workspace visibility.
+   - Add a section in `lib/navigation.ts` when the module needs a sidebar entry.
+   - Add the module to `WorkspaceModuleId`, `DEFAULT_MODULE_PRESENTATION`, `WORKSPACE_MODULE_ORDER`, and `WORKSPACE_MODULES` in `lib/workspace-products.ts` / `lib/workspaces.ts` when it must appear independently.
+   - Add quick actions in `lib/primary-actions.ts` only when there is a natural first action.
+7. Register user roles when the module introduces module-specific staff personas.
+   - User-account roles are registered in `lib/platform/vertical-role-registry.ts`.
+   - Profile-wide roles belong in `VERTICAL_ROLE_REGISTRY`; add-on/module-driven roles belong in `FEATURE_ROLE_REGISTRY`.
+   - Role defaults must also be reflected in `lib/platform/user-entitlements.ts` so users created with that role inherit the right enabled feature access.
+   - Example: CRM uses the existing `SALES_EXEC` user-account role and registers it against `crm.customers`; `SALES_REP` is an employee position, not a login role.
+   - Do not hard-code role dropdowns. HR employee onboarding, web user management, platform admin dialogs, and TUI user wizards should consume `getAllowedUserRoleOptionsForWorkspace` or the TUI wrapper in `scripts/platform/user-role-options.ts`.
+8. Add template access in `lib/platform/client-templates.ts`.
+   - Include the bundle in relevant templates.
+   - Use `disabledFeatureKeys` only to remove inherited features from a template.
+9. Add marketing/pricing metadata if the bundle is paid.
+   - Add category mapping in `lib/marketing/pricing.ts`.
+   - Update this document's bundle table and feature mapping.
+10. Add regression coverage.
+   - Extend `lib/workspace-feature-resolution.test.ts` for route gating, sidebar visibility, and bundle membership.
+   - Add role-registry assertions when the module registers user roles.
+   - Extend `lib/marketing/pricing.test.ts` when marketing/product pricing references the new bundle.
+11. Run validation before syncing:
+    - `pnpm test -- lib/workspace-feature-resolution.test.ts`
+    - `pnpm test -- lib/marketing/pricing.test.ts` if pricing changed
+    - `pnpm platform:audit-feature-gates`
+    - `pnpm lint`
+12. Run TUI `Sync Catalog` to materialize catalog rows to DB.
+13. Confirm the sync result count and the admin bundle list.
+    - The sync wizard should report the expected bundle count.
+    - `/admin/commercial?view=bundles` should show the system bundle as source `SYSTEM`.
+
+For extra server checks outside route gating, use `hasFeature(companyId, "feature.key")` from `lib/platform/features.ts`.
 
 ## Current Platform TUI Modules
 

--- a/lib/marketing/pricing.ts
+++ b/lib/marketing/pricing.ts
@@ -184,6 +184,7 @@ export function tierPriceFor(tier: MarketingTier, period: BillingPeriod): number
 
 export type AddOnCategory =
   | "Industry"
+  | "Sales & CRM"
   | "Finance"
   | "Workforce"
   | "Assets & Safety"
@@ -207,6 +208,7 @@ const ADD_ON_CATEGORY_BY_CODE: Record<string, AddOnCategory> = {
   ADDON_GOLD_ADVANCED: "Industry",
   ADDON_SCRAP_METAL_SUITE: "Industry",
   ADDON_RETAIL_SUITE: "Industry",
+  ADDON_CRM_CORE: "Sales & CRM",
   ADDON_AUTOS_SUITE: "Industry",
   ADDON_SCHOOLS_SUITE: "Industry",
   ADDON_ACCOUNTING_CORE: "Finance",
@@ -224,6 +226,7 @@ const ADD_ON_CATEGORY_BY_CODE: Record<string, AddOnCategory> = {
 
 export const ADD_ON_CATEGORY_ORDER: AddOnCategory[] = [
   "Industry",
+  "Sales & CRM",
   "Finance",
   "Workforce",
   "Assets & Safety",

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -249,6 +249,15 @@ export const navSections: NavSection[] = [
     })),
   },
   {
+    id: "crm",
+    title: "CRM",
+    description: "Customer profiles, loyalty, and ledgers",
+    featureKey: "crm.customers",
+    items: [
+      { href: "/retail/customers", icon: Users, label: "Customers" },
+    ],
+  },
+  {
     id: "gold",
     title: "Gold Operations",
     description: "Production, settlement, and control tasks",

--- a/lib/platform/feature-catalog.ts
+++ b/lib/platform/feature-catalog.ts
@@ -14,6 +14,7 @@ export type FeatureDomain =
   | "schools"
   | "autos"
   | "retail"
+  | "crm"
   | "portal"
   | "reports"
   | "admin";
@@ -178,6 +179,8 @@ export const FEATURE_CATALOG: FeatureCatalogEntry[] = [
   f({ key: "retail.promotions", name: "Retail Promotions", description: "Price lists, markdowns, and promotion rules.", domain: "retail", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
   f({ key: "retail.shifts", name: "Retail Shifts", description: "Shift control, cash-up, and register reconciliation.", domain: "retail", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
   f({ key: "retail.reports", name: "Retail Reports", description: "Retail dashboards and reporting surfaces.", domain: "retail", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
+
+  f({ key: "crm.customers", name: "Customer CRM", description: "Customer profiles, customer search, loyalty summaries, and customer ledgers.", domain: "crm", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
 
   f({ key: "portal.core", name: "Portal Core", description: "External/customer portal shell and shared navigation.", domain: "portal", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
   f({ key: "portal.schools", name: "School Portal", description: "School-facing portal experiences and APIs.", domain: "portal", defaultEnabled: false, isBillable: true, monthlyPrice: 0 }),
@@ -467,7 +470,18 @@ export const FEATURE_BUNDLES: FeatureBundleDefinition[] = [
       "retail.promotions",
       "retail.shifts",
       "retail.reports",
+      "crm.customers",
       "portal.pos",
+    ],
+  },
+  {
+    code: "ADDON_CRM_CORE",
+    name: "CRM Core",
+    description: "Customer profiles, search, loyalty visibility, and customer-ledger workflows.",
+    monthlyPrice: 19,
+    additionalSiteMonthlyPrice: 5,
+    features: [
+      "crm.customers",
     ],
   },
   {

--- a/lib/platform/gating/route-registry.ts
+++ b/lib/platform/gating/route-registry.ts
@@ -93,6 +93,7 @@ export const PAGE_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "page", prefix: "/car-sales/financing", featureKey: "autos.financing" },
   { scope: "page", prefix: "/car-sales", featureKey: "autos.core" },
 
+  { scope: "page", prefix: "/retail/customers", featureKey: "crm.customers" },
   { scope: "page", prefix: "/retail/catalog", featureKey: "retail.catalog" },
   { scope: "page", prefix: "/retail/purchasing", featureKey: "retail.purchasing" },
   { scope: "page", prefix: "/retail/merchandising", featureKey: "retail.promotions" },
@@ -104,6 +105,7 @@ export const PAGE_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "page", prefix: "/retail", featureKey: "retail.core" },
   { scope: "page", prefix: "/thrift", featureKey: "retail.core" },
 
+  { scope: "page", prefix: "/portal/pos/customers", featureKey: "crm.customers" },
   { scope: "page", prefix: "/portal/pos", featureKey: "retail.pos" },
   { scope: "page", prefix: "/portal/parent", featureKey: "schools.portal.parent" },
   { scope: "page", prefix: "/portal/student", featureKey: "schools.portal.student" },
@@ -349,6 +351,7 @@ export const API_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "api", prefix: "/api/v2/car-sales/financing", featureKey: "autos.financing" },
   { scope: "api", prefix: "/api/v2/car-sales", featureKey: "autos.core" },
 
+  { scope: "api", prefix: "/api/retail/customers", featureKey: "crm.customers" },
   { scope: "api", prefix: "/api/retail/catalog", featureKey: "retail.catalog" },
   { scope: "api", prefix: "/api/retail/purchasing", featureKey: "retail.purchasing" },
   { scope: "api", prefix: "/api/retail/promotions", featureKey: "retail.promotions" },
@@ -357,6 +360,7 @@ export const API_FEATURE_ROUTES: FeatureRouteEntry[] = [
   { scope: "api", prefix: "/api/retail/reports", featureKey: "retail.reports" },
   { scope: "api", prefix: "/api/retail", featureKey: "retail.core" },
   { scope: "api", prefix: "/api/thrift", featureKey: "retail.core" },
+  { scope: "api", prefix: "/api/v2/retail/customers", featureKey: "crm.customers" },
   { scope: "api", prefix: "/api/v2/retail/catalog", featureKey: "retail.catalog" },
   { scope: "api", prefix: "/api/v2/retail/purchasing", featureKey: "retail.purchasing" },
   { scope: "api", prefix: "/api/v2/retail/promotions", featureKey: "retail.promotions" },

--- a/lib/platform/user-entitlements.ts
+++ b/lib/platform/user-entitlements.ts
@@ -111,6 +111,7 @@ const ROLE_PREFIX_ALLOWLIST: Record<string, readonly string[] | null> = {
     "core.multitenancy.",
     "autos.leads",
     "autos.deals",
+    "crm.",
     "portal.autos",
   ],
   FINANCE_OFFICER: [

--- a/lib/platform/vertical-role-registry.ts
+++ b/lib/platform/vertical-role-registry.ts
@@ -7,6 +7,13 @@ export type VerticalRoleRegistration = {
   roles: UserRole[];
 };
 
+export type FeatureRoleRegistration = {
+  id: string;
+  roles: UserRole[];
+  featureKeys?: string[];
+  featurePrefixes?: string[];
+};
+
 export const USER_ROLE_LABELS: Partial<Record<UserRole, string>> = {
   SUPERADMIN: "Superadmin",
   MANAGER: "Manager",
@@ -35,7 +42,51 @@ export const VERTICAL_ROLE_REGISTRY: Record<ManagedWorkspaceProfile, VerticalRol
   GENERAL: { roles: ["SUPERADMIN", "MANAGER", "CLERK", "OPERATOR", "FINANCE_OFFICER"] },
 };
 
-export function getRegisteredRoles(profile: ManagedWorkspaceProfile): UserRole[] {
-  return VERTICAL_ROLE_REGISTRY[profile]?.roles ?? VERTICAL_ROLE_REGISTRY.GENERAL.roles;
+export const FEATURE_ROLE_REGISTRY: FeatureRoleRegistration[] = [
+  {
+    id: "crm",
+    roles: ["SALES_EXEC"],
+    featureKeys: ["crm.customers"],
+    featurePrefixes: ["crm."],
+  },
+];
+
+function normalizeFeatureKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function registrationMatchesFeatures(
+  registration: FeatureRoleRegistration,
+  enabledFeatures: string[] | undefined,
+): boolean {
+  const normalizedFeatures = (enabledFeatures ?? []).map(normalizeFeatureKey);
+  if (normalizedFeatures.length === 0) return false;
+
+  const featureKeys = new Set((registration.featureKeys ?? []).map(normalizeFeatureKey));
+  const prefixes = (registration.featurePrefixes ?? []).map(normalizeFeatureKey);
+
+  return normalizedFeatures.some(
+    (feature) =>
+      featureKeys.has(feature) ||
+      prefixes.some((prefix) => feature.startsWith(prefix)),
+  );
+}
+
+export function getRegisteredRoles(
+  profile: ManagedWorkspaceProfile,
+  enabledFeatures?: string[],
+): UserRole[] {
+  const roles = new Set<UserRole>(
+    VERTICAL_ROLE_REGISTRY[profile]?.roles ?? VERTICAL_ROLE_REGISTRY.GENERAL.roles,
+  );
+
+  for (const registration of FEATURE_ROLE_REGISTRY) {
+    if (!registrationMatchesFeatures(registration, enabledFeatures)) continue;
+    for (const role of registration.roles) {
+      roles.add(role);
+    }
+  }
+
+  return Array.from(roles);
 }
 

--- a/lib/platform/vertical-roles.ts
+++ b/lib/platform/vertical-roles.ts
@@ -78,7 +78,7 @@ export function getAllowedUserRolesForWorkspace(args: {
   enabledFeatures?: string[] | undefined;
 }): UserRole[] {
   const profile = resolveWorkspaceProfileForRoles(args);
-  return getRegisteredRoles(profile);
+  return getRegisteredRoles(profile, args.enabledFeatures);
 }
 
 export function getAllowedUserRoleOptionsForWorkspace(args: {

--- a/lib/primary-actions.ts
+++ b/lib/primary-actions.ts
@@ -97,6 +97,7 @@ const PRODUCT_PRIMARY_ACTIONS: Record<VerticalProductId, NavItem[]> = {
     { href: "/stores/receive", icon: ArrowDownward, label: "Receive Stock" },
     { href: "/stores/issue", icon: ArrowUpward, label: "Issue Stock" },
     { href: "/stores/inventory", icon: Package, label: "Stock on Hand" },
+    { href: "/retail/customers", icon: Users, label: "Customers" },
     { href: "/human-resources", icon: Users, label: "Employees" },
     { href: "/reports", icon: BarChart3, label: "Reports" },
   ],

--- a/lib/workspace-feature-resolution.test.ts
+++ b/lib/workspace-feature-resolution.test.ts
@@ -15,8 +15,10 @@ import {
   getClientTemplateFeatureKeys,
   getClientTemplateWorkspaceProfile,
 } from "@/lib/platform/client-templates";
-import { FEATURE_BUNDLES } from "@/lib/platform/feature-catalog";
-import { resolveFeatureKeyForPath } from "@/lib/platform/gating/route-registry";
+import { FEATURE_BUNDLES, FEATURE_CATALOG } from "@/lib/platform/feature-catalog";
+import { isKnownFeatureKey } from "@/lib/platform/gating/catalog-utils";
+import { getAllRouteFeatureKeys, resolveFeatureKeyForPath } from "@/lib/platform/gating/route-registry";
+import { getAllowedUserRolesForWorkspace } from "@/lib/platform/vertical-roles";
 import { getPrimaryQuickActions } from "@/lib/primary-actions";
 import { resolveWorkspaceVerticalProductBundle } from "@/lib/workspace-products";
 import { getWorkspaceSidebarModel } from "@/lib/workspaces";
@@ -43,6 +45,11 @@ function isMiningHref(href: string): boolean {
 }
 
 describe("feature catalog bundles", () => {
+  it("maps every route feature to a known catalog feature key", () => {
+    const unknownRouteKeys = getAllRouteFeatureKeys().filter((key) => !isKnownFeatureKey(key));
+    expect(unknownRouteKeys).toEqual([]);
+  });
+
   it("keeps mining daily ops out of ADDON_OPERATIONS_CORE", () => {
     const operationsCore = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_OPERATIONS_CORE");
     expect(operationsCore).toBeDefined();
@@ -54,6 +61,19 @@ describe("feature catalog bundles", () => {
   it("collects mining daily ops in ADDON_MINE_DAILY_OPS", () => {
     const mineOps = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_MINE_DAILY_OPS");
     expect(mineOps?.features.slice().sort()).toEqual(MINE_DAILY_OPS_FEATURE_KEYS.slice().sort());
+  });
+
+  it("exposes CRM as a first-class add-on bundle", () => {
+    expect(FEATURE_CATALOG.some((feature) => feature.key === "crm.customers")).toBe(true);
+
+    const crm = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_CRM_CORE");
+    expect(crm).toBeDefined();
+    expect(crm?.features).toContain("crm.customers");
+  });
+
+  it("keeps Retail Suite entitled to customer CRM", () => {
+    const retail = FEATURE_BUNDLES.find((bundle) => bundle.code === "ADDON_RETAIL_SUITE");
+    expect(retail?.features).toContain("crm.customers");
   });
 });
 
@@ -86,6 +106,34 @@ describe("client templates", () => {
       expect(getClientTemplateWorkspaceProfile(template.code)).not.toBeNull();
     }
   });
+});
+
+describe("vertical role registration", () => {
+  it("registers CRM sales roles only when CRM features are enabled", () => {
+    expect(
+      getAllowedUserRolesForWorkspace({
+        workspaceProfile: "GENERAL",
+        enabledFeatures: [],
+      }),
+    ).not.toContain("SALES_EXEC");
+
+    expect(
+      getAllowedUserRolesForWorkspace({
+        workspaceProfile: "GENERAL",
+        enabledFeatures: ["crm.customers"],
+      }),
+    ).toContain("SALES_EXEC");
+  });
+
+  it("keeps Autos sales roles registered through the Autos profile", () => {
+    expect(
+      getAllowedUserRolesForWorkspace({
+        workspaceProfile: "AUTOS",
+        enabledFeatures: [],
+      }),
+    ).toContain("SALES_EXEC");
+  });
+
 });
 
 describe("vertical product resolution", () => {
@@ -170,6 +218,16 @@ describe("primary quick actions", () => {
 });
 
 describe("workspace sidebar model", () => {
+  it("shows CRM navigation when only CRM customers is enabled", () => {
+    const model = getWorkspaceSidebarModel({
+      role: "MANAGER",
+      enabledFeatures: ["crm.customers"],
+      workspaceProfile: "GENERAL",
+    });
+    const hrefs = model.sections.flatMap((section) => section.items.map((item) => item.href));
+    expect(hrefs).toContain("/retail/customers");
+  });
+
   it("multi-site sidebar contains no mining hrefs anywhere", () => {
     const model = getWorkspaceSidebarModel({
       role: "MANAGER",
@@ -207,5 +265,11 @@ describe("route gating", () => {
     expect(resolveFeatureKeyForPath("/shift-report")).toBe("ops.shift-report.submit");
     expect(resolveFeatureKeyForPath("/attendance")).toBe("ops.attendance.mark");
     expect(resolveFeatureKeyForPath("/plant-report")).toBe("ops.plant-report.submit");
+  });
+
+  it("gates retail customer surfaces behind CRM", () => {
+    expect(resolveFeatureKeyForPath("/retail/customers")).toBe("crm.customers");
+    expect(resolveFeatureKeyForPath("/portal/pos/customers")).toBe("crm.customers");
+    expect(resolveFeatureKeyForPath("/api/v2/retail/customers/search")).toBe("crm.customers");
   });
 });

--- a/lib/workspace-products.ts
+++ b/lib/workspace-products.ts
@@ -17,6 +17,7 @@ export type WorkspaceModuleId =
   | "schools"
   | "car-sales"
   | "retail"
+  | "crm"
   | "hr"
   | "stores"
   | "maintenance"
@@ -98,6 +99,10 @@ const DEFAULT_MODULE_PRESENTATION: Record<WorkspaceModuleId, WorkspaceModulePres
   },
   retail: {
     title: "Retail",
+    description: "",
+  },
+  crm: {
+    title: "CRM",
     description: "",
   },
   hr: {

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -120,6 +120,7 @@ const WORKSPACE_MODULE_ORDER: readonly WorkspaceModuleId[] = [
   "schools",
   "car-sales",
   "retail",
+  "crm",
   "hr",
   "stores",
   "maintenance",
@@ -234,6 +235,12 @@ const WORKSPACE_MODULES: Record<WorkspaceModuleId, WorkspaceModuleDefinition> = 
       return items;
     },
   },
+  crm: createSectionModule({
+    id: "crm",
+    label: "CRM",
+    sectionId: "crm",
+    homeHref: "/retail/customers",
+  }),
   hr: createSectionModule({
     id: "hr",
     label: "Human Resources",

--- a/scripts/platform/audit-feature-gates.ts
+++ b/scripts/platform/audit-feature-gates.ts
@@ -1,10 +1,7 @@
 import { FEATURE_CATALOG } from "../../lib/platform/feature-catalog";
 import { FEATURE_CAPABILITIES } from "../../lib/platform/gating/capability-registry";
+import { normalizeFeatureKey } from "../../lib/platform/gating/catalog-utils";
 import { API_FEATURE_ROUTES, PAGE_FEATURE_ROUTES } from "../../lib/platform/gating/route-registry";
-
-function normalizeFeatureKey(value: string): string {
-  return value.trim().toLowerCase();
-}
 
 function distinct(values: string[]): string[] {
   return Array.from(new Set(values)).sort();

--- a/scripts/platform/domain/user-management-service.ts
+++ b/scripts/platform/domain/user-management-service.ts
@@ -5,13 +5,13 @@ import { prisma } from "../prisma";
 import {
   USER_ACCOUNT_STATUSES,
   USER_MANAGEMENT_ROLES,
-  USER_ROLES,
   type ChangeUserRoleInput,
   type CreateUserInput,
   type ListUsersInput,
   type ResetUserPasswordInput,
   type SetUserStatusInput,
   type UserCreateResult,
+  type UserManagementRole,
   type UserResetPasswordResult,
   type UserRole,
   type UserRoleChangeResult,
@@ -20,9 +20,67 @@ import {
 } from "../types";
 import { appendAuditEvent } from "./audit-ledger";
 import { formatDate, normalizeEmail, normalizeEnum, normalizePasswordInput } from "./helpers";
+import { getAllowedUserRolesForWorkspace } from "../../../lib/platform/vertical-roles";
 
-function normalizeAssignableRole(role: string): UserRole {
-  return normalizeEnum(role, "role", USER_ROLES);
+function normalizeAssignableRole(role: string): UserManagementRole {
+  return normalizeEnum(role, "role", USER_MANAGEMENT_ROLES);
+}
+
+function isUserManagementRole(role: UserRole): role is UserManagementRole {
+  return (USER_MANAGEMENT_ROLES as readonly string[]).includes(role);
+}
+
+async function getCompanyRoleContext(companyId: string) {
+  const company = await prisma.company.findUnique({
+    where: { id: companyId },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      workspaceProfile: true,
+      featureFlags: {
+        where: {
+          isEnabled: true,
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+        },
+        select: {
+          feature: { select: { key: true } },
+        },
+      },
+    },
+  });
+
+  if (!company) return null;
+
+  return {
+    id: company.id,
+    name: company.name,
+    slug: company.slug,
+    workspaceProfile: company.workspaceProfile,
+    enabledFeatures: company.featureFlags.map((flag) => flag.feature.key),
+  };
+}
+
+function getAllowedAssignableRoles(context: {
+  workspaceProfile: string | null;
+  enabledFeatures: string[];
+}): UserManagementRole[] {
+  return getAllowedUserRolesForWorkspace({
+    workspaceProfile: context.workspaceProfile,
+    enabledFeatures: context.enabledFeatures,
+  }).filter(isUserManagementRole);
+}
+
+function assertAssignableRoleForCompany(
+  role: UserManagementRole,
+  context: { workspaceProfile: string | null; enabledFeatures: string[] },
+) {
+  const allowedRoles = getAllowedAssignableRoles(context);
+  if (!allowedRoles.includes(role)) {
+    throw new Error(
+      `Selected role ${role} is not available for this company's enabled features.`,
+    );
+  }
 }
 
 function assertManagedLifecycleTarget(user: { role: string; email: string }) {
@@ -86,10 +144,7 @@ export async function listUsers(input?: ListUsersInput): Promise<UserSummary[]> 
     where.isActive = normalizeEnum(input.status, "status", USER_ACCOUNT_STATUSES) === "ACTIVE";
   }
   if (input?.role) {
-    const role = normalizeEnum(input.role, "role", USER_ROLES);
-    if (role === "SUPERADMIN") {
-      throw new Error("SUPERADMIN users are managed in the Admins module.");
-    }
+    const role = normalizeEnum(input.role, "role", USER_MANAGEMENT_ROLES);
     where.role = role;
   }
 
@@ -124,10 +179,7 @@ export async function listUsers(input?: ListUsersInput): Promise<UserSummary[]> 
 }
 
 export async function createUser(input: CreateUserInput): Promise<UserCreateResult> {
-  const company = await prisma.company.findUnique({
-    where: { id: input.companyId },
-    select: { id: true, name: true, slug: true },
-  });
+  const company = await getCompanyRoleContext(input.companyId);
   if (!company) throw new Error(`Organization not found for id: ${input.companyId}`);
 
   await assertHasActiveSuperadmin(input.companyId);
@@ -137,6 +189,7 @@ export async function createUser(input: CreateUserInput): Promise<UserCreateResu
   if (!name) throw new Error("User name cannot be empty.");
   const normalizedPassword = normalizePasswordInput(input.password, "Password");
   const role = normalizeAssignableRole(input.role || "CLERK");
+  assertAssignableRoleForCompany(role, company);
 
   const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
   if (existing) throw new Error(`User already exists for email: ${email}`);
@@ -307,8 +360,11 @@ export async function changeUserRole(input: ChangeUserRoleInput): Promise<UserRo
 
   assertManagedLifecycleTarget({ role: before.role, email: before.email });
   await assertHasActiveSuperadmin(before.companyId);
+  const company = await getCompanyRoleContext(before.companyId);
+  if (!company) throw new Error(`Organization not found for id: ${before.companyId}`);
+  assertAssignableRoleForCompany(afterRole, company);
 
-  const beforeRole = normalizeEnum(before.role, "role", USER_ROLES);
+  const beforeRole = normalizeEnum(before.role, "role", USER_MANAGEMENT_ROLES);
   if (beforeRole === afterRole) {
     throw new Error(`User ${before.email} is already ${afterRole}.`);
   }

--- a/scripts/platform/modules/wizards/user-create-wizard.tsx
+++ b/scripts/platform/modules/wizards/user-create-wizard.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Text, useInput } from "ink";
 
-import type { OrganizationListItem, PlatformServices, UserManagementRole } from "../../types";
+import type { OrganizationListItem, PlatformServices } from "../../types";
+import { getUserRoleOptionsForOrganization } from "../../user-role-options";
 import { applyTextInput, useInputLock } from "../input-utils";
 import { SelectorList } from "./selector-list";
 import { WizardFrame } from "./wizard-frame";
@@ -19,7 +20,11 @@ type Step = 0 | 1 | 2 | 3;
 type UserField = "email" | "name" | "password";
 
 const USER_FIELDS: UserField[] = ["email", "name", "password"];
-const ROLE_OPTIONS: UserManagementRole[] = ["MANAGER", "CLERK"];
+
+function getDefaultRoleIndex(options: Array<{ value: string }>): number {
+  const clerkIndex = options.findIndex((option) => option.value === "CLERK");
+  return clerkIndex >= 0 ? clerkIndex : 0;
+}
 
 export function UserCreateWizard({
   actor,
@@ -72,7 +77,18 @@ export function UserCreateWizard({
   }, [focusCompanyId, services.org]);
 
   const selectedCompany = organizations[companyIndex] ?? null;
-  const selectedRole = ROLE_OPTIONS[roleIndex] ?? ROLE_OPTIONS[1];
+  const roleOptions = useMemo(
+    () => getUserRoleOptionsForOrganization(selectedCompany),
+    [selectedCompany],
+  );
+  const selectedRole = roleOptions[roleIndex]?.value ?? roleOptions[0]?.value ?? "MANAGER";
+
+  useEffect(() => {
+    setRoleIndex((current) => {
+      if (current < roleOptions.length) return current;
+      return getDefaultRoleIndex(roleOptions);
+    });
+  }, [roleOptions]);
 
   async function runCreate() {
     if (!selectedCompany) return;
@@ -103,7 +119,7 @@ export function UserCreateWizard({
         name: "",
         password: "",
       });
-      setRoleIndex(1);
+      setRoleIndex(getDefaultRoleIndex(roleOptions));
       setStep(1);
       setFieldIndex(0);
     } catch (error) {
@@ -167,6 +183,7 @@ export function UserCreateWizard({
           setErrorMessage("Password must be at least 8 characters.");
           return;
         }
+        setRoleIndex(getDefaultRoleIndex(roleOptions));
         setStep(2);
         return;
       }
@@ -182,10 +199,14 @@ export function UserCreateWizard({
         return;
       }
       if (key.downArrow) {
-        setRoleIndex((current) => Math.min(Math.max(0, ROLE_OPTIONS.length - 1), current + 1));
+        setRoleIndex((current) => Math.min(Math.max(0, roleOptions.length - 1), current + 1));
         return;
       }
       if (key.return) {
+        if (roleOptions.length === 0) {
+          setErrorMessage("No roles are available for the selected company's enabled features.");
+          return;
+        }
         setStep(3);
       }
       return;
@@ -199,7 +220,7 @@ export function UserCreateWizard({
   return (
     <WizardFrame
       title="Create User Wizard"
-      description="Create MANAGER or CLERK users with company-scoped context."
+      description="Create feature-aware managed users with company-scoped context."
       step={step}
       steps={["Select Company", "User Details", "Select Role", "Review & Confirm"]}
       statusMessage={statusMessage}
@@ -231,10 +252,10 @@ export function UserCreateWizard({
             <>
               <Text>company: {selectedCompany ? `${selectedCompany.name} (${selectedCompany.slug})` : "<none>"}</Text>
               <SelectorList
-                items={ROLE_OPTIONS}
+                items={roleOptions}
                 selectedIndex={roleIndex}
                 emptyMessage="No roles available."
-                render={(item) => item}
+                render={(item) => `${item.label} (${item.value})`}
               />
             </>
           ) : null}

--- a/scripts/platform/modules/wizards/user-list-wizard.tsx
+++ b/scripts/platform/modules/wizards/user-list-wizard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Text, useInput } from "ink";
 
 import type { OrganizationListItem, PlatformServices, UserAccountStatus, UserManagementRole, UserSummary } from "../../types";
+import { getAllUserManagementRoleOptions, getUserRoleOptionsForOrganization } from "../../user-role-options";
 import { applyTextInput, useInputLock } from "../input-utils";
 import { SelectorList } from "./selector-list";
 import { WizardFrame } from "./wizard-frame";
@@ -24,7 +25,6 @@ interface CompanyOption {
   slug: string;
 }
 
-const ROLE_FILTERS: RoleFilter[] = ["ALL", "MANAGER", "CLERK"];
 const STATUS_FILTERS: StatusFilter[] = ["ALL", "ACTIVE", "INACTIVE"];
 const FIELDS: Field[] = ["search", "status", "role"];
 
@@ -86,10 +86,38 @@ export function UserListWizard({ services, focusCompanyId, setInputLocked, onBac
 
   const selectedCompany = companyOptions[companyIndex] ?? null;
   const activeField = FIELDS[fieldIndex] ?? FIELDS[0];
+  const roleFilterOptions = useMemo(() => {
+    const options = [{ value: "ALL" as RoleFilter, label: "All Roles" }];
+    const seen = new Set<RoleFilter>(["ALL"]);
+    const scopedCompanies = selectedCompany?.id
+      ? companies.filter((company) => company.id === selectedCompany.id)
+      : companies;
+    const sourceOptions = scopedCompanies.length > 0
+      ? scopedCompanies.flatMap((company) => getUserRoleOptionsForOrganization(company))
+      : getAllUserManagementRoleOptions();
+
+    for (const option of sourceOptions) {
+      if (seen.has(option.value)) continue;
+      seen.add(option.value);
+      options.push({ value: option.value, label: option.label });
+    }
+
+    return options;
+  }, [companies, selectedCompany]);
+  const roleFilterCycle = useMemo(
+    () => roleFilterOptions.map((option) => option.value),
+    [roleFilterOptions],
+  );
+  const roleFilterLabel = roleFilterOptions.find((option) => option.value === roleFilter)?.label ?? roleFilter;
 
   useEffect(() => {
     setCompanyIndex((current) => Math.min(Math.max(0, companyOptions.length - 1), current));
   }, [companyOptions.length]);
+
+  useEffect(() => {
+    if (roleFilterCycle.includes(roleFilter)) return;
+    setRoleFilter("ALL");
+  }, [roleFilter, roleFilterCycle]);
 
   const runSearch = useCallback(async () => {
     setLoading(true);
@@ -168,7 +196,7 @@ export function UserListWizard({ services, focusCompanyId, setInputLocked, onBac
 
       if ((key.leftArrow || key.rightArrow || input === " ") && activeField === "role") {
         const direction: 1 | -1 = key.leftArrow ? -1 : 1;
-        const next = nextFromCycle(ROLE_FILTERS, roleFilter, direction);
+        const next = nextFromCycle(roleFilterCycle, roleFilter, direction);
         setRoleFilter(next);
         return;
       }
@@ -186,7 +214,7 @@ export function UserListWizard({ services, focusCompanyId, setInputLocked, onBac
   return (
     <WizardFrame
       title="List/Search Users Wizard"
-      description="Browse MANAGER and CLERK users by company scope, status, role, and search query."
+      description="Browse managed users by company scope, status, feature-aware role, and search query."
       step={step}
       steps={["Select Company Scope", "Filters & Results"]}
       statusMessage={statusMessage}
@@ -211,7 +239,7 @@ export function UserListWizard({ services, focusCompanyId, setInputLocked, onBac
               <Text>scope: {selectedCompany ? `${selectedCompany.name} (${selectedCompany.slug})` : "<none>"}</Text>
               <Text color={fieldIndex === 0 ? "cyan" : undefined}>search: {search || "<none>"}</Text>
               <Text color={fieldIndex === 1 ? "cyan" : undefined}>status: {statusFilter}</Text>
-              <Text color={fieldIndex === 2 ? "cyan" : undefined}>role: {roleFilter}</Text>
+              <Text color={fieldIndex === 2 ? "cyan" : undefined}>role: {roleFilter === "ALL" ? roleFilterLabel : `${roleFilterLabel} (${roleFilter})`}</Text>
               <Text dimColor>results: {results.length}</Text>
               {results.length === 0 ? (
                 <Text dimColor>No users match current filters.</Text>

--- a/scripts/platform/modules/wizards/user-role-wizard.tsx
+++ b/scripts/platform/modules/wizards/user-role-wizard.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Text, useInput } from "ink";
 
-import type { PlatformServices, UserManagementRole, UserSummary } from "../../types";
+import type { OrganizationListItem, PlatformServices, UserManagementRole, UserSummary } from "../../types";
+import { getUserRoleOptionsForOrganization } from "../../user-role-options";
 import { applyTextInput, useInputLock } from "../input-utils";
 import { SelectorList } from "./selector-list";
 import { WizardFrame } from "./wizard-frame";
@@ -17,11 +18,13 @@ interface UserRoleWizardProps {
 
 type Step = 0 | 1 | 2 | 3;
 
-const ROLE_OPTIONS: UserManagementRole[] = ["MANAGER", "CLERK"];
-
-function getSuggestedRole(user: UserSummary | null): UserManagementRole {
-  if (!user || user.role === "CLERK") return "MANAGER";
-  return "CLERK";
+function getSuggestedRole(
+  user: UserSummary | null,
+  options: Array<{ value: UserManagementRole }>,
+): UserManagementRole {
+  const fallback = options[0]?.value ?? "MANAGER";
+  if (!user) return fallback;
+  return options.find((option) => option.value !== user.role)?.value ?? fallback;
 }
 
 function filterUsers(users: UserSummary[], query: string) {
@@ -42,6 +45,7 @@ export function UserRoleWizard({
   onBackToTree,
 }: UserRoleWizardProps) {
   const [step, setStep] = useState<Step>(0);
+  const [companies, setCompanies] = useState<OrganizationListItem[]>([]);
   const [users, setUsers] = useState<UserSummary[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
@@ -59,9 +63,13 @@ export function UserRoleWizard({
     let ignore = false;
     async function loadUsers() {
       try {
-        const rows = await services.user.list({ companyId: focusCompanyId || undefined, limit: 100 });
+        const [companyRows, userRows] = await Promise.all([
+          services.org.list({ limit: 100 }),
+          services.user.list({ companyId: focusCompanyId || undefined, limit: 100 }),
+        ]);
         if (!ignore) {
-          setUsers(rows);
+          setCompanies(companyRows);
+          setUsers(userRows);
           setSelectedIndex(0);
         }
       } catch (error) {
@@ -72,11 +80,19 @@ export function UserRoleWizard({
     return () => {
       ignore = true;
     };
-  }, [focusCompanyId, services.user]);
+  }, [focusCompanyId, services.org, services.user]);
 
   const visibleUsers = useMemo(() => filterUsers(users, searchQuery), [users, searchQuery]);
   const selected = visibleUsers[selectedIndex] ?? null;
-  const selectedRole = ROLE_OPTIONS[roleIndex] ?? ROLE_OPTIONS[0];
+  const selectedCompany = useMemo(
+    () => companies.find((company) => company.id === selected?.companyId) ?? null,
+    [companies, selected?.companyId],
+  );
+  const roleOptions = useMemo(
+    () => getUserRoleOptionsForOrganization(selectedCompany),
+    [selectedCompany],
+  );
+  const selectedRole = roleOptions[roleIndex]?.value ?? roleOptions[0]?.value ?? "MANAGER";
   const requiresTypedConfirmation = false;
   const confirmPhrase = useMemo(
     () => `CONFIRM ROLE ${selected?.email || "user"} ${selectedRole}`,
@@ -151,8 +167,8 @@ export function UserRoleWizard({
           setErrorMessage("No user selected.");
           return;
         }
-        const suggested = getSuggestedRole(selected);
-        const nextIndex = ROLE_OPTIONS.indexOf(suggested);
+        const suggested = getSuggestedRole(selected, roleOptions);
+        const nextIndex = roleOptions.findIndex((option) => option.value === suggested);
         setRoleIndex(nextIndex >= 0 ? nextIndex : 0);
         setStep(1);
         return;
@@ -167,10 +183,14 @@ export function UserRoleWizard({
         return;
       }
       if (key.downArrow) {
-        setRoleIndex((current) => Math.min(Math.max(0, ROLE_OPTIONS.length - 1), current + 1));
+        setRoleIndex((current) => Math.min(Math.max(0, roleOptions.length - 1), current + 1));
         return;
       }
       if (key.return) {
+        if (roleOptions.length === 0) {
+          setErrorMessage("No roles are available for this user's company features.");
+          return;
+        }
         setStep(2);
       }
       return;
@@ -203,7 +223,7 @@ export function UserRoleWizard({
   return (
     <WizardFrame
       title="Change User Role Wizard"
-      description="Switch MANAGER and CLERK roles with review before apply."
+      description="Assign feature-aware managed user roles with review before apply."
       step={step}
       steps={["Select User", "Select Role", "Reason", "Review & Confirm"]}
       statusMessage={statusMessage}
@@ -230,10 +250,10 @@ export function UserRoleWizard({
             <>
               <Text>user: {selected?.email || "<none>"}</Text>
               <SelectorList
-                items={ROLE_OPTIONS}
+                items={roleOptions}
                 selectedIndex={roleIndex}
                 emptyMessage="No roles available."
-                render={(item) => item}
+                render={(item) => `${item.label} (${item.value})`}
               />
             </>
           ) : null}

--- a/scripts/platform/services.ts
+++ b/scripts/platform/services.ts
@@ -1190,7 +1190,7 @@ async function listOrganizations(input?: ListOrganizationsInput): Promise<Organi
 
   const companies = await prisma.company.findMany({
     where,
-    select: { id: true, name: true, slug: true, tenantStatus: true, isProvisioned: true, createdAt: true, updatedAt: true },
+    select: { id: true, name: true, slug: true, workspaceProfile: true, tenantStatus: true, isProvisioned: true, createdAt: true, updatedAt: true },
     orderBy: { name: "asc" },
     take: input?.limit ?? 100,
     skip: input?.skip ?? 0,
@@ -1198,17 +1198,23 @@ async function listOrganizations(input?: ListOrganizationsInput): Promise<Organi
 
   const rows = await Promise.all(
     companies.map(async (company) => {
-      const [siteCount, activeSiteCount, userCount, activeUserCount] = await Promise.all([
+      const [siteCount, activeSiteCount, userCount, activeUserCount, features] = await Promise.all([
         prisma.site.count({ where: { companyId: company.id } }),
         prisma.site.count({ where: { companyId: company.id, isActive: true } }),
         prisma.user.count({ where: { companyId: company.id } }),
         prisma.user.count({ where: { companyId: company.id, isActive: true } }),
+        listFeatures({ companyId: company.id }),
       ]);
+      const enabledFeatures = features
+        .filter((feature) => feature.enabled)
+        .map((feature) => feature.feature);
 
       return {
         id: company.id,
         name: company.name,
         slug: company.slug,
+        workspaceProfile: company.workspaceProfile,
+        enabledFeatures,
         status: company.tenantStatus as OrganizationStatus,
         isProvisioned: company.isProvisioned,
         siteCount,

--- a/scripts/platform/types.ts
+++ b/scripts/platform/types.ts
@@ -106,6 +106,8 @@ export interface OrganizationListItem {
   id: string;
   name: string;
   slug: string;
+  workspaceProfile: string | null;
+  enabledFeatures: string[];
   status: OrganizationStatus;
   isProvisioned: boolean;
   siteCount: number;

--- a/scripts/platform/user-role-options.ts
+++ b/scripts/platform/user-role-options.ts
@@ -1,0 +1,43 @@
+import {
+  getAllowedUserRoleOptionsForWorkspace,
+  USER_ROLE_LABELS,
+} from "../../lib/platform/vertical-roles";
+import {
+  USER_MANAGEMENT_ROLES,
+  type OrganizationListItem,
+  type UserManagementRole,
+  type UserRole,
+} from "./types";
+
+export type UserManagementRoleOption = {
+  value: UserManagementRole;
+  label: string;
+};
+
+const USER_MANAGEMENT_ROLE_SET = new Set<string>(USER_MANAGEMENT_ROLES);
+
+function isUserManagementRole(role: string): role is UserManagementRole {
+  return USER_MANAGEMENT_ROLE_SET.has(role);
+}
+
+export function getUserRoleLabel(role: UserRole | UserManagementRole): string {
+  return USER_ROLE_LABELS[role as UserRole] ?? role;
+}
+
+export function getUserRoleOptionsForOrganization(
+  organization: Pick<OrganizationListItem, "workspaceProfile" | "enabledFeatures"> | null | undefined,
+): UserManagementRoleOption[] {
+  return getAllowedUserRoleOptionsForWorkspace({
+    workspaceProfile: organization?.workspaceProfile,
+    enabledFeatures: organization?.enabledFeatures,
+  }).filter((option): option is UserManagementRoleOption =>
+    isUserManagementRole(option.value),
+  );
+}
+
+export function getAllUserManagementRoleOptions(): UserManagementRoleOption[] {
+  return USER_MANAGEMENT_ROLES.map((role) => ({
+    value: role,
+    label: getUserRoleLabel(role),
+  }));
+}


### PR DESCRIPTION
## Summary
- Add CRM as a first-class catalog domain with `crm.customers`, `ADDON_CRM_CORE`, route gating, navigation, workspace visibility, quick action, and pricing metadata.
- Register CRM-driven sales roles through the shared vertical role registry so `SALES_EXEC` appears only when CRM/autos features are available.
- Wire platform admin and TUI user role selectors to feature-aware role options, and document the module/bundle/role registration process.

## Root Cause
Catalog sync only materializes code-defined catalog entries. CRM customer screens existed, but there was no CRM feature domain, `crm.customers` feature, or CRM bundle in the source catalog, so sync had nothing to create and customer routes fell through to broader retail gating.

## Validation
- `vitest run lib/workspace-feature-resolution.test.ts` passed: 35 tests.
- Touched-file ESLint passed with 0 errors; existing unrelated warnings remain in `components/admin-portal/wizards/identity-hub-wizards.tsx` for unused `companyName` props.
- Full `tsc --noEmit` still fails on pre-existing Prisma client/export and implicit-any issues across the repo.