### PR TITLE
Carry the quiet rail into the primary sidebar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -247,9 +247,13 @@
     text-underline-offset: 3px;
   }
 
-  p a:not(.btn):not(.badge):not(.tag),
-  li a:not(.btn):not(.badge):not(.tag),
-  .lede a:not(.btn):not(.badge):not(.tag) {
+  /* `:not([class])`, not the package's `:not(.btn):not(.badge):not(.tag)`.
+     Menus are `<ul><li><a>`, so the looser selector underlined every item in
+     the app sidebar — the links this rule is for are the unstyled ones inside
+     running text, and those never carry a class. */
+  p a:not([class]),
+  li a:not([class]),
+  .lede a:not([class]) {
     text-decoration: underline;
     text-decoration-thickness: 1px;
     text-underline-offset: 2px;

--- a/components/admin-portal/shell/admin-sidebar.tsx
+++ b/components/admin-portal/shell/admin-sidebar.tsx
@@ -55,15 +55,15 @@ export function AdminSidebar({
                   href={item.href}
                   onClick={onNavigate}
                   className={cn(
-                    "group flex min-h-11 items-center gap-3 rounded-[10px] border border-transparent px-3 py-2 text-[var(--sidebar-item-fg-muted)] transition-[background-color,color,transform,box-shadow] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] lg:min-h-10",
+                    "group flex min-h-11 items-center gap-3 rounded-[8px] px-3 py-2 text-[var(--sidebar-item-fg-muted)] transition-[background-color,color] duration-[var(--motion-duration-fast,120ms)] ease-[var(--motion-ease-standard,ease)] lg:min-h-10",
                     isActive
-                      ? "border-[var(--sidebar-item-active-border)] bg-[var(--sidebar-item-active-bg)] text-[var(--sidebar-item-active-fg)] shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]"
-                      : "hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)]",
+                      ? "bg-[var(--sidebar-item-active-bg)] text-[var(--sidebar-item-active-fg)]"
+                      : "hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)]",
                   )}
                 >
                   <div
                     className={cn(
-                      "flex shrink-0 items-center justify-center rounded-[10px] border border-transparent transition-colors duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
+                      "flex shrink-0 items-center justify-center transition-colors duration-[var(--motion-duration-fast,120ms)] ease-[var(--motion-ease-standard,ease)]",
                       isActive
                         ? "text-[var(--sidebar-item-active-fg)]"
                         : "text-[var(--sidebar-item-icon)]",

--- a/components/admin-portal/shell/workspace-switcher.tsx
+++ b/components/admin-portal/shell/workspace-switcher.tsx
@@ -61,8 +61,8 @@ export function WorkspaceSwitcher({ activeCompanyId, companies }: Props) {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
-          className="group/switcher h-11 w-full justify-between rounded-[10px] bg-[var(--surface-base)] px-2.5 text-left text-[var(--sidebar-item-fg-muted)] shadow-none transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)] data-[state=open]:border-[var(--sidebar-item-active-border)] data-[state=open]:bg-[var(--sidebar-item-active-bg)] data-[state=open]:text-[var(--sidebar-item-active-fg)] lg:h-10"
+          variant="ghost"
+          className="group/switcher h-11 w-full justify-between rounded-[8px] border-0 bg-transparent px-2.5 text-left text-[var(--sidebar-item-fg-muted)] shadow-none transition-[background-color,color] duration-[var(--motion-duration-fast,120ms)] ease-[var(--motion-ease-standard,ease)] hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)] data-[state=open]:bg-[var(--sidebar-item-active-bg)] data-[state=open]:text-[var(--sidebar-item-active-fg)] lg:h-10"
         >
           <span className="flex min-w-0 items-center gap-2.5 text-left">
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] bg-[#1f1c18] text-[10px] font-semibold text-white">

--- a/components/layout/app-sidebar/sidebar-account-menu.tsx
+++ b/components/layout/app-sidebar/sidebar-account-menu.tsx
@@ -47,12 +47,7 @@ export function SidebarAccountMenu({
             <DropdownMenuTrigger asChild>
               <SidebarMenuButton
                 tooltip="Workspace"
-                className={cn(
-                  "h-11 min-w-0 rounded-xl border border-[var(--edge-subtle)]/70 px-2.5 text-[14px] font-semibold text-[var(--sidebar-item-fg)] lg:h-10",
-                  "transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
-                  "hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)]",
-                  "data-[active=true]:border-[var(--sidebar-item-active-border)] data-[active=true]:bg-[var(--sidebar-item-active-bg)] data-[active=true]:text-[var(--sidebar-item-active-fg)]",
-                )}
+                className="h-11 min-w-0 px-2.5 font-semibold text-[var(--sidebar-item-fg)] lg:h-10"
               >
                 <div className="inline-flex size-6 shrink-0 items-center justify-center rounded-[8px] bg-[#1b1d23] text-white transition-transform duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]">
                   <WorkspaceIcon className="h-4 w-4" />

--- a/components/layout/app-sidebar/sidebar-nav-sections.tsx
+++ b/components/layout/app-sidebar/sidebar-nav-sections.tsx
@@ -44,13 +44,7 @@ function SidebarNavLink({
         size="sm"
         isActive={isActive}
         tooltip={item.label}
-        className={cn(
-          "h-11 rounded-[10px] border-transparent! px-2.5 text-[14px] font-medium lg:h-9",
-          "text-text-muted transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)]",
-          "hover:translate-x-[1px] hover:bg-surface-base hover:text-text-strong",
-          "data-[active=true]:bg-surface-base data-[active=true]:text-[var(--sidebar-item-active-fg)] data-[active=true]:shadow-popover",
-          className,
-        )}
+        className={cn("h-11 px-2.5 lg:h-9", className)}
       >
         <Link
           href={item.href}
@@ -146,10 +140,7 @@ function SidebarExpandableSection({
               onClick={onToggle}
               isActive={hasActiveChild}
               tooltip={section.title}
-              className={cn(
-                "h-11 rounded-[10px] px-2.5 lg:h-9 bg-transparent shadow-none!",
-                "text-[14px] font-medium text-[var(--sidebar-item-fg-muted)] transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px]",
-              )}
+              className="h-11 bg-transparent px-2.5 lg:h-9"
             >
               {React.createElement(sectionIcon, {
                 className: cn(
@@ -182,7 +173,7 @@ function SidebarExpandableSection({
         >
           <div className="overflow-hidden">
             <SidebarGroupContent className="mt-0 pl-4 pr-0.5">
-              <SidebarMenu className="relative ml-2 gap-1 border-l border-[var(--edge-subtle)] pl-2.5">
+              <SidebarMenu className="relative ml-2 gap-1 pl-2.5">
                 {section.items.map((item) => (
                   <SidebarNavLink
                     key={item.href}
@@ -219,7 +210,7 @@ export function SidebarHomeLink({
               asChild
               isActive={isActive}
               tooltip={label}
-              className="h-11 rounded-[10px] border border-[var(--edge-subtle)]/70 px-2.5 text-[14px] font-medium text-[var(--sidebar-item-fg-muted)] transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)] data-[active=true]:border-[var(--sidebar-item-active-border)] data-[active=true]:bg-[var(--sidebar-item-active-bg)] data-[active=true]:text-[var(--sidebar-item-active-fg)] data-[active=true]:shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)] lg:h-9"
+              className="h-11 px-2.5 lg:h-9"
             >
               <Link
                 href={href}

--- a/components/layout/app-sidebar/sidebar-quick-actions.tsx
+++ b/components/layout/app-sidebar/sidebar-quick-actions.tsx
@@ -59,12 +59,7 @@ export function SidebarQuickActions({
                     asChild
                     isActive={isActive}
                     tooltip={item.label}
-                    className={cn(
-                      "h-11 rounded-[10px] border border-[var(--edge-subtle)]/70 px-2.5 text-[14px] font-medium text-[var(--sidebar-item-fg-muted)] lg:h-9",
-                      "transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)] hover:shadow-none",
-                      "hover:text-[var(--sidebar-item-hover-fg)]",
-                      "data-[active=true]:border-[var(--sidebar-item-active-border)] data-[active=true]:bg-[var(--sidebar-item-active-bg)] data-[active=true]:text-[var(--sidebar-item-active-fg)] data-[active=true]:shadow-[inset_0_0_0_1px_var(--sidebar-item-active-border)]",
-                    )}
+                    className="h-11 px-2.5 lg:h-9"
                   >
                     <Link href={item.href} onClick={closeMobileNav}>
                       <item.icon
@@ -84,10 +79,8 @@ export function SidebarQuickActions({
                         <SidebarMenuButton
                           tooltip="Create"
                           className={cn(
-                            "h-11 rounded-[10px] border border-[var(--edge-subtle)]/70 px-2.5 text-[14px] font-medium text-[var(--sidebar-item-fg-muted)] lg:h-9",
-                            "transition-[background-color,color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)]",
-                            "hover:text-[var(--sidebar-item-hover-fg)]",
-                            "data-[state=open]:border-[var(--sidebar-item-active-border)] data-[state=open]:bg-[var(--sidebar-item-active-bg)] data-[state=open]:text-[var(--sidebar-item-active-fg)]",
+                            "h-11 px-2.5 lg:h-9",
+                            "data-[state=open]:bg-[var(--sidebar-item-active-bg)] data-[state=open]:text-[var(--sidebar-item-active-fg)]",
                           )}
                         >
                           <MedusaCirclePlusIcon className="h-4 w-4" />

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -241,7 +241,7 @@ const SidebarGroup = React.forwardRef<
   <div
     ref={ref}
     data-sidebar="group"
-    className={cn("rounded-[18px] border border-transparent", className)}
+    className={cn("rounded-[8px]", className)}
     {...props}
   />
 ));
@@ -302,8 +302,14 @@ const SidebarMenuItem = React.forwardRef<
 ));
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
+/**
+ * A sidebar row is navigation, not a control. It carries no outline and no
+ * shadow, and it does not shift on hover — hover and active are the same soft
+ * fill, separated by the weight of the label. This is the same contract as
+ * `.rail-item` in globals.css; the two surfaces should read identically.
+ */
 const sidebarMenuButtonVariants = cva(
-  "relative flex w-full items-center gap-2.5 rounded-[12px] border border-transparent px-2.5 py-2 text-[14px] font-medium text-sidebar-foreground/76 transition-[color,background-color,box-shadow,border-color,transform] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] hover:translate-x-[1px] hover:bg-[var(--sidebar-accent)] hover:text-foreground hover:shadow-none data-[active=true]:border-[var(--edge-default)] data-[active=true]:border-px data-[active=true]:bg-[var(--action-secondary-bg)] data-[active=true]:text-foreground data-[active=true]:shadow-[inset_0_0_0_1px_var(--edge-default)] data-[collapsed=true]:mx-auto data-[collapsed=true]:h-10 data-[collapsed=true]:w-10 data-[collapsed=true]:justify-center data-[collapsed=true]:px-0 data-[collapsed=true]:py-0 data-[collapsed=true]:[&_span]:hidden [&_svg]:shrink-0",
+  "relative flex w-full items-center gap-2.5 rounded-[8px] border-0 px-2.5 py-2 text-[14px] font-medium text-[var(--sidebar-item-fg-muted)] shadow-none transition-[color,background-color] duration-[var(--motion-duration-fast,120ms)] ease-[var(--motion-ease-standard,ease)] hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-item-hover-fg)] hover:shadow-none data-[active=true]:bg-[var(--sidebar-item-active-bg)] data-[active=true]:font-semibold data-[active=true]:text-[var(--sidebar-item-active-fg)] data-[collapsed=true]:mx-auto data-[collapsed=true]:h-10 data-[collapsed=true]:w-10 data-[collapsed=true]:justify-center data-[collapsed=true]:px-0 data-[collapsed=true]:py-0 data-[collapsed=true]:[&_span]:hidden [&_svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Follow-up to #127, which fixed the secondary rails and left the app sidebar as it was. It is the same surface and it had the same problems — plus one that #127 introduced.

## The outlines

Two things were drawing them:

1. The quick actions (Overview, Create), the home link and the workspace switcher each carried a literal `border border-[var(--edge-subtle)]/70`, so every row read as a control rather than a destination.
2. `sidebarMenuButtonVariants` layered a second box on the active row — a border, an inset ring, *and* `shadow-popover`, a drop shadow sized for a floating panel sitting on a 36px nav item.

## The underline

That one was mine. #127 carried over the design system's prose rule with its `:not(.btn):not(.badge):not(.tag)` guard. A menu is `<ul><li><a>`, so `li a:not(.btn):not(.badge):not(.tag)` matched every sidebar link and underlined it — which is exactly what showed up on "Overview".

Scoped to `:not([class])` instead. The links that rule exists for are the unstyled ones inside running text, and those never carry a class.

## Changes

- **`sidebarMenuButtonVariants`** loses every border and shadow. Hover and active are one soft fill separated by the weight of the label — the same contract as `.rail-item`, at the same 8px radius. The `hover:translate-x-[1px]` nudge goes with them, so rows no longer twitch under the cursor.
- **Rows stop hand-rolling** their own colours, borders and shadows and now just set their height, so the variant is the single place this surface is described. That also removes the `border-transparent!` override someone had already needed to add.
- **Admin portal sidebar** and its workspace switcher get the same pass.
- **`border-l` guide** on expanded sub-items dropped; the indent already carries the hierarchy.

## Verification

- `npx tsc --noEmit` — clean (same pre-existing `role-consistency.test.ts` failure, unrelated).
- `npx eslint` on the diff — 0 errors.
- `npx next build` — compiles successfully.
- Rendered the resolved class strings against the compiled stylesheet in Chromium and read computed styles:
  - no border or shadow on any row, active or not;
  - classed links never underline, at rest or on hover;
  - unstyled links in `<p>` and `<li>` still underline, and table id links still underline on hover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM7fHSF4cT5nxSbJNoh9F)_