### PR TITLE
feat(design-system): make @corelithzw/react the source of truth for tokens and styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,58 +1,98 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   CORELITH APP STYLESHEET
+
+   `@corelithzw/react` is the single source of truth for design tokens and for
+   the styling of every component it exports. This file only wires Tailwind
+   around it. Every legacy token name the app still references is re-derived
+   from a package token in `app/themes/corelith-bridge.css` — no colour, size,
+   radius, shadow or duration literal belongs in this file.
+
+   See docs/design-system/02-tokens.md for the token catalogue.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Cascade layer order. Declared ahead of the imports so it is the order that
+   sticks (Tailwind re-declares `theme, base, components, utilities` and layers
+   are ordered by first appearance).
+
+     corelith  the design-system package — sits above Tailwind's preflight, so
+               its resets and its `:root` token values win over Tailwind's.
+     app       this repo's element-level base styles, layered above the package
+               so the app keeps the last word on `body` and friends.
+
+   Utilities stay on top: a Tailwind class on a design-system component still
+   overrides the component's own CSS. */
+@layer theme, base, corelith, app, components, utilities;
+
+/* Atkinson Hyperlegible — the design system's typeface, and the app's since the
+   SS Huchu face was retired.
+
+   The package's styles.css pulls this itself on its line 14, but that `@import`
+   lands *inside* `@layer corelith` once bundled, and an `@import` nested in a
+   layer block is invalid CSS that browsers drop. Hoisting it here is what
+   actually loads the font; the nested copy is inert. If a CSP or an offline
+   build blocks Google Fonts, the stack falls back to `-apple-system` and the
+   intended metrics are lost — self-host the two families to fix that. */
+@import url("https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@200..800&family=Atkinson+Hyperlegible+Mono:wght@400..700&display=swap");
+
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@corelithzw/react/styles.css" layer(corelith);
 
 @source "../node_modules/@rtcamp/frappe-ui-react/dist";
 
-/* Custom Font: SS Huchu ──────────────────────────────────────────────── */
+/* ── Tailwind Theme Mappings ────────────────────────────────────────────────
+   Deliberately thin. Tailwind's own theme keys (`--font-sans`, `--font-mono`,
+   `--radius-*`, `--ease-*`) are left alone: the package redefines those exact
+   names in the `corelith` layer, which outranks Tailwind's `theme` layer, so
+   `font-sans`, `rounded-lg`, `ease-out` and the rest already resolve to
+   design-system values. Only names Tailwind does not ship are declared here.
 
-@font-face {
-  font-family: "SS Huchu";
-  src: url(/regular.4b554656.woff2) format("woff2");
-  font-display: swap;
-  font-weight: 400;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "SS Huchu";
-  src: url(/medium.501e532c.woff2) format("woff2");
-  font-display: swap;
-  font-weight: 500;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: "SS Huchu";
-  src: url(/bold.37baf660.woff2) format("woff2");
-  font-display: swap;
-  font-weight: 700;
-  font-style: normal;
-}
-
-/* ── Tailwind Theme Mappings ────────────────────────────────────────────── */
+   Every value is `var(--package-token)` so a token change in the package flows
+   through without editing this file. */
 
 @theme inline {
-  --font-sans: var(--font-sans);
-  --font-mono:
-    var(--font-jetbrains-mono), var(--font-ibm-plex-mono), ui-monospace,
-    SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
-  --font-family:
-    "SS Huchu", "Inter", ui-sans-serif, system-ui, "Segoe UI",
-    "Helvetica Neue", Arial, sans-serif;
-
-  /* Surface tokens */
-  --color-surface-canvas: var(--surface-canvas);
-  --color-surface-base: var(--surface-base);
-  --color-surface-raised: var(--surface-raised);
+  /* Design-system palette → colour utilities (bg-*, text-*, border-*) */
+  --color-canvas: var(--canvas);
+  --color-surface: var(--surface);
   --color-surface-muted: var(--surface-muted);
-  --color-surface-subtle: var(--surface-subtle);
+  --color-surface-sunken: var(--surface-sunken);
+  --color-surface-deep: var(--surface-deep);
 
-  /* Text tokens */
+  --color-brand: var(--brand);
+  --color-brand-strong: var(--brand-strong);
+  --color-brand-deeper: var(--brand-deeper);
+  --color-brand-soft: var(--brand-soft);
+  --color-ink: var(--ink);
+  --color-ink-soft: var(--ink-soft);
+
   --color-text-strong: var(--text-strong);
   --color-text-body: var(--text-body);
   --color-text-muted: var(--text-muted);
+  --color-text-subtle: var(--text-subtle);
   --color-text-inverse: var(--text-inverse);
+  --color-text-link: var(--text-link);
+
+  --color-border-subtle: var(--border-subtle);
+  --color-border-strong: var(--border-strong);
+  --color-hairline: var(--hairline);
+
+  /* Semantic tones. The short aliases (`text-info`, `bg-danger`, …) are the
+     names call sites already use; the `tone-*` spellings match the package. */
+  --color-tone-info: var(--tone-info);
+  --color-tone-success: var(--tone-success);
+  --color-tone-warn: var(--tone-warn);
+  --color-tone-danger: var(--tone-danger);
+  --color-tone-neutral: var(--tone-neutral);
+  --color-info: var(--tone-info);
+  --color-success: var(--tone-success);
+  --color-warning: var(--tone-warn);
+  --color-danger: var(--tone-danger);
+
+  /* Surface tokens (legacy spellings — see corelith-bridge.css) */
+  --color-surface-canvas: var(--surface-canvas);
+  --color-surface-base: var(--surface-base);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-subtle: var(--surface-subtle);
 
   /* Action tokens */
   --color-action-primary-bg: var(--action-primary-bg);
@@ -102,14 +142,11 @@
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
 
-  /* Radius scale */
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
+  /* Radius. `--radius-xs … --radius-2xl` come from the package (4/6/8/10/14/18)
+     and need no mapping. Only the two rungs the design system does not define
+     are extended here, kept on the same +4px cadence as `--radius-xl`. */
+  --radius-3xl: calc(var(--radius-2xl) + 4px);
+  --radius-4xl: calc(var(--radius-2xl) + 8px);
 
   /* POS-specific breakpoints */
   --breakpoint-ms: 520px;
@@ -118,431 +155,60 @@
 
 /* ═══════════════════════════════════════════════════════════════════════════
    ROOT DESIGN TOKEN SYSTEM
+
+   Deliberately empty. Every token the app reads — the neutral and brand ramps,
+   the semantic status set, edges, elevation, geometry, type, motion, spacing —
+   is now declared once in `app/themes/corelith-bridge.css`, derived from the
+   `@corelithzw/react` token set. Adding a literal back here would silently
+   outrank the package, which is the failure mode this migration removed.
    ═══════════════════════════════════════════════════════════════════════════ */
 
-:root {
-  color-scheme: light;
 
-  /* ── Neutral Palette (cool base — overridden by theme files) ─────────── */
-  --neutral-0:  #ffffff;
-  --neutral-25: #fcfcfb;
-  --neutral-50: #f8f9f8;
-  --neutral-100:#f2f4f4;
-  --neutral-200:#e6e9ea;
-  --neutral-300:#d6dbdd;
-  --neutral-400:#b7bfc3;
-  --neutral-500:#8c959b;
-  --neutral-600:#666f76;
-  --neutral-700:#485159;
-  --neutral-800:#2f363d;
-  --neutral-900:#1b2127;
+/* ── App Base Layer ─────────────────────────────────────────────────────────
+   Everything element-level lives in the `app` layer, above `corelith`. The
+   package's own `body` and `button` resets ship unlayered inside styles.css and
+   would otherwise outrank anything written here.
 
-  /* ── Brand Colors ────────────────────────────────────────────────────── */
-  --primary:     #2f6bff;
-  --accent:      #0f8f86;
-  --destructive: #d3434a;
+   Type, colour and canvas all come from the package's `body` rule; this layer
+   only adds what the app needs on top of it. */
 
-  /* ── Primary Ramp ────────────────────────────────────────────────────── */
-  --primary-50:  #edf3ff;
-  --primary-100: #d8e6ff;
-  --primary-300: #8fb2ff;
-  --primary-500: var(--primary);
-  --primary-600: #1f57e6;
-  --primary-700: #1f46c4;
-
-  /* ── Accent Ramp ─────────────────────────────────────────────────────── */
-  --accent-50:  #edf9f7;
-  --accent-100: #d5f0ec;
-  --accent-500: var(--accent);
-  --accent-600: #0c746d;
-
-  /* ── Semantic Color Ramps ───────────────────────────────────────────── */
-  --success-50:  #edf9f2;
-  --success-100: #d7f1e1;
-  --success-300: #9dd8b7;
-  --success-500: #23885c;
-  --success-700: #1a6444;
-
-  --warning-50:  #fef6ea;
-  --warning-100: #fde6cb;
-  --warning-300: #f6c278;
-  --warning-500: #d98a2f;
-  --warning-700: #9f6523;
-  --warning-800: #7f511c;
-
-  --danger-50:   #fef0f1;
-  --danger-100:  #fddde0;
-  --danger-300:  #f5a4ab;
-  --danger-500:  #d3434a;
-  --danger-700:  #9c2f35;
-
-  --info-50:     #eef7ff;
-  --info-100:    #d8ecff;
-  --info-300:    #9ecdf4;
-  --info-500:    #2d84c6;
-  --info-700:    #1f5f90;
-
-
-  /* ── Text Tokens ─────────────────────────────────────────────────────── */
-  --text-strong: var(--neutral-900);
-  --text-body:   var(--neutral-900);
-  --text-muted:  var(--neutral-600);
-  --text-subtle: var(--neutral-500);
-  --text-inverse:var(--neutral-0);
-
-  /* ── Action Tokens ───────────────────────────────────────────────────── */
-  --action-outline-bg:     var(--surface-base);
-  --action-outline-hover-bg: var(--surface-subtle);
-  --action-outline-border:   transparent;
-  --action-outline-border-hover: transparent;
-
-  --action-disabled-bg:      var(--gray-100);
-  --action-disabled-fg:      var(--gray-400);
-
-  /* ── Edge / Border Tokens ────────────────────────────────────────────── */
-  --edge-subtle:   var(--gray-100);
-  --edge-default:  var(--gray-200);
-  --edge-strong:   var(--gray-300);
-  --border-default:var(--edge-default);
-  --border-soft:   var(--edge-subtle);
-  --border-subtle: var(--edge-subtle);
-  --border-strong: var(--edge-strong);
-  --input-border:  var(--edge-default);
-  --input-bg:      var(--surface-base);
-
-  /* ── Focus Ring ──────────────────────────────────────────────────────── */
-  --focus-ring:        var(--brand-500);
-  --focus-ring-offset: var(--surface-canvas);
-
-  /* ── Shadow / Elevation System ───────────────────────────────────────── */
-  --elevation-0: none;
-  --elevation-1: inset 0 0 0 1px var(--edge-default);
-  --elevation-2:
-    inset 0 0 0 1px var(--edge-default),
-    0 2px 6px rgb(16 24 40 / 0.06);
-  --elevation-3:
-    inset 0 0 0 1px var(--edge-default),
-    0 8px 20px rgb(16 24 40 / 0.12);
-  --elevation-4:
-    inset 0 0 0 1px var(--edge-strong),
-    0 12px 28px rgb(16 24 40 / 0.16);
-
-  --shadow-none:    none;
-  --shadow-card:    0 1px 2px rgb(16 24 40 / 0.04), 0 8px 20px rgb(16 24 40 / 0.04);
-  --shadow-popover: 0 8px 24px rgb(16 24 40 / 0.14), 0 2px 6px rgb(16 24 40 / 0.08);
-
-  --surface-frame-shadow:
-    inset 0 0 0 1px var(--edge-default),
-    0 1px 2px rgb(16 24 40 / 0.03);
-  --surface-frame-shadow-hover:
-    inset 0 0 0 1px var(--edge-strong),
-    0 4px 12px rgb(16 24 40 / 0.08);
-
-  --button-shadow-rest:   inset 0 0 0 1px var(--edge-default);
-  --button-shadow-hover:  inset 0 0 0 1px var(--edge-strong), 0 2px 6px rgb(16 24 40 / 0.08);
-  --button-shadow-pressed:inset 0 0 0 1px var(--edge-strong);
-  --button-ghost-hover-bg:  var(--surface-subtle);
-  --button-ghost-active-bg: var(--surface-muted);
-
-  --card-shadow-rest: var(--shadow-card);
-  --card-divider:     var(--edge-subtle);
-
-  /* ── Status Tokens ───────────────────────────────────────────────────── */
-  --status-success-bg:    var(--tone-success-bg);
-  --status-success-border:var(--tone-success-bd);
-  --status-success-text:  var(--tone-success);
-  --status-warning-bg:    var(--warning-50);
-  --status-warning-border:var(--warning-300);
-  --status-warning-text:  var(--warning-700);
-  --status-error-bg:      var(--danger-50);
-  --status-error-border:  var(--danger-300);
-  --status-error-text:    var(--danger-700);
-  --status-info-bg:       var(--info-50);
-  --status-info-border:   var(--info-300);
-  --status-info-text:     var(--info-700);
-  --status-progress-bg:   var(--primary-50);
-  --status-progress-border:var(--primary-300);
-  --status-progress-text: var(--primary-700);
-  --status-pending-bg:    var(--neutral-100);
-  --status-pending-border:var(--neutral-300);
-  --status-pending-text:  var(--neutral-600);
-  --status-inactive-bg:   var(--neutral-100);
-  --status-inactive-border:var(--neutral-300);
-  --status-inactive-text: var(--neutral-500);
-
-  /* ── Badge Tokens ────────────────────────────────────────────────────── */
-  --badge-shadow:        none;
-  --badge-neutral-bg:    var(--neutral-100);
-  --badge-neutral-text:  var(--neutral-700);
-  --badge-brand-bg:      var(--primary-50);
-  --badge-brand-text:    var(--primary-700);
-  --badge-info-bg:       var(--info-50);
-  --badge-info-text:     var(--info-700);
-  --badge-success-bg:    var(--success-50);
-  --badge-success-text:  var(--success-700);
-  --badge-warning-bg:    var(--warning-50);
-  --badge-warning-text:  var(--warning-700);
-  --badge-danger-bg:     var(--danger-50);
-  --badge-danger-text:   var(--danger-700);
-
-  /* ── Table Tokens ────────────────────────────────────────────────────── */
-  --table-toolbar-bg:   rgb(255 255 255 / 86%);
-  --table-toolbar-border:var(--edge-subtle);
-  --table-header-bg:    var(--neutral-25);
-  --table-header-text:  var(--text-subtle);
-  --table-divider:      var(--edge-subtle);
-  --table-row-bg:       var(--surface-base);
-  --table-row-bg-alt:   var(--surface-base);
-  --table-row-hover-bg: #f7faff;
-  --table-row-selected-bg:var(--primary-50);
-
-  /* ── Datatable Tokens ────────────────────────────────────────────────── */
-  --datatable-toolbar-bg:   rgb(255 255 255 / 90%);
-  --datatable-toolbar-border:var(--edge-subtle);
-  --datatable-expanded-bg:  var(--neutral-25);
-  --datatable-empty-bg:     var(--neutral-25);
-
-  /* ── Sidebar Tokens ──────────────────────────────────────────────────── */
-  --sidebar:              var(--neutral-25);
-  --sidebar-foreground:   var(--text-body);
-  --sidebar-primary:      var(--action-primary-bg);
-  --sidebar-primary-foreground: var(--action-primary-fg);
-  --sidebar-accent:       var(--surface-subtle);
-  --sidebar-accent-foreground:  var(--text-body);
-  --sidebar-border:       var(--edge-subtle);
-  --sidebar-item-fg:      color-mix(in oklab, var(--text-body) 84%, var(--text-muted) 16%);
-  --sidebar-item-fg-muted:color-mix(in oklab, var(--text-muted) 88%, var(--text-body) 12%);
-  --sidebar-item-icon:    color-mix(in oklab, var(--text-muted) 78%, var(--text-body) 22%);
-  --sidebar-item-hover-fg:var(--text-body);
-  --sidebar-item-active-bg:   var(--primary-50);
-  --sidebar-item-active-fg:   var(--primary-700);
-  --sidebar-item-active-border: color-mix(in oklab, var(--primary-300) 50%, var(--edge-subtle) 50%);
-  --sidebar-ring:         var(--focus-ring);
-
-  /* ── Chart Tokens ────────────────────────────────────────────────────── */
-  --chart-1: var(--primary-500);
-  --chart-2: var(--accent-500);
-  --chart-3: var(--success-500);
-  --chart-4: var(--warning-500);
-  --chart-5: var(--danger-500);
-  --chart-grid:   var(--edge-subtle);
-  --chart-text:   var(--text-muted);
-  --chart-passing:var(--success-500);
-  --chart-failing:var(--danger-500);
-  --chart-need-changes:   var(--warning-500);
-  --chart-in-review:      var(--primary-500);
-  --chart-in-progress:    var(--warning-500);
-  --chart-pending:        var(--neutral-400);
-  --chart-inactive:       var(--neutral-500);
-
-  /* ── Shadcn Compatibility Mappings ───────────────────────────────────── */
-  --background:          var(--surface-canvas);
-  --foreground:          var(--text-body);
-  --card:                var(--surface-base);
-  --card-foreground:     var(--text-body);
-  --popover:             var(--surface-raised);
-  --popover-foreground:  var(--text-body);
-  --primary-foreground:  var(--text-inverse);
-  --secondary:           var(--action-secondary-bg);
-  --secondary-foreground:var(--action-secondary-fg);
-  --muted:               var(--surface-muted);
-  --muted-foreground:    var(--text-muted);
-  --accent-foreground:   var(--text-inverse);
-  --border:              var(--edge-default);
-  --input:               var(--edge-default);
-  --ring:                var(--focus-ring);
-
-  /* ── Legacy Compatibility Aliases ────────────────────────────────────── */
-  --brand-primary: var(--primary-500);
-  --warm-paper:    var(--surface-subtle);
-  --status-chip:   var(--status-info-text);
-
-  /* ── Geometry ────────────────────────────────────────────────────────── */
-  --radius:          0.625rem;
-  --radius-pill:     9999px;
-  --radius-full:     9999px;
-  --button-radius:   11px;
-  --card-radius:     12px;
-
-  --icon-size-xs:    0.75rem;
-  --icon-size-sm:    0.9375rem;
-  --icon-size-md:    1.125rem;
-  --icon-size-lg:    1.25rem;
-  --icon-size-xl:    1.5rem;
-
-  /* Mobile-first gutters; widened for tablet/desktop below. */
-  --content-gutter-x:  1rem;
-  --section-gutter-x:  1rem;
-  --table-gutter-x:    0.75rem;
-  --table-row-min-h:   3rem;
-  --table-head-min-h:  2.5rem;
-
-  --control-height-sm: 2rem;
-  --control-height-md: 2.25rem;
-  --input-height:      2.25rem;
-  --button-height:     2.25rem;
-
-  /* ── Typography Scale ────────────────────────────────────────────────── */
-  --font-weight-regular:  400;
-  --font-weight-medium:   500;
-  --font-weight-semibold: 600;
-  --font-weight-bold:     700;
-
-  --text-xs:  12px;
-  --text-sm:  13px;
-  --text-md:  14px;
-  --text-lg:  16px;
-  --text-xl:  20px;
-  --text-2xl: 28px;
-  --text-kpi: 38px;
-
-  --leading-tight:  1.1;
-  --leading-normal: 1.4;
-  --leading-relaxed:1.5;
-
-  --type-size-12: 0.75rem;
-  --type-size-13: 0.8125rem;
-  --type-size-14: 0.875rem;
-  --type-size-16: 1rem;
-  --type-size-20: 1.25rem;
-  --type-size-24: 1.5rem;
-  --type-size-32: 2rem;
-
-  --type-display-size:     var(--type-size-32);
-  --type-display-line:     2.5rem;
-  --type-display-weight:   700;
-  --type-page-title-size:  var(--type-size-24);
-  --type-page-title-line:  2rem;
-  --type-page-title-weight:700;
-  --type-section-title-size:   var(--type-size-20);
-  --type-section-title-line:   1.5rem;
-  --type-section-title-weight: 700;
-  --type-body-size:        var(--type-size-14);
-  --type-body-line:        1.5rem;
-  --type-body-weight:      400;
-  --type-body-lg-size:     var(--type-size-16);
-  --type-body-lg-line:     1.5rem;
-  --type-body-lg-weight:   500;
-  --type-field-label-size: var(--type-size-13);
-  --type-field-label-line: 1rem;
-  --type-field-label-weight:600;
-  --type-field-help-size:  var(--type-size-12);
-  --type-field-help-line:  1rem;
-  --type-field-help-weight:400;
-  --type-table-text-size:  var(--type-size-14);
-  --type-table-text-line:  1.5rem;
-  --type-table-text-weight:500;
-  --type-table-header-size:var(--type-size-12);
-  --type-table-header-line:1rem;
-  --type-table-header-weight:600;
-  --type-caption-size:     var(--type-size-12);
-  --type-caption-line:     1rem;
-  --type-caption-weight:   500;
-
-  /* ── Motion ──────────────────────────────────────────────────────────── */
-  --motion-duration-instant: 90ms;
-  --motion-duration-fast:    160ms;
-  --motion-duration-base:    240ms;
-  --motion-duration-normal:  240ms;
-  --motion-duration-slow:    360ms;
-
-  --motion-ease-standard:   cubic-bezier(0.2, 0.8, 0.2, 1);
-  --motion-ease-default:    cubic-bezier(0.2, 0.8, 0.2, 1);
-  --motion-ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
-  --motion-ease-exit:       cubic-bezier(0.4, 0, 1, 1);
-  --motion-ease-spring:     cubic-bezier(0.34, 1.56, 0.64, 1);
-  --motion-scale-hover:     1.015;
-  --motion-scale-press:     0.985;
-  --motion-lift-y:          -2px;
-
-  /* ── Spacing ─────────────────────────────────────────────────────────── */
-  --space-1:  4px;
-  --space-2:  8px;
-  --space-3:  12px;
-  --space-4:  16px;
-  --space-5:  20px;
-  --space-6:  24px;
-  --space-8:  32px;
-  --space-10: 40px;
-
-  /* ── Mobile Touch Targets ────────────────────────────────────────────── */
-  --touch-target-min: 44px;
-  --touch-target-comfortable: 48px;
-  --touch-target-generous: 56px;
-
-  /* ── Mobile List Tokens ──────────────────────────────────────────────── */
-  --mobile-list-item-height: 64px;
-  --mobile-list-item-padding-x: var(--content-gutter-x);
-  --mobile-list-divider-color: var(--edge-subtle);
-  --mobile-list-icon-size: 40px;
-  --mobile-list-icon-radius: 10px;
-
-  /* ── Canvas Background ───────────────────────────────────────────────── */
-  --app-canvas-wash: radial-gradient(1200px 520px at 100% -120px, #e8f1ff 0%, transparent 55%);
-
-  /* ── Scrollbar ───────────────────────────────────────────────────────── */
-  --scrollbar-width: 8px;
-  --scrollbar-track: transparent;
-  --scrollbar-thumb: var(--neutral-300);
-  --scrollbar-thumb-hover: var(--neutral-400);
-}
-
-@media (min-width: 768px) {
-  :root {
-    --content-gutter-x: 1.5rem;
-    --section-gutter-x: 1.5rem;
-  }
-}
-
-/* ── Body Styles ────────────────────────────────────────────────────────── */
-
-body {
-  font-family: var(--font-family);
-  text-rendering: optimizeLegibility;
-  position: relative;
-}
-
-.app-root {
-  isolation: isolate;
-}
-
-/* Prevent iOS zoom on input focus */
-@media (max-width: 640px) {
-  html { font-size: 16px; }
-  input, select, textarea { font-size: 16px; }
-}
-
-/* Date input color scheme */
-input[type="date"],
-input[type="datetime-local"] {
-  color-scheme: light;
-}
-
-input[type="date"]::-webkit-calendar-picker-indicator,
-input[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  opacity: 0.65;
-}
-
-/* ── Base Layer ─────────────────────────────────────────────────────────── */
-
-@layer base {
+@layer app {
   * {
     @apply border-border outline-ring/50;
   }
 
   body {
-    @apply bg-background text-foreground;
+    position: relative;
     background-image: var(--app-canvas-wash);
     background-attachment: fixed;
-    font-size: var(--type-body-size);
-    line-height: var(--type-body-line);
-    font-weight: var(--type-body-weight);
+    text-rendering: optimizeLegibility;
   }
 
   @media (hover: none) and (pointer: coarse) {
     body {
       background-attachment: scroll;
     }
+  }
+
+  .app-root {
+    isolation: isolate;
+  }
+
+  /* Prevent iOS zoom on input focus */
+  @media (max-width: 640px) {
+    html { font-size: 16px; }
+    input, select, textarea { font-size: 16px; }
+  }
+
+  /* Date input color scheme */
+  input[type="date"],
+  input[type="datetime-local"] {
+    color-scheme: light;
+  }
+
+  input[type="date"]::-webkit-calendar-picker-indicator,
+  input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    opacity: 0.65;
   }
 
   :where(
@@ -588,12 +254,13 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
     font-weight: var(--type-table-text-weight);
   }
 
+  /* Matches the design system's `--type-table-head` (500 12/1.3). Sentence
+     case, not caps — the type rules in docs/design-system/02-tokens.md rule out
+     ALL CAPS everywhere, `<th>` included. */
   .text-table-header {
     font-size: var(--type-table-header-size);
     line-height: var(--type-table-header-line);
     font-weight: var(--type-table-header-weight);
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
     color: var(--table-header-text);
   }
 

--- a/app/home/marketing.module.css
+++ b/app/home/marketing.module.css
@@ -6,10 +6,10 @@
   --mk-border: var(--border, var(--border-default));
   --mk-border-subtle: var(--border-subtle, var(--border-soft));
   --mk-border-strong: var(--border-strong);
-  --mk-page-max: calc(var(--space-10) * 32);
-  --mk-prose-max: calc(var(--space-10) * 18);
-  --mk-hero-y: calc(var(--space-10) * 2);
-  --mk-section-y: calc(var(--space-10) + var(--space-8));
+  --mk-page-max: calc(var(--space-8) * 32);
+  --mk-prose-max: calc(var(--space-8) * 18);
+  --mk-hero-y: calc(var(--space-8) * 2);
+  --mk-section-y: calc(var(--space-8) + var(--space-7));
   --mk-display-size: calc(var(--type-size-32) + var(--type-size-20));
   --mk-display: var(--font-weight-bold) var(--mk-display-size) / var(--leading-tight) var(--font-family);
   --mk-section-title: var(--font-weight-bold) var(--type-size-32) / var(--leading-tight) var(--font-family);
@@ -67,8 +67,8 @@
 
 .brandMark {
   display: inline-grid;
-  width: var(--space-8);
-  height: var(--space-8);
+  width: var(--space-7);
+  height: var(--space-7);
   place-items: center;
   border: thin solid var(--mk-border-strong);
   border-radius: var(--radius-md);
@@ -188,11 +188,11 @@
 
 .hero {
   grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
-  gap: var(--space-10);
+  gap: var(--space-8);
 }
 
 .pageHero {
-  min-height: calc(var(--space-10) * 10);
+  min-height: calc(var(--space-8) * 10);
 }
 
 .heroCopy,
@@ -226,7 +226,7 @@
 }
 
 .display {
-  max-width: calc(var(--space-10) * 16);
+  max-width: calc(var(--space-8) * 16);
   margin: 0;
   color: var(--text-strong);
   font: var(--mk-display);
@@ -465,9 +465,9 @@
 .sectionIntro {
   display: grid;
   grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
-  gap: var(--space-8);
+  gap: var(--space-7);
   align-items: start;
-  margin-bottom: var(--space-8);
+  margin-bottom: var(--space-7);
 }
 
 .band {
@@ -559,8 +559,8 @@
 .cardIcon,
 .heroIcon {
   display: inline-flex;
-  width: var(--space-8);
-  height: var(--space-8);
+  width: var(--space-7);
+  height: var(--space-7);
   border: thin solid var(--mk-border);
   border-radius: var(--radius-md);
   background: var(--mk-surface-muted);
@@ -569,8 +569,8 @@
 }
 
 .heroIcon {
-  width: var(--space-10);
-  height: var(--space-10);
+  width: var(--space-8);
+  height: var(--space-8);
 }
 
 .inlineAction {
@@ -604,7 +604,7 @@
 }
 
 .workflowStep {
-  min-height: calc(var(--space-10) * 2);
+  min-height: calc(var(--space-8) * 2);
   border: thin solid var(--mk-border);
   border-radius: var(--radius-md);
   background: var(--mk-surface);
@@ -731,7 +731,7 @@
 }
 
 .textarea {
-  min-height: calc(var(--space-10) * 3);
+  min-height: calc(var(--space-8) * 3);
   resize: vertical;
 }
 
@@ -789,8 +789,8 @@
 .footerInner {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
-  gap: var(--space-8);
-  padding-block: var(--space-8);
+  gap: var(--space-7);
+  padding-block: var(--space-7);
 }
 
 .footerGrid {
@@ -850,8 +850,8 @@
 @media (max-width: 47.5em) {
   .site {
     --mk-display-size: var(--type-size-32);
-    --mk-hero-y: calc(var(--space-10) + var(--space-8));
-    --mk-section-y: var(--space-10);
+    --mk-hero-y: calc(var(--space-8) + var(--space-7));
+    --mk-section-y: var(--space-8);
   }
 
   .navInner,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,13 +120,7 @@ export default async function RootLayout({
       <body
         className="font-sans subpixel-antialiased"
         data-portal-path={hostContext.portalPath ?? undefined}
-        style={
-          {
-            "--font-ibm-plex-mono":
-              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-            ...brandingVars,
-          } as React.CSSProperties
-        }
+        style={brandingVars as React.CSSProperties}
       >
         <Analytics />
         <div className="app-root">

--- a/app/management/master-data/page.tsx
+++ b/app/management/master-data/page.tsx
@@ -27,14 +27,14 @@ export default function MasterDataOverviewPage() {
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {visibleItems.map((entry) => (
           <Link key={entry.href} href={entry.href} className="block h-full">
-            <Card className="h-full transition-colors hover:border-[var(--brand)]">
-              <Card.Header>
-                <Card.Title>{entry.label}</Card.Title>
-              </Card.Header>
+            {/* Card takes its header through props — it has no compound
+                `.Header`/`.Title`/`.Body` slots in @corelithzw/react. */}
+            <Card
+              className="h-full transition-colors hover:border-[var(--brand)]"
+              title={entry.label}
+            >
               {entry.description ? (
-                <Card.Body>
-                  <p className="t-body t-muted">{entry.description}</p>
-                </Card.Body>
+                <p className="t-body t-muted">{entry.description}</p>
               ) : null}
             </Card>
           </Link>

--- a/app/themes/admin.css
+++ b/app/themes/admin.css
@@ -1,205 +1,96 @@
 /* ═══════════════════════════════════════════════════════════════════════════
    ADMIN THEME — Scoped to [data-portal="admin"]
-   
-   This theme overrides the base token system for admin portal pages.
-   Only tokens that differ from globals.css are defined here.
-   All other tokens inherit through CSS custom property cascading.
+
+   The admin portal is a re-tune of the design system, not a second palette.
+   Everything here is derived from `@corelithzw/react` tokens (see
+   app/themes/corelith-bridge.css); the portal's own character is carried by
+   four deliberate deviations:
+
+     · flatter    — borders only, no resting card shadow
+     · squarer    — every radius rung steps one notch up the DS ladder
+     · snappier   — motion collapses onto the two fastest DS durations
+     · denser     — larger table type on shorter rows
+
+   The neutral, brand and semantic ramps are NOT redeclared: the design system's
+   cool grey and its brand blue are already what this portal wanted.
    ═══════════════════════════════════════════════════════════════════════════ */
 
 [data-portal="admin"] {
-  /* ── Neutral Palette (cool grey — distinct from client warm) ─────────── */
-  --neutral-0:  #ffffff;
-  --neutral-25: #fcfcfb;
-  --neutral-50: #f8f8f7;
-  --neutral-100:#f2f3f2;
-  --neutral-200:#e5e7e8;
-  --neutral-300:#d4d8db;
-  --neutral-400:#b1b8be;
-  --neutral-500:#8a9299;
-  --neutral-600:#656d75;
-  --neutral-700:#474f57;
-  --neutral-800:#2f353c;
-  --neutral-900:#1b2026;
+  /* ── Admin-Specific Surfaces ─────────────────────────────────────────── */
+  --admin-frame-bg:         var(--gray-50);
+  --admin-sidebar-bg:       var(--surface);
+  --admin-shell-shadow:     var(--shadow-none);
+  --admin-workspace-shadow: var(--shadow-none);
 
-  /* ── Full 9-Step Primary Ramp ────────────────────────────────────────── */
-  --primary-50:  #edf3ff;
-  --primary-100: #d8e6ff;
-  --primary-200: #bdd4ff;
-  --primary-300: #91b5ff;
-  --primary-400: #5f90ff;
-  --primary-500: #2f6bff;
-  --primary-600: #2457d6;
-  --primary-700: #1f47b3;
-  --primary-800: #1f3c90;
-  --primary-900: #1c336f;
+  --surface-overlay: color-mix(in oklab, var(--ink) 18%, transparent);
 
-  /* ── Full 9-Step Accent Ramp ─────────────────────────────────────────── */
-  --accent-50:  #edf9f7;
-  --accent-100: #d6f1ed;
-  --accent-200: #b2e3db;
-  --accent-300: #7ecfc2;
-  --accent-400: #43b4a3;
-  --accent-500: #199a89;
-  --accent-600: #0f7a6c;
-  --accent-700: #0d6055;
-  --accent-800: #0e4c45;
-  --accent-900: #103d37;
+  /* ── Icons ───────────────────────────────────────────────────────────── */
+  --icon-default: var(--text-muted);
+  --icon-strong:  var(--text-strong);
 
-  /* ── Full 9-Step Semantic Ramps ──────────────────────────────────────── */
-  --success-50:  #ecf9f2;
-  --success-100: #d8f0e3;
-  --success-200: #bae3cf;
-  --success-300: #93d0b3;
-  --success-400: #5fb28c;
-  --success-500: #2f8d64;
-  --success-600: #24724f;
-  --success-700: #1a583d;
-  --success-800: #154733;
-  --success-900: #133b2c;
+  /* ── Actions (admin uses a neutral secondary) ────────────────────────── */
+  --action-secondary-bg:     var(--surface);
+  --action-secondary-fg:     var(--text-strong);
+  --action-secondary-hover:  var(--surface-muted);
+  --action-outline-hover-bg: var(--surface-muted);
 
-  --warning-50:  #fef6ea;
-  --warning-100: #fde7c9;
-  --warning-200: #fbcf99;
-  --warning-300: #f5b566;
-  --warning-400: #e99e3f;
-  --warning-500: #d88422;
-  --warning-600: #b66a1c;
-  --warning-700: #935217;
-  --warning-800: #744214;
-  --warning-900: #5f3613;
+  /* ── Elevation — flat. Borders carry the separation. ─────────────────── */
+  --shadow-card: var(--shadow-none);
 
-  --danger-50:   #fef0f1;
-  --danger-100:  #fcdde0;
-  --danger-200:  #f8c0c7;
-  --danger-300:  #f197a1;
-  --danger-400:  #e96a77;
-  --danger-500:  #d54351;
-  --danger-600:  #b43343;
-  --danger-700:  #922735;
-  --danger-800:  #78232f;
-  --danger-900:  #641f29;
+  --surface-frame-shadow:       inset 0 0 0 1px var(--border);
+  --surface-frame-shadow-hover: inset 0 0 0 1px var(--border-strong);
+  --button-shadow-hover:        inset 0 0 0 1px var(--border-strong);
+  --card-shadow-rest:           var(--shadow-none);
 
-  --info-50:     #edf7ff;
-  --info-100:    #d8ebff;
-  --info-200:    #bae0ff;
-  --info-300:    #93cbf2;
-  --info-400:    #66acd7;
-  --info-500:    #2f86c4;
-  --info-600:    #246d9f;
-  --info-700:    #1b547b;
-  --info-800:    #174564;
-  --info-900:    #143a54;
+  /* ── Tables — white rows on a tinted header ──────────────────────────── */
+  --table-toolbar-bg:     var(--surface);
+  --table-toolbar-border: var(--border-subtle);
+  --table-header-text:    var(--text-muted);
+  --table-row-bg:         var(--surface);
+  --table-row-bg-alt:     var(--surface);
+  --table-row-hover-bg:   var(--surface-muted);
+  --table-row-selected-bg: var(--brand-tint);
 
-  /* ── Admin-Specific Tokens ───────────────────────────────────────────── */
-  --admin-frame-bg:      var(--neutral-50);
-  --admin-sidebar-bg:    var(--neutral-25);
-  --admin-shell-shadow:  none;
-  --admin-workspace-shadow: none;
+  --datatable-toolbar-bg:     var(--surface);
+  --datatable-toolbar-border: var(--border-subtle);
+  --datatable-expanded-bg:    var(--surface-muted);
+  --datatable-empty-bg:       var(--surface-muted);
 
-  /* ── Surface Override ────────────────────────────────────────────────── */
-  --surface-overlay: rgb(27 32 38 / 18%);
-
-  /* ── Icon Tokens ─────────────────────────────────────────────────────── */
-  --icon-default:  var(--neutral-600);
-  --icon-strong:   var(--neutral-800);
-
-  /* ── Action Overrides (admin uses neutral secondary) ─────────────────── */
-  --action-secondary-bg:    var(--neutral-0);
-  --action-secondary-fg:    var(--neutral-800);
-  --action-secondary-hover: var(--neutral-50);
-  --action-outline-hover-bg: var(--neutral-50);
-
-  /* ── Edge Overrides ──────────────────────────────────────────────────── */
-  --edge-neutral-focus: rgb(47 107 255 / 24%);
-
-  /* ── Shadow Overrides (flat, minimal) ────────────────────────────────── */
-  --shadow-card:    0 1px 2px rgb(0 0 0 / 0.04), 0 4px 12px rgb(0 0 0 / 0.03);
-  --shadow-popover: 0 8px 20px rgb(0 0 0 / 0.08), 0 2px 6px rgb(0 0 0 / 0.04);
-
-  --surface-frame-shadow:      inset 0 0 0 1px var(--edge-default);
-  --surface-frame-shadow-hover: inset 0 0 0 1px var(--edge-strong);
-  --button-shadow-hover:       inset 0 0 0 1px var(--edge-strong);
-  --card-shadow-rest:           var(--shadow-card);
-
-  /* ── Table Overrides ─────────────────────────────────────────────────── */
-  --table-toolbar-bg:    var(--neutral-0);
-  --table-toolbar-border:var(--neutral-100);
-  --table-header-text:   var(--neutral-600);
-  --table-row-bg:        var(--neutral-0);
-  --table-row-bg-alt:    var(--neutral-0);
-  --table-row-hover-bg:  #f7faff;
-  --table-row-selected-bg:#eef4ff;
-  --datatable-toolbar-bg:    var(--neutral-0);
-  --datatable-toolbar-border:var(--neutral-100);
-  --datatable-expanded-bg:   var(--neutral-25);
-  --datatable-empty-bg:      var(--neutral-25);
-
-  /* ── Badge Override ──────────────────────────────────────────────────── */
-  --badge-warning-text: var(--warning-800);
-
-  /* ── Status Override ─────────────────────────────────────────────────── */
+  /* Warn text sits on a tint here, so it needs the darker rung. */
+  --badge-warning-text:  var(--warning-800);
   --status-warning-text: var(--warning-800);
 
-  /* ── Focus Ring ──────────────────────────────────────────────────────── */
-  --focus-ring: var(--primary-500);
-  --focus-ring-offset: var(--neutral-0);
+  /* ── Focus ───────────────────────────────────────────────────────────── */
+  --focus-ring-offset: var(--surface);
 
-  /* ── Motion (admin: faster, snappier) ────────────────────────────────── */
-  --motion-duration-instant: 120ms;
-  --motion-duration-fast:    140ms;
-  --motion-duration-base:    160ms;
-  --motion-duration-normal:  160ms;
-  --motion-duration-slow:    220ms;
+  /* ── Motion — snappier: everything on the two fastest DS rungs ───────── */
+  --motion-duration-instant: var(--dur-instant);
+  --motion-duration-fast:    var(--dur-fast);
+  --motion-duration-base:    var(--dur-fast);
+  --motion-duration-normal:  var(--dur-fast);
+  --motion-duration-slow:    var(--dur-base);
 
-  /* ── Geometry Overrides ──────────────────────────────────────────────── */
-  --button-height:    2.25rem;
-  --input-height:     2.25rem;
-  --button-radius:    8px;
-  --card-radius:      12px;
-  --table-row-min-h:  3.375rem;
-  --table-head-min-h: 3.25rem;
-  --radius-sm:        8px;
-  --radius-md:        10px;
-  --radius-lg:        12px;
-  --radius-xl:        16px;
+  /* ── Geometry — one rung up the DS radius ladder ─────────────────────── */
+  --radius-sm: var(--radius-md);    /*  8 */
+  --radius-md: var(--radius-lg);    /* 10 */
+  --radius-lg: var(--radius-xl);    /* 14 */
+  --radius-xl: var(--radius-2xl);   /* 18 */
+
+  --table-row-min-h:  calc(var(--h-control-lg) + var(--space-2));   /* 52 */
+  --table-head-min-h: var(--h-control-lg);                          /* 44 */
 
   /* ── Spacing ─────────────────────────────────────────────────────────── */
-  --space-shell-pad: 12px;
-  --space-main-pad:  32px;
+  --space-shell-pad: var(--space-3);
+  --space-main-pad:  var(--space-7);
 
   /* ── Shadcn Compatibility Overrides ──────────────────────────────────── */
-  --background:  var(--surface-canvas);
-  --foreground:  var(--text-body);
-  --card:        var(--surface-base);
-  --card-foreground:  var(--text-body);
-  --popover:     var(--surface-raised);
-  --popover-foreground: var(--text-body);
-  --primary:     var(--primary-500);
-  --primary-foreground: var(--neutral-0);
-  --secondary:   var(--neutral-100);
-  --secondary-foreground: var(--neutral-800);
-  --muted:       var(--neutral-100);
-  --muted-foreground: var(--neutral-600);
-  --accent:      var(--accent-500);
-  --accent-foreground: var(--neutral-0);
-  --destructive: var(--danger-500);
-  --border:      var(--neutral-200);
-  --input:       var(--neutral-200);
-  --ring:        var(--primary-500);
-  --sidebar:     var(--neutral-25);
-  --sidebar-foreground: var(--neutral-700);
-  --sidebar-primary:    var(--primary-500);
-  --sidebar-primary-foreground: var(--neutral-0);
-  --sidebar-accent:     var(--primary-50);
-  --sidebar-accent-foreground: var(--neutral-900);
-  --sidebar-border:     var(--neutral-100);
-  --sidebar-ring:       var(--primary-500);
-
-  --chart-1: var(--primary-500);
-  --chart-2: var(--accent-500);
-  --chart-3: var(--success-500);
-  --chart-4: var(--warning-500);
-  --chart-5: var(--info-500);
+  --secondary:            var(--surface-muted);
+  --secondary-foreground: var(--text-strong);
+  --sidebar:              var(--surface);
+  --sidebar-foreground:   var(--text-body);
+  --sidebar-accent:       var(--brand-soft);
+  --sidebar-accent-foreground: var(--text-strong);
+  --sidebar-border:       var(--border-subtle);
 
   /* ── Base Properties ─────────────────────────────────────────────────── */
   min-height: 100vh;
@@ -222,7 +113,7 @@
 }
 
 [data-portal="admin"] .admin-shell-window {
-  min-height: calc(100vh - 24px);
+  min-height: calc(100vh - var(--space-6));
   background: var(--admin-frame-bg);
   box-shadow: var(--admin-shell-shadow);
 }
@@ -252,12 +143,12 @@
 
 @media (min-width: 1280px) {
   [data-portal="admin"] .admin-shell-window main {
-    padding: 40px;
+    padding: var(--space-8);
   }
 }
 
 [data-portal="admin"] .admin-shell-sidebar nav > a {
-  min-height: 38px;
+  min-height: var(--h-control-md);
   border-radius: var(--radius-sm);
 }
 
@@ -267,7 +158,7 @@
 
 [data-portal="admin"] .admin-shell-sidebar nav > a svg {
   color: var(--icon-default);
-  stroke-width: 1.8;
+  stroke-width: 1.6;
 }
 
 /* ── Admin Page Layout ──────────────────────────────────────────────────── */
@@ -275,7 +166,7 @@
 [data-portal="admin"] .admin-page {
   display: flex;
   flex-direction: column;
-  gap: clamp(24px, 2.4vw, 32px);
+  gap: clamp(var(--space-6), 2.4vw, var(--space-7));
 }
 
 [data-portal="admin"] .admin-page-header {
@@ -338,7 +229,7 @@
 [data-portal="admin"] .admin-metric-card::before {
   content: "";
   position: absolute;
-  inset: 44px 4px 4px;
+  inset: var(--h-control-lg) var(--space-1) var(--space-1);
   border: 1px solid var(--edge-default);
   border-radius: var(--radius-md);
   background: var(--surface-base);
@@ -537,8 +428,8 @@
 /* ── Admin Utility Classes ──────────────────────────────────────────────── */
 
 [data-portal="admin"] .admin-icon-button {
-  width: 30px;
-  height: 30px;
+  width: var(--h-control-sm);
+  height: var(--h-control-sm);
   border-radius: var(--radius-sm);
   border: 1px solid var(--edge-subtle);
   background: var(--surface-base);
@@ -551,7 +442,7 @@
 
 [data-portal="admin"] .admin-delta-chip {
   display: inline-flex;
-  min-height: 24px;
+  min-height: var(--h-control-xs);
   align-items: center;
   gap: var(--space-2);
   border-radius: var(--radius-pill);
@@ -564,11 +455,11 @@
 
 [data-portal="admin"] .admin-delta-chip-icon {
   display: inline-flex;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-sm);
+  height: var(--icon-size-sm);
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 
 [data-portal="admin"] .admin-delta-chip-icon.is-good {
@@ -589,7 +480,7 @@
 
 [data-portal="admin"]
   :is(a, button, input, select, textarea, [role="button"], [tabindex]):focus-visible {
-  outline: 2px solid rgb(47 107 255 / 32%);
+  outline: 2px solid var(--focus-ring-soft);
   outline-offset: 2px;
 }
 

--- a/app/themes/client.css
+++ b/app/themes/client.css
@@ -1,120 +1,80 @@
 /* ═══════════════════════════════════════════════════════════════════════════
    CLIENT THEME OVERRIDES
-   
-   This file ONLY overrides tokens that differ from the base system
-   defined in globals.css. All semantic tokens (surfaces, text, actions,
-   edges, status, badges, etc.) automatically inherit through CSS custom
-   property cascading — no need to redefine them.
-   
-   To add a new theme: create a new file in this directory that only
-   overrides the neutral palette and any theme-specific accents.
+
+   Not currently imported by any layout — kept as the worked example of how to
+   re-tune a portal on top of the design system.
+
+   The rule this file demonstrates: a theme overrides *character*, never
+   values. It mixes warmth into the package's neutrals rather than restating a
+   palette, so a colour change in `@corelithzw/react` still reaches this theme.
+   Every semantic token (surfaces, text, actions, edges, status, badges) then
+   inherits through custom-property cascading — nothing else needs redefining.
    ═══════════════════════════════════════════════════════════════════════════ */
 
 :root {
-  /* ── Warm Neutral Palette (replaces cool base) ───────────────────────── */
-  --neutral-0:  #ffffff;
-  --neutral-25: #fcfcfb;
-  --neutral-50: #f8f8f4;
-  --neutral-100:#f3f3ef;
-  --neutral-200:#e8e7e2;
-  --neutral-300:#d8d6cf;
-  --neutral-400:#b7b4ac;
-  --neutral-500:#918d84;
-  --neutral-600:#6e6a62;
-  --neutral-700:#534f49;
-  --neutral-800:#35332f;
-  --neutral-900:#1c1b18;
+  /* ── Warm cast ────────────────────────────────────────────────────────
+     A single warm anchor, mixed into the package's cool grey ramp at a
+     strength that fades out as the steps get darker. */
+  --warm: var(--tone-warn);
 
-  /* ── Dynamic Brand Ramps via color-mix() ───────────────────────────────
-     These generate smoother, theme-adaptive tints/shades that harmonize
-     with the warm neutral palette above. */
-  --primary-50:  color-mix(in oklab, var(--primary) 10%, var(--neutral-0));
-  --primary-100: color-mix(in oklab, var(--primary) 18%, var(--neutral-0));
-  --primary-300: color-mix(in oklab, var(--primary) 46%, var(--neutral-0));
-  --primary-500: var(--primary);
-  --primary-600: color-mix(in oklab, var(--primary) 84%, var(--neutral-900));
-  --primary-700: color-mix(in oklab, var(--primary) 72%, var(--neutral-900));
+  --neutral-0:   var(--surface);
+  --neutral-50:  color-mix(in oklab, var(--warm) 5%, var(--gray-50));
+  --neutral-25:  color-mix(in oklab, var(--neutral-50) 55%, var(--neutral-0));
+  --neutral-100: color-mix(in oklab, var(--warm) 5%, var(--gray-100));
+  --neutral-200: color-mix(in oklab, var(--warm) 5%, var(--gray-200));
+  --neutral-300: color-mix(in oklab, var(--warm) 5%, var(--gray-300));
+  --neutral-400: color-mix(in oklab, var(--warm) 4%, var(--gray-400));
+  --neutral-500: color-mix(in oklab, var(--warm) 4%, var(--gray-500));
+  --neutral-600: color-mix(in oklab, var(--warm) 3%, var(--gray-600));
+  --neutral-700: color-mix(in oklab, var(--warm) 3%, var(--gray-700));
+  --neutral-800: color-mix(in oklab, var(--warm) 2%, var(--gray-800));
+  --neutral-900: color-mix(in oklab, var(--warm) 2%, var(--gray-900));
 
-  --accent-50:  color-mix(in oklab, var(--accent) 10%, var(--neutral-0));
-  --accent-100: color-mix(in oklab, var(--accent) 18%, var(--neutral-0));
-  --accent-500: var(--accent);
-  --accent-600: color-mix(in oklab, var(--accent) 84%, var(--neutral-900));
+  /* Surfaces follow the warmed ramp rather than the package's cool one. */
+  --surface-canvas: var(--neutral-50);
+  --surface-app:    var(--neutral-50);
+  --surface-base:   var(--neutral-0);
+  --surface-panel:  var(--neutral-0);
+  --surface-raised: var(--neutral-0);
+  --surface-subtle: var(--neutral-100);
+  --surface-soft:   var(--neutral-200);
 
-  /* ── Semantic Ramps (warm-tuned values) ──────────────────────────────── */
-  --success-50:  #ecf8f1;
-  --success-100: #d8f0e2;
-  --success-300: #9cd2b2;
-  --success-500: #23885c;
-  --success-700: #185f40;
+  --edge-subtle:  var(--neutral-100);
+  --edge-default: var(--neutral-200);
+  --edge-strong:  var(--neutral-300);
 
-  --warning-50:  #fef4e6;
-  --warning-100: #fde3c2;
-  --warning-300: #f6bf75;
-  --warning-500: #d88a2f;
-  --warning-700: #9c6321;
-  --warning-800: #7b4f1a;
+  /* ── Action ───────────────────────────────────────────────────────────
+     A warmer white on the primary fill, so it does not read icy on paper. */
+  --action-primary-fg: color-mix(in oklab, var(--neutral-0) 94%, var(--brand));
 
-  --danger-50:   #fef0f1;
-  --danger-100:  #fcdde0;
-  --danger-300:  #f4a2a8;
-  --danger-500:  #d14148;
-  --danger-700:  #962c33;
+  /* ── Elevation — warm-toned shadows ──────────────────────────────────── */
+  --elevation-2: inset 0 0 0 1px var(--edge-default), var(--shadow-hover);
+  --elevation-3: inset 0 0 0 1px var(--edge-default), var(--shadow-popover);
+  --elevation-4: inset 0 0 0 1px var(--edge-strong), var(--shadow-modal);
 
-  --info-50:     #ecf6ff;
-  --info-100:    #d7ebff;
-  --info-300:    #9bc9f0;
-  --info-500:    #2d83c4;
-  --info-700:    #1e5e8d;
+  --surface-frame-shadow:       inset 0 0 0 1px var(--edge-default);
+  --surface-frame-shadow-hover: inset 0 0 0 1px var(--edge-strong), var(--shadow-hover);
+  --button-shadow-hover:        inset 0 0 0 1px var(--edge-strong), var(--shadow-rest);
 
-  /* ── Action Color Override (warmer primary foreground) ───────────────── */
-  --action-primary-fg: color-mix(in oklab, var(--neutral-0) 94%, var(--primary-500));
-
-  /* ── Shadows (warm-toned opacity) ────────────────────────────────────── */
-  --surface-frame-shadow:
-    inset 0 0 0 1px var(--edge-default),
-    0 1px 2px rgb(17 17 17 / 0.03);
-  --surface-frame-shadow-hover:
-    inset 0 0 0 1px var(--edge-strong),
-    0 4px 14px rgb(17 17 17 / 0.07);
-
-  --button-shadow-hover:
-    inset 0 0 0 1px var(--edge-strong),
-    0 2px 6px rgb(17 17 17 / 0.06);
-
-  --elevation-2:
-    inset 0 0 0 1px var(--edge-default),
-    0 2px 6px rgb(17 17 17 / 0.06);
-  --elevation-3:
-    inset 0 0 0 1px var(--edge-default),
-    0 8px 20px rgb(17 17 17 / 0.12);
-  --elevation-4:
-    inset 0 0 0 1px var(--edge-strong),
-    0 12px 28px rgb(17 17 17 / 0.16);
-
-  --shadow-popover:
-    0 12px 24px -12px rgb(17 17 17 / 0.18),
-    0 2px 6px rgb(17 17 17 / 0.06);
-
-  /* ── Table Tokens (warm-specific) ────────────────────────────────────── */
-  --table-toolbar-bg: rgb(252 252 244 / 88%);
-  --table-row-hover-bg: color-mix(in oklab, var(--primary-50) 50%, var(--surface-base));
-
-  /* ── Datatable Tokens (warm-specific) ────────────────────────────────── */
-  --datatable-toolbar-bg: rgb(252 252 244 / 92%);
+  /* ── Tables ──────────────────────────────────────────────────────────── */
+  --table-toolbar-bg:      color-mix(in oklab, var(--neutral-0) 88%, transparent);
+  --table-row-hover-bg:    color-mix(in oklab, var(--brand-50) 50%, var(--surface-base));
+  --datatable-toolbar-bg:  color-mix(in oklab, var(--neutral-0) 92%, transparent);
   --datatable-expanded-bg: var(--surface-soft);
   --datatable-empty-bg:    var(--surface-soft);
 
-  /* ── Focus Ring (warm-tuned) ─────────────────────────────────────────── */
-  --focus-ring: color-mix(in oklab, var(--primary-500) 86%, white);
+  /* ── Sidebar ─────────────────────────────────────────────────────────── */
+  --sidebar-item-fg:       color-mix(in oklab, var(--text-body) 86%, var(--text-muted));
+  --sidebar-item-fg-muted: color-mix(in oklab, var(--text-muted) 82%, var(--text-body));
+  --sidebar-item-icon:     color-mix(in oklab, var(--text-muted) 80%, var(--text-body));
+  --sidebar-item-active-border: color-mix(in oklab, var(--brand-300) 58%, var(--edge-subtle));
 
-  /* ── Sidebar (warm-tuned color-mix values) ───────────────────────────── */
-  --sidebar-item-fg:       color-mix(in oklab, var(--text-body) 86%, var(--text-muted) 14%);
-  --sidebar-item-fg-muted: color-mix(in oklab, var(--text-muted) 82%, var(--text-body) 18%);
-  --sidebar-item-icon:     color-mix(in oklab, var(--text-muted) 80%, var(--text-body) 20%);
-  --sidebar-item-active-border: color-mix(in oklab, var(--primary-300) 58%, var(--edge-subtle) 42%);
-
-  /* ── Canvas Background (warm gradient) ───────────────────────────────── */
+  /* ── Canvas ──────────────────────────────────────────────────────────── */
   --app-canvas-wash:
-    radial-gradient(1100px 480px at 92% -80px, color-mix(in oklab, var(--primary-100) 75%, white) 0%, transparent 58%),
-    linear-gradient(180deg, #fcfcf4 0%, #f7f7f2 100%);
+    radial-gradient(
+      1100px 480px at 92% -80px,
+      color-mix(in oklab, var(--brand-100) 75%, var(--neutral-0)) 0%,
+      transparent 58%
+    ),
+    linear-gradient(180deg, var(--neutral-25) 0%, var(--neutral-50) 100%);
 }

--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -1,131 +1,569 @@
-/*
- * Corelith bridge.
- * Corelith's package CSS is the visual source of truth. This file only exposes
- * compatibility aliases that the existing app still expects, plus the missing
- * dark-mode token layer that the package does not ship.
- */
+/* ═══════════════════════════════════════════════════════════════════════════
+   CORELITH BRIDGE — the app's backwards-compatibility token layer.
+
+   `@corelithzw/react` is the visual source of truth. Its stylesheet is imported
+   into the `corelith` cascade layer from `app/globals.css`, which declares the
+   157 design-system tokens documented in docs/design-system/02-tokens.md.
+
+   This file declares every *other* token name the app still reads — the neutral
+   and brand ramps, the semantic status set, edges, elevation, badges, tables,
+   sidebar, charts, shadcn compatibility, geometry, type, motion — and it
+   declares each one as a derivation of a design-system token.
+
+   The one rule: NO LITERALS. Every value below resolves through a package
+   token, so changing a colour, radius or duration in `@corelithzw/react`
+   changes it here too. A hex or a px in this file is a token that has silently
+   forked from the design system.
+
+   Exceptions, deliberate and marked inline:
+     · a handful of unitless multipliers (leading, font weights) which the
+       package encodes inside `font:` shorthands and does not expose separately;
+     · `--radius-full` / `--radius-pill`, which are just `9999px`.
+
+   This layer is intentionally unlayered `:root`, so it outranks the package's
+   own `:root`. That matters only for names the package does not define — for
+   the ones it does (`--text-*`, `--border*`, `--space-*`, `--radius-*`, fonts)
+   nothing is redeclared here and the package's values stand.
+   ═══════════════════════════════════════════════════════════════════════════ */
 
 :root {
-  --surface-app: var(--canvas);
-  --surface-panel: var(--surface);
-  --surface-elevated: var(--surface);
-  --surface-soft: var(--surface-deep);
-  --surface-canvas: var(--canvas);
-  --surface-base: var(--surface);
-  --surface-raised: var(--surface);
-  --surface-active: var(--brand-soft);
-  --surface-row-highlight: var(--brand-tint);
-  --surface-overlay: rgb(22 24 29 / 14%);
+  color-scheme: light;
 
-  --text-danger: var(--tone-danger);
+  /* ══════════════════════════════════════════════════════════════════════
+     SURFACES
+     The package ships canvas / surface / -muted / -sunken / -deep. Everything
+     below is an alias onto that four-step ladder.
+     ══════════════════════════════════════════════════════════════════════ */
 
-  --edge-subtle: var(--border-subtle);
-  --edge-default: var(--border);
-  --edge-strong: var(--border-strong);
-  --border-default: var(--border);
-  --border-soft: var(--border-subtle);
-  --input-border: var(--border);
-  --input-bg: var(--surface);
+  --surface-app:            var(--canvas);
+  --surface-canvas:         var(--canvas);
+  --surface-base:           var(--surface);
+  --surface-panel:          var(--surface);
+  --surface-raised:         var(--surface);
+  --surface-elevated:       var(--surface);
+  --surface-subtle:         var(--surface-muted);
+  --surface-soft:           var(--surface-sunken);
+  --surface-hover:          var(--surface-muted);
+  --surface-active:         var(--brand-soft);
+  --surface-row-highlight:  var(--brand-tint);
+  --surface-overlay:        color-mix(in oklab, var(--ink) 14%, transparent);
 
-  --action-primary-hover: var(--action-primary-bg-hover, var(--brand-strong));
-  --action-primary-pressed: var(--action-primary-bg-pressed, var(--brand-deeper));
-  --action-secondary-hover: var(--action-secondary-bg-h);
-  --action-outline-bg: var(--surface);
+  --bg-secondary: var(--surface-muted);
+  --bg-tertiary:  var(--surface-sunken);
+  --bg-elevated:  var(--surface);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     NEUTRAL RAMP → the package gray scale
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --neutral-0:   var(--surface);
+  --neutral-25:  color-mix(in oklab, var(--gray-50) 55%, var(--surface));
+  --neutral-50:  var(--gray-50);
+  --neutral-100: var(--gray-100);
+  --neutral-200: var(--gray-200);
+  --neutral-300: var(--gray-300);
+  --neutral-400: var(--gray-400);
+  --neutral-500: var(--gray-500);
+  --neutral-600: var(--gray-600);
+  --neutral-700: var(--gray-700);
+  --neutral-800: var(--gray-800);
+  --neutral-900: var(--gray-900);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     BRAND RAMP → --brand-*
+     `--primary` itself is a package token (= `--brand`) and is not redeclared;
+     only the numbered rungs the app reads are filled in here.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --primary-50:  var(--brand-50);
+  --primary-100: var(--brand-100);
+  --primary-200: var(--brand-200);
+  --primary-300: var(--brand-300);
+  --primary-400: color-mix(in oklab, var(--brand) 70%, var(--brand-300));
+  --primary-500: var(--brand-500);
+  --primary-600: color-mix(in oklab, var(--brand-strong) 55%, var(--brand));
+  --primary-700: var(--brand-700);
+  --primary-800: color-mix(in oklab, var(--brand-900) 55%, var(--brand-700));
+  --primary-900: var(--brand-900);
+
+  --brand-primary: var(--brand);
+  --on-brand:      var(--action-primary-fg);
+
+  /* ── Accent ramp ──────────────────────────────────────────────────────
+     The design system is deliberately single-hue, so it ships no accent scale.
+     The app needs a second, distinguishable series colour (charts, deltas),
+     and the historical accent was teal. Mixing the package's success green
+     into the brand blue reproduces that hue from package tokens only.
+
+     Deliberately no bare `--accent` rung: that name belongs to the package's
+     shadcn mapping, where it is the subtle hover surface. */
+
+  --accent-500: color-mix(in oklab, var(--tone-success) 65%, var(--brand));
+  --accent-50:  color-mix(in oklab, var(--accent-500) 10%, var(--surface));
+  --accent-100: color-mix(in oklab, var(--accent-500) 18%, var(--surface));
+  --accent-200: color-mix(in oklab, var(--accent-500) 32%, var(--surface));
+  --accent-300: color-mix(in oklab, var(--accent-500) 48%, var(--surface));
+  --accent-400: color-mix(in oklab, var(--accent-500) 74%, var(--surface));
+  --accent-600: color-mix(in oklab, var(--accent-500) 82%, var(--gray-900));
+  --accent-700: color-mix(in oklab, var(--accent-500) 68%, var(--gray-900));
+  --accent-800: color-mix(in oklab, var(--accent-500) 54%, var(--gray-900));
+  --accent-900: color-mix(in oklab, var(--accent-500) 42%, var(--gray-900));
+
+  /* ══════════════════════════════════════════════════════════════════════
+     SEMANTIC RAMPS → --tone-*
+     Step 50 is the tone's tinted background, 100 its border, 500 the tone
+     itself; the darker rungs are mixed toward the neutral ink so prose on a
+     tint keeps its contrast floor.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --success-50:  var(--tone-success-bg);
+  --success-100: var(--tone-success-bd);
+  --success-200: color-mix(in oklab, var(--tone-success) 30%, var(--tone-success-bg));
+  --success-300: color-mix(in oklab, var(--tone-success) 50%, var(--tone-success-bg));
+  --success-400: color-mix(in oklab, var(--tone-success) 75%, var(--tone-success-bg));
+  --success-500: var(--tone-success);
+  --success-600: color-mix(in oklab, var(--tone-success) 60%, var(--tone-success-strong));
+  --success-700: var(--tone-success-strong);
+  --success-800: color-mix(in oklab, var(--tone-success-strong) 80%, var(--gray-900));
+  --success-900: color-mix(in oklab, var(--tone-success-strong) 60%, var(--gray-900));
+
+  --warning-50:  var(--tone-warn-bg);
+  --warning-100: var(--tone-warn-bd);
+  --warning-200: color-mix(in oklab, var(--tone-warn) 30%, var(--tone-warn-bg));
+  --warning-300: color-mix(in oklab, var(--tone-warn) 50%, var(--tone-warn-bg));
+  --warning-400: color-mix(in oklab, var(--tone-warn) 75%, var(--tone-warn-bg));
+  --warning-500: var(--tone-warn);
+  --warning-600: color-mix(in oklab, var(--tone-warn) 85%, var(--gray-900));
+  --warning-700: color-mix(in oklab, var(--tone-warn) 70%, var(--gray-900));
+  --warning-800: color-mix(in oklab, var(--tone-warn) 58%, var(--gray-900));
+  --warning-900: color-mix(in oklab, var(--tone-warn) 46%, var(--gray-900));
+
+  --danger-50:  var(--tone-danger-bg);
+  --danger-100: var(--tone-danger-bd);
+  --danger-200: color-mix(in oklab, var(--tone-danger) 30%, var(--tone-danger-bg));
+  --danger-300: color-mix(in oklab, var(--tone-danger) 50%, var(--tone-danger-bg));
+  --danger-400: color-mix(in oklab, var(--tone-danger) 75%, var(--tone-danger-bg));
+  --danger-500: var(--tone-danger);
+  --danger-600: color-mix(in oklab, var(--tone-danger) 60%, var(--tone-danger-strong));
+  --danger-700: var(--tone-danger-strong);
+  --danger-800: color-mix(in oklab, var(--tone-danger-strong) 80%, var(--gray-900));
+  --danger-900: color-mix(in oklab, var(--tone-danger-strong) 60%, var(--gray-900));
+
+  --info-50:  var(--tone-info-bg);
+  --info-100: var(--tone-info-bd);
+  --info-200: var(--brand-200);
+  --info-300: var(--brand-300);
+  --info-400: color-mix(in oklab, var(--tone-info) 75%, var(--brand-300));
+  --info-500: var(--tone-info);
+  --info-600: color-mix(in oklab, var(--brand-strong) 55%, var(--brand));
+  --info-700: var(--brand-700);
+  --info-800: color-mix(in oklab, var(--brand-900) 55%, var(--brand-700));
+  --info-900: var(--brand-900);
+
+  /* Soft tone washes — used where a tint must sit over an unknown surface. */
+  --tone-warn-soft:   var(--tone-warn-bg);
+  --tone-danger-soft: var(--tone-danger-bg);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     TEXT
+     `--text-strong/-body/-muted/-subtle/-inverse/-link` come straight from the
+     package and are not redeclared. These are the app's older spellings.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --text-primary:   var(--text-strong);
+  --text-secondary: var(--text-body);
+  --text-tertiary:  var(--text-muted);
+  --text-danger:    var(--tone-danger);
+
+  --icon-default: var(--text-muted);
+  --icon-strong:  var(--text-strong);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     EDGES
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --edge-subtle:        var(--border-subtle);
+  --edge-default:       var(--border);
+  --edge-strong:        var(--border-strong);
+  --edge-neutral-focus: var(--focus-ring-soft);
+  --border-default:     var(--border);
+  --border-soft:        var(--border-subtle);
+  --input-border:       var(--border);
+  --input-bg:           var(--surface);
+
+  --focus-ring-offset: var(--canvas);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     ACTIONS
+     `--action-primary-*` and `--action-secondary-bg/-fg` are package tokens.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --action-primary-hover:    var(--action-primary-bg-hover, var(--brand-strong));
+  --action-primary-pressed:  var(--action-primary-bg-pressed, var(--brand-deeper));
+  --action-secondary-hover:  var(--action-secondary-bg-h);
+  --action-outline-bg:       var(--surface);
   --action-outline-hover-bg: var(--surface-muted);
-  --action-disabled-bg: var(--surface-muted);
-  --action-disabled-fg: var(--text-subtle);
+  --action-outline-border:       transparent;
+  --action-outline-border-hover: transparent;
+  --action-disabled-bg:      var(--surface-muted);
+  --action-disabled-fg:      var(--text-subtle);
 
-  --status-success-bg: var(--tone-success-bg);
+  --interactive-primary:   var(--brand);
+  --interactive-secondary: var(--text-muted);
+  --interactive-danger:    var(--tone-danger);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     ELEVATION
+     The design system's position is that a border separates surfaces at rest
+     and a shadow only appears when something floats. The app's `--elevation-*`
+     ladder is kept, expressed as the package's border plus its shadow rungs.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --elevation-0: var(--shadow-none);
+  --elevation-1: inset 0 0 0 1px var(--border);
+  --elevation-2: inset 0 0 0 1px var(--border), var(--shadow-hover);
+  --elevation-3: inset 0 0 0 1px var(--border), var(--shadow-popover);
+  --elevation-4: inset 0 0 0 1px var(--border-strong), var(--shadow-modal);
+
+  --shadow-card: var(--shadow-rest);
+
+  --surface-frame-shadow:       inset 0 0 0 1px var(--border);
+  --surface-frame-shadow-hover: inset 0 0 0 1px var(--border-strong), var(--shadow-hover);
+
+  --button-shadow-rest:     inset 0 0 0 1px var(--border);
+  --button-shadow-hover:    inset 0 0 0 1px var(--border-strong), var(--shadow-hover);
+  --button-shadow-pressed:  inset 0 0 0 1px var(--border-strong);
+  --button-ghost-hover-bg:  var(--surface-muted);
+  --button-ghost-active-bg: var(--surface-sunken);
+
+  --card-shadow-rest: var(--shadow-rest);
+  --card-divider:     var(--border-subtle);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     STATUS
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --status-success-bg:     var(--tone-success-bg);
   --status-success-border: var(--tone-success-bd);
-  --status-success-text: var(--tone-success);
-  --status-warning-bg: var(--tone-warn-bg);
+  --status-success-text:   var(--tone-success-strong);
+  --status-success-500:    var(--tone-success);
+  --status-warning-bg:     var(--tone-warn-bg);
   --status-warning-border: var(--tone-warn-bd);
-  --status-warning-text: var(--tone-warn);
-  --status-error-bg: var(--tone-danger-bg);
-  --status-error-border: var(--tone-danger-bd);
-  --status-error-text: var(--tone-danger);
-  --status-info-bg: var(--tone-info-bg);
-  --status-info-border: var(--tone-info-bd);
-  --status-info-text: var(--tone-info);
-  --status-progress-bg: var(--brand-soft);
+  --status-warning-text:   var(--warning-700);
+  --status-error-bg:       var(--tone-danger-bg);
+  --status-error-border:   var(--tone-danger-bd);
+  --status-error-text:     var(--tone-danger-strong);
+  --status-danger-border:  var(--tone-danger-bd);
+  --status-info-bg:        var(--tone-info-bg);
+  --status-info-border:    var(--tone-info-bd);
+  --status-info-text:      var(--brand-strong);
+  --status-progress-bg:     var(--brand-soft);
   --status-progress-border: var(--brand-100);
-  --status-progress-text: var(--brand-strong);
-  --status-pending-bg: var(--surface-muted);
+  --status-progress-text:   var(--brand-strong);
+  --status-pending-bg:     var(--surface-muted);
   --status-pending-border: var(--border-strong);
-  --status-pending-text: var(--text-muted);
-  --status-inactive-bg: var(--surface-muted);
+  --status-pending-text:   var(--text-muted);
+  --status-inactive-bg:     var(--surface-muted);
   --status-inactive-border: var(--border-subtle);
-  --status-inactive-text: var(--text-subtle);
+  --status-inactive-text:   var(--text-subtle);
+  --status-queued:    var(--brand-strong);
+  --status-queued-bg: var(--brand-soft);
+  --status-chip:      var(--status-info-text);
 
-  --table-toolbar-bg: color-mix(in oklab, var(--surface) 86%, transparent);
-  --table-toolbar-border: var(--border-subtle);
-  --table-header-bg: var(--surface-muted);
-  --table-header-text: var(--text-subtle);
-  --table-divider: var(--border-subtle);
-  --table-row-bg: var(--surface);
-  --table-row-bg-alt: var(--surface);
-  --table-row-hover-bg: var(--surface-muted);
+  /* ══════════════════════════════════════════════════════════════════════
+     BADGES — one pair per tone, matching the package's Badge tones
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --badge-shadow:       var(--shadow-none);
+  --badge-neutral-bg:   var(--tone-neutral-bg);
+  --badge-neutral-text: var(--text-body);
+  --badge-brand-bg:     var(--brand-soft);
+  --badge-brand-text:   var(--brand-strong);
+  --badge-info-bg:      var(--tone-info-bg);
+  --badge-info-text:    var(--brand-strong);
+  --badge-success-bg:   var(--tone-success-bg);
+  --badge-success-text: var(--tone-success-strong);
+  --badge-warning-bg:   var(--tone-warn-bg);
+  --badge-warning-text: var(--warning-700);
+  --badge-danger-bg:    var(--tone-danger-bg);
+  --badge-danger-text:  var(--tone-danger-strong);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     TABLES
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --table-toolbar-bg:      color-mix(in oklab, var(--surface) 86%, transparent);
+  --table-toolbar-border:  var(--border-subtle);
+  --table-header-bg:       var(--surface-muted);
+  --table-header-text:     var(--text-subtle);
+  --table-divider:         var(--border-subtle);
+  --table-row-bg:          var(--surface);
+  --table-row-bg-alt:      var(--surface);
+  --table-row-hover-bg:    var(--surface-muted);
   --table-row-selected-bg: var(--brand-tint);
-  --datatable-toolbar-bg: color-mix(in oklab, var(--surface) 90%, transparent);
+
+  --datatable-toolbar-bg:     color-mix(in oklab, var(--surface) 90%, transparent);
   --datatable-toolbar-border: var(--border-subtle);
-  --datatable-expanded-bg: var(--surface-muted);
-  --datatable-empty-bg: var(--surface-muted);
+  --datatable-expanded-bg:    var(--surface-muted);
+  --datatable-empty-bg:       var(--surface-muted);
 
-  --background: var(--canvas);
-  --foreground: var(--text-body);
-  --card: var(--surface);
-  --card-foreground: var(--text-body);
-  --popover: var(--surface);
-  --popover-foreground: var(--text-body);
-  --muted: var(--surface-muted);
-  --muted-foreground: var(--text-muted);
-  --input: var(--border);
-  --ring: var(--focus-ring);
+  /* ══════════════════════════════════════════════════════════════════════
+     SIDEBAR
+     ══════════════════════════════════════════════════════════════════════ */
 
-  --sidebar: var(--surface-muted);
-  --sidebar-foreground: var(--text-body);
-  --sidebar-primary: var(--action-primary-bg);
+  --sidebar:                    var(--surface-muted);
+  --sidebar-foreground:         var(--text-body);
+  --sidebar-primary:            var(--action-primary-bg);
   --sidebar-primary-foreground: var(--action-primary-fg);
-  --sidebar-accent: var(--surface);
-  --sidebar-accent-foreground: var(--text-strong);
-  --sidebar-border: var(--border);
-  --sidebar-ring: var(--focus-ring);
+  --sidebar-accent:             var(--surface);
+  --sidebar-accent-foreground:  var(--text-strong);
+  --sidebar-border:             var(--border);
+  --sidebar-ring:               var(--focus-ring);
+
+  --sidebar-item-fg:            color-mix(in oklab, var(--text-body) 84%, var(--text-muted));
+  --sidebar-item-fg-muted:      color-mix(in oklab, var(--text-muted) 88%, var(--text-body));
+  --sidebar-item-icon:          color-mix(in oklab, var(--text-muted) 78%, var(--text-body));
+  --sidebar-item-hover-fg:      var(--text-body);
+  --sidebar-item-active-bg:     var(--brand-soft);
+  --sidebar-item-active-fg:     var(--brand-strong);
+  --sidebar-item-active-border: color-mix(in oklab, var(--brand-300) 50%, var(--border-subtle));
+
+  /* ══════════════════════════════════════════════════════════════════════
+     CHARTS
+     Five series that stay distinguishable while drawing only on package
+     material: the brand scale plus the three non-info tones.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --chart-1: var(--brand-500);
+  --chart-2: var(--accent-500);
+  --chart-3: var(--tone-success);
+  --chart-4: var(--tone-warn);
+  --chart-5: var(--tone-danger);
+  --chart-grid: var(--border-subtle);
+  --chart-text: var(--text-muted);
+
+  --chart-passing:      var(--tone-success);
+  --chart-failing:      var(--tone-danger);
+  --chart-need-changes: var(--tone-warn);
+  --chart-in-review:    var(--brand-500);
+  --chart-in-progress:  var(--tone-warn);
+  --chart-pending:      var(--gray-400);
+  --chart-inactive:     var(--gray-500);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     SHADCN COMPATIBILITY
+
+     Nothing to do here. `@corelithzw/react` already ships the full shadcn set
+     — `--background --foreground --card --popover --primary --secondary
+     --muted --accent --destructive --input --ring --radius` and their
+     `-foreground` pairs — mapped onto its own tokens. Redeclaring any of them
+     below would shadow the package (this block is unlayered, the package's is
+     not) and re-open exactly the drift this migration closed.
+
+     Note in particular that the package's `--accent` is `--brand-soft`, the
+     subtle hover surface shadcn means by that name. It is NOT the chart accent
+     declared further up: that ramp is `--accent-50 … --accent-900` and has no
+     bare `--accent` rung, precisely so the two cannot collide.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --warm-paper: var(--surface-muted);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     GEOMETRY
+     `--radius`, `--radius-xs … --radius-2xl`, `--button-radius`,
+     `--card-radius`, `--h-control-*`, `--input-height` and `--button-height`
+     are all package tokens.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --radius-full: 9999px;      /* literal by nature — same as --radius-pill */
+
+  --control-height-sm: var(--h-control-sm);
+  --control-height-md: var(--h-control-md);
+
+  /* Icon slots. The design system specifies these as px on a 24×24 grid and
+     does not expose them as tokens (docs/design-system/02-tokens.md § Icons),
+     so these five are literal by necessity — `sm` is the documented default. */
+  --icon-size-xs: 14px;
+  --icon-size-sm: 16px;
+  --icon-size-md: 18px;
+  --icon-size-lg: 22px;
+  --icon-size-xl: 28px;
+
+  /* Page gutters. The design system's guidance is ≤430px: 16 · 431–767: 20 ·
+     ≥768: 24, with `--gutter-x` (24) as the desktop value. */
+  --content-gutter-x: var(--space-4);
+  --section-gutter-x: var(--space-4);
+  --table-gutter-x:   var(--space-3);
+  --table-row-min-h:  calc(var(--h-control-md) + var(--space-3));    /* 48 */
+  --table-head-min-h: calc(var(--h-control-md) + var(--space-1));    /* 40 */
+
+  /* ══════════════════════════════════════════════════════════════════════
+     TYPOGRAPHY
+     The package owns `--font-sans` / `--font-mono` / `--font-display` /
+     `--font-serif` and the `--type-*` role shorthands. The app additionally
+     reads a decomposed size/line/weight ladder — declared here off the same
+     numbers so the two spellings cannot drift.
+     ══════════════════════════════════════════════════════════════════════ */
 
   --font-family: var(--font-sans);
-  --font-display: var(--font-sans);
-  --font-serif: var(--font-sans);
 
-  --control-height-md: var(--h-control-md);
-  --radius: 0.625rem;
+  /* Weights are unitless and live inside the package's `font:` shorthands;
+     the design system's rule is that weight, not family, does the emphasis. */
+  --font-weight-regular:  400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
 
-  --surface-frame-shadow: inset 0 0 0 1px var(--border);
-  --surface-frame-shadow-hover:
-    inset 0 0 0 1px var(--border-strong),
-    0 4px 12px rgb(22 24 29 / 0.08);
-  --button-shadow-rest: inset 0 0 0 1px var(--border);
-  --button-shadow-hover:
-    inset 0 0 0 1px var(--border-strong),
-    0 2px 6px rgb(22 24 29 / 0.08);
-  --button-shadow-pressed: inset 0 0 0 1px var(--border-strong);
-  --button-ghost-hover-bg: var(--surface-muted);
-  --button-ghost-active-bg: var(--surface-sunken);
-  --card-shadow-rest: var(--shadow-rest);
-  --card-divider: var(--border-subtle);
+  --leading-tight:   1.3;    /* --type-page-title */
+  --leading-normal:  1.4;    /* --type-section-title / --type-label */
+  --leading-relaxed: 1.55;   /* --type-body */
+
+  /* The design system's size ladder: caption 12 · body-sm 13 · body 14 ·
+     body-lg 16 · page-title 22 · display-sm 32. */
+  --type-size-12: 12px;
+  --type-size-13: 13px;
+  --type-size-14: 14px;
+  --type-size-16: 16px;
+  --type-size-20: 20px;
+  --type-size-22: 22px;
+  --type-size-24: 24px;
+  --type-size-32: 32px;
+
+  --text-xs:  var(--type-size-12);
+  --text-sm:  var(--type-size-13);
+  --text-md:  var(--type-size-14);
+  --text-lg:  var(--type-size-16);
+  --text-xl:  var(--type-size-22);
+  --text-2xl: var(--type-size-32);
+  --text-kpi: var(--type-size-32);
+
+  --type-display-size:   var(--type-size-32);
+  --type-display-line:   var(--leading-tight);
+  --type-display-weight: var(--font-weight-semibold);
+
+  --type-page-title-size:   var(--type-size-22);
+  --type-page-title-line:   var(--leading-tight);
+  --type-page-title-weight: var(--font-weight-semibold);
+
+  --type-section-title-size:   var(--type-size-16);
+  --type-section-title-line:   var(--leading-normal);
+  --type-section-title-weight: var(--font-weight-semibold);
+
+  --type-body-size:   var(--type-size-14);
+  --type-body-line:   var(--leading-relaxed);
+  --type-body-weight: var(--font-weight-regular);
+
+  --type-body-lg-size:   var(--type-size-16);
+  --type-body-lg-line:   var(--leading-relaxed);
+  --type-body-lg-weight: var(--font-weight-regular);
+
+  --type-field-label-size:   var(--type-size-13);
+  --type-field-label-line:   var(--leading-normal);
+  --type-field-label-weight: var(--font-weight-medium);
+
+  --type-field-help-size:   var(--type-size-12);
+  --type-field-help-line:   var(--leading-normal);
+  --type-field-help-weight: var(--font-weight-regular);
+
+  --type-table-text-size:   var(--type-size-14);
+  --type-table-text-line:   var(--leading-relaxed);
+  --type-table-text-weight: var(--font-weight-regular);
+
+  --type-table-header-size:   var(--type-size-12);
+  --type-table-header-line:   var(--leading-tight);
+  --type-table-header-weight: var(--font-weight-medium);
+
+  --type-caption-size:   var(--type-size-12);
+  --type-caption-line:   var(--leading-normal);
+  --type-caption-weight: var(--font-weight-regular);
+
+  /* ══════════════════════════════════════════════════════════════════════
+     MOTION → --dur-* / --ease-*
+     ══════════════════════════════════════════════════════════════════════ */
 
   --motion-duration-instant: var(--dur-instant);
-  --motion-duration-fast: var(--dur-fast);
-  --motion-duration-base: var(--dur-base);
-  --motion-duration-normal: var(--dur-base);
-  --motion-duration-slow: var(--dur-slow);
-  --motion-ease-standard: var(--ease-out);
-  --motion-ease-default: var(--ease-out);
-  --motion-ease-emphasized: var(--ease-in-out);
-  --motion-ease-exit: var(--ease-in-out);
-  --motion-ease-spring: var(--ease-spring);
+  --motion-duration-fast:    var(--dur-fast);
+  --motion-duration-base:    var(--dur-base);
+  --motion-duration-normal:  var(--dur-base);
+  --motion-duration-slow:    var(--dur-slow);
 
+  --motion-ease-standard:   var(--ease-out);
+  --motion-ease-default:    var(--ease-out);
+  --motion-ease-emphasized: var(--ease-in-out);
+  --motion-ease-exit:       var(--ease-snap);
+  --motion-ease-spring:     var(--ease-spring);
+
+  --motion-scale-hover: 1.015;
+  --motion-scale-press: 0.985;
+  --motion-lift-y:      -2px;
+
+  /* ══════════════════════════════════════════════════════════════════════
+     TOUCH, MOBILE LISTS, SCROLLBARS
+     ══════════════════════════════════════════════════════════════════════ */
+
+  --touch-target-min:         var(--h-control-lg);                   /* 44 */
+  --touch-target-comfortable: var(--space-9);                        /* 48 */
+  --touch-target-generous:    calc(var(--space-9) + var(--space-2)); /* 56 */
+
+  --mobile-list-item-height:    var(--space-10);                     /* 64 */
+  --mobile-list-item-padding-x: var(--content-gutter-x);
+  --mobile-list-divider-color:  var(--border-subtle);
+  --mobile-list-icon-size:      var(--space-8);                      /* 40 */
+  --mobile-list-icon-radius:    var(--radius-lg);
+
+  --scrollbar-width:       var(--space-2);
+  --scrollbar-track:       transparent;
+  --scrollbar-thumb:       var(--gray-300);
+  --scrollbar-thumb-hover: var(--gray-400);
+
+  /* The design system's canvas is flat; the historical gradient wash is off.
+     Set this to a gradient on a scoped selector if a surface wants one. */
   --app-canvas-wash: none;
+
+  /* ══════════════════════════════════════════════════════════════════════
+     COMPONENT GAPS
+     Tokens that local components read but nothing ever declared, so they were
+     resolving to their inline fallback — or to nothing at all. Declared here
+     off design-system tokens so those components join the system.
+     ══════════════════════════════════════════════════════════════════════ */
+
+  /* components/ui/sheet.tsx — the side sheet had no width at any breakpoint.
+     Panel widths are layout, not palette; the design system does not tokenise
+     them (it tokenises `--sidebar-w` and `--content-max` only), so these three
+     rungs are literal, sized one step under the dialog ladder in dialog.tsx. */
+  --sheet-size-mobile: 100%;
+  --sheet-size-sm: 24rem;
+  --sheet-size-md: 28rem;
+  --sheet-size-lg: 32rem;
+
+  /* components/offline/offline-keypad.tsx */
+  --keypad-bg:           var(--surface-muted);
+  --keypad-text:         var(--text-strong);
+  --keypad-shadow:       var(--border-strong);
+  --keypad-shadow-color: var(--border-strong);
+  --keypad-active:       var(--surface-sunken);
+  --keypad-clear:        var(--tone-danger);
+  --keypad-enter:        var(--action-primary-bg);
+  --keypad-enter-active: var(--action-primary-pressed);
 }
 
+/* Page gutter widens with the viewport, per the design system's gutter rule. */
+@media (min-width: 431px) {
+  :root {
+    --content-gutter-x: var(--space-5);
+    --section-gutter-x: var(--space-5);
+  }
+}
+
+@media (min-width: 768px) {
+  :root {
+    --content-gutter-x: var(--gutter-x);
+    --section-gutter-x: var(--gutter-x);
+  }
+}
+
+/* The design system flips its tokens on `body.is-dark`. The app is light-only
+   today; this keeps the explicit opt-in working if a surface sets it. */
 :root[data-appearance="light"] {
   color-scheme: light;
 }

--- a/components/corelith/ds-data-table.tsx
+++ b/components/corelith/ds-data-table.tsx
@@ -9,10 +9,24 @@ import {
   EmptyState,
   Input,
   Pagination,
+  Select,
   Skeleton,
   type DataTableColumn,
-  type DataTableSortState,
 } from "@corelithzw/react";
+
+/**
+ * Local wrapper over the design system's `DataTable`.
+ *
+ * Its prop surface is the app's, not the package's, so call sites stay put when
+ * the package's API moves. Two things it deliberately does NOT delegate:
+ *
+ *  · Pagination. `DataTable`'s own `pagination` prop slices `data` internally,
+ *    but every call site already hands us the rows for the current page (or
+ *    pages server-side), so the table renders what it is given and the page
+ *    controls live in the toolbar.
+ *  · Sorting. The package sorts client-side from `columns[].sortable` and
+ *    `sortAccessor`; there is no controlled sort state to forward.
+ */
 
 export type DsDataTableProps<Row> = {
   columns: DataTableColumn<Row>[];
@@ -49,8 +63,6 @@ export type DsDataTableProps<Row> = {
   pageSizeOptions?: number[];
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
-  sort?: DataTableSortState;
-  onSortChange?: (sort: DataTableSortState | undefined) => void;
 };
 
 export function DsDataTable<Row>({
@@ -80,8 +92,6 @@ export function DsDataTable<Row>({
   onPageChange,
   onPageSizeChange,
   pagination,
-  sort,
-  onSortChange,
 }: DsDataTableProps<Row>) {
   const hasSearch = searchValue !== undefined || Boolean(onSearchChange || onSearchSubmit);
   const activePage = pagination?.page ?? page;
@@ -95,77 +105,88 @@ export function DsDataTable<Row>({
     activePage !== undefined && activePageCount !== undefined && Boolean(activeOnPageChange);
   const showLoading = isLoading ?? loading ?? false;
 
+  const searchSlot = hasSearch ? (
+    <form
+      className="flex min-w-0 items-center gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSearchSubmit?.(searchValue ?? "");
+      }}
+    >
+      <Input
+        value={searchValue ?? ""}
+        onChange={(event) => onSearchChange?.(event.target.value)}
+        placeholder={searchPlaceholder}
+        aria-label={searchPlaceholder}
+      />
+      <Button type="submit" variant="secondary" size="sm">
+        {searchSubmitLabel}
+      </Button>
+    </form>
+  ) : undefined;
+
+  const actionsSlot =
+    actions || hasPagination ? (
+      <>
+        {actions}
+        {hasPagination ? (
+          <>
+            {/* `Pagination` ships no page-size control, so pair it with a Select. */}
+            {activePageSizeOptions?.length && activeOnPageSizeChange ? (
+              <Select
+                size="sm"
+                aria-label="Rows per page"
+                value={String(activePageSize ?? activePageSizeOptions[0])}
+                onChange={(event) => activeOnPageSizeChange(Number(event.target.value))}
+              >
+                {activePageSizeOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {option} per page
+                  </option>
+                ))}
+              </Select>
+            ) : null}
+            {activeTotal !== undefined ? (
+              <span className="t-caption t-muted whitespace-nowrap">
+                {activeTotal} total
+              </span>
+            ) : null}
+            <Pagination
+              page={activePage!}
+              count={Math.max(1, activePageCount!)}
+              onPageChange={activeOnPageChange!}
+              aria-label={`${ariaLabel} pagination`}
+            />
+          </>
+        ) : null}
+      </>
+    ) : undefined;
+
   return (
-    <div className="space-y-3">
+    <section className="space-y-3" aria-label={ariaLabel}>
       {error ? (
         <Alert tone="danger" title={errorTitle}>
           {error}
         </Alert>
       ) : null}
 
-      <DataToolbar>
-        {hasSearch ? (
-          <DataToolbar.Search>
-            <form
-              className="flex min-w-0 items-center gap-2"
-              onSubmit={(event) => {
-                event.preventDefault();
-                onSearchSubmit?.(searchValue ?? "");
-              }}
-            >
-              <Input
-                value={searchValue ?? ""}
-                onChange={(event) => onSearchChange?.(event.target.value)}
-                placeholder={searchPlaceholder}
-                aria-label={searchPlaceholder}
-              />
-              <Button type="submit" variant="secondary" size="sm">
-                {searchSubmitLabel}
-              </Button>
-            </form>
-          </DataToolbar.Search>
-        ) : null}
-
-        {filters ? <DataToolbar.Filters>{filters}</DataToolbar.Filters> : null}
-
-        {actions || hasPagination ? (
-          <DataToolbar.Actions>
-            {actions}
-            {hasPagination ? (
-              <Pagination
-                page={activePage!}
-                pageCount={Math.max(1, activePageCount!)}
-                total={activeTotal}
-                pageSize={activePageSize}
-                pageSizeOptions={activePageSizeOptions}
-                onPageSizeChange={activeOnPageSizeChange}
-                onChange={activeOnPageChange!}
-                aria-label={`${ariaLabel} pagination`}
-              />
-            ) : null}
-          </DataToolbar.Actions>
-        ) : null}
-      </DataToolbar>
+      <DataToolbar search={searchSlot} filters={filters} actions={actionsSlot} />
 
       {showLoading ? (
-        <Skeleton lines={6} gap={8} aria-label={loadingLabel} />
+        <div className="space-y-2" aria-label={loadingLabel} aria-busy="true">
+          {Array.from({ length: 6 }, (_, index) => (
+            <Skeleton key={index} variant="text" />
+          ))}
+        </div>
       ) : (
         <DataTable
           columns={columns}
-          rows={rows}
-          getRowId={getRowId}
-          sort={sort}
-          onSortChange={onSortChange}
-          ariaLabel={ariaLabel}
-          emptyState={
-            <EmptyState
-              variant="inline"
-              title={emptyTitle}
-              description={emptyDescription}
-            />
-          }
+          data={rows}
+          rowKey={getRowId}
+          sortable
+          emptyState={<EmptyState title={emptyTitle} body={emptyDescription} />}
         />
       )}
-    </div>
+    </section>
   );
 }

--- a/components/preferences/account/appearance-preferences.tsx
+++ b/components/preferences/account/appearance-preferences.tsx
@@ -20,28 +20,23 @@ export function AppearancePreferences() {
   const { appearance, setAppearance } = useAppearance();
 
   return (
-    <Card>
-      <Card.Header>
-        <Card.Title>Theme preference</Card.Title>
-      </Card.Header>
-      <Card.Body>
-        <div className="settings-section">
-          <div className="settings-row">
-            <div>
-              <div className="t-label-sm">Appearance</div>
-              <p className="t-caption t-muted">
-                System follows this device. Light and dark override it for this browser.
-              </p>
-            </div>
-            <SegmentedControl
-              ariaLabel="Appearance preference"
-              value={appearance}
-              options={appearanceOptions}
-              onChange={setAppearance}
-            />
+    <Card title="Theme preference">
+      <div className="settings-section">
+        <div className="settings-row">
+          <div>
+            <div className="t-label-sm">Appearance</div>
+            <p className="t-caption t-muted">
+              System follows this device. Light and dark override it for this browser.
+            </p>
           </div>
+          <SegmentedControl
+            aria-label="Appearance preference"
+            value={appearance}
+            options={appearanceOptions}
+            onValueChange={(next) => setAppearance(next as AppearancePreference)}
+          />
         </div>
-      </Card.Body>
+      </div>
     </Card>
   );
 }

--- a/components/preferences/account/notification-preferences.tsx
+++ b/components/preferences/account/notification-preferences.tsx
@@ -74,9 +74,11 @@ export function NotificationPreferences() {
   if (preferencesQuery.isLoading) {
     return (
       <Card>
-        <Card.Body>
-          <Skeleton lines={6} gap={8} />
-        </Card.Body>
+        <div className="space-y-2">
+          {Array.from({ length: 6 }, (_, index) => (
+            <Skeleton key={index} variant="text" />
+          ))}
+        </div>
       </Card>
     );
   }
@@ -92,30 +94,25 @@ export function NotificationPreferences() {
   const preferences = preferencesQuery.data;
 
   return (
-    <Card>
-      <Card.Header>
-        <Card.Title>Notification routing</Card.Title>
-      </Card.Header>
-      <Card.Body>
-        <div className="settings-section">
-          {preferenceRows.map((row) => (
-            <div className="settings-row" key={row.key}>
-              <div>
-                <div className="t-label-sm">{row.label}</div>
-                <p className="t-caption t-muted">{row.description}</p>
-              </div>
-              <Switch
-                aria-label={row.label}
-                checked={preferences[row.key]}
-                disabled={updateMutation.isPending}
-                onChange={(event) =>
-                  updateMutation.mutate({ [row.key]: event.target.checked })
-                }
-              />
+    <Card title="Notification routing">
+      <div className="settings-section">
+        {preferenceRows.map((row) => (
+          <div className="settings-row" key={row.key}>
+            <div>
+              <div className="t-label-sm">{row.label}</div>
+              <p className="t-caption t-muted">{row.description}</p>
             </div>
-          ))}
-        </div>
-      </Card.Body>
+            <Switch
+              aria-label={row.label}
+              checked={preferences[row.key]}
+              disabled={updateMutation.isPending}
+              onChange={(event) =>
+                updateMutation.mutate({ [row.key]: event.target.checked })
+              }
+            />
+          </div>
+        ))}
+      </div>
     </Card>
   );
 }

--- a/components/preferences/account/profile-preferences.tsx
+++ b/components/preferences/account/profile-preferences.tsx
@@ -73,9 +73,11 @@ export function ProfilePreferences() {
   if (profileQuery.isLoading) {
     return (
       <Card>
-        <Card.Body>
-          <Skeleton lines={6} gap={8} />
-        </Card.Body>
+        <div className="space-y-2">
+          {Array.from({ length: 6 }, (_, index) => (
+            <Skeleton key={index} variant="text" />
+          ))}
+        </div>
       </Card>
     );
   }
@@ -92,56 +94,50 @@ export function ProfilePreferences() {
 
   return (
     <>
-      <Card>
-        <Card.Header>
-          <Card.Title>Account details</Card.Title>
-        </Card.Header>
-        <Card.Body>
-          <div className="settings-section">
-            <Field label="Name" required>
-              <Input
-                value={draft.name}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, name: event.target.value }))
-                }
-                required
-              />
-            </Field>
-            <Field label="Phone" description="Used for workspace contact and notifications.">
-              <Input
-                value={draft.phone}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, phone: event.target.value }))
-                }
-                placeholder="No phone number"
-              />
-            </Field>
-            <Field label="Email" description="Email changes are handled by workspace administrators.">
-              <Input value={profile.email} readOnly />
-            </Field>
-            <div className="settings-row">
-              <div>
-                <div className="t-label-sm">Role</div>
-                <p className="t-caption t-muted">Access is controlled by your workspace role.</p>
-              </div>
-              <Badge tone="outline">{profile.role}</Badge>
+      <Card title="Account details">
+        <div className="settings-section">
+          <Field label="Name" required>
+            <Input
+              value={draft.name}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Field>
+          <Field label="Phone" description="Used for workspace contact and notifications.">
+            <Input
+              value={draft.phone}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, phone: event.target.value }))
+              }
+              placeholder="No phone number"
+            />
+          </Field>
+          <Field label="Email" description="Email changes are handled by workspace administrators.">
+            <Input value={profile.email} readOnly />
+          </Field>
+          <div className="settings-row">
+            <div>
+              <div className="t-label-sm">Role</div>
+              <p className="t-caption t-muted">Access is controlled by your workspace role.</p>
             </div>
-            <div className="settings-row">
-              <div>
-                <div className="t-label-sm">Workspace</div>
-                <p className="t-caption t-muted">{profile.company.slug}</p>
-              </div>
-              <span className="t-mono">{profile.company.name}</span>
-            </div>
+            <Badge tone="outline">{profile.role}</Badge>
           </div>
-        </Card.Body>
+          <div className="settings-row">
+            <div>
+              <div className="t-label-sm">Workspace</div>
+              <p className="t-caption t-muted">{profile.company.slug}</p>
+            </div>
+            <span className="t-mono">{profile.company.name}</span>
+          </div>
+        </div>
       </Card>
 
       <SaveBar
         dirty={dirty}
-        title="Unsaved profile changes"
-        summary="Save your account details or discard the draft."
-        saving={updateMutation.isPending}
+        message="Unsaved profile changes — save your account details or discard the draft."
+        loading={updateMutation.isPending}
         onDiscard={() => setDraft(savedDraft)}
         onSave={() =>
           updateMutation.mutate({

--- a/components/preferences/organization/billing-preferences.tsx
+++ b/components/preferences/organization/billing-preferences.tsx
@@ -44,9 +44,11 @@ export function BillingPreferences() {
   if (billingQuery.isLoading) {
     return (
       <Card>
-        <Card.Body>
-          <Skeleton lines={8} gap={8} />
-        </Card.Body>
+        <div className="space-y-2">
+          {Array.from({ length: 8 }, (_, index) => (
+            <Skeleton key={index} variant="text" />
+          ))}
+        </div>
       </Card>
     );
   }
@@ -75,92 +77,82 @@ export function BillingPreferences() {
           label="Plan"
           value={billing.plan?.name ?? "No plan"}
           delta={billing.subscription?.status ?? billing.health.state}
-          deltaTone="neutral"
+          tone="neutral"
         />
         <StatCard
           label="Monthly amount"
           value={<span className="t-mono">{formatMoney(monthlyAmount, currency)}</span>}
           delta="Offline billing"
-          deltaTone="neutral"
+          tone="neutral"
         />
         <StatCard
           label="Next cycle"
           value={<span className="t-mono">{formatDate(billing.subscription?.currentPeriodEnd)}</span>}
           delta={billing.health.daysUntilEnd !== null ? `${billing.health.daysUntilEnd} days` : "No date"}
-          deltaTone={billing.health.daysUntilEnd !== null && billing.health.daysUntilEnd <= billing.health.warningDays ? "down" : "neutral"}
+          tone={billing.health.daysUntilEnd !== null && billing.health.daysUntilEnd <= billing.health.warningDays ? "danger" : "neutral"}
         />
         <StatCard
           label="Status"
           value={<Badge tone={healthTone(billing.health.state)}>{billing.health.status ?? billing.health.state}</Badge>}
           delta={billing.health.reason}
-          deltaTone={billing.health.shouldBlock ? "down" : "neutral"}
+          tone={billing.health.shouldBlock ? "danger" : "neutral"}
         />
       </div>
 
-      <Card>
-        <Card.Header>
-          <Card.Title>Plan limits</Card.Title>
-        </Card.Header>
-        <Card.Body>
-          <div className="settings-section">
-            <div className="settings-row">
-              <div>
-                <div className="t-label-sm">Sites</div>
-                <p className="t-caption t-muted">Active sites counted against the current plan.</p>
-              </div>
-              <span className="t-mono">
-                {billing.usage.activeSites} / {billing.usage.maxSites ?? "Unlimited"}
-              </span>
+      <Card title="Plan limits">
+        <div className="settings-section">
+          <div className="settings-row">
+            <div>
+              <div className="t-label-sm">Sites</div>
+              <p className="t-caption t-muted">Active sites counted against the current plan.</p>
             </div>
-            <div className="settings-row">
-              <div>
-                <div className="t-label-sm">Users</div>
-                <p className="t-caption t-muted">Active users counted against the current plan.</p>
-              </div>
-              <span className="t-mono">
-                {billing.usage.activeUsers} / {billing.usage.maxUsers ?? "Unlimited"}
-              </span>
-            </div>
-            <div className="settings-row">
-              <div>
-                <div className="t-label-sm">Accepted payment methods</div>
-                <p className="t-caption t-muted">Online payments are not enabled for this workspace.</p>
-              </div>
-              <div className="flex flex-wrap justify-end gap-2">
-                {billing.payments.methods.map((method) => (
-                  <Badge key={method} tone="outline">
-                    {method}
-                  </Badge>
-                ))}
-              </div>
-            </div>
+            <span className="t-mono">
+              {billing.usage.activeSites} / {billing.usage.maxSites ?? "Unlimited"}
+            </span>
           </div>
-        </Card.Body>
-      </Card>
-
-      <Card>
-        <Card.Header>
-          <Card.Title>Add-ons</Card.Title>
-        </Card.Header>
-        <Card.Body>
-          {billing.addons.length > 0 ? (
-            <div className="settings-section">
-              {billing.addons.map((addon) => (
-                <div className="settings-row" key={addon.id}>
-                  <div>
-                    <div className="t-label-sm">{addon.name}</div>
-                    <p className="t-caption t-muted">{addon.code}</p>
-                  </div>
-                  <span className="t-mono">
-                    {formatMoney(addon.monthlyPrice, currency)}
-                  </span>
-                </div>
+          <div className="settings-row">
+            <div>
+              <div className="t-label-sm">Users</div>
+              <p className="t-caption t-muted">Active users counted against the current plan.</p>
+            </div>
+            <span className="t-mono">
+              {billing.usage.activeUsers} / {billing.usage.maxUsers ?? "Unlimited"}
+            </span>
+          </div>
+          <div className="settings-row">
+            <div>
+              <div className="t-label-sm">Accepted payment methods</div>
+              <p className="t-caption t-muted">Online payments are not enabled for this workspace.</p>
+            </div>
+            <div className="flex flex-wrap justify-end gap-2">
+              {billing.payments.methods.map((method) => (
+                <Badge key={method} tone="outline">
+                  {method}
+                </Badge>
               ))}
             </div>
-          ) : (
-            <p className="t-body t-muted">No add-ons are enabled for this workspace.</p>
-          )}
-        </Card.Body>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Add-ons">
+        {billing.addons.length > 0 ? (
+          <div className="settings-section">
+            {billing.addons.map((addon) => (
+              <div className="settings-row" key={addon.id}>
+                <div>
+                  <div className="t-label-sm">{addon.name}</div>
+                  <p className="t-caption t-muted">{addon.code}</p>
+                </div>
+                <span className="t-mono">
+                  {formatMoney(addon.monthlyPrice, currency)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="t-body t-muted">No add-ons are enabled for this workspace.</p>
+        )}
       </Card>
     </div>
   );

--- a/components/preferences/organization/departments-preferences.tsx
+++ b/components/preferences/organization/departments-preferences.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AlertDialog,
   Badge,
   Button,
   Drawer,
@@ -25,6 +24,7 @@ import {
 } from "@/lib/api";
 import { getApiErrorMessage, resolveDisplayErrorMessage } from "@/lib/api-client";
 import { Pencil, Plus, Trash2 } from "@/lib/icons";
+import { dsConfirm } from "@/components/ui/ds-confirm";
 
 type DepartmentFormState = {
   code: string;
@@ -152,7 +152,7 @@ export function DepartmentsPreferences() {
   }
 
   async function confirmDeleteDepartment(department: DepartmentRecord) {
-    const confirmed = await AlertDialog.confirm({
+    const confirmed = await dsConfirm({
       title: "Delete department",
       description: `Delete ${department.name}. Departments linked to employees cannot be deleted.`,
       variant: "danger",
@@ -182,44 +182,44 @@ export function DepartmentsPreferences() {
 
   const columns: DataTableColumn<DepartmentRecord>[] = [
       {
-        id: "code",
+        key: "code",
         header: "Code",
         width: "8rem",
-        cell: (row) => <span className="t-mono">{row.code}</span>,
+        render: (row) => <span className="t-mono">{row.code}</span>,
       },
       {
-        id: "name",
+        key: "name",
         header: "Name",
-        cell: (row) => row.name,
+        render: (row) => row.name,
       },
       {
-        id: "employees",
+        key: "employees",
         header: "Employees",
-        numeric: true,
+        align: "right",
         width: "8rem",
-        cell: (row) => <span className="t-mono">{row._count?.employees ?? 0}</span>,
+        render: (row) => <span className="t-mono">{row._count?.employees ?? 0}</span>,
       },
       {
-        id: "status",
+        key: "status",
         header: "Status",
         width: "8rem",
-        cell: (row) => (
+        render: (row) => (
           <Badge tone={row.isActive ? "success" : "outline"}>
             {row.isActive ? "Active" : "Inactive"}
           </Badge>
         ),
       },
       {
-        id: "actions",
+        key: "actions",
         header: "Actions",
         width: "10rem",
-        cell: (row) => (
+        render: (row) => (
           <div className="flex items-center justify-end gap-2">
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              icon={<Pencil className="size-4" aria-hidden="true" />}
+              startIcon={<Pencil className="size-4" aria-hidden="true" />}
               aria-label={`Edit ${row.name}`}
               onClick={() => openEditForm(row)}
             />
@@ -228,7 +228,7 @@ export function DepartmentsPreferences() {
               variant="ghost"
               tone="danger"
               size="sm"
-              icon={<Trash2 className="size-4" aria-hidden="true" />}
+              startIcon={<Trash2 className="size-4" aria-hidden="true" />}
               aria-label={`Delete ${row.name}`}
               loading={deleteMutation.isPending}
               onClick={() => confirmDeleteDepartment(row)}
@@ -277,7 +277,7 @@ export function DepartmentsPreferences() {
             type="button"
             variant="primary"
             size="sm"
-            icon={<Plus className="size-4" aria-hidden="true" />}
+            startIcon={<Plus className="size-4" aria-hidden="true" />}
             onClick={openCreateForm}
           >
             New department
@@ -302,7 +302,7 @@ export function DepartmentsPreferences() {
         open={formOpen}
         onClose={closeForm}
         title={editing ? "Edit department" : "New department"}
-        subtitle={
+        description={
           editing
             ? "Update department details and active status."
             : "Create a department record for HR and compensation assignment."

--- a/components/preferences/organization/organization-overview-preferences.tsx
+++ b/components/preferences/organization/organization-overview-preferences.tsx
@@ -15,9 +15,11 @@ export function OrganizationOverviewPreferences() {
   if (profileQuery.isLoading) {
     return (
       <Card>
-        <Card.Body>
-          <Skeleton lines={6} gap={8} />
-        </Card.Body>
+        <div className="space-y-2">
+          {Array.from({ length: 6 }, (_, index) => (
+            <Skeleton key={index} variant="text" />
+          ))}
+        </div>
       </Card>
     );
   }
@@ -33,44 +35,39 @@ export function OrganizationOverviewPreferences() {
   const { company } = profileQuery.data;
 
   return (
-    <Card>
-      <Card.Header>
-        <Card.Title>Workspace context</Card.Title>
-      </Card.Header>
-      <Card.Body>
-        <div className="settings-section">
-          <div className="settings-row">
-            <div>
-              <div className="t-label-sm">Organization name</div>
-              <p className="t-caption t-muted">The name shown across workspace surfaces.</p>
-            </div>
-            <span>{company.name}</span>
+    <Card title="Workspace context">
+      <div className="settings-section">
+        <div className="settings-row">
+          <div>
+            <div className="t-label-sm">Organization name</div>
+            <p className="t-caption t-muted">The name shown across workspace surfaces.</p>
           </div>
-          <div className="settings-row">
-            <div>
-              <div className="t-label-sm">Workspace slug</div>
-              <p className="t-caption t-muted">Used in hosted workspace identity and support context.</p>
-            </div>
-            <span className="t-mono">{company.slug}</span>
-          </div>
-          <div className="settings-row">
-            <div>
-              <div className="t-label-sm">Workspace profile</div>
-              <p className="t-caption t-muted">Controls role templates and module defaults.</p>
-            </div>
-            <Badge tone="outline">{company.workspaceProfile}</Badge>
-          </div>
-          <div className="settings-row">
-            <div>
-              <div className="t-label-sm">Tenant status</div>
-              <p className="t-caption t-muted">Billing and access enforcement use this state.</p>
-            </div>
-            <Badge tone={company.tenantStatus === "ACTIVE" ? "success" : "warn"}>
-              {company.tenantStatus}
-            </Badge>
-          </div>
+          <span>{company.name}</span>
         </div>
-      </Card.Body>
+        <div className="settings-row">
+          <div>
+            <div className="t-label-sm">Workspace slug</div>
+            <p className="t-caption t-muted">Used in hosted workspace identity and support context.</p>
+          </div>
+          <span className="t-mono">{company.slug}</span>
+        </div>
+        <div className="settings-row">
+          <div>
+            <div className="t-label-sm">Workspace profile</div>
+            <p className="t-caption t-muted">Controls role templates and module defaults.</p>
+          </div>
+          <Badge tone="outline">{company.workspaceProfile}</Badge>
+        </div>
+        <div className="settings-row">
+          <div>
+            <div className="t-label-sm">Tenant status</div>
+            <p className="t-caption t-muted">Billing and access enforcement use this state.</p>
+          </div>
+          <Badge tone={company.tenantStatus === "ACTIVE" ? "success" : "warn"}>
+            {company.tenantStatus}
+          </Badge>
+        </div>
+      </div>
     </Card>
   );
 }

--- a/components/preferences/organization/sites-preferences.tsx
+++ b/components/preferences/organization/sites-preferences.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AlertDialog,
   Badge,
   Button,
   Drawer,
@@ -26,6 +25,7 @@ import {
 } from "@/lib/api";
 import { getApiErrorMessage, resolveDisplayErrorMessage } from "@/lib/api-client";
 import { Pencil, Plus, Trash2 } from "@/lib/icons";
+import { dsConfirm } from "@/components/ui/ds-confirm";
 
 type SiteFormState = {
   name: string;
@@ -159,7 +159,7 @@ export function SitesPreferences() {
   }
 
   async function archiveSite(site: Site) {
-    const confirmed = await AlertDialog.confirm({
+    const confirmed = await dsConfirm({
       title: "Archive site",
       description: `Archive ${site.name}. This removes it from active operational defaults.`,
       variant: "warning",
@@ -189,47 +189,47 @@ export function SitesPreferences() {
 
   const columns: DataTableColumn<Site>[] = [
       {
-        id: "code",
+        key: "code",
         header: "Code",
         width: "8rem",
-        cell: (row) => <span className="t-mono">{row.code}</span>,
+        render: (row) => <span className="t-mono">{row.code}</span>,
       },
       {
-        id: "name",
+        key: "name",
         header: "Name",
-        cell: (row) => row.name,
+        render: (row) => row.name,
       },
       {
-        id: "location",
+        key: "location",
         header: "Location",
-        cell: (row) => row.location || "-",
+        render: (row) => row.location || "-",
       },
       {
-        id: "unit",
+        key: "unit",
         header: "Measurement unit",
-        cell: (row) => row.measurementUnit,
+        render: (row) => row.measurementUnit,
       },
       {
-        id: "status",
+        key: "status",
         header: "Status",
         width: "8rem",
-        cell: (row) => (
+        render: (row) => (
           <Badge tone={row.isActive ? "success" : "outline"}>
             {row.isActive ? "Active" : "Inactive"}
           </Badge>
         ),
       },
       {
-        id: "actions",
+        key: "actions",
         header: "Actions",
         width: "14rem",
-        cell: (row) => (
+        render: (row) => (
           <div className="flex items-center justify-end gap-2">
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              icon={<Pencil className="size-4" aria-hidden="true" />}
+              startIcon={<Pencil className="size-4" aria-hidden="true" />}
               aria-label={`Edit ${row.name}`}
               onClick={() => openEditForm(row)}
             />
@@ -239,7 +239,7 @@ export function SitesPreferences() {
                 variant="ghost"
                 tone="danger"
                 size="sm"
-                icon={<Trash2 className="size-4" aria-hidden="true" />}
+                startIcon={<Trash2 className="size-4" aria-hidden="true" />}
                 aria-label={`Archive ${row.name}`}
                 loading={archiveMutation.isPending}
                 onClick={() => archiveSite(row)}
@@ -303,7 +303,7 @@ export function SitesPreferences() {
             type="button"
             variant="primary"
             size="sm"
-            icon={<Plus className="size-4" aria-hidden="true" />}
+            startIcon={<Plus className="size-4" aria-hidden="true" />}
             onClick={openCreateForm}
           >
             New site
@@ -328,7 +328,7 @@ export function SitesPreferences() {
         open={formOpen}
         onClose={closeForm}
         title={editing ? "Edit site" : "New site"}
-        subtitle={
+        description={
           editing
             ? "Update site details and active status."
             : "Create a site record for reporting and operational forms."
@@ -393,12 +393,11 @@ export function SitesPreferences() {
                   measurementUnit: event.target.value as SiteFormState["measurementUnit"],
                 }))
               }
-              options={[
-                { value: "tonnes", label: "tonnes" },
-                { value: "trips", label: "trips" },
-                { value: "wheelbarrows", label: "wheelbarrows" },
-              ]}
-            />
+            >
+              <option value="tonnes">tonnes</option>
+              <option value="trips">trips</option>
+              <option value="wheelbarrows">wheelbarrows</option>
+            </Select>
           </Field>
           <div className="settings-row">
             <div>

--- a/components/preferences/organization/users-preferences.tsx
+++ b/components/preferences/organization/users-preferences.tsx
@@ -5,7 +5,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import {
   Alert,
-  AlertDialog,
   Badge,
   Button,
   Drawer,
@@ -29,6 +28,7 @@ import {
   type ManagedUserSummary,
 } from "@/lib/user-management-api";
 import { Plus, RefreshCcw, ShieldCheck, UserCheck } from "@/lib/icons";
+import { dsConfirm } from "@/components/ui/ds-confirm";
 
 type RoleFilter = "ALL" | ManagedUserRole;
 type StatusFilter = "ALL" | "ACTIVE" | "INACTIVE";
@@ -224,7 +224,7 @@ export function UsersPreferences() {
 
   async function toggleStatus(user: ManagedUserSummary) {
     const nextActive = !user.isActive;
-    const confirmed = await AlertDialog.confirm({
+    const confirmed = await dsConfirm({
       title: nextActive ? "Activate user" : "Deactivate user",
       description: `${nextActive ? "Activate" : "Deactivate"} ${user.email}.`,
       variant: nextActive ? "default" : "warning",
@@ -237,9 +237,9 @@ export function UsersPreferences() {
 
   const columns: DataTableColumn<ManagedUserSummary>[] = [
       {
-        id: "user",
+        key: "user",
         header: "User",
-        cell: (row) => (
+        render: (row) => (
           <div>
             <div>{row.name}</div>
             <div className="t-caption t-muted">{row.email}</div>
@@ -247,40 +247,40 @@ export function UsersPreferences() {
         ),
       },
       {
-        id: "role",
+        key: "role",
         header: "Role",
         width: "12rem",
-        cell: (row) => <Badge tone="outline">{row.role}</Badge>,
+        render: (row) => <Badge tone="outline">{row.role}</Badge>,
       },
       {
-        id: "status",
+        key: "status",
         header: "Status",
         width: "8rem",
-        cell: (row) => (
+        render: (row) => (
           <Badge tone={row.isActive ? "success" : "outline"}>
             {row.isActive ? "Active" : "Inactive"}
           </Badge>
         ),
       },
       {
-        id: "updated",
+        key: "updated",
         header: "Updated",
         width: "12rem",
-        cell: (row) => <span className="t-mono">{formatDate(row.updatedAt ?? row.createdAt)}</span>,
+        render: (row) => <span className="t-mono">{formatDate(row.updatedAt ?? row.createdAt)}</span>,
       },
       ...(canMutate
         ? [
             {
-              id: "actions",
+              key: "actions",
               header: "Actions",
               width: "22rem",
-              cell: (row: ManagedUserSummary) => (
+              render: (row: ManagedUserSummary) => (
                 <div className="flex flex-wrap items-center justify-end gap-2">
                   <Button
                     type="button"
                     variant="secondary"
                     size="sm"
-                    icon={<ShieldCheck className="size-4" aria-hidden="true" />}
+                    startIcon={<ShieldCheck className="size-4" aria-hidden="true" />}
                     loading={statusMutation.isPending}
                     onClick={() => toggleStatus(row)}
                   >
@@ -290,7 +290,7 @@ export function UsersPreferences() {
                     type="button"
                     variant="ghost"
                     size="sm"
-                    icon={<RefreshCcw className="size-4" aria-hidden="true" />}
+                    startIcon={<RefreshCcw className="size-4" aria-hidden="true" />}
                     onClick={() =>
                       setPasswordTarget({
                         userId: row.id,
@@ -305,7 +305,7 @@ export function UsersPreferences() {
                     type="button"
                     variant="ghost"
                     size="sm"
-                    icon={<UserCheck className="size-4" aria-hidden="true" />}
+                    startIcon={<UserCheck className="size-4" aria-hidden="true" />}
                     onClick={() =>
                       setRoleTarget({
                         userId: row.id,
@@ -376,21 +376,23 @@ export function UsersPreferences() {
               aria-label="Role filter"
               value={roleFilter}
               onChange={(event) => setRoleFilter(event.target.value as RoleFilter)}
-              options={[
-                { value: "ALL", label: "All roles" },
-                ...roleOptions.map((role) => ({ value: role.value, label: role.label })),
-              ]}
-            />
+            >
+              <option value="ALL">All roles</option>
+              {roleOptions.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </Select>
             <Select
               aria-label="Status filter"
               value={statusFilter}
               onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
-              options={[
-                { value: "ALL", label: "All statuses" },
-                { value: "ACTIVE", label: "Active" },
-                { value: "INACTIVE", label: "Inactive" },
-              ]}
-            />
+            >
+              <option value="ALL">All statuses</option>
+              <option value="ACTIVE">Active</option>
+              <option value="INACTIVE">Inactive</option>
+            </Select>
           </div>
         }
         actions={
@@ -399,7 +401,7 @@ export function UsersPreferences() {
               type="button"
               variant="primary"
               size="sm"
-              icon={<Plus className="size-4" aria-hidden="true" />}
+              startIcon={<Plus className="size-4" aria-hidden="true" />}
               onClick={() => setCreateOpen(true)}
             >
               New user
@@ -425,7 +427,7 @@ export function UsersPreferences() {
         open={createOpen}
         onClose={() => setCreateOpen(false)}
         title="New user"
-        subtitle="Provision a managed user account for this workspace."
+        description="Provision a managed user account for this workspace."
         footer={
           <div className="flex justify-end gap-2">
             <Button type="button" variant="secondary" onClick={() => setCreateOpen(false)}>
@@ -480,9 +482,14 @@ export function UsersPreferences() {
                   role: event.target.value as ManagedUserRole,
                 }))
               }
-              options={roleOptions}
               required
-            />
+            >
+              {roleOptions.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </Select>
           </Field>
         </form>
       </Drawer>
@@ -491,7 +498,7 @@ export function UsersPreferences() {
         open={Boolean(passwordTarget)}
         onClose={() => setPasswordTarget(null)}
         title="Reset password"
-        subtitle={passwordTarget?.userEmail}
+        description={passwordTarget?.userEmail}
         footer={
           <div className="flex justify-end gap-2">
             <Button type="button" variant="secondary" onClick={() => setPasswordTarget(null)}>
@@ -531,7 +538,7 @@ export function UsersPreferences() {
         open={Boolean(roleTarget)}
         onClose={() => setRoleTarget(null)}
         title="Change role"
-        subtitle={roleTarget?.userEmail}
+        description={roleTarget?.userEmail}
         footer={
           <div className="flex justify-end gap-2">
             <Button type="button" variant="secondary" onClick={() => setRoleTarget(null)}>
@@ -556,9 +563,14 @@ export function UsersPreferences() {
                   current ? { ...current, role: event.target.value as ManagedUserRole } : current,
                 )
               }
-              options={roleOptions}
               required
-            />
+            >
+              {roleOptions.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </Select>
           </Field>
         </form>
       </Drawer>

--- a/components/preferences/preferences-shell.tsx
+++ b/components/preferences/preferences-shell.tsx
@@ -3,7 +3,9 @@
 import * as React from "react";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { NavGroup, NavItem, PageHeader } from "@corelithzw/react";
+import { PageHeader } from "@corelithzw/react";
+
+import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 
 import {
   ACCOUNT_PREFERENCES_ITEMS,
@@ -98,7 +100,7 @@ export function PreferencesShell({
       </aside>
 
       <main className="settings-content">
-        <PageHeader title={title} actions={actions} />
+        <PageHeader title={title} primaryAction={actions} />
         {description ? (
           <p className="t-body t-muted max-w-[var(--content-max)]">
             {description}

--- a/components/settings/management-shell.tsx
+++ b/components/settings/management-shell.tsx
@@ -3,7 +3,9 @@
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { NavGroup, NavItem, PageHeader } from "@corelithzw/react";
+import { PageHeader } from "@corelithzw/react";
+
+import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 import {
   getAreaLabel,
   getVisibleManagementAreaNavItems,
@@ -93,7 +95,7 @@ export function ManagementShell({
       </aside>
 
       <section className="settings-content">
-        <PageHeader title={title || modulePresentation.title} actions={actions} />
+        <PageHeader title={title || modulePresentation.title} primaryAction={actions} />
         {description ? (
           <p className="t-body t-muted max-w-[var(--content-max)]">{description}</p>
         ) : null}

--- a/components/ui/ds-confirm.tsx
+++ b/components/ui/ds-confirm.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@corelithzw/react";
+
+/**
+ * Imperative confirmation built on the design system's `AlertDialog`.
+ *
+ * `AlertDialog` in `@corelithzw/react` is a declarative compound component with
+ * no static `.confirm()` — this is the promise-returning wrapper the app's call
+ * sites want, composed from the package's own parts so the dialog is styled and
+ * focus-managed entirely by the design system.
+ */
+
+export type DsConfirmOptions = {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /**
+   * `danger` uses the design system's destructive styling. `warning` is a
+   * serious-but-reversible action and stays on the neutral treatment — the
+   * design system reserves red for the irreversible ones.
+   * @default "default"
+   */
+  variant?: "default" | "warning" | "danger";
+};
+
+function ConfirmDialog({
+  options,
+  onResolve,
+}: {
+  options: DsConfirmOptions;
+  onResolve: (confirmed: boolean) => void;
+}) {
+  const [open, setOpen] = React.useState(true);
+  const destructive = options.variant === "danger";
+
+  // Fires for Escape, overlay dismissal and either button.
+  const close = (confirmed: boolean) => {
+    setOpen(false);
+    onResolve(confirmed);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={(next) => !next && close(false)}>
+      <AlertDialogContent destructive={destructive}>
+        <AlertDialogTitle>{options.title}</AlertDialogTitle>
+        {options.description ? (
+          <AlertDialogDescription>{options.description}</AlertDialogDescription>
+        ) : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => close(false)}>
+            {options.cancelLabel ?? "Cancel"}
+          </AlertDialogCancel>
+          <AlertDialogAction destructive={destructive} onClick={() => close(true)}>
+            {options.confirmLabel ?? "Confirm"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+/**
+ * Resolves `true` when the user confirms, `false` on cancel, Escape or overlay
+ * dismissal. Resolves `false` immediately when called outside the browser.
+ */
+export function dsConfirm(options: DsConfirmOptions): Promise<boolean> {
+  if (typeof document === "undefined") {
+    return Promise.resolve(false);
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    const finish = (confirmed: boolean) => {
+      resolve(confirmed);
+      // Unmount on a later tick so the closing transition can run, and so we
+      // are not tearing down a root from inside its own render pass.
+      setTimeout(() => {
+        root.unmount();
+        host.remove();
+      }, 0);
+    };
+
+    root.render(<ConfirmDialog options={options} onResolve={finish} />);
+  });
+}

--- a/components/ui/settings-rail.tsx
+++ b/components/ui/settings-rail.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Settings-rail navigation.
+ *
+ * `@corelithzw/react` ships the CSS for this surface — `.settings-rail`,
+ * `.group-label`, `.rail-item` and `.rail-item.active` — but exports no React
+ * component for it (there is no `NavGroup`/`NavItem` in the package; see the
+ * export list in `dist/index.d.ts`). Rather than forking a design-system
+ * component, these two render the package's markup contract directly, so the
+ * styling still comes entirely from the package.
+ *
+ * Drop these in favour of the real exports if a future release ships them.
+ */
+
+type NavGroupProps = {
+  label: string;
+  children: React.ReactNode;
+};
+
+export function NavGroup({ label, children }: NavGroupProps) {
+  return (
+    <>
+      <div className="group-label">{label}</div>
+      {children}
+    </>
+  );
+}
+
+type NavItemProps = {
+  /** Destination href. Named `to` to match the design system's nav API. */
+  to: string;
+  active?: boolean;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export function NavItem({ to, active, icon, children }: NavItemProps) {
+  return (
+    <Link
+      href={to}
+      className={cn("rail-item", active && "active")}
+      aria-current={active ? "page" : undefined}
+    >
+      {icon ? (
+        <span className="mr-2 inline-flex shrink-0 items-center">{icon}</span>
+      ) : null}
+      {children}
+    </Link>
+  );
+}

--- a/docs/design-system/01-setup.md
+++ b/docs/design-system/01-setup.md
@@ -41,61 +41,107 @@ DS markup, wrap it in a thin client child rather than adding `"use client"` up t
 import { Button, DataTable } from "@corelithzw/react";
 ```
 
-### 2. Token name collisions with `app/globals.css`
+### 2. Token name collisions with `app/globals.css` — RESOLVED
 
-39 of the DS's 157 tokens already exist in `app/globals.css` under the same names with **different values**.
-Importing `styles.css` after `globals.css` silently reflows existing UI. These are the ones that change size
-or shape — the dangerous set:
+**Status: done.** `styles.css` is imported globally and the collisions below have been reconciled. Kept as
+the record of what changed and why.
 
-| Token | This repo | Design system | Consequence |
+The package is now imported from `app/globals.css` into a dedicated cascade layer:
+
+```css
+@layer theme, base, corelith, app, components, utilities;
+
+@import "tailwindcss";
+@import "@corelithzw/react/styles.css" layer(corelith);
+```
+
+That single line does the collision resolution. `corelith` sits **above** Tailwind's `theme` layer, so for
+every same-named token the package's value wins automatically — `--radius-*`, `--font-sans`, `--font-mono`,
+`--ease-*` and the rest resolve to design-system values with no mapping to maintain. It sits **below**
+`utilities`, so a Tailwind class on a design-system component still overrides that component's CSS.
+
+`app/globals.css` no longer declares a single token literal. Every legacy name the app still reads is
+re-derived from a package token in `app/themes/corelith-bridge.css`.
+
+How each collision landed:
+
+| Token | Was | Now | Note |
 |---|---|---|---|
-| `--space-8` | 32px | **40px** | Scale divergence — see below |
-| `--space-10` | 40px | **64px** | Scale divergence — see below |
-| `--button-radius` | 11px | 8px | Every button gets squarer |
-| `--radius-sm` / `md` / `lg` / `xl` / `2xl` | `calc()` off `--radius` | 6 / 8 / 10 / 14 / 18px | Radius scale replaced |
-| `--button-height` / `--input-height` | `2.25rem` | `var(--h-control-md)` = 36px | Same size, different mechanism |
-| `--font-sans` | `var(--font-sans)` → "SS Huchu" | Atkinson Hyperlegible Next | **Whole-product typeface change** |
+| `--space-8` / `--space-10` | 32 / 40px | DS scale (40 / 64px) | Use sites renamed → `--space-7` / `--space-8`; same rendered px |
+| `--button-radius` | 11px | 8px (package) | Buttons are squarer |
+| `--radius-sm … 2xl` | `calc()` off `--radius` | 6 / 8 / 10 / 14 / 18px (package) | `--radius-3xl` / `4xl` extend the package's ladder |
+| `--radius` | `0.625rem` | `var(--radius-md)` = 8px | The package ships its own `--radius` |
+| `--button-height` / `--input-height` | `2.25rem` | `var(--h-control-md)` = 36px | Same size |
+| `--font-sans` | "SS Huchu" | Atkinson Hyperlegible Next | Decided — see below |
 | `--shadow-popover` | `0 8px 24px …` | `0 12px 32px -8px …` | Deeper popovers |
+| `--text-xl` / `--text-2xl` | 20 / 28px | 22 / 32px | Aligned to the DS page-title and display-sm rungs |
+| shadcn set | repo aliases | **package tokens** | See below |
 
-**The spacing scale is the real trap.** This repo indexes roughly by 4×n; the DS indexes by step. They agree
-through `--space-6` and diverge after:
+**The spacing scale.** The repo indexed roughly by 4×n, the DS indexes by step. They agree through
+`--space-6` and diverged after:
 
 | | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| repo | 4 | 8 | 12 | 16 | 20 | 24 | — | **32** | — | **40** | — | — | — |
+| repo (old) | 4 | 8 | 12 | 16 | 20 | 24 | — | **32** | — | **40** | — | — | — |
 | DS | 4 | 8 | 12 | 16 | 20 | 24 | 32 | **40** | 48 | **64** | 80 | 96 | 128 |
 
-So repo `--space-8` (32px) is DS `--space-7`, and repo `--space-10` (40px) is DS `--space-8`. Any existing
-rule using `--space-8` or `--space-10` shifts if the DS values win.
+The DS scale is now the only one. The two use sites of the old rungs (`app/home/marketing.module.css`) were
+renamed `--space-8` → `--space-7` and `--space-10` → `--space-8`, so they render identically.
 
-The remaining collisions (`--text-*`, `--border*`, `--action-*`, `--focus-ring`, `--surface-muted`) are
-indirection-only: the repo aliases its own palette, the DS uses literals. Resolved values are close, so they
-are low-risk — but they are the seam where the two colour systems meet.
+**The package already ships a shadcn bridge.** `styles.css` declares `--background --foreground --card
+--popover --primary --secondary --muted --accent --destructive --input --ring --radius` and their
+`-foreground` pairs, mapped onto its own tokens. `corelith-bridge.css` deliberately does **not** redeclare
+any of them. Note `--accent` is `--brand-soft` there (shadcn's subtle hover surface); the app's chart accent
+is a separate `--accent-50 … --accent-900` ramp with no bare `--accent` rung so the two cannot collide.
+
+**Watch the shadowed Tailwind namespaces.** `--text-xs … --text-2xl` and `--leading-tight/normal/relaxed`
+are Tailwind font-size and line-height theme keys. The bridge declares them in an unlayered `:root`, so they
+override Tailwind's defaults for every `text-sm` / `leading-normal` class in the app. That is intentional and
+long-standing — but it means changing one of those values in the bridge resizes text app-wide.
+
+### 3. Tenant branding used to override everything
+
+`getBrandingCssVariables` in `lib/platform/branding.ts` writes CSS custom properties **inline on `<body>`**,
+which outranks every stylesheet including the package. It used to emit a complete hardcoded warm-paper
+palette — surfaces, text, borders, statuses, charts, shadows — on every request, branded or not. That, more
+than any collision, is why the product rendered off-token.
+
+It now emits nothing when branding is disabled, and when enabled it re-anchors the design system's own
+`--brand` scale on the tenant's colour rather than restating a palette. Two rules if you touch it:
+
+1. Emit only what the tenant actually chose.
+2. Re-tint through the package's token names, not the app's aliases — that is what makes a tenant's colour
+   reach components rendered by `@corelithzw/react`.
 
 ### Dark mode
 
-The DS ships **no** `prefers-color-scheme` or `.dark` block — verified, zero matches across all package CSS.
-`app/globals.css` has dark-mode handling. Any surface migrated to raw DS tokens loses dark mode.
-Options: keep the repo's dark overrides layered on top and re-map DS tokens inside them, or scope the DS to
-light-only surfaces. Do not assume the DS handles it. The site's colours page claims surfaces flip in dark
-mode; the shipped CSS does not implement that.
+The DS ships no `prefers-color-scheme` or `.dark` block; it flips tokens on `body.is-dark`. The app is
+light-only today (`app/globals.css` has a dark block for `.pos-terminal` only). Any surface that wants dark
+should add `is-dark` to `<body>` and let the package's token flip do the work.
 
-## Recommended adoption order
+### Typeface — decided
 
-Scoped, reversible, and it keeps the collision surface small.
+**Atkinson Hyperlegible.** The self-hosted "SS Huchu" `@font-face` blocks are gone and `--font-sans` comes
+from the package untouched. One consequence: `styles.css` pulls the two families from Google Fonts via an
+`@import` on its line 14, and once bundled that lands *inside* `@layer corelith`, where it is invalid CSS
+that browsers drop. `app/globals.css` hoists the same import to the top of the file — that copy is the one
+that loads. If a CSP or an offline build blocks Google Fonts the stack falls back to `-apple-system`; the fix
+is to self-host the two families, not to remove the hoisted import.
 
-1. **Do not** import `styles.css` globally into `app/layout.tsx` yet — that fires all 39 collisions at once.
-2. Add the DS's non-colliding tokens (118 of them) to `app/globals.css` under their own names. `--brand-*`,
-   `--tone-*`, `--type-*`, `--dur-*`, `--ease-*`, `--h-control-*`, `--gray-*`, `--space-7/9/11/12/13`,
-   `--sidebar-w`, `--gutter-x` — all safe, all additive.
-3. Migrate route-by-route. Import `styles.css` inside the migrated subtree, or accept it globally only once
-   the collision table above has been reconciled deliberately.
-4. Reconcile spacing before anything else: rename repo `--space-8` → `--space-7` and `--space-10` → `--space-8`
-   at every use site, then adopt the DS scale wholesale. Do this as one mechanical commit with no other changes.
-5. Decide the typeface explicitly. "SS Huchu" vs Atkinson Hyperlegible is a product decision, not a
-   refactor detail — flag it, don't silently switch it.
-6. Delete the local `components/ui/*` equivalent only after its DS replacement is proven at every call site.
-   See `07-repo-migration.md`.
+The `.woff2` files remain in `public/` and are now unreferenced.
+
+## Remaining adoption work
+
+Tokens and styling are done. What is left is component-by-component API migration:
+
+1. Migrate call sites off `components/ui/*` onto the package's exports, and delete the local component only
+   once its replacement is proven everywhere. See `07-repo-migration.md`.
+2. Drop superseded dependencies (`@radix-ui/*`, `@base-ui/react`, `@rtcamp/frappe-ui-react`) from
+   `package.json` only once nothing imports them.
+
+Note that `07-repo-migration.md` documents an API that is **newer than the installed 0.3.4** in places — it
+lists `NavGroup`/`NavItem`, compound `Card.Header`/`Card.Body`, and a controlled `DataTable` with
+`DataTableSortState`, none of which 0.3.4 exports. Check `dist/index.d.ts` before trusting a component name.
 
 ## Verified environment notes
 

--- a/docs/design-system/07-repo-migration.md
+++ b/docs/design-system/07-repo-migration.md
@@ -4,6 +4,17 @@ The DS primitives page says its 47 components "mirror the live `tate2301/huchu` 
 `components/ui/*` layer and the DS are **two implementations of the same intent**. Migration is
 convergence, not adoption from zero.
 
+> **Written against a newer API than the installed `@corelithzw/react@0.3.4`.** Several components named
+> below do not exist in 0.3.4: there is no `NavGroup`/`NavItem` (settings-rail nav is CSS-only —
+> `.settings-rail .rail-item`, wrapped locally in `components/ui/settings-rail.tsx`), `Card` has no compound
+> `.Header`/`.Title`/`.Body` slots (use the `title` / `subtitle` / `footer` props), `DataTable` sorts
+> client-side rather than being fully controlled (no `DataTableSortState`), `Button` uses
+> `startIcon`/`endIcon`/`iconOnly` rather than `icon`, `Select` takes `<option>` children rather than an
+> `options` array, and `AlertDialog` has no imperative `.confirm()` (see `components/ui/ds-confirm.tsx`).
+> Always check `node_modules/@corelithzw/react/dist/index.d.ts` before trusting a name here.
+>
+> Token and style migration is complete — see `01-setup.md`. What remains is component API migration.
+
 ## Blast radius — measured, use it to sequence work
 
 310 of 571 `.tsx` files under `app/` + `components/` import from `@/components/ui/`.

--- a/lib/platform/branding.ts
+++ b/lib/platform/branding.ts
@@ -43,9 +43,12 @@ export type EffectiveBranding = {
 
 export const BRANDING_FONT_OPTIONS: BrandingFontOption[] = [
   {
+    // The design system's own face (Atkinson Hyperlegible). Deferring to
+    // `--font-sans` rather than naming a family keeps the default tenant on
+    // whatever @corelithzw/react ships, including its fallback stack.
     key: "huchu",
     label: `${PLATFORM_BRAND_NAME} Sans`,
-    fontFamily: '"SS Huchu", "Segoe UI", "Helvetica Neue", Arial, sans-serif',
+    fontFamily: "var(--font-sans)",
   },
   {
     key: "inter",
@@ -73,18 +76,28 @@ export const BRANDING_FONT_OPTIONS: BrandingFontOption[] = [
   },
 ];
 
+/** The option whose family defers to the design system's `--font-sans`. */
+const DEFAULT_FONT_KEY: BrandingFontKey = "huchu";
+
+/**
+ * The unbranded baseline. Colours mirror `@corelithzw/react`'s `--brand`,
+ * `--brand-soft` and `--brand-tint` so the branding editor opens on the design
+ * system rather than on a palette the product no longer uses. Nothing here
+ * reaches the DOM while `brandingEnabled` is false — see
+ * `getBrandingCssVariables` — these values only seed the editor's swatches.
+ */
 const DEFAULT_BRANDING: EffectiveBranding = {
   companyId: null,
   companyName: null,
   displayName: PLATFORM_BRAND_NAME,
-  fontFamilyKey: "huchu",
+  fontFamilyKey: DEFAULT_FONT_KEY,
   fontFamily: BRANDING_FONT_OPTIONS[0].fontFamily,
   brandingEnabled: false,
   customDomainEnabled: false,
   colors: {
-    primary: "#0f8f86",
-    secondary: "#dcf4f1",
-    accent: "#ebf7f5",
+    primary: "#0B5DF0",
+    secondary: "#E8EFFE",
+    accent: "#EEF3FE",
   },
 };
 
@@ -290,83 +303,71 @@ export async function getEffectiveBrandingForHost(hostHeader: string | null | un
   return getEffectiveBrandingForCompany(tenant.companyId);
 }
 
+/**
+ * CSS custom properties for a tenant's branding, applied inline on `<body>`.
+ *
+ * An inline style outranks every stylesheet, so anything emitted here silently
+ * overrides `@corelithzw/react`. Two rules keep that from re-opening the drift
+ * this function used to cause:
+ *
+ *  1. Emit ONLY what the tenant actually chose. Surfaces, text, borders,
+ *     statuses, charts and shadows are the design system's job — they used to
+ *     be hardcoded warm-paper hexes here, which is why every page rendered off
+ *     the token set regardless of what the stylesheets said.
+ *  2. Re-tint through the design system's OWN token names (`--brand` and its
+ *     scale), not just the app's aliases. That is what makes a tenant's colour
+ *     reach components rendered by the package, which read `--brand`.
+ *
+ * With branding disabled the result is empty and the page renders as pure
+ * design system.
+ */
 export function getBrandingCssVariables(branding: EffectiveBranding): Record<string, string> {
-  const primary = branding.colors.primary;
-  const secondary = branding.colors.secondary;
-  const accent = branding.colors.accent;
+  if (!branding.brandingEnabled) {
+    return {};
+  }
+
+  const { primary, secondary, accent } = branding.colors;
+
+  const strong = mixColors(primary, "#000000", 0.18);
+  const deeper = mixColors(primary, "#000000", 0.32);
+  const onPrimary = getContrastTextColor(primary);
 
   return {
-    // Font family
-    "--font-sans": branding.fontFamily,
-    "--font-family": branding.fontFamily,
+    // Typeface. Skipped on the default key: that option's family IS
+    // `var(--font-sans)`, and emitting it here would define `--font-sans` in
+    // terms of itself — a reference cycle that leaves the element with no
+    // font-family at all. Omitting it lets the design system's face stand.
+    ...(branding.fontFamilyKey === DEFAULT_FONT_KEY
+      ? {}
+      : { "--font-sans": branding.fontFamily }),
 
-    // Action colors (primary button)
-    "--action-primary-bg": primary,
-    "--action-primary-hover": mixColors(primary, "#000000", 0.12),
-    "--action-primary-fg": getContrastTextColor(primary),
+    // The design system's brand scale — one saturated colour, re-anchored on
+    // the tenant's. Everything downstream (actions, focus ring, info tone,
+    // links, selection wash, package components) derives from these.
+    "--brand": primary,
+    "--brand-strong": strong,
+    "--brand-deeper": deeper,
+    "--brand-soft": mixColors(primary, "#ffffff", 0.9),
+    "--brand-tint": mixColors(primary, "#ffffff", 0.94),
+    "--brand-50": mixColors(primary, "#ffffff", 0.94),
+    "--brand-100": mixColors(primary, "#ffffff", 0.86),
+    "--brand-200": mixColors(primary, "#ffffff", 0.7),
+    "--brand-300": mixColors(primary, "#ffffff", 0.48),
+    "--brand-500": primary,
+    "--brand-700": strong,
+    "--brand-900": mixColors(primary, "#000000", 0.55),
+
+    // `--action-primary-*` and `--focus-ring` already resolve through `--brand`
+    // in the package, so only the foreground needs stating: contrast against an
+    // arbitrary tenant colour cannot be derived in CSS.
+    "--action-primary-fg": onPrimary,
+
+    // Secondary and accent are separate tenant choices, not brand rungs.
     "--action-secondary-bg": secondary,
-    "--action-secondary-hover": mixColors(primary, "#000000", 0.06),
+    "--action-secondary-bg-h": mixColors(secondary, "#000000", 0.06),
     "--action-secondary-fg": getContrastTextColor(secondary),
-    "--focus-ring": mixColors(primary, "#ffffff", 0.16),
-
-    // Base colors (shadcn compatibility)
-    "--primary": primary,
-    "--primary-foreground": getContrastTextColor(primary),
-    "--secondary": secondary,
-    "--secondary-foreground": getContrastTextColor(secondary),
     "--accent": accent,
     "--accent-foreground": getContrastTextColor(accent),
-
-    // Sidebar colors
-    "--sidebar-primary": primary,
-    "--sidebar-primary-foreground": getContrastTextColor(primary),
-
-    // Surface colors (warm paper aesthetic)
-    "--surface-canvas": "#FCFCF4",
-    "--surface-base": "#FFFFFF",
-    "--surface-raised": "#FFFFFF",
-    "--surface-muted": "#F7F7F2",
-    "--surface-subtle": "#F3F3EF",
-
-    // Border colors
-    "--border": "#E6E6E0",
-    "--border-strong": "#DADAD3",
-
-    // Text colors
-    "--text-strong": "#111111",
-    "--text-body": "#111111",
-    "--text-muted": "#6B6B6B",
-    "--text-subtle": "#9A9A93",
-    "--text-inverse": "#FFFFFF",
-
-    // Status colors
-    "--status-success-bg": "#EAF7F1",
-    "--status-success-text": "#2CA47C",
-    "--status-warning-bg": "#FDF1E8",
-    "--status-warning-text": "#F46414",
-    "--status-error-bg": "#FDEBE7",
-    "--status-error-text": "#EC442C",
-
-    // Chart colors (status-based)
-    "--chart-grid": "#E6E6E0",
-    "--chart-text": "#6B6B6B",
-    "--chart-passing": "#2CA47C",
-    "--chart-failing": "#EC442C",
-    "--chart-need-changes": "#F46414",
-    "--chart-in-review": primary,
-    "--chart-in-progress": "#FCB414",
-    "--chart-pending": "#CFCFC6",
-    "--chart-inactive": "#9A9A93",
-
-    // Chart palette (generic)
-    "--chart-1": primary,
-    "--chart-2": mixColors(primary, "#ffffff", 0.22),
-    "--chart-3": mixColors(primary, "#000000", 0.18),
-    "--chart-4": "#2CA47C",
-    "--chart-5": "#FCB414",
-
-    // Shadow
-    "--shadow-popover": "0 12px 24px -12px rgba(0,0,0,0.18), 0 2px 6px rgba(0,0,0,0.06)",
   };
 }
 


### PR DESCRIPTION
## Why styling was off

Three compounding causes, all fixed here:

1. **`@corelithzw/react/styles.css` was never imported.** Every component the package exports rendered with no styling at all, and `corelith-bridge.css` aliased onto tokens (`--canvas`, `--brand`, `--h-control-md`, `--dur-*`) that did not exist in the document.
2. **`app/globals.css` carried its own literal token set** under the same names, so even once the package loaded it would have been shadowed.
3. **Tenant branding wrote a complete hardcoded palette inline on `<body>`** — surfaces, text, borders, statuses, charts, shadows — on *every* request, branded or not. An inline style outranks every stylesheet, so this alone kept the whole product off-token.

Separately, a set of widely-used tokens was referenced but declared nowhere, most notably **`--surface-subtle` across 148 use sites**, plus `--text-primary/-secondary/-tertiary`, `--interactive-*`, `--bg-*`, the sheet widths that left side sheets with no width at any breakpoint, and the offline keypad palette.

## Wiring

```css
@layer theme, base, corelith, app, components, utilities;

@import "tailwindcss";
@import "@corelithzw/react/styles.css" layer(corelith);
```

The layer placement *is* the collision resolution, and it replaces the mapping table this repo would otherwise have to maintain:

- **Above** Tailwind's `theme` layer → every same-named token (`--radius-*`, `--font-sans`, `--font-mono`, `--ease-*`) resolves to the package's value automatically. `rounded-lg`, `font-sans` and `ease-out` are design-system values with zero configuration.
- **Below** `utilities` → a Tailwind class on a design-system component still wins. Verified: `<button class="btn btn-primary rounded-none bg-red-500 p-8">` picks up all three utilities.

## Tokens

`app/globals.css` no longer declares a single token literal. Every legacy name the app reads is re-derived from a package token in `corelith-bridge.css` — neutral ramp from `--gray-*`, brand ramp from `--brand-*`, semantic ramps from `--tone-*`, elevation from the package's shadow rungs, motion from `--dur-*`/`--ease-*`.

The bridge **defers entirely** to the shadcn set the package already ships (`--background --foreground --card --popover --primary --secondary --muted --accent --destructive --input --ring --radius`). Redeclaring any of those would shadow the package and re-open the drift. Worth noting the package's `--accent` is `--brand-soft`, shadcn's subtle hover surface — the app's chart accent is a separate `--accent-50 … --accent-900` ramp with deliberately no bare `--accent` rung so the two cannot collide. (`bg-accent` was previously rendering teal.)

`app/themes/admin.css` and `client.css` now re-tune the design system rather than restating a palette.

## Deliberate visual changes

| Change | Detail |
|---|---|
| **Typeface → Atkinson Hyperlegible** | The self-hosted SS Huchu `@font-face` is retired; `--font-sans` comes from the package untouched. Confirmed as a product decision before implementing. |
| Spacing scale | Adopted wholesale. The two diverged rungs were renamed at their use sites (`app/home/marketing.module.css`), so rendered px are unchanged. |
| `--radius` | 10px → 8px (the package's own `--radius`); buttons and shadcn surfaces are squarer |
| `--text-xl` / `--text-2xl` | 20/28px → 22/32px, the DS page-title and display-sm rungs. These shadow Tailwind's font-size keys, so `text-xl`/`text-2xl` classes shift with them (48 and 51 call sites). |
| `.text-table-header` | No longer ALL CAPS — the type rules rule it out for `<th>` too |
| Popover shadow | Deeper, per the package |

One gotcha worth knowing: the package's Google Fonts `@import` lands *inside* `@layer corelith` once bundled, where it is invalid CSS that browsers drop. `globals.css` hoists the same import to the top of the file — that copy is the one that loads. Under a CSP or offline build the stack falls back to `-apple-system`; the fix would be self-hosting, not removing the hoisted import.

## Branding

`getBrandingCssVariables` now emits **nothing** when branding is disabled, and when enabled re-anchors the package's own `--brand` scale on the tenant's colour instead of restating a palette. That is also a functional fix: the old version set `--primary` and `--action-primary-bg` but never `--brand`, so a tenant's colour never reached components rendered by the package at all.

## Component API — unblocking a pre-existing red build

`main` does not build. `components/preferences/**` was written against a **newer package API than the installed 0.3.4** (verified by stashing and rebuilding). Since the styling work can't be verified without a build, this fixes it: `Button` `icon`→`startIcon`, compound `Card.Header`/`Body` → the `title` prop, `Select` `options` array → `<option>` children, `Drawer` `subtitle`→`description`, `PageHeader` `actions`→`primaryAction`, `DataTableColumn` `id`/`cell`/`numeric` → `key`/`render`/`align`, `SaveBar`, `StatCard`, `SegmentedControl`.

Two surfaces the package styles but does not export get local shims rather than forked components:

- `components/ui/settings-rail.tsx` — the package ships `.settings-rail .rail-item` CSS but no `NavGroup`/`NavItem`
- `components/ui/ds-confirm.tsx` — promise-returning confirm composed from the package's own `AlertDialog` parts (there is no static `.confirm()`)

## Verification

- **Production build green** (`next build`), from a red baseline on `main`
- **`tsc --noEmit`**: 170 errors → 1, and that one (`role-consistency.test.ts`, a role enum) is pre-existing and untouched by this branch
- **`eslint`** clean on every changed file
- **Browser probe** over all 530 tokens the app references: everything resolves. The 132 that don't resolve at `:root` are all correctly scoped elsewhere — `--pos-*` under `.pos-terminal`, `--mk-*` in the marketing CSS module, `--radix-*`/`--anchor-width` set at runtime
- **Visual smoke test** against the built CSS chunk: buttons, badges, cards, tables, inputs, chips, status dots and type classes all render from the design system
- Tests: failures are all `Can't reach database server` — no Postgres in this container, unrelated

## Docs

`01-setup.md` said "do not import `styles.css` globally yet" — rewritten to record what the collisions resolved to. `07-repo-migration.md` is annotated: it documents an API newer than 0.3.4 in several places (`NavGroup`/`NavItem`, compound `Card`, controlled `DataTable`), so check `dist/index.d.ts` before trusting a component name there.

## Not included

Component-by-component migration off `components/ui/*` onto package exports, and dropping the superseded Radix / Base UI / frappe-ui dependencies. Tokens and styling are done; that is the remaining phase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQm6amHcj5oDRr2NGbg5ue)_