### PR TITLE
Unify secondary navigation on one quiet rail and tab strip

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -218,6 +218,276 @@
     outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
   }
+
+  /* ── Links ──────────────────────────────────────────────────────────────
+     The package's `tokens.css` paints every anchor `--text-link` (blue) and
+     underlines it on hover. Almost every anchor in this app is navigation or a
+     table affordance rather than a prose reference, so that rule turned rails,
+     tabs and cells into a page full of hyperlinks. Anchors inherit their
+     surrounding colour here; prose opts back in through `.link`, and links
+     inside running text keep an underline so they stay distinguishable without
+     relying on colour (WCAG 1.4.1). */
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  a:hover { text-decoration: none; }
+
+  .link { color: var(--text-link); }
+
+  /* Declared after the reset above, and each selector outranks `a:hover`, so
+     the surfaces that genuinely want an underline keep it: deliberate accent
+     links, the text-button variant, table id cells, and links inside running
+     text (WCAG 1.4.1 — prose links must not rely on colour alone). */
+  .link:hover,
+  .btn-link:hover,
+  .dtable .id-link:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  p a:not(.btn):not(.badge):not(.tag),
+  li a:not(.btn):not(.badge):not(.tag),
+  .lede a:not(.btn):not(.badge):not(.tag) {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECONDARY NAVIGATION — the vertical rail and the in-page tab strip.
+
+   Both surfaces follow the same rule: secondary navigation is a quiet list,
+   not a stack of controls. No outline, no shadow, no link colour, no
+   underline. Rest is body text on nothing; hover and active share one soft
+   fill and are separated by the weight of the label. Brand colour is the
+   primary-action colour and is never spent on marking position.
+
+   `.settings-rail` is the package's class name for this surface and
+   `.nav-rail` the app's general one — they render identically, and
+   `components/ui/nav-rail.tsx` is the only thing that should emit either.
+   This lives in `@layer app` so it outranks the package's own `.settings-rail`
+   block while Tailwind utilities still win over both.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+@layer app {
+  :root {
+    /* Outer bound for a page carrying its own secondary sidebar. */
+    --shell-max: 1536px;
+  }
+
+  .settings-layout {
+    display: grid;
+    grid-template-columns: var(--rail-w, 220px) minmax(0, 1fr);
+    gap: 32px;
+    /* Was `32px 64px`. `.content-shell` already applies `--content-gutter-x`
+       and `py-6`, so that padding stacked on top of the frame's own and pushed
+       the rail a couple of inches off the edge. Only the trailing space below
+       the last section is ours to add. */
+    padding: 0 0 24px;
+    max-width: var(--shell-max);
+    margin-inline: auto;
+    width: 100%;
+  }
+
+  @media (max-width: 900px) {
+    .settings-layout {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 20px;
+    }
+  }
+
+  .settings-rail,
+  .nav-rail {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .settings-rail .group-label,
+  .nav-rail .group-label {
+    font: var(--type-caption);
+    color: var(--text-subtle);
+    padding: 18px 12px 6px;
+  }
+
+  .settings-rail > .group-label:first-child,
+  .nav-rail > .group-label:first-child { padding-top: 2px; }
+
+  .settings-rail .rail-item,
+  .nav-rail .rail-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-width: 0;
+    min-height: 36px;
+    padding: 0 12px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    box-shadow: none;
+    font: 500 14px/1.2 var(--font-sans);
+    color: var(--text-body);
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color var(--motion-duration-fast, 120ms) var(--motion-ease-standard, ease),
+      color var(--motion-duration-fast, 120ms) var(--motion-ease-standard, ease);
+  }
+
+  .settings-rail .rail-item:hover,
+  .nav-rail .rail-item:hover {
+    background: var(--surface-muted);
+    color: var(--text-strong);
+  }
+
+  .settings-rail .rail-item.active,
+  .nav-rail .rail-item.active {
+    background: var(--surface-muted);
+    color: var(--text-strong);
+    font-weight: 600;
+  }
+
+  .settings-rail .rail-item:disabled,
+  .nav-rail .rail-item:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .settings-rail .rail-item .tag,
+  .nav-rail .rail-item .tag { margin-left: 8px; }
+
+  .settings-rail .rail-item-icon,
+  .nav-rail .rail-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex: none;
+    color: var(--text-muted);
+  }
+
+  .settings-rail .rail-item:hover .rail-item-icon,
+  .settings-rail .rail-item.active .rail-item-icon,
+  .nav-rail .rail-item:hover .rail-item-icon,
+  .nav-rail .rail-item.active .rail-item-icon { color: var(--text-strong); }
+
+  .settings-rail .rail-item-label,
+  .nav-rail .rail-item-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-rail .rail-item-count,
+  .nav-rail .rail-item-count {
+    margin-left: auto;
+    flex: none;
+    font: 500 11px/1 var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-subtle);
+  }
+
+  .settings-rail .rail-item.active .rail-item-count,
+  .nav-rail .rail-item.active .rail-item-count { color: var(--text-muted); }
+
+  .settings-rail .rail-item-trailing,
+  .nav-rail .rail-item-trailing {
+    margin-left: auto;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Below `lg` the rail becomes a scrolling strip rather than eating the whole
+     first screen before any content appears. */
+  .nav-rail[data-orientation="responsive"] {
+    flex-direction: row;
+    gap: 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .nav-rail[data-orientation="responsive"]::-webkit-scrollbar { display: none; }
+  .nav-rail[data-orientation="responsive"] .rail-item { width: auto; flex: none; }
+  .nav-rail[data-orientation="responsive"] .rail-item-label { overflow: visible; }
+  /* A group heading only reads as one once the rail is a column again. */
+  .nav-rail[data-orientation="responsive"] > .group-label { display: none; }
+
+  @media (min-width: 1024px) {
+    .nav-rail[data-orientation="responsive"] {
+      flex-direction: column;
+      gap: 1px;
+      overflow-x: visible;
+    }
+    .nav-rail[data-orientation="responsive"] .rail-item { width: 100%; }
+    .nav-rail[data-orientation="responsive"] > .group-label { display: block; }
+  }
+
+  /* ── Section tabs ────────────────────────────────────────────────────────
+     The in-page horizontal strip that sits above a section's content, usually
+     beside a rail. Active is strong text over a neutral indicator — not a blue
+     label on a blue rule, which is what six modules had each reinvented. */
+
+  .section-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    /* `flex-end`, not `stretch` — inside a stretched grid row (`.settings-content`
+       is `display: grid`) stretching would tear the active indicator away from
+       its label and leave it floating at the bottom of the row. */
+    align-items: flex-end;
+    align-content: flex-end;
+    gap: 2px;
+    width: 100%;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .section-tabs .section-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    margin-bottom: -1px;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    font: 500 13px/1.2 var(--font-sans);
+    color: var(--text-muted);
+    white-space: nowrap;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      color var(--motion-duration-fast, 120ms) var(--motion-ease-standard, ease),
+      border-color var(--motion-duration-fast, 120ms) var(--motion-ease-standard, ease);
+  }
+
+  .section-tabs .section-tab:hover { color: var(--text-strong); }
+
+  .section-tabs .section-tab.active {
+    color: var(--text-strong);
+    font-weight: 600;
+    border-bottom-color: var(--text-strong);
+  }
+
+  .section-tabs .section-tab svg {
+    width: 16px;
+    height: 16px;
+    flex: none;
+    color: currentColor;
+  }
+
+  .section-tabs .section-tab-count {
+    font: 500 11px/1 var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-subtle);
+  }
 }
 
 /* ── Utility Classes ────────────────────────────────────────────────────── */

--- a/app/gold/import/[id]/_components/studio/import-tabs.tsx
+++ b/app/gold/import/[id]/_components/studio/import-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
 import {
   Dashboard,
   TableRows,
@@ -55,12 +55,11 @@ export function ImportTabRail({
   exceptionCount?: number;
 }) {
   return (
-    <nav
-      aria-label="Import sections"
-      className="flex w-44 shrink-0 flex-col gap-0.5 border-r border-[--border] bg-[--surface-base] p-2"
+    <NavRail
+      label="Import sections"
+      className="w-44 shrink-0 border-r border-[--border] bg-[--surface-base] p-2"
     >
       {TABS.map(({ id, label, icon: Icon }) => {
-        const isActive = id === active;
         const badgeCount =
           id === "ledger" && anomalyCount && anomalyCount > 0
             ? anomalyCount
@@ -69,41 +68,26 @@ export function ImportTabRail({
               : null;
 
         return (
-          <button
+          <NavRailItem
             key={id}
-            type="button"
+            active={id === active}
             onClick={() => onChange(id)}
-            aria-current={isActive ? "page" : undefined}
-            className={cn(
-              // Base: shadcn button-like sizing + typography from the design system
-              "group relative flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-medium transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-              isActive
-                ? // Active: solid surface + primary text + a left accent bar so
-                  // the selection is unmissable across both light and dark
-                  // themes (the previous border-r approach was easy to miss).
-                  "bg-[--action-secondary-bg] text-[--action-primary-bg] shadow-[inset_2px_0_0_0_var(--action-primary-bg)]"
-                : "text-[--text-muted] hover:bg-[--surface-muted] hover:text-[--text-strong]",
-            )}
+            icon={<Icon className="size-4" />}
+            trailing={
+              badgeCount ? (
+                <Badge
+                  variant={id === "exceptions" ? "destructive" : "warning"}
+                  className="h-4 min-w-[1rem] justify-center px-1 text-[10px] tabular-nums"
+                >
+                  {badgeCount > 99 ? "99+" : badgeCount}
+                </Badge>
+              ) : null
+            }
           >
-            <Icon
-              className={cn(
-                "h-4 w-4 shrink-0",
-                isActive ? "" : "text-[--text-subtle] group-hover:text-[--text-muted]",
-              )}
-            />
-            <span className="flex-1 truncate">{label}</span>
-            {badgeCount ? (
-              <Badge
-                variant={id === "exceptions" ? "destructive" : "warning"}
-                className="h-4 min-w-[1rem] justify-center px-1 text-[10px] tabular-nums"
-              >
-                {badgeCount > 99 ? "99+" : badgeCount}
-              </Badge>
-            ) : null}
-          </button>
+            {label}
+          </NavRailItem>
         );
       })}
-    </nav>
+    </NavRail>
   );
 }

--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -324,9 +324,12 @@
   --sidebar-item-fg-muted:      color-mix(in oklab, var(--text-muted) 88%, var(--text-body));
   --sidebar-item-icon:          color-mix(in oklab, var(--text-muted) 78%, var(--text-body));
   --sidebar-item-hover-fg:      var(--text-body);
-  --sidebar-item-active-bg:     var(--brand-soft);
-  --sidebar-item-active-fg:     var(--brand-strong);
-  --sidebar-item-active-border: color-mix(in oklab, var(--brand-300) 50%, var(--border-subtle));
+  /* Selection is marked by a soft neutral fill and a stronger label, not by
+     colour. Brand is the primary-action colour — spending it on "you are here"
+     puts the loudest thing on the page next to every action that matters. */
+  --sidebar-item-active-bg:     var(--sidebar-accent);
+  --sidebar-item-active-fg:     var(--text-strong);
+  --sidebar-item-active-border: transparent;
 
   /* ══════════════════════════════════════════════════════════════════════
      CHARTS

--- a/components/accounting/accounting-shell.tsx
+++ b/components/accounting/accounting-shell.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { PageActions } from "@/components/layout/page-actions";
 import { PageHeading } from "@/components/layout/page-heading";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { ACCOUNTING_CATEGORIES, ACCOUNTING_TABS, type AccountingTab } from "@/lib/accounting/tab-config";
 import { filterAccountingTabsByFeatures } from "@/lib/accounting/visibility";
-import { cn } from "@/lib/utils";
 import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
 
 export type { AccountingTab } from "@/lib/accounting/tab-config";
@@ -63,77 +63,52 @@ export function AccountingShell({
   );
 
   return (
-    <div className="w-full space-y-4">
+    <div className="container mx-auto w-full space-y-4">
       {actions ? <PageActions>{actions}</PageActions> : null}
       <PageHeading
         title={title ?? modulePresentation.title}
         className="mb-2"
       />
 
-      <div className="flex gap-6">
-        {/* Vertical category nav — sidebar-style */}
-        <nav
-          aria-label="Accounting category navigation"
-          className="flex w-[11rem] shrink-0 flex-col gap-0.5"
+      <div className="flex flex-col gap-4 lg:flex-row lg:gap-8">
+        {/* Vertical category nav — same rail as Settings */}
+        <NavRail
+          label="Accounting category navigation"
+          orientation="responsive"
+          className="lg:w-[var(--rail-w)] lg:shrink-0"
         >
           {visibleCategories.map((category) => {
             const categoryTab = visibleTabs.find((tab) => tab.categoryId === category.id);
             if (!categoryTab) return null;
-            const isActive = activeCategoryId === category.id;
             return (
-              <Link
+              <NavRailItem
                 key={category.id}
-                href={categoryTab.href}
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] font-medium transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
-                  "hover:translate-x-[1px] hover:bg-surface-base hover:text-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-                  isActive
-                    ? "bg-surface-base text-[var(--sidebar-item-active-fg)] shadow-popover"
-                    : "text-[var(--sidebar-item-fg-muted)]",
-                )}
+                to={categoryTab.href}
+                active={activeCategoryId === category.id}
+                icon={<category.icon className="size-4" aria-hidden="true" />}
               >
-                <category.icon
-                  className={cn(
-                    "h-4 w-4 shrink-0",
-                    isActive ? "text-[var(--sidebar-item-active-fg)]" : "text-[var(--sidebar-item-icon)]",
-                  )}
-                />
-                <span className="truncate">{category.label}</span>
-              </Link>
+                {category.label}
+              </NavRailItem>
             );
           })}
-        </nav>
+        </NavRail>
 
         {/* Content area */}
         <div className="min-w-0 flex-1 space-y-5">
           {/* Sub-tabs row — horizontal tabs only */}
           {visibleTabsForActiveCategory.length > 1 && (
-            <nav
-              aria-label="Accounting section navigation"
-              className="flex w-full flex-wrap gap-1 border-b border-[var(--edge-subtle)] pb-0"
-            >
-              {visibleTabsForActiveCategory.map((tab) => {
-                const isActive = activeTab === tab.id;
-                return (
-                  <Link
-                    key={tab.id}
-                    href={tab.href}
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "inline-flex items-center gap-2 whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-semibold transition-colors",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-                      isActive
-                        ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                        : "border-transparent text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    <tab.icon className="size-4" />
-                    {tab.label}
-                  </Link>
-                );
-              })}
-            </nav>
+            <SectionTabs label="Accounting section navigation">
+              {visibleTabsForActiveCategory.map((tab) => (
+                <SectionTab
+                  key={tab.id}
+                  to={tab.href}
+                  active={activeTab === tab.id}
+                  icon={<tab.icon aria-hidden="true" />}
+                >
+                  {tab.label}
+                </SectionTab>
+              ))}
+            </SectionTabs>
           )}
 
           {children}

--- a/components/cctv/cctv-shell.tsx
+++ b/components/cctv/cctv-shell.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, type ReactNode } from "react";
 import { useSession } from "next-auth/react";
 
@@ -13,7 +12,7 @@ import {
   Video,
   type LucideIcon,
 } from "@/lib/icons";
-import { cn } from "@/lib/utils";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
 
@@ -85,40 +84,28 @@ export function CCTVShell({
         <Camera />
         <h1 className="font-semibold text-xl">{modulePresentation.title}</h1>
       </div>
-      <nav
-        aria-label="CCTV navigation"
-        className="border-b border-[var(--edge-subtle)]"
+      <SectionTabs
+        label="CCTV navigation"
+        className="flex-nowrap items-end justify-between gap-3 px-2"
       >
-        <div className="flex flex-wrap items-end justify-between gap-3 px-2">
-          <div className="flex flex-wrap gap-1">
-            {visibleTabs.map((tab) => {
-              const isActive = activeTab === tab.id;
-              return (
-                <Link
-                  key={tab.id}
-                  href={tab.href}
-                  aria-current={isActive ? "page" : undefined}
-                  className={cn(
-                    "inline-flex min-h-10 items-center justify-center gap-2 border-b-0 px-3 py-2 text-sm font-medium transition-all",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                    isActive
-                      ? "border-primary border-b-2  text-primary"
-                      : "border-transparent bg-transparent text-muted-foreground hover:bg-[var(--surface-subtle)] hover:text-foreground",
-                  )}
-                >
-                  <tab.icon className="h-4 w-4" />
-                  <span>{tab.label}</span>
-                </Link>
-              );
-            })}
-          </div>
-          {navActions ? (
-            <div className="flex flex-wrap items-center gap-2 py-1">
-              {navActions}
-            </div>
-          ) : null}
-        </div>
-      </nav>
+        <span className="flex flex-wrap items-end gap-0.5">
+          {visibleTabs.map((tab) => (
+            <SectionTab
+              key={tab.id}
+              to={tab.href}
+              active={activeTab === tab.id}
+              icon={<tab.icon aria-hidden="true" />}
+            >
+              {tab.label}
+            </SectionTab>
+          ))}
+        </span>
+        {navActions ? (
+          <span className="flex flex-wrap items-center gap-2 py-1">
+            {navActions}
+          </span>
+        ) : null}
+      </SectionTabs>
 
       {children}
     </div>

--- a/components/gold/gold-shell.tsx
+++ b/components/gold/gold-shell.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useSyncExternalStore, type ReactNode } from "react";
 import { useSession } from "next-auth/react";
 
 import { PageActions } from "@/components/layout/page-actions";
 import { PageHeading } from "@/components/layout/page-heading";
-import { cn } from "@/lib/utils";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { type GoldTab, GOLD_TABS } from "@/lib/gold/tab-config";
 import { filterGoldTabsByFeatures } from "@/lib/gold/visibility";
 import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
-import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 
 type GoldShellProps = {
   activeTab: GoldTab;
@@ -79,33 +77,18 @@ export function GoldShell({
         className="mb-4"
       />
 
-      <nav aria-label="Gold navigation">
-        <Tabs value={activeTab}>
-          <TabsList>
-            {visibleTabs.map((tab) => {
-              const isActive = tab.id === activeTab;
-              return (
-                <TabsTrigger value={tab.id} key={tab.id} asChild>
-                  <Link
-                    href={tab.href}
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "inline-flex items-center justify-center whitespace-nowrap border-b-2 px-3 py-2 text-sm font-semibold transition-colors",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                      isActive
-                        ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                        : "border-transparent text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    <tab.icon className="size-5" />
-                    <span className="ml-2">{modulePresentation.tabLabels?.[tab.id] ?? tab.label}</span>
-                  </Link>
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
-        </Tabs>
-      </nav>
+      <SectionTabs label="Gold navigation">
+        {visibleTabs.map((tab) => (
+          <SectionTab
+            key={tab.id}
+            to={tab.href}
+            active={tab.id === activeTab}
+            icon={<tab.icon aria-hidden="true" />}
+          >
+            {modulePresentation.tabLabels?.[tab.id] ?? tab.label}
+          </SectionTab>
+        ))}
+      </SectionTabs>
 
       <div className="space-y-6">{children}</div>
     </div>

--- a/components/human-resources/hr-shell.tsx
+++ b/components/human-resources/hr-shell.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { PageActions } from "@/components/layout/page-actions";
 import { PageHeading } from "@/components/layout/page-heading";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
-import { cn } from "@/lib/utils";
 import {
   HR_CATEGORIES,
   HR_TABS,
@@ -82,78 +82,51 @@ export function HrShell({
   );
 
   return (
-    <div className="w-full space-y-4">
+    <div className="container mx-auto w-full space-y-4">
       {actions ? <PageActions>{actions}</PageActions> : null}
       <PageHeading
         title={title ?? modulePresentation.title}
         className="mb-2"
       />
 
-      <div className="flex gap-6">
-        <nav
-          aria-label="Human resources category navigation"
-          className="flex w-[11rem] shrink-0 flex-col gap-0.5"
+      <div className="flex flex-col gap-4 lg:flex-row lg:gap-8">
+        <NavRail
+          label="Human resources category navigation"
+          orientation="responsive"
+          className="lg:w-[var(--rail-w)] lg:shrink-0"
         >
           {visibleCategories.map((category) => {
             const categoryTab = visibleTabs.find(
               (tab) => tab.categoryId === category.id,
             );
             if (!categoryTab) return null;
-            const isActive = activeCategoryId === category.id;
             return (
-              <Link
+              <NavRailItem
                 key={category.id}
-                href={categoryTab.href}
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "flex items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] font-medium transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
-                  "hover:translate-x-[1px] hover:bg-surface-base hover:text-text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-                  isActive
-                    ? "bg-surface-base text-[var(--sidebar-item-active-fg)] shadow-popover"
-                    : "text-[var(--sidebar-item-fg-muted)]",
-                )}
+                to={categoryTab.href}
+                active={activeCategoryId === category.id}
+                icon={<category.icon className="size-4" aria-hidden="true" />}
               >
-                <category.icon
-                  className={cn(
-                    "h-4 w-4 shrink-0",
-                    isActive
-                      ? "text-[var(--sidebar-item-active-fg)]"
-                      : "text-[var(--sidebar-item-icon)]",
-                  )}
-                />
-                <span className="truncate">{category.label}</span>
-              </Link>
+                {category.label}
+              </NavRailItem>
             );
           })}
-        </nav>
+        </NavRail>
 
         <div className="min-w-0 flex-1 space-y-5">
           {visibleTabsForActiveCategory.length > 1 && (
-            <nav
-              aria-label="Human resources section navigation"
-              className="flex w-full flex-wrap gap-1 border-b border-[var(--edge-subtle)] pb-0"
-            >
-              {visibleTabsForActiveCategory.map((tab) => {
-                const isActive = activeTab === tab.id;
-                return (
-                  <Link
-                    key={tab.id}
-                    href={tab.href}
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "inline-flex items-center gap-2 whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-semibold transition-colors",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-                      isActive
-                        ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                        : "border-transparent text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    <tab.icon className="size-4" />
-                    {tab.label}
-                  </Link>
-                );
-              })}
-            </nav>
+            <SectionTabs label="Human resources section navigation">
+              {visibleTabsForActiveCategory.map((tab) => (
+                <SectionTab
+                  key={tab.id}
+                  to={tab.href}
+                  active={activeTab === tab.id}
+                  icon={<tab.icon aria-hidden="true" />}
+                >
+                  {tab.label}
+                </SectionTab>
+              ))}
+            </SectionTabs>
           )}
 
           {children}

--- a/components/maintenance/maintenance-shell.tsx
+++ b/components/maintenance/maintenance-shell.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { PageActions } from "@/components/layout/page-actions";
 import { PageHeading } from "@/components/layout/page-heading";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
-import { cn } from "@/lib/utils";
 import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
 import {
   Calendar,
@@ -102,31 +101,18 @@ export function MaintenanceShell({
         className="mb-4"
       />
 
-      <nav
-        aria-label="Maintenance navigation"
-        className="flex w-full flex-wrap justify-start gap-2 border-b border-[var(--edge-subtle)] pb-1"
-      >
-        {visibleTabs.map((tab) => {
-          const isActive = activeTab === tab.id;
-          return (
-            <Link
-              key={tab.id}
-              href={tab.href}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-semibold transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                isActive
-                  ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <tab.icon className="size-5" />
-              <span className="ml-2">{modulePresentation.tabLabels?.[tab.id] ?? tab.label}</span>
-            </Link>
-          );
-        })}
-      </nav>
+      <SectionTabs label="Maintenance navigation">
+        {visibleTabs.map((tab) => (
+          <SectionTab
+            key={tab.id}
+            to={tab.href}
+            active={activeTab === tab.id}
+            icon={<tab.icon aria-hidden="true" />}
+          >
+            {modulePresentation.tabLabels?.[tab.id] ?? tab.label}
+          </SectionTab>
+        ))}
+      </SectionTabs>
 
       {children}
     </div>

--- a/components/preferences/preferences-shell.tsx
+++ b/components/preferences/preferences-shell.tsx
@@ -87,7 +87,7 @@ export function PreferencesShell({
   );
 
   return (
-    <div className="settings-layout w-full">
+    <div className="settings-layout container mx-auto w-full">
       <aside className="settings-rail" aria-label="Preferences navigation">
         <NavGroup label="Account">
           {renderNavItems(accountItems, pathname)}

--- a/components/settings/management-shell.tsx
+++ b/components/settings/management-shell.tsx
@@ -59,7 +59,7 @@ export function ManagementShell({
   const areaLabel = getAreaLabel(area);
 
   return (
-    <div className="settings-layout w-full">
+    <div className="settings-layout container mx-auto w-full">
       <aside className="settings-rail" aria-label="Management navigation">
         <NavGroup label="Settings">
           {visibleModules.map((module) => {

--- a/components/stores/stores-shell.tsx
+++ b/components/stores/stores-shell.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { PageActions } from "@/components/layout/page-actions";
 import { PageHeading } from "@/components/layout/page-heading";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { filterHrefItemsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
-import { cn } from "@/lib/utils";
 import { Fuel, History, Home, Minus, Package, Plus } from "@/lib/icons";
 import type { LucideIcon } from "@/lib/icons";
 import { getWorkspaceModulePresentation } from "@/lib/workspace-products";
@@ -101,31 +100,18 @@ export function StoresShell({
         className="mb-4"
       />
 
-      <nav
-        aria-label="Stores navigation"
-        className="flex w-full flex-wrap justify-start gap-2 border-b border-[var(--edge-subtle)] pb-1"
-      >
-        {visibleTabs.map((tab) => {
-          const isActive = activeTab === tab.id;
-          return (
-            <Link
-              key={tab.id}
-              href={buildHref(tab.href)}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-semibold transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                isActive
-                  ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
-                  : "border-transparent text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <tab.icon className="h-4 w-4" />
-              <span className="ml-2">{modulePresentation.tabLabels?.[tab.id] ?? tab.label}</span>
-            </Link>
-          );
-        })}
-      </nav>
+      <SectionTabs label="Stores navigation">
+        {visibleTabs.map((tab) => (
+          <SectionTab
+            key={tab.id}
+            to={buildHref(tab.href)}
+            active={activeTab === tab.id}
+            icon={<tab.icon aria-hidden="true" />}
+          >
+            {modulePresentation.tabLabels?.[tab.id] ?? tab.label}
+          </SectionTab>
+        ))}
+      </SectionTabs>
 
       {children}
     </div>

--- a/components/ui/nav-rail.tsx
+++ b/components/ui/nav-rail.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Vertical secondary navigation — the one rail every module shares.
+ *
+ * The visual contract lives in `app/styles/components.css` under `.nav-rail`
+ * (aliased by the older `.settings-rail`): a quiet list of labels with a soft
+ * fill for hover and active, no outline, no shadow, no link colour and no
+ * underline. Anything that used to render this as a stack of `<Button>`s or as
+ * bare `<Link>`s picking up the global anchor colour should render these
+ * instead, so the rail in Accounting reads exactly like the rail in Settings.
+ *
+ * Items are anchors when given a `to`, and real buttons when given `onClick` —
+ * client-side view switchers should not be links.
+ */
+
+type NavRailProps = React.ComponentPropsWithoutRef<"nav"> & {
+  /** Accessible name for the rail, e.g. "Accounting category navigation". */
+  label: string;
+  /**
+   * `responsive` collapses the rail into a horizontally scrolling strip below
+   * the `lg` breakpoint instead of stacking full height on small screens.
+   */
+  orientation?: "vertical" | "responsive";
+};
+
+export function NavRail({
+  label,
+  orientation = "vertical",
+  className,
+  children,
+  ...props
+}: NavRailProps) {
+  return (
+    <nav
+      aria-label={label}
+      data-orientation={orientation}
+      className={cn("nav-rail", className)}
+      {...props}
+    >
+      {children}
+    </nav>
+  );
+}
+
+type NavRailGroupProps = {
+  /** Omit for an ungrouped rail — the label row is skipped entirely. */
+  label?: string;
+  children: React.ReactNode;
+};
+
+export function NavRailGroup({ label, children }: NavRailGroupProps) {
+  return (
+    <>
+      {label ? <div className="group-label">{label}</div> : null}
+      {children}
+    </>
+  );
+}
+
+type NavRailItemBaseProps = {
+  active?: boolean;
+  icon?: React.ReactNode;
+  /** Right-aligned count. Rendered muted and tabular, never as a badge. */
+  count?: number;
+  /**
+   * Right-aligned slot for the rare item that needs more than a count — a
+   * severity badge, say. Prefer `count`; a rail of badges is a rail of noise.
+   */
+  trailing?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+};
+
+type NavRailItemProps = NavRailItemBaseProps &
+  (
+    | { to: string; onClick?: never; disabled?: never }
+    | { to?: never; onClick: () => void; disabled?: boolean }
+  );
+
+export function NavRailItem({
+  to,
+  active,
+  icon,
+  count,
+  trailing,
+  className,
+  onClick,
+  disabled,
+  children,
+}: NavRailItemProps) {
+  const inner = (
+    <>
+      {icon ? (
+        <span className="rail-item-icon" aria-hidden="true">
+          {icon}
+        </span>
+      ) : null}
+      <span className="rail-item-label">{children}</span>
+      {typeof count === "number" ? (
+        <span className="rail-item-count">{count}</span>
+      ) : null}
+      {trailing ? <span className="rail-item-trailing">{trailing}</span> : null}
+    </>
+  );
+
+  const classes = cn("rail-item", active && "active", className);
+
+  if (to) {
+    return (
+      <Link
+        href={to}
+        className={classes}
+        aria-current={active ? "page" : undefined}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      onClick={onClick}
+      disabled={disabled}
+      aria-current={active ? "true" : undefined}
+    >
+      {inner}
+    </button>
+  );
+}

--- a/components/ui/section-tabs.tsx
+++ b/components/ui/section-tabs.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * In-page horizontal tab strip — the row that sits above a section's content,
+ * usually next to a {@link NavRail}.
+ *
+ * Styling lives in `app/styles/components.css` under `.section-tabs`. The
+ * active tab is strong text over a neutral rule; it is deliberately not the
+ * brand colour, which is reserved for primary actions. Modules used to inline
+ * their own `border-b-2 border-[var(--action-primary-bg)] text-[…]` variant of
+ * this, which is why every one of them drifted.
+ */
+
+type SectionTabsProps = React.ComponentPropsWithoutRef<"nav"> & {
+  /** Accessible name, e.g. "Accounting section navigation". */
+  label: string;
+};
+
+export function SectionTabs({
+  label,
+  className,
+  children,
+  ...props
+}: SectionTabsProps) {
+  return (
+    <nav aria-label={label} className={cn("section-tabs", className)} {...props}>
+      {children}
+    </nav>
+  );
+}
+
+type SectionTabBaseProps = {
+  active?: boolean;
+  icon?: React.ReactNode;
+  count?: number;
+  className?: string;
+  children: React.ReactNode;
+};
+
+type SectionTabProps = SectionTabBaseProps &
+  (
+    | { to: string; onClick?: never; disabled?: never }
+    | { to?: never; onClick: () => void; disabled?: boolean }
+  );
+
+export function SectionTab({
+  to,
+  active,
+  icon,
+  count,
+  className,
+  onClick,
+  disabled,
+  children,
+}: SectionTabProps) {
+  const inner = (
+    <>
+      {icon}
+      <span>{children}</span>
+      {typeof count === "number" ? (
+        <span className="section-tab-count">{count}</span>
+      ) : null}
+    </>
+  );
+
+  const classes = cn("section-tab", active && "active", className);
+
+  if (to) {
+    return (
+      <Link
+        href={to}
+        className={classes}
+        aria-current={active ? "page" : undefined}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      onClick={onClick}
+      disabled={disabled}
+      aria-current={active ? "true" : undefined}
+    >
+      {inner}
+    </button>
+  );
+}

--- a/components/ui/settings-rail.tsx
+++ b/components/ui/settings-rail.tsx
@@ -1,21 +1,21 @@
 "use client";
 
 import * as React from "react";
-import Link from "next/link";
 
-import { cn } from "@/lib/utils";
+import { NavRailGroup, NavRailItem } from "@/components/ui/nav-rail";
 
 /**
  * Settings-rail navigation.
  *
- * `@corelithzw/react` ships the CSS for this surface — `.settings-rail`,
- * `.group-label`, `.rail-item` and `.rail-item.active` — but exports no React
- * component for it (there is no `NavGroup`/`NavItem` in the package; see the
- * export list in `dist/index.d.ts`). Rather than forking a design-system
- * component, these two render the package's markup contract directly, so the
- * styling still comes entirely from the package.
+ * This is now a thin alias over `components/ui/nav-rail.tsx`, which owns the
+ * markup contract (`.rail-item`, `.group-label`) that `.settings-rail` and
+ * `.nav-rail` share. Settings and Preferences keep calling `NavGroup`/`NavItem`
+ * because that is the design system's nav API naming; every other module uses
+ * `NavRail`/`NavRailItem` directly.
  *
- * Drop these in favour of the real exports if a future release ships them.
+ * `@corelithzw/react` still exports no React component for this surface (there
+ * is no `NavGroup`/`NavItem` in `dist/index.d.ts`), only the CSS — drop this
+ * file in favour of the real exports if a future release ships them.
  */
 
 type NavGroupProps = {
@@ -24,12 +24,7 @@ type NavGroupProps = {
 };
 
 export function NavGroup({ label, children }: NavGroupProps) {
-  return (
-    <>
-      <div className="group-label">{label}</div>
-      {children}
-    </>
-  );
+  return <NavRailGroup label={label}>{children}</NavRailGroup>;
 }
 
 type NavItemProps = {
@@ -42,15 +37,8 @@ type NavItemProps = {
 
 export function NavItem({ to, active, icon, children }: NavItemProps) {
   return (
-    <Link
-      href={to}
-      className={cn("rail-item", active && "active")}
-      aria-current={active ? "page" : undefined}
-    >
-      {icon ? (
-        <span className="mr-2 inline-flex shrink-0 items-center">{icon}</span>
-      ) : null}
+    <NavRailItem to={to} active={active} icon={icon}>
       {children}
-    </Link>
+    </NavRailItem>
   );
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -15,7 +15,7 @@ const TabsList = React.forwardRef<
     ref={ref}
     data-slot="tabs-list"
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-[12px] border border-[var(--border-default)] bg-muted p-1 text-muted-foreground shadow-none",
+      "inline-flex h-9 max-w-full items-center gap-1 overflow-x-auto rounded-[10px] bg-[var(--surface-muted)] p-1 text-[var(--text-muted)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
       className,
     )}
     {...props}
@@ -34,10 +34,12 @@ const TabsTrigger = React.forwardRef<
     asChild={asChild}
     data-slot="tabs-trigger"
     className={cn(
-      "inline-flex h-7 items-center justify-center whitespace-nowrap rounded-[10px] border border-transparent px-3 text-sm font-medium transition-[background-color,color,border-color,box-shadow] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-default)]",
+      "inline-flex h-7 shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[7px] px-3 text-[13px] font-medium transition-[background-color,color] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-default)]",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-offset-0",
+      "hover:text-[var(--text-strong)]",
       "disabled:pointer-events-none disabled:opacity-50",
-      "data-[state=active]:border-[var(--border-default)] data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-[var(--button-shadow-rest)]",
+      "data-[state=active]:bg-[var(--surface)] data-[state=active]:font-semibold data-[state=active]:text-[var(--text-strong)] data-[state=active]:shadow-[var(--shadow-rest)]",
+      "[&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/components/ui/vertical-data-views.tsx
+++ b/components/ui/vertical-data-views.tsx
@@ -1,7 +1,8 @@
+"use client";
+
 import * as React from "react";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
 import { cn } from "@/lib/utils";
 
 export type VerticalDataViewItem = {
@@ -20,6 +21,14 @@ type VerticalDataViewsProps = {
   children: React.ReactNode;
 };
 
+/**
+ * A view switcher rendered as the shared nav rail.
+ *
+ * These were `<Button>`s carrying a border and a pill radius, so a list of
+ * views read as a column of controls rather than as navigation. They are now
+ * the same quiet rail Settings uses, and counts sit at the right as plain
+ * tabular text instead of outlined badges.
+ */
 export function VerticalDataViews({
   items,
   value,
@@ -28,44 +37,31 @@ export function VerticalDataViews({
   railLabel = "Views",
   children,
 }: VerticalDataViewsProps) {
+  const accessibleLabel = typeof railLabel === "string" ? railLabel : "Views";
+
   return (
     <section
-      className={cn("grid gap-4 lg:grid-cols-[210px_minmax(0,1fr)]", className)}
+      className={cn(
+        "grid gap-4 lg:grid-cols-[var(--rail-w)_minmax(0,1fr)]",
+        className,
+      )}
     >
-      <aside className="space-y-2 lg:sticky lg:top-16 lg:self-start">
-        <h3 className="px-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">
-          {railLabel}
-        </h3>
-        <div className="-mx-1 overflow-x-auto pb-1 lg:mx-0 lg:overflow-visible lg:pb-0">
-          <div className="flex gap-2 px-1 lg:grid lg:gap-1.5 lg:px-0">
+      <aside className="lg:sticky lg:top-16 lg:self-start">
+        <NavRail label={accessibleLabel} orientation="responsive">
+          {railLabel ? <div className="group-label">{railLabel}</div> : null}
           {items.map((item) => (
-            <Button
+            <NavRailItem
               key={item.id}
-              type="button"
-              variant="ghost"
-              className={cn(
-                "h-11 min-w-fit justify-between rounded-full border border-transparent px-3.5 text-[13px] shadow-none lg:h-10 lg:w-full lg:rounded-xl",
-                item.id === value
-                  ? "border-[var(--edge-subtle)] bg-[var(--surface-subtle)] text-[var(--text-strong)] hover:bg-[var(--surface-subtle)]"
-                  : "text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] hover:text-[var(--text-strong)]",
-              )}
+              active={item.id === value}
+              count={item.count}
               onClick={() => onValueChange(item.id)}
             >
-              <span className="truncate text-left">{item.label}</span>
-              {typeof item.count === "number" ? (
-                <Badge
-                  variant={item.id === value ? "secondary" : "outline"}
-                  className="rounded-full px-2 py-0 font-mono text-[10px]"
-                >
-                  {item.count}
-                </Badge>
-              ) : null}
-            </Button>
+              {item.label}
+            </NavRailItem>
           ))}
-          </div>
-        </div>
+        </NavRail>
       </aside>
-      <div className="space-y-2.5">{children}</div>
+      <div className="min-w-0 space-y-2.5">{children}</div>
     </section>
   );
 }


### PR DESCRIPTION
Every module had reinvented its own vertical nav and in-page tab row, and they had drifted apart. The Settings rail was already right — this makes it the only answer.

## What was wrong

- **Accounting / HR rails** rendered outlined, shadowed rows with brand-blue labels (`bg-surface-base … text-[var(--sidebar-item-active-fg)] shadow-popover`).
- **`VerticalDataViews`** was a column of bordered `<Button variant="ghost">`s with pill radii and outlined count badges — a list of views reading as a stack of controls.
- **Six modules** each inlined their own `border-b-2 border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]` sub-tab, so the active tab was a blue label on a blue rule.
- **Gold** wrapped underline tabs *inside* a segmented `TabsList` pill — two tab styles stacked on one row.
- **The Gold import rail** marked selection with a brand accent bar and brand text.
- The design system paints every `<a>` `--text-link` (blue) and underlines it on hover, so rails, tabs and table cells all read as hyperlinks.

## Changes

**New primitives**
- `components/ui/nav-rail.tsx` — `NavRail` / `NavRailGroup` / `NavRailItem`. Items are anchors when given a `to` and real `<button>`s when given an `onClick`; a client-side view switcher should not be a link.
- `components/ui/section-tabs.tsx` — `SectionTabs` / `SectionTab` for the in-page horizontal strip.
- `components/ui/settings-rail.tsx` becomes a thin alias so Settings and Preferences keep their `NavGroup`/`NavItem` naming.

**Where the CSS lives**
The `app/styles/*.css` files are not imported anywhere — the live CSS ships from `@corelithzw/react` into `@layer corelith`. The new rules go in `@layer app` in `globals.css`, the layer that outranks it, while Tailwind utilities still win over both.

**Selection is neutral, not coloured**
Hover and active share one soft fill and are separated by the weight of the label. Brand is the primary-action colour; spending it on "you are here" put the loudest thing on the page next to every action that matters. Same change applied to `--sidebar-item-active-*` for the primary sidebar.

**Links**
Anchors inherit their surrounding colour and drop the hover underline. Prose links, `.btn-link` and table id links keep their underline — declared after the reset, each selector outranking it — so running text still satisfies WCAG 1.4.1 without recolouring the app. `.link` opts in to the accent.

**Tabs**
Radix tabs rebuilt as a clean segmented control: muted track, no borders anywhere, active is a raised surface with a hairline shadow.

**Spacing**
`.settings-layout` no longer stacks `32px 64px` on top of the frame's own `--content-gutter-x` and `py-6` — that is what pushed the rail a couple of inches off the edge. Shells carrying a secondary sidebar use `container mx-auto`.

**Responsive**
Below `lg` the rails collapse into a horizontally scrolling strip instead of eating the whole first screen before any content appears.

## Call-outs

- Table id links (`.dtable .id-link`) lose their brand colour and now signal with a hover underline only. That follows from "links must not be coloured" but it is a design-system component that was not named directly — easy to restore if you want it kept.
- `--motion-duration-fast` / `--motion-ease-standard` are referenced across the app but defined nowhere, so those transitions silently no-op. The new rules pass fallbacks; the pre-existing uses are untouched.

## Verification

- `npx tsc --noEmit` — clean (one pre-existing failure in `lib/platform/role-consistency.test.ts`, unrelated).
- `npx eslint` on the diff — 0 errors (4 pre-existing `description is unused` warnings).
- `npx next build` — compiles successfully.
- Rendered the compiled stylesheet in Chromium and probed computed styles: rail matches the reference, active tab indicator hugs its label, segmented control shows the raised active pill, and prose / `.btn-link` / id-link underlines all survive the reset while nav links do not.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM7fHSF4cT5nxSbJNoh9F)_