### PR TITLE
fix(crm,ui): repair the CRM's broken data layer, styling and dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ zz-probe3.mjs
 zz-probe4.mjs
 zz-probe5.mjs
 zz-probe6.mjs
+zz-probe7.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -50,13 +50,6 @@ next-env.d.ts
 .codex
 .claude
 
-# local-only scratch seed (not part of the repo)
-scripts/zz-local-seed.ts
-zz-probe.mjs
-zz-t.ts
-zz-probe2.mjs
-zz-probe3.mjs
-zz-probe4.mjs
-zz-probe5.mjs
-zz-probe6.mjs
-zz-probe7.mjs
+# Local-only scratch: seeds and browser probes used while verifying a change.
+zz-*
+scripts/zz-*

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ next-env.d.ts
 .vercel
 .codex
 .claude
+
+# local-only scratch seed (not part of the repo)
+scripts/zz-local-seed.ts
+zz-probe.mjs
+zz-t.ts
+zz-probe2.mjs
+zz-probe3.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ zz-probe.mjs
 zz-t.ts
 zz-probe2.mjs
 zz-probe3.mjs
+zz-probe4.mjs
+zz-probe5.mjs
+zz-probe6.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 ## Design System & UX Playbook (Required)
 - For every implementation, read `docs/design-system/README.md` first, then read the relevant files in `docs/design-system/` before changing code. These docs contain the canonical design-system setup, tokens, components, composition patterns, rules, reference URLs, and repo migration guidance.
 - Follow `docs/ux/platform-ux-playbook.md` for all UX/UI changes.
+- `docs/design-system/08-cookbook-patterns.md` carries the distilled cookbook recipes — dashboards, kanban, filterable tables, command palette, grouped lists, save bar, and the table→cards rule for mobile. Read it before building any of those shapes; it saves fetching the site.
 - Treat design-system and playbook rules as default system behavior unless a task explicitly overrides them.
 - Key non-negotiables:
   - One table per active view; use vertical tabs for multi-table contexts.

--- a/app/api/v2/crm/dashboard/route.ts
+++ b/app/api/v2/crm/dashboard/route.ts
@@ -1,0 +1,284 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { hasCrmFullAccess } from "@/lib/crm/scope";
+import { ageingBucket } from "@/lib/crm/collections";
+import { ensureDefaultPipeline } from "@/lib/crm/pipelines";
+
+/**
+ * Everything the CRM home needs, in one round trip.
+ *
+ * The old summary answered three questions — open leads, weighted pipeline,
+ * overdue follow-ups — and ignored deals, quotes, invoices, work orders and
+ * site visits entirely. Someone opening the module could not tell whether
+ * anything needed them today. This answers the whole lifecycle: what is in
+ * flight, what is owed to a customer, what is owed to us, and what is booked.
+ *
+ * Deltas are computed against a single "previous period" boundary here rather
+ * than in each caller, so the dashboard and the report cannot disagree.
+ */
+
+/** A rep sees their own numbers; a manager sees the team's. */
+function ownerScope(userId: string, isManager: boolean) {
+  return isManager ? {} : { assignedToId: userId };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const companyId = session.user.companyId;
+    const isManager = hasCrmFullAccess(session.user.role);
+    const scope = ownerScope(session.user.id, isManager);
+
+    const now = new Date();
+    const startOfToday = new Date(now);
+    startOfToday.setHours(0, 0, 0, 0);
+    const endOfToday = new Date(startOfToday);
+    endOfToday.setDate(endOfToday.getDate() + 1);
+    const periodDays = 30;
+    const periodStart = new Date(now.getTime() - periodDays * 24 * 3600 * 1000);
+    const previousStart = new Date(now.getTime() - 2 * periodDays * 24 * 3600 * 1000);
+    const weekAhead = new Date(now.getTime() + 7 * 24 * 3600 * 1000);
+
+    // A company always has at least the default pipeline; the board, the deal
+    // form and this dashboard all assume one exists.
+    await prisma.$transaction((tx) => ensureDefaultPipeline(tx, companyId));
+
+    const [
+      openDeals,
+      wonThisPeriod,
+      wonPreviousPeriod,
+      lostThisPeriod,
+      stages,
+      taskCounts,
+      legacyOverdue,
+      quotations,
+      openInvoices,
+      workOrders,
+      upcomingVisits,
+      pendingApprovals,
+    ] = await Promise.all([
+      prisma.crmDeal.findMany({
+        where: { companyId, status: "OPEN", archivedAt: null, ...scope },
+        select: {
+          id: true,
+          value: true,
+          probability: true,
+          stageId: true,
+          stageEnteredAt: true,
+          expectedCloseDate: true,
+          stage: { select: { id: true, name: true, position: true, inactivityDays: true } },
+        },
+      }),
+
+      prisma.crmDeal.aggregate({
+        where: { companyId, wonAt: { gte: periodStart }, ...scope },
+        _count: { _all: true },
+        _sum: { value: true },
+      }),
+      prisma.crmDeal.aggregate({
+        where: { companyId, wonAt: { gte: previousStart, lt: periodStart }, ...scope },
+        _count: { _all: true },
+        _sum: { value: true },
+      }),
+      prisma.crmDeal.count({
+        where: { companyId, lostAt: { gte: periodStart }, ...scope },
+      }),
+
+      prisma.crmPipelineStage.findMany({
+        where: { pipeline: { companyId, isDefault: true }, archivedAt: null },
+        select: { id: true, name: true, position: true, status: true },
+        orderBy: { position: "asc" },
+      }),
+
+      prisma.crmTask.groupBy({
+        by: ["status"],
+        where: { companyId, ...(isManager ? {} : { assignedToId: session.user.id }) },
+        _count: { _all: true },
+      }),
+
+      prisma.crmFollowUp.count({
+        where: {
+          companyId,
+          status: "PENDING",
+          dueAt: { lt: now },
+          ...(isManager ? {} : { assignedToId: session.user.id }),
+        },
+      }),
+
+      prisma.crmLeadDocument.findMany({
+        where: { companyId, type: "QUOTATION", createdAt: { gte: periodStart } },
+        select: {
+          id: true,
+          amount: true,
+          currency: true,
+          // A quotation's state lives on its approval record, not the document.
+          approval: { select: { status: true } },
+        },
+      }),
+
+      prisma.salesInvoice.findMany({
+        where: {
+          companyId,
+          status: { notIn: ["PAID", "VOIDED"] },
+          // Only invoices that came out of the CRM belong on the CRM's home.
+          quotationId: { not: null },
+        },
+        select: { id: true, total: true, amountPaid: true, dueDate: true, currency: true },
+      }),
+
+      prisma.crmWorkOrder.groupBy({
+        by: ["status"],
+        where: { companyId },
+        _count: { _all: true },
+      }),
+
+      prisma.crmAppointment.count({
+        where: {
+          companyId,
+          status: "SCHEDULED",
+          scheduledStart: { gte: now, lte: weekAhead },
+          ...(isManager ? {} : { assignedToId: session.user.id }),
+        },
+      }),
+
+      prisma.crmDiscountApproval.count({
+        where: { companyId, status: "PENDING" },
+      }),
+    ]);
+
+    const grossValue = openDeals.reduce((sum, deal) => sum + (deal.value ?? 0), 0);
+    const weightedValue = openDeals.reduce(
+      (sum, deal) => sum + ((deal.value ?? 0) * (deal.probability ?? 0)) / 100,
+      0,
+    );
+
+    // "Stale" is the stage's own inactivity budget, not a global number — a
+    // deal can sit in Quoted for a fortnight and be fine, but three days in New
+    // is not.
+    const stale = openDeals.filter((deal) => {
+      const days = deal.stage.inactivityDays;
+      if (!days) return false;
+      return now.getTime() - deal.stageEnteredAt.getTime() > days * 24 * 3600 * 1000;
+    });
+
+    const closingThisWeek = openDeals.filter(
+      (deal) => deal.expectedCloseDate && deal.expectedCloseDate <= weekAhead,
+    );
+
+    const byStage = stages.map((stage) => {
+      const deals = openDeals.filter((deal) => deal.stageId === stage.id);
+      return {
+        id: stage.id,
+        name: stage.name,
+        status: stage.status,
+        count: deals.length,
+        value: deals.reduce((sum, deal) => sum + (deal.value ?? 0), 0),
+      };
+    });
+
+    const taskByStatus = Object.fromEntries(
+      taskCounts.map((row) => [row.status, row._count._all]),
+    ) as Record<string, number>;
+
+    const [tasksOverdue, tasksToday] = await Promise.all([
+      prisma.crmTask.count({
+        where: {
+          companyId,
+          status: "OPEN",
+          dueAt: { lt: startOfToday },
+          ...(isManager ? {} : { assignedToId: session.user.id }),
+        },
+      }),
+      prisma.crmTask.count({
+        where: {
+          companyId,
+          status: "OPEN",
+          dueAt: { gte: startOfToday, lt: endOfToday },
+          ...(isManager ? {} : { assignedToId: session.user.id }),
+        },
+      }),
+    ]);
+
+    const balanceOf = (invoice: { total: number; amountPaid: number }) =>
+      Math.max(0, invoice.total - invoice.amountPaid);
+
+    const receivable = openInvoices.reduce((sum, invoice) => sum + balanceOf(invoice), 0);
+    const overdueReceivable = openInvoices
+      .filter((invoice) => invoice.dueDate && invoice.dueDate < now)
+      .reduce((sum, invoice) => sum + balanceOf(invoice), 0);
+
+    const ageing = openInvoices.reduce<Record<string, { count: number; value: number }>>(
+      (buckets, invoice) => {
+        const bucket = ageingBucket(invoice.dueDate ?? now, now);
+        const row = buckets[bucket] ?? { count: 0, value: 0 };
+        row.count += 1;
+        row.value += balanceOf(invoice);
+        buckets[bucket] = row;
+        return buckets;
+      },
+      {},
+    );
+
+    const workOrderByStatus = Object.fromEntries(
+      workOrders.map((row) => [row.status, row._count._all]),
+    ) as Record<string, number>;
+
+    const wonValue = wonThisPeriod._sum.value ?? 0;
+    const previousWonValue = wonPreviousPeriod._sum.value ?? 0;
+
+    return successResponse({
+      scope: isManager ? "TEAM" : "MINE",
+      periodDays,
+      pipeline: {
+        openDeals: openDeals.length,
+        grossValue,
+        weightedValue,
+        byStage,
+        stale: stale.length,
+        closingThisWeek: closingThisWeek.length,
+      },
+      won: {
+        count: wonThisPeriod._count._all,
+        value: wonValue,
+        lost: lostThisPeriod,
+        // Null rather than 0% when there is no baseline — a fabricated
+        // "+100%" against nothing is worse than saying nothing.
+        valueDeltaPercent:
+          previousWonValue > 0
+            ? Math.round(((wonValue - previousWonValue) / previousWonValue) * 100)
+            : null,
+        previousValue: previousWonValue,
+      },
+      tasks: {
+        overdue: tasksOverdue,
+        today: tasksToday,
+        open: taskByStatus.OPEN ?? 0,
+        legacyOverdue,
+      },
+      documents: {
+        quotationsRaised: quotations.length,
+        quotedValue: quotations.reduce((sum, doc) => sum + doc.amount, 0),
+        awaitingApproval: quotations.filter((doc) => doc.approval?.status === "PENDING").length,
+        pendingDiscountApprovals: pendingApprovals,
+      },
+      collections: {
+        outstanding: receivable,
+        overdue: overdueReceivable,
+        invoiceCount: openInvoices.length,
+        ageing,
+      },
+      delivery: {
+        workOrders: workOrderByStatus,
+        upcomingVisits,
+      },
+    });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/dashboard error:", error);
+    return errorResponse("Failed to build the dashboard");
+  }
+}

--- a/app/api/v2/crm/intake-forms/route.ts
+++ b/app/api/v2/crm/intake-forms/route.ts
@@ -35,8 +35,37 @@ export async function GET(request: NextRequest) {
     const forms = await prisma.crmIntakeForm.findMany({
       where: { companyId: session.user.companyId },
       orderBy: { createdAt: "desc" },
+      include: {
+        // A form's list entry is useless without its numbers: a link nobody
+        // has filled in and one bringing work in every day look identical
+        // otherwise.
+        _count: { select: { submissions: true } },
+        submissions: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { createdAt: true },
+        },
+      },
     });
-    return successResponse({ data: forms });
+
+    const formIds = forms.map((form) => form.id);
+    const converted = formIds.length
+      ? await prisma.crmIntakeSubmission.groupBy({
+          by: ["formId"],
+          where: { companyId: session.user.companyId, formId: { in: formIds }, leadId: { not: null } },
+          _count: { _all: true },
+        })
+      : [];
+    const convertedByForm = new Map(converted.map((row) => [row.formId, row._count._all]));
+
+    return successResponse({
+      data: forms.map(({ _count, submissions, ...form }) => ({
+        ...form,
+        submissionCount: _count.submissions,
+        convertedCount: convertedByForm.get(form.id) ?? 0,
+        lastSubmissionAt: submissions[0]?.createdAt ?? null,
+      })),
+    });
   } catch (error) {
     console.error("[API] GET /api/v2/crm/intake-forms error:", error);
     return errorResponse("Failed to fetch intake forms");

--- a/app/crm/follow-ups/page.tsx
+++ b/app/crm/follow-ups/page.tsx
@@ -9,7 +9,10 @@ export default async function CrmFollowUpsPage() {
   if (!session?.user) redirect("/login");
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6">
-      <PageHeading title="Follow-ups" />
+      <PageHeading
+        title="Follow-ups"
+        description="Everything owed to a customer, across leads, deals, companies and sites."
+      />
       <CrmFollowUpsContent />
     </div>
   );

--- a/app/crm/layout.tsx
+++ b/app/crm/layout.tsx
@@ -1,18 +1,10 @@
 import type { ReactNode } from "react";
 
-import { GlobalSearch } from "@/components/crm/search/global-search";
-
 /**
- * Every CRM page carries the global search. It is the fastest route to any
- * record, so it belongs on the layout rather than being repeated per page.
+ * The CRM's own layout is deliberately thin. Global search used to live here,
+ * which made "find anything" a CRM-only affordance; it now sits in the navbar
+ * and is reachable from every page in the app.
  */
 export default function CrmLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="space-y-4">
-      <div className="flex justify-end">
-        <GlobalSearch />
-      </div>
-      {children}
-    </div>
-  );
+  return <div className="space-y-4">{children}</div>;
 }

--- a/app/crm/leads/page.tsx
+++ b/app/crm/leads/page.tsx
@@ -18,11 +18,16 @@ export default async function CrmLeadsPage({ searchParams }: { searchParams: Sea
     if (typeof value === "string") params.set(key, value);
     else if (Array.isArray(value) && value[0]) params.set(key, value.join(","));
   }
-  const view = params.get("view") === "board" ? "BOARD" : "TABLE";
+  // The board is the pipeline, and the pipeline is what people open this page
+  // to look at. The table stays one click away for filtering and bulk edits.
+  const view = params.get("view") === "table" ? "TABLE" : "BOARD";
 
   return (
     <div className="mx-auto w-full max-w-[110rem] space-y-6">
-      <PageHeading title="Leads & Pipeline" />
+      <PageHeading
+        title="Leads & Pipeline"
+        description="Every enquiry in flight, and the stage it is sitting in."
+      />
       <LeadsWorkspace
         initialFilters={parseLeadFiltersFromParams(params)}
         initialView={view}

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,7 +20,18 @@
                so the app keeps the last word on `body` and friends.
 
    Utilities stay on top: a Tailwind class on a design-system component still
-   overrides the component's own CSS. */
+   overrides the component's own CSS.
+
+   This statement has to be the first `@layer` the browser sees. Layer order is
+   fixed by first appearance and unknown names are appended at the end, so when
+   frappe's theme was imported from `app/layout.tsx` ahead of this file it
+   established `theme, base, components, utilities` on its own and `corelith`
+   and `app` landed *after* `utilities`. Every Tailwind utility in the app then
+   lost to the design system's element resets — `button { padding: 0 }` beat
+   `px-2`, headings collapsed to body size, and segmented controls, menus and
+   comboboxes all rendered unstyled. `app/layout.tsx` imports this file first
+   for that reason; frappe's `@source` directive rules out pulling it in here
+   through `@import`, so import order is what holds the line. */
 @layer theme, base, corelith, app, components, utilities;
 
 /* Atkinson Hyperlegible — the design system's typeface, and the app's since the

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,6 +48,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@corelithzw/react/styles.css" layer(corelith);
+/* Components the package exports but whose CSS never made it into its bundle.
+   Same layer, so it behaves exactly as if the package had shipped it — and it
+   goes away the day a release does. See the file header for the audit. */
+@import "./themes/corelith-missing.css" layer(corelith);
 
 @source "../node_modules/@rtcamp/frappe-ui-react/dist";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,12 @@
-import "@rtcamp/frappe-ui-react/theme";
+// `globals.css` first, and it has to stay first: its `@layer` statement is the
+// one that must reach the browser before any other. Frappe's theme is a second
+// Tailwind build that declares `theme, base, components, utilities` and knows
+// nothing of ours, so when it was imported ahead of this file it set the order
+// itself and `corelith`/`app` — unknown names at that point — were appended
+// after `utilities`. The design system's element resets then outranked every
+// Tailwind utility in the app.
 import "./globals.css";
+import "@rtcamp/frappe-ui-react/theme";
 import "./themes/corelith-bridge.css";
 import { Analytics } from "@vercel/analytics/next";
 import { Suspense } from "react";
@@ -118,7 +125,11 @@ export default async function RootLayout({
 
       </head>
       <body
-        className="font-sans subpixel-antialiased"
+        /* No `font-sans`: frappe's theme ships its own `.font-sans` utility
+           with Inter baked in literally, and two Tailwind builds writing the
+           same utility into the same layer means the later one wins. The design
+           system's `body` rule sets the family and is the authority here. */
+        className="subpixel-antialiased"
         data-portal-path={hostContext.portalPath ?? undefined}
         style={brandingVars as React.CSSProperties}
       >

--- a/app/stores/catalogue/page.tsx
+++ b/app/stores/catalogue/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+import { PageHeading } from "@/components/layout/page-heading";
+import { CataloguePanel } from "@/components/inventory/catalogue-panel";
+import { authOptions } from "@/lib/auth";
+
+/**
+ * The shared catalogue's own home.
+ *
+ * It was only reachable from CRM settings, which is the wrong door: the
+ * catalogue is a Stock & Inventory concern that the CRM, Retail and the
+ * workshop all read from. The CRM tab still works and renders this same panel.
+ */
+export default async function StoresCataloguePage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login");
+
+  return (
+    <div className="mx-auto w-full max-w-7xl space-y-6">
+      <PageHeading
+        title="Catalogue"
+        description="Everything the business sells — goods, materials and services — priced once for every module."
+      />
+      <CataloguePanel />
+    </div>
+  );
+}

--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -26,6 +26,19 @@
    nothing is redeclared here and the package's values stand.
    ═══════════════════════════════════════════════════════════════════════════ */
 
+/* The same layer order `app/globals.css` declares, repeated here because this
+   file is a separate stylesheet entry and the bundler is free to emit it first.
+   Cascade layer order is fixed by *first appearance* in the document: whichever
+   sheet lands first sets it, and names it does not mention are appended at the
+   end. When this file went out without the declaration it established
+   `theme, base, components, utilities`, so `corelith` and `app` — unknown at
+   that point — were appended *after* `utilities`. That inverted the whole
+   system: the package's `button { padding: 0 }` reset started beating `px-2`,
+   its element styles beat every Tailwind override on the page, and headings,
+   segmented controls, menus and comboboxes all lost their app-side styling.
+   Declaring the order identically in both entries makes it order-independent. */
+@layer theme, base, corelith, app, components, utilities;
+
 :root {
   color-scheme: light;
 

--- a/app/themes/corelith-missing.css
+++ b/app/themes/corelith-missing.css
@@ -1,0 +1,383 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   COMPONENT CSS THE DESIGN-SYSTEM PACKAGE SHIPS WITHOUT
+
+   `@corelithzw/react@0.3.4` bundles `dist/styles.css` from a subset of the
+   docs-site stylesheets, and several components it exports were left out of
+   that bundle. Their JSX renders the right class names and nothing styles
+   them, so the component comes out as unstyled flow content:
+
+     PageHeader   `.dash-page-h` — its source says "Maps to .dash-page-h in
+                  dash.css", and dash.css is not in the bundle. Every page
+                  title in the app was a bare <h1>, which Tailwind's preflight
+                  resets to inherit — 14px at weight 400, the same as body
+                  text. This is the "headings are small text" bug.
+     Field        `.p-field*` — labels, help text and error text unstyled.
+     Drawer       `.p-drawer*` — no overlay, no panel, no positioning; a sheet
+                  rendered inline at the bottom of the page.
+     TextArea     `.p-textarea`
+     EmptyState   `.empty-state-illustration`, `.empty-state-action`
+     Button       `.btn-label`, `.btn-icon-lead`, `.btn-icon-trail`,
+                  `.is-loading`
+     Card         `.card-actions`, `.card-tone-*`
+     DataToolbar  `.data-toolbar-filters`, `.data-toolbar-actions`
+     Tabs         `.tabs-trigger`
+
+   Written to the package's own conventions: tokens only — no colour, size,
+   radius, shadow or duration literal — and the same selector shapes the
+   bundled CSS uses, so this file can be deleted wholesale the day a release
+   ships the real thing. Imported into `layer(corelith)` from `globals.css`,
+   which is where the package's CSS would have put it, so app utilities still
+   win over everything here.
+
+   Verified against the package sources under
+   `node_modules/@corelithzw/react/src`, not guessed from the class names.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── PageHeader ─────────────────────────────────────────────────────────────
+   header.dash-page-h > div.meta > (nav.crumbs, h1, p.lede, div.h-pills)
+                      > div.actions                                          */
+
+.dash-page-h {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-5);
+}
+
+.dash-page-h > .meta {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.dash-page-h .crumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font: var(--type-caption);
+  color: var(--text-muted);
+}
+
+.dash-page-h .crumbs a {
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.dash-page-h .crumbs a:hover {
+  color: var(--text-strong);
+}
+
+.dash-page-h .crumbs .sep {
+  color: var(--text-subtle);
+}
+
+.dash-page-h .crumbs .current {
+  color: var(--text-body);
+}
+
+.dash-page-h h1 {
+  font: var(--type-page-title);
+  color: var(--text-strong);
+  margin: 0;
+  /* The title has to wrap rather than push the action row off a phone. */
+  overflow-wrap: anywhere;
+}
+
+.dash-page-h .lede {
+  font: var(--type-body);
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 68ch;
+}
+
+.dash-page-h .h-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.dash-page-h .h-pills .p {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-3);
+  min-height: var(--space-7);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--tone-neutral-bd);
+  background: var(--tone-neutral-bg);
+  color: var(--text-muted);
+  font: var(--type-label-sm);
+  white-space: nowrap;
+}
+
+.dash-page-h .h-pills .p.b {
+  border-color: var(--tone-info-bd);
+  background: var(--tone-info-bg);
+  color: var(--tone-info);
+}
+
+.dash-page-h .h-pills .p.s {
+  border-color: var(--tone-success-bd);
+  background: var(--tone-success-bg);
+  color: var(--tone-success);
+}
+
+.dash-page-h .h-pills .p.w {
+  border-color: var(--tone-warn-bd);
+  background: var(--tone-warn-bg);
+  color: var(--tone-warn);
+}
+
+.dash-page-h .h-pills .p.d {
+  border-color: var(--tone-danger-bd);
+  background: var(--tone-danger-bg);
+  color: var(--tone-danger);
+}
+
+.dash-page-h > .actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  flex: none;
+}
+
+/* On a phone the action row goes full width under the title rather than
+   competing with it for a line. */
+@media (max-width: 640px) {
+  .dash-page-h > .actions {
+    width: 100%;
+  }
+}
+
+/* ── Field ──────────────────────────────────────────────────────────────────
+   div.p-field > (label.p-field-label, control, p.p-field-description,
+                  p.p-field-error)                                           */
+
+.p-field {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.p-field-label {
+  font: var(--type-label);
+  color: var(--text-body);
+}
+
+.p-field-description {
+  font: var(--type-body-sm);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.p-field-error {
+  font: var(--type-body-sm);
+  color: var(--tone-danger);
+  margin: 0;
+}
+
+/* An invalid field paints its own control rather than making every call site
+   remember to pass the state down. */
+.p-field[data-invalid="true"] .input,
+.p-field[data-invalid="true"] .select,
+.p-field[data-invalid="true"] .p-textarea {
+  border-color: var(--tone-danger);
+}
+
+/* ── Drawer ─────────────────────────────────────────────────────────────────
+   div.p-drawer-overlay + aside.p-drawer.p-drawer-{right|left|bottom}         */
+
+.p-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: color-mix(in oklab, var(--ink) 32%, transparent);
+}
+
+.p-drawer {
+  position: fixed;
+  z-index: 61;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  box-shadow: var(--shadow-modal);
+  max-width: 100vw;
+  max-height: 100dvh;
+}
+
+.p-drawer-right,
+.p-drawer-left {
+  top: 0;
+  bottom: 0;
+  width: min(40rem, 100vw);
+}
+
+.p-drawer-right {
+  right: 0;
+  border-left: 1px solid var(--border);
+}
+
+.p-drawer-left {
+  left: 0;
+  border-right: 1px solid var(--border);
+}
+
+.p-drawer-bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 90dvh;
+  border-top: 1px solid var(--border);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+}
+
+.p-drawer-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border-bottom: 1px solid var(--border-subtle);
+  font: var(--type-section-title);
+  color: var(--text-strong);
+}
+
+.p-drawer-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-5);
+}
+
+.p-drawer-footer {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-5);
+  border-top: 1px solid var(--border-subtle);
+  /* Keeps the confirm button clear of a phone's home indicator. */
+  padding-bottom: max(var(--space-4), env(safe-area-inset-bottom));
+}
+
+/* ── TextArea ───────────────────────────────────────────────────────────── */
+
+.p-textarea {
+  display: block;
+  width: 100%;
+  min-height: calc(var(--space-9) * 2);
+  padding: var(--space-3);
+  resize: vertical;
+  line-height: 1.55;
+}
+
+/* ── EmptyState ─────────────────────────────────────────────────────────── */
+
+.empty-state-illustration {
+  margin-bottom: var(--space-2);
+  color: var(--text-subtle);
+}
+
+.empty-state-action {
+  margin-top: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* ── Button internals ────────────────────────────────────────────────────── */
+
+.btn-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.btn-icon-lead,
+.btn-icon-trail {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+}
+
+.btn.is-loading {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+/* ── Card extras ─────────────────────────────────────────────────────────── */
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+
+.card-tone-brand {
+  border-color: var(--tone-info-bd);
+}
+
+.card-tone-success {
+  border-color: var(--tone-success-bd);
+}
+
+.card-tone-warn {
+  border-color: var(--tone-warn-bd);
+}
+
+.card-tone-danger {
+  border-color: var(--tone-danger-bd);
+}
+
+/* ── DataToolbar ─────────────────────────────────────────────────────────── */
+
+.data-toolbar-filters,
+.data-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.data-toolbar-actions {
+  margin-left: auto;
+  flex-wrap: nowrap;
+}
+
+/* ── Tabs trigger ────────────────────────────────────────────────────────── */
+
+.tabs-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  min-height: var(--space-8);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  font: var(--type-label);
+  color: var(--text-muted);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.tabs-trigger:hover {
+  color: var(--text-strong);
+}
+
+.tabs-trigger[aria-selected="true"],
+.tabs-trigger[data-state="active"] {
+  background: var(--surface);
+  color: var(--text-strong);
+  box-shadow: var(--shadow-rest);
+}

--- a/app/themes/corelith-missing.css
+++ b/app/themes/corelith-missing.css
@@ -20,7 +20,18 @@
                   `.is-loading`
      Card         `.card-actions`, `.card-tone-*`
      DataToolbar  `.data-toolbar-filters`, `.data-toolbar-actions`
-     Tabs         `.tabs-trigger`
+     Tabs         every class the component emits. `Tabs` renders
+                  `.utabs/.stabs/.ptabs/.vtabs` with `.utab/.stab/.ptab/.vtab`
+                  triggers, and *none* of those eight names exists in the
+                  bundle or in the docs site's own components.css — the
+                  component's class names outran its CSS. The stylesheet does
+                  carry `.under-tabs`, `.seg-tabs` and `.iconstrip`, which are
+                  what p-tabs.html says the three variants look like, so the
+                  rules below reproduce those against the names the component
+                  actually emits.
+     KpiGrid      every `.kpi-cell*` child — the executive KPI row rendered as
+                  a column of naked numbers
+     RowCard      `.b-row-card-title`, `.b-row-card-sub`
 
    Written to the package's own conventions: tokens only — no colour, size,
    radius, shadow or duration literal — and the same selector shapes the
@@ -354,30 +365,285 @@
   flex-wrap: nowrap;
 }
 
-/* ── Tabs trigger ────────────────────────────────────────────────────────── */
+/* ── Tabs ───────────────────────────────────────────────────────────────────
+   div[role=tablist].{utabs|stabs|ptabs|vtabs} > button.{utab|stab|ptab|vtab}
+   The active trigger carries `.current`, `aria-selected="true"` and
+   `data-state="active"`; all three are matched so the styling holds however
+   the trigger is rendered, including through `asChild`.
 
-.tabs-trigger {
+   Heights follow p-tabs.html: 40px underline, 36 segmented, 32 pill.        */
+
+/* Underline — the default, and the one that belongs above page content. */
+.utabs {
+  display: flex;
+  gap: var(--space-6);
+  border-bottom: 1px solid var(--border);
+  padding: 0 var(--space-1);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.utabs::-webkit-scrollbar {
+  display: none;
+}
+
+.utab {
+  flex: none;
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 0 var(--space-3);
-  min-height: var(--space-8);
+  min-height: 40px;
+  padding: 0;
   border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
   background: transparent;
-  border-radius: var(--radius-md);
-  font: var(--type-label);
+  font: 500 14px/1 var(--font-sans);
   color: var(--text-muted);
   white-space: nowrap;
   cursor: pointer;
 }
 
-.tabs-trigger:hover {
+.utab:hover {
   color: var(--text-strong);
 }
 
-.tabs-trigger[aria-selected="true"],
-.tabs-trigger[data-state="active"] {
+.utab.current,
+.utab[aria-selected="true"],
+.utab[data-state="active"] {
+  color: var(--text-strong);
+  border-bottom-color: var(--brand);
+}
+
+/* Segmented — a control, not a header. Sits on the muted surface. */
+.stabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: var(--surface-muted);
+  border-radius: var(--radius-lg);
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.stabs::-webkit-scrollbar {
+  display: none;
+}
+
+.stab {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 36px;
+  padding: 0 var(--space-4);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  font: 500 13px/1 var(--font-sans);
+  color: var(--text-muted);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.stab:hover {
+  color: var(--text-strong);
+}
+
+.stab.current,
+.stab[aria-selected="true"],
+.stab[data-state="active"] {
   background: var(--surface);
   color: var(--text-strong);
-  box-shadow: var(--shadow-rest);
+  box-shadow: var(--shadow-inset-soft);
+}
+
+/* Pill — the compact one, for a filter row rather than page navigation. */
+.ptabs {
+  display: inline-flex;
+  gap: var(--space-2);
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.ptabs::-webkit-scrollbar {
+  display: none;
+}
+
+.ptab {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  font: 500 13px/1 var(--font-sans);
+  color: var(--text-muted);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.ptab:hover {
+  color: var(--text-strong);
+  border-color: var(--border-strong);
+}
+
+.ptab.current,
+.ptab[aria-selected="true"],
+.ptab[data-state="active"] {
+  background: var(--brand-soft);
+  border-color: var(--brand-100);
+  color: var(--brand-strong);
+}
+
+/* Vertical — a rail beside the content, same quiet-list rule as .nav-rail. */
+.vtabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.vtab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 36px;
+  padding: 0 var(--space-3);
+  border: none;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  font: 500 14px/1.2 var(--font-sans);
+  color: var(--text-body);
+  text-align: left;
+  cursor: pointer;
+}
+
+.vtab:hover {
+  background: var(--surface-muted);
+  color: var(--text-strong);
+}
+
+.vtab.current,
+.vtab[aria-selected="true"],
+.vtab[data-state="active"] {
+  background: var(--surface-muted);
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+/* ── KpiGrid ────────────────────────────────────────────────────────────────
+   div.kpi-grid.kpi-grid-{n} > div.kpi-item > div.kpi-cell
+     > (div.kpi-cell-h > span.kpi-cell-lbl + span.kpi-cell-chev)
+     > div.kpi-cell-val
+     > div.kpi-cell-foot > (span.kpi-cell-delta[.tone-*] + span.kpi-cell-spark)
+
+   `.kpi-grid` itself is styled by the package; only the cell internals are
+   missing, which left the executive KPI row as a column of naked numbers.   */
+
+.kpi-item {
+  min-width: 0;
+}
+
+.kpi-cell {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  min-width: 0;
+}
+
+/* The whole cell is the target when it links somewhere. */
+a.kpi-cell:hover,
+button.kpi-cell:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-muted);
+}
+
+.kpi-cell-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.kpi-cell-lbl {
+  font: var(--type-eyebrow);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kpi-cell-chev {
+  flex: none;
+  display: inline-flex;
+  color: var(--text-subtle);
+}
+
+.kpi-cell-val {
+  font: var(--type-display-sm);
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.kpi-cell-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-height: var(--space-5);
+}
+
+.kpi-cell-delta {
+  font: var(--type-body-sm);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.kpi-cell-delta.tone-success {
+  color: var(--tone-success);
+}
+
+.kpi-cell-delta.tone-warn {
+  color: var(--tone-warn);
+}
+
+.kpi-cell-delta.tone-danger {
+  color: var(--tone-danger);
+}
+
+.kpi-cell-spark {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-subtle);
+}
+
+/* ── RowCard title/subtitle ─────────────────────────────────────────────────
+   `.b-row-card` is styled by the package but these two children are not, so
+   the title and its subtitle rendered at the same weight and ran together.  */
+
+.b-row-card-title {
+  font: var(--type-label);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.b-row-card-sub {
+  font: var(--type-body-sm);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/components/crm/crm-dashboard-content.tsx
+++ b/components/crm/crm-dashboard-content.tsx
@@ -1,112 +1,321 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { fetchJson } from "@/lib/api-client";
-import { CRM_STAGE_LABELS } from "@/lib/crm/pipeline";
-import type { CrmLeadStage } from "@prisma/client";
+import { Alert, Card, EmptyState, KpiGrid, RowCard, Skeleton, StatHero } from "@corelithzw/react";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { AGEING_LABELS, type AgeingBucket } from "@/lib/crm/collections";
+import {
+  Calendar,
+  CheckCircle,
+  ChevronRight,
+  Clock,
+  FileText,
+  Receipt,
+  Wrench,
+} from "@/lib/icons";
 
-type Summary = {
-  funnel: { total: number; won: number; winRate: number; stages: Array<{ stage: CrmLeadStage; label: string; count: number }> };
-  pipeline: { openLeads: number; grossValue: number; weightedValue: number };
-  followUps: { overdue: number; byStatus: Record<string, number> };
+type DashboardData = {
+  scope: "TEAM" | "MINE";
+  periodDays: number;
+  pipeline: {
+    openDeals: number;
+    grossValue: number;
+    weightedValue: number;
+    byStage: Array<{ id: string; name: string; status: string; count: number; value: number }>;
+    stale: number;
+    closingThisWeek: number;
+  };
+  won: {
+    count: number;
+    value: number;
+    lost: number;
+    valueDeltaPercent: number | null;
+    previousValue: number;
+  };
+  tasks: { overdue: number; today: number; open: number; legacyOverdue: number };
+  documents: {
+    quotationsRaised: number;
+    quotedValue: number;
+    awaitingApproval: number;
+    pendingDiscountApprovals: number;
+  };
+  collections: {
+    outstanding: number;
+    overdue: number;
+    invoiceCount: number;
+    ageing: Partial<Record<AgeingBucket, { count: number; value: number }>>;
+  };
+  delivery: { workOrders: Record<string, number>; upcomingVisits: number };
 };
 
-type FollowUp = {
-  id: string;
-  title: string;
-  dueAt: string;
-  lead: { id: string; leadNo: string; title: string | null } | null;
-  client: { id: string; name: string } | null;
-};
-
-function Stat({ label, value }: { label: string; value: string | number }) {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-sm font-medium text-[var(--text-muted)]">{label}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-2xl font-semibold">{value}</p>
-      </CardContent>
-    </Card>
-  );
+function money(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
 }
 
+/**
+ * The CRM home, built to the KPI hero + drilldown recipe: one hero number, a
+ * row of secondary KPIs, then rows that lead somewhere.
+ *
+ * The previous version answered three questions and ignored deals, quotes,
+ * invoices, work orders and site visits, so it could not tell you whether
+ * anything needed you today. Every number here is a link to the list it came
+ * from — a dashboard that cannot be drilled into is a poster.
+ */
 export function CrmDashboardContent() {
-  const summary = useQuery({
-    queryKey: ["crm-summary"],
-    queryFn: () => fetchJson<Summary>("/api/v2/crm/insights/summary"),
-  });
-  const overdue = useQuery({
-    queryKey: ["crm-followups-overdue"],
-    queryFn: () =>
-      fetchJson<{ data: FollowUp[] }>("/api/v2/crm/follow-ups?overdue=true").then((r) => r.data),
+  const router = useRouter();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["crm-dashboard"],
+    queryFn: () => fetchJson<DashboardData>("/api/v2/crm/dashboard"),
   });
 
-  const s = summary.data;
+  if (error) {
+    return (
+      <Alert tone="danger" title="Couldn't load the dashboard">
+        {getApiErrorMessage(error)}
+      </Alert>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="space-y-4" aria-busy="true" aria-live="polite">
+        <Skeleton height={132} />
+        <Skeleton height={96} />
+        <Skeleton height={220} />
+      </div>
+    );
+  }
+
+  const { pipeline, won, tasks, documents, collections, delivery } = data;
+  const needsAttention = tasks.overdue + tasks.legacyOverdue;
+  const nothingYet = pipeline.openDeals === 0 && won.count === 0 && documents.quotationsRaised === 0;
+
+  if (nothingYet) {
+    return (
+      <EmptyState
+        title="Nothing in the pipeline yet"
+        body="Once a deal is open, this page shows what is in flight, what is owed to a customer, and what is owed to you."
+        action={
+          <Link href="/crm/deals?new=1" className="btn btn-primary">
+            Start a deal
+          </Link>
+        }
+      />
+    );
+  }
+
+  const openWorkOrders =
+    (delivery.workOrders.SCHEDULED ?? 0) + (delivery.workOrders.IN_PROGRESS ?? 0);
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
-        <Stat label="Open leads" value={s?.pipeline.openLeads ?? "—"} />
-        <Stat label="Weighted pipeline" value={s ? `$${s.pipeline.weightedValue.toLocaleString()}` : "—"} />
-        <Stat label="Win rate" value={s ? `${s.funnel.winRate}%` : "—"} />
-        <Stat label="Overdue follow-ups" value={s?.followUps.overdue ?? "—"} />
-      </div>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Pipeline by stage</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {(s?.funnel.stages ?? []).map((stage) => (
-              <Link key={stage.stage} href={`/crm/leads?stages=${stage.stage}`}>
-                <Badge variant="outline" className="text-sm">
-                  {CRM_STAGE_LABELS[stage.stage] ?? stage.label}: {stage.count}
-                </Badge>
-              </Link>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between gap-2">
-          <CardTitle>Overdue follow-ups</CardTitle>
-          <Link
-            href="/crm/leads?overdueOnly=1"
-            className="text-sm text-[var(--text-muted)] hover:underline"
-          >
-            See the leads →
+    <div className="space-y-5">
+      {/* Hero: weighted pipeline is the one number that answers "how are we
+          doing". Gross sits underneath it because the two are always read
+          together and a weighted figure alone invites the wrong question. */}
+      <StatHero
+        label="Weighted pipeline"
+        value={money(pipeline.weightedValue)}
+        subtitle={`${pipeline.openDeals} open deal${pipeline.openDeals === 1 ? "" : "s"} · ${money(pipeline.grossValue)} gross`}
+        change={
+          won.valueDeltaPercent === null
+            ? `${money(won.value)} won in the last ${data.periodDays} days`
+            : `${won.valueDeltaPercent >= 0 ? "+" : ""}${won.valueDeltaPercent}% won vs the previous ${data.periodDays} days`
+        }
+        trend={
+          won.valueDeltaPercent === null
+            ? "neutral"
+            : won.valueDeltaPercent >= 0
+              ? "up"
+              : "down"
+        }
+        action={
+          <Link href="/crm/leads" className="btn btn-secondary btn-sm">
+            Open the board
           </Link>
-        </CardHeader>
-        <CardContent>
-          {overdue.data && overdue.data.length > 0 ? (
-            <ul className="divide-y divide-[var(--border)]">
-              {overdue.data.map((f) => (
-                <li key={f.id} className="flex flex-wrap items-center justify-between gap-2 py-2 text-sm">
-                  <span className="min-w-0">
-                    {f.title}
-                    {f.lead ? (
-                      <Link href={`/crm/leads/${f.lead.id}`} className="ml-2 text-[var(--text-muted)] underline">
-                        {f.lead.leadNo}
-                      </Link>
-                    ) : null}
-                  </span>
-                  <span className="text-[var(--text-muted)]">{new Date(f.dueAt).toLocaleDateString()}</span>
-                </li>
-              ))}
-            </ul>
+        }
+      />
+
+      <KpiGrid cols={4}>
+        <KpiGrid.Item
+          label="Needs chasing"
+          value={needsAttention}
+          delta={tasks.today > 0 ? `${tasks.today} due today` : "nothing due today"}
+          tone={needsAttention > 0 ? "danger" : "neutral"}
+          onClick={() => router.push("/crm/follow-ups")}
+        />
+        <KpiGrid.Item
+          label="Quoted"
+          value={money(documents.quotedValue)}
+          delta={`${documents.quotationsRaised} in ${data.periodDays} days`}
+          onClick={() => router.push("/crm/deals")}
+        />
+        <KpiGrid.Item
+          label="Owed to us"
+          value={money(collections.outstanding)}
+          delta={
+            collections.overdue > 0 ? `${money(collections.overdue)} overdue` : "all within terms"
+          }
+          tone={collections.overdue > 0 ? "warn" : "neutral"}
+          onClick={() => router.push("/crm/collections")}
+        />
+        <KpiGrid.Item
+          label="Won"
+          value={won.count}
+          delta={won.lost > 0 ? `${won.lost} lost` : "none lost"}
+          tone={won.count > 0 ? "success" : "neutral"}
+          onClick={() => router.push("/crm/insights")}
+        />
+      </KpiGrid>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold">What needs you</h2>
+        <div className="grid gap-2">
+          <RowCard
+            icon={<Clock className="size-4" />}
+            title="Overdue follow-ups"
+            subtitle={
+              needsAttention === 0
+                ? "Nothing overdue."
+                : `${needsAttention} past due · ${tasks.open} open in total`
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/follow-ups")}
+          />
+          <RowCard
+            icon={<CheckCircle className="size-4" />}
+            title="Deals going stale"
+            subtitle={
+              pipeline.stale === 0
+                ? "Every deal has moved inside its stage's window."
+                : `${pipeline.stale} sitting longer than their stage allows`
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/leads")}
+          />
+          <RowCard
+            icon={<FileText className="size-4" />}
+            title="Quotes awaiting a decision"
+            subtitle={
+              documents.awaitingApproval === 0 && documents.pendingDiscountApprovals === 0
+                ? "Nothing waiting on a customer or a manager."
+                : [
+                    documents.awaitingApproval > 0
+                      ? `${documents.awaitingApproval} with the customer`
+                      : null,
+                    documents.pendingDiscountApprovals > 0
+                      ? `${documents.pendingDiscountApprovals} discount${documents.pendingDiscountApprovals === 1 ? "" : "s"} to approve`
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/deals")}
+          />
+          <RowCard
+            icon={<Receipt className="size-4" />}
+            title="Invoices to collect"
+            subtitle={
+              collections.invoiceCount === 0
+                ? "Nothing outstanding from a CRM quote."
+                : `${collections.invoiceCount} open · ${money(collections.outstanding)} outstanding`
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/collections")}
+          />
+          <RowCard
+            icon={<Wrench className="size-4" />}
+            title="Work in the field"
+            subtitle={
+              openWorkOrders === 0 && delivery.upcomingVisits === 0
+                ? "Nothing scheduled."
+                : [
+                    openWorkOrders > 0 ? `${openWorkOrders} work order${openWorkOrders === 1 ? "" : "s"} live` : null,
+                    delivery.upcomingVisits > 0
+                      ? `${delivery.upcomingVisits} visit${delivery.upcomingVisits === 1 ? "" : "s"} this week`
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/work-orders")}
+          />
+          <RowCard
+            icon={<Calendar className="size-4" />}
+            title="Closing this week"
+            subtitle={
+              pipeline.closingThisWeek === 0
+                ? "Nothing forecast to close in the next seven days."
+                : `${pipeline.closingThisWeek} deal${pipeline.closingThisWeek === 1 ? "" : "s"} expected to close`
+            }
+            status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
+            onClick={() => router.push("/crm/deals")}
+          />
+        </div>
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card title="Pipeline by stage">
+          {pipeline.byStage.length === 0 ? (
+            <p className="text-sm text-[var(--text-muted)]">No stages configured yet.</p>
           ) : (
-            <p className="text-sm text-[var(--text-muted)]">Nothing overdue. Nice.</p>
+            <ul className="space-y-2">
+              {pipeline.byStage.map((stage) => {
+                const share =
+                  pipeline.grossValue > 0 ? (stage.value / pipeline.grossValue) * 100 : 0;
+                return (
+                  <li key={stage.id}>
+                    <Link
+                      href={`/crm/deals?stageId=${stage.id}`}
+                      className="flex items-center gap-3 text-sm hover:underline"
+                    >
+                      <span className="w-32 shrink-0 truncate">{stage.name}</span>
+                      <span
+                        className="h-2 rounded-full bg-[var(--brand)]"
+                        style={{ width: `${Math.max(share, stage.count > 0 ? 3 : 0)}%` }}
+                        aria-hidden="true"
+                      />
+                      <span className="ml-auto shrink-0 font-mono text-xs text-[var(--text-muted)]">
+                        {stage.count} · {money(stage.value)}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
           )}
-        </CardContent>
-      </Card>
+        </Card>
+
+        <Card title="Ageing on what we are owed">
+          {collections.invoiceCount === 0 ? (
+            <p className="text-sm text-[var(--text-muted)]">
+              Nothing outstanding on a CRM invoice.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {(Object.keys(AGEING_LABELS) as AgeingBucket[]).map((bucket) => {
+                const row = collections.ageing[bucket];
+                return (
+                  <li
+                    key={bucket}
+                    className="flex items-center justify-between gap-3 text-sm"
+                  >
+                    <span>{AGEING_LABELS[bucket]}</span>
+                    <span className="font-mono text-xs text-[var(--text-muted)]">
+                      {row ? `${row.count} · ${money(row.value)}` : "—"}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Card>
+      </div>
     </div>
   );
 }

--- a/components/crm/crm-follow-ups-content.tsx
+++ b/components/crm/crm-follow-ups-content.tsx
@@ -1,68 +1,215 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
 
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import { fetchJson } from "@/lib/api-client";
+import { Alert, Badge, Button, EmptyState, StatCard } from "@corelithzw/react";
+import { ClientDate } from "@/components/ui/client-date";
+import { useToast } from "@/components/ui/use-toast";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { fetchCrmTasks } from "@/lib/crm/crm-v2";
+import { TASK_QUEUE_LABELS, type TaskQueue } from "@/lib/crm/tasks";
+import { Plus } from "@/lib/icons";
 
-type FollowUp = {
+import { TaskFormSheet } from "./tasks/task-form-sheet";
+import { TaskList } from "./tasks/task-list";
+
+/**
+ * Follow-ups — the "what do I owe someone" queue.
+ *
+ * This is the same task infrastructure the record pages use, not a second
+ * to-do system. It also surfaces the older `CrmFollowUp` rows the lead flow
+ * still writes: those pre-date generic tasks and would otherwise be invisible
+ * here, which is how this page came to look empty while work was outstanding.
+ */
+
+type LegacyFollowUp = {
   id: string;
   title: string;
   dueAt: string;
   status: string;
+  notes: string | null;
   lead: { id: string; leadNo: string; title: string | null } | null;
   client: { id: string; name: string } | null;
+  assignedTo: { id: string; name: string } | null;
 };
 
+const QUEUES: TaskQueue[] = [
+  "TODAY",
+  "OVERDUE",
+  "UPCOMING",
+  "MINE",
+  "UNASSIGNED",
+  "TEAM",
+  "COMPLETED",
+];
+
+const EMPTY_MESSAGES: Partial<Record<TaskQueue, string>> = {
+  TODAY: "Nothing due today.",
+  OVERDUE: "Nothing overdue — the queue is clean.",
+  UPCOMING: "Nothing booked in yet.",
+  MINE: "You have no open follow-ups.",
+  UNASSIGNED: "Every follow-up has an owner.",
+  TEAM: "No open follow-ups across the team.",
+  COMPLETED: "Nothing completed yet.",
+};
+
+/** The three counts worth knowing before reading a single row. */
+const HEADLINE_QUEUES: TaskQueue[] = ["OVERDUE", "TODAY", "UPCOMING"];
+
 export function CrmFollowUpsContent() {
+  const { data: session } = useSession();
   const queryClient = useQueryClient();
-  // Snapshot "now" once at mount so render stays pure.
-  const [now] = useState(() => Date.now());
-  const followUps = useQuery({
-    queryKey: ["crm-followups-all"],
-    queryFn: () =>
-      fetchJson<{ data: FollowUp[] }>("/api/v2/crm/follow-ups?status=PENDING").then((r) => r.data),
+  const { toast } = useToast();
+  const [queue, setQueue] = useState<TaskQueue>("TODAY");
+  const [creating, setCreating] = useState(false);
+
+  const tasks = useQuery({
+    queryKey: ["crm-tasks", queue],
+    queryFn: () => fetchCrmTasks({ queue, limit: 200 }),
   });
 
-  const complete = useMutation({
-    mutationFn: (id: string) =>
-      fetchJson(`/api/v2/crm/follow-ups/${id}`, { method: "PATCH", body: JSON.stringify({ status: "COMPLETED" }) }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["crm-followups-all"] }),
+  const headline = useQueries({
+    queries: HEADLINE_QUEUES.map((value) => ({
+      queryKey: ["crm-tasks", "count", value],
+      queryFn: () => fetchCrmTasks({ queue: value, limit: 1 }),
+    })),
   });
+
+  const legacy = useQuery({
+    queryKey: ["crm-followups-legacy"],
+    queryFn: () => fetchJson<{ data: LegacyFollowUp[] }>("/api/v2/crm/follow-ups?status=PENDING"),
+  });
+
+  const legacyRows = useMemo(() => legacy.data?.data ?? [], [legacy.data]);
+  const taskRows = tasks.data?.data ?? [];
+
+  const completeLegacy = useMutation({
+    mutationFn: (id: string) =>
+      fetchJson(`/api/v2/crm/follow-ups/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "COMPLETED" }),
+      }),
+    onSuccess: () => {
+      toast({ title: "Follow-up closed" });
+      queryClient.invalidateQueries({ queryKey: ["crm-followups-legacy"] });
+    },
+    onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
+  });
+
+  const nothingAtAll =
+    !tasks.isLoading && taskRows.length === 0 && legacyRows.length === 0 && queue === "TODAY";
 
   return (
-    <Card>
-      <CardContent className="p-0">
-        <ul className="divide-y divide-[var(--border)]">
-          {(followUps.data ?? []).map((f) => {
-            const overdue = new Date(f.dueAt).getTime() < now;
-            return (
-              <li key={f.id} className="flex flex-wrap items-center justify-between gap-2 p-3 text-sm">
-                <span className="min-w-0">
-                  {overdue ? <Badge variant="outline" className="mr-2 text-red-600">Overdue</Badge> : null}
-                  {f.title}
-                  {f.lead ? (
-                    <Link href={`/crm/leads/${f.lead.id}`} className="ml-2 text-[var(--text-muted)] underline">
-                      {f.lead.leadNo}
-                    </Link>
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-3">
+        {HEADLINE_QUEUES.map((value, index) => {
+          const count = headline[index]?.data?.pagination?.total ?? 0;
+          return (
+            <StatCard
+              key={value}
+              label={TASK_QUEUE_LABELS[value]}
+              value={count}
+              tone={value === "OVERDUE" && count > 0 ? "danger" : "neutral"}
+            />
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SegmentedControl
+          options={QUEUES.map((value) => ({ value, label: TASK_QUEUE_LABELS[value] }))}
+          value={queue}
+          onValueChange={(value) => setQueue(value as TaskQueue)}
+          size="sm"
+          ariaLabel="Follow-up queue"
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          startIcon={<Plus className="size-4" />}
+          onClick={() => setCreating(true)}
+        >
+          New follow-up
+        </Button>
+      </div>
+
+      {tasks.error ? (
+        <Alert tone="danger" title="Couldn't load follow-ups">
+          {getApiErrorMessage(tasks.error)}
+        </Alert>
+      ) : null}
+
+      {nothingAtAll ? (
+        <EmptyState
+          title="Nothing to chase today"
+          body="Follow-ups raised on a lead, deal, company or site all land here."
+          action={
+            <Button variant="primary" size="sm" onClick={() => setCreating(true)}>
+              Add a follow-up
+            </Button>
+          }
+        />
+      ) : (
+        <TaskList
+          tasks={taskRows}
+          isLoading={tasks.isLoading}
+          emptyMessage={EMPTY_MESSAGES[queue]}
+          currentUserId={session?.user?.id}
+        />
+      )}
+
+      {legacyRows.length ? (
+        <section className="space-y-2">
+          <div>
+            <h2 className="text-sm font-semibold">Lead reminders</h2>
+            <p className="text-sm text-[var(--text-muted)]">
+              Raised from a lead before follow-ups became tasks. They behave the
+              same way — tick one off when it is done.
+            </p>
+          </div>
+          <ul className="divide-y divide-[var(--border-subtle)] rounded-[var(--radius-md)] border border-[var(--border-subtle)]">
+            {legacyRows.map((row) => (
+              <li key={row.id} className="flex flex-wrap items-center justify-between gap-3 p-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                    {row.title}
+                    <Badge tone="neutral" size="sm">
+                      Lead reminder
+                    </Badge>
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
+                    <ClientDate value={row.dueAt} mode="datetime" />
+                    <span>{row.assignedTo?.name ?? "Unassigned"}</span>
+                    {row.lead ? (
+                      <Link href={`/crm/leads/${row.lead.id}`} className="hover:underline">
+                        {row.lead.title ?? row.lead.leadNo}
+                      </Link>
+                    ) : null}
+                    {row.client ? <span>{row.client.name}</span> : null}
+                  </div>
+                  {row.notes ? (
+                    <p className="mt-1 text-xs text-[var(--text-muted)]">{row.notes}</p>
                   ) : null}
-                  <span className="ml-2 text-[var(--text-muted)]">{new Date(f.dueAt).toLocaleString()}</span>
-                </span>
-                <Button size="sm" variant="outline" onClick={() => complete.mutate(f.id)}>
+                </div>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={completeLegacy.isPending}
+                  onClick={() => completeLegacy.mutate(row.id)}
+                >
                   Done
                 </Button>
               </li>
-            );
-          })}
-          {followUps.data && followUps.data.length === 0 ? (
-            <li className="p-3 text-sm text-[var(--text-muted)]">No pending follow-ups.</li>
-          ) : null}
-        </ul>
-      </CardContent>
-    </Card>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <TaskFormSheet open={creating} onOpenChange={setCreating} currentUserId={session?.user?.id} />
+    </div>
   );
 }

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -1,32 +1,69 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
-import { fetchJson } from "@/lib/api-client";
+import { Alert, Badge, Button, Card, EmptyState, Skeleton, StatCard } from "@corelithzw/react";
+import { ClientDate } from "@/components/ui/client-date";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { CopyLink, ExternalLink, Plus } from "@/lib/icons";
 
-type Form = {
+type IntakeForm = {
   id: string;
   name: string;
+  headline: string | null;
   publicToken: string;
   isActive: boolean;
+  submissionCount: number;
+  convertedCount: number;
+  lastSubmissionAt: string | null;
 };
 
+type Submission = {
+  id: string;
+  status: string;
+  createdAt: string;
+  contactName: string | null;
+  form: { id: string; name: string } | null;
+  lead: { id: string; leadNo: string } | null;
+};
+
+function publicUrl(token: string): string {
+  if (typeof window === "undefined") return `/f/${token}`;
+  return `${window.location.origin}/f/${token}`;
+}
+
+/**
+ * Intake forms.
+ *
+ * A form is a lead source, so the list is built around the numbers that make
+ * it one: how many people have filled it in, how many of those became a real
+ * lead, and when it last did anything. The previous version listed names and a
+ * copy link, which cannot tell a form nobody has ever used from one bringing
+ * work in every day.
+ */
 export function CrmFormsContent() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [copied, setCopied] = useState<string | null>(null);
 
   const forms = useQuery({
     queryKey: ["crm-forms"],
-    queryFn: () => fetchJson<{ data: Form[] }>("/api/v2/crm/intake-forms").then((r) => r.data),
+    queryFn: () => fetchJson<{ data: IntakeForm[] }>("/api/v2/crm/intake-forms"),
+  });
+
+  const submissions = useQuery({
+    queryKey: ["crm-submissions", "recent"],
+    queryFn: () => fetchJson<{ data: Submission[] }>("/api/v2/crm/submissions?limit=8"),
   });
 
   const create = useMutation({
     mutationFn: () =>
-      fetchJson<Form>("/api/v2/crm/intake-forms", {
+      fetchJson<IntakeForm>("/api/v2/crm/intake-forms", {
         method: "POST",
         body: JSON.stringify({ name: "New intake form", fields: [], services: [] }),
       }),
@@ -34,40 +71,184 @@ export function CrmFormsContent() {
       queryClient.invalidateQueries({ queryKey: ["crm-forms"] });
       router.push(`/crm/forms/${form.id}`);
     },
+    onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
   });
 
+  const rows = forms.data?.data ?? [];
+  const totals = rows.reduce(
+    (sum, form) => ({
+      submissions: sum.submissions + form.submissionCount,
+      converted: sum.converted + form.convertedCount,
+      live: sum.live + (form.isActive ? 1 : 0),
+    }),
+    { submissions: 0, converted: 0, live: 0 },
+  );
+
+  const copyLink = async (form: IntakeForm) => {
+    try {
+      await navigator.clipboard.writeText(publicUrl(form.publicToken));
+      setCopied(form.id);
+      toast({ title: "Link copied", description: "Anyone with it can fill the form in." });
+    } catch {
+      toast({ title: "Couldn't copy the link", variant: "destructive" });
+    }
+  };
+
+  if (forms.error) {
+    return (
+      <Alert tone="danger" title="Couldn't load the forms">
+        {getApiErrorMessage(forms.error)}
+      </Alert>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={() => create.mutate()} disabled={create.isPending}>
+    <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <StatCard label="Live forms" value={totals.live} footer={`${rows.length} in total`} />
+        <StatCard label="Submissions" value={totals.submissions} footer="All time" />
+        <StatCard
+          label="Became a lead"
+          value={totals.converted}
+          tone={totals.converted > 0 ? "success" : "neutral"}
+          footer={
+            totals.submissions > 0
+              ? `${Math.round((totals.converted / totals.submissions) * 100)}% of submissions`
+              : "Nothing submitted yet"
+          }
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Your forms</h2>
+          <p className="text-sm text-[var(--text-muted)]">
+            Share the link anywhere — a submission lands in the CRM as a lead,
+            assigned and scored on the way in.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          startIcon={<Plus className="size-4" />}
+          disabled={create.isPending}
+          onClick={() => create.mutate()}
+        >
           New form
         </Button>
       </div>
-      <Card>
-        <CardContent className="p-0">
-          <ul className="divide-y divide-[var(--border)]">
-            {(forms.data ?? []).map((f) => (
-              <li key={f.id} className="flex flex-wrap items-center justify-between gap-2 p-3 text-sm">
-                <span className="min-w-0">
-                  <button className="font-medium underline" onClick={() => router.push(`/crm/forms/${f.id}`)}>
-                    {f.name}
-                  </button>
-                  {!f.isActive ? <Badge variant="outline" className="ml-2">Inactive</Badge> : null}
-                </span>
-                <button
-                  className="text-[var(--text-muted)] underline"
-                  onClick={() => navigator.clipboard?.writeText(`${window.location.origin}/f/${f.publicToken}`)}
-                >
-                  Copy public link
-                </button>
+
+      {forms.isLoading ? (
+        <Skeleton height={180} />
+      ) : rows.length === 0 ? (
+        <EmptyState
+          title="No intake forms yet"
+          body="A form is the cheapest lead source you have — put one on the website and enquiries arrive already in the pipeline."
+          action={
+            <Button variant="primary" size="sm" onClick={() => create.mutate()}>
+              Build the first form
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {rows.map((form) => (
+            <Card key={form.id}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <Link
+                    href={`/crm/forms/${form.id}`}
+                    className="text-sm font-semibold hover:underline"
+                  >
+                    {form.name}
+                  </Link>
+                  {form.headline ? (
+                    <p className="truncate text-sm text-[var(--text-muted)]">{form.headline}</p>
+                  ) : null}
+                </div>
+                <Badge tone={form.isActive ? "success" : "neutral"} size="sm">
+                  {form.isActive ? "Live" : "Paused"}
+                </Badge>
+              </div>
+
+              <dl className="mt-3 grid grid-cols-3 gap-2 text-sm">
+                <div>
+                  <dt className="text-xs text-[var(--text-muted)]">Submissions</dt>
+                  <dd className="font-mono">{form.submissionCount}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-[var(--text-muted)]">Became leads</dt>
+                  <dd className="font-mono">{form.convertedCount}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-[var(--text-muted)]">Last one</dt>
+                  <dd className="text-xs">
+                    {form.lastSubmissionAt ? (
+                      <ClientDate value={form.lastSubmissionAt} mode="date" />
+                    ) : (
+                      "—"
+                    )}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button size="sm" variant="secondary" onClick={() => copyLink(form)}>
+                  <CopyLink className="mr-1.5 size-4" />
+                  {copied === form.id ? "Copied" : "Copy link"}
+                </Button>
+                <Button size="sm" variant="ghost" asChild>
+                  <a href={`/f/${form.publicToken}`} target="_blank" rel="noreferrer">
+                    <ExternalLink className="mr-1.5 size-4" />
+                    Preview
+                  </a>
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => router.push(`/crm/forms/${form.id}`)}>
+                  Edit
+                </Button>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold">Latest submissions</h2>
+        {submissions.isLoading ? (
+          <Skeleton height={120} />
+        ) : (submissions.data?.data ?? []).length === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]">Nothing has been submitted yet.</p>
+        ) : (
+          <ul className="divide-y divide-[var(--border-subtle)] rounded-[var(--radius-md)] border border-[var(--border-subtle)]">
+            {(submissions.data?.data ?? []).map((submission) => (
+              <li
+                key={submission.id}
+                className="flex flex-wrap items-center justify-between gap-2 p-3 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="font-medium">{submission.contactName ?? "Someone"}</span>
+                  <span className="text-[var(--text-muted)]">
+                    {" "}
+                    via {submission.form?.name ?? "a form"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-[var(--text-muted)]">
+                  <ClientDate value={submission.createdAt} mode="datetime" />
+                  {submission.lead ? (
+                    <Link href={`/crm/leads/${submission.lead.id}`} className="hover:underline">
+                      {submission.lead.leadNo}
+                    </Link>
+                  ) : (
+                    <Badge tone="warn" size="sm">
+                      Not converted
+                    </Badge>
+                  )}
+                </div>
               </li>
             ))}
-            {forms.data && forms.data.length === 0 ? (
-              <li className="p-3 text-sm text-[var(--text-muted)]">No intake forms yet.</li>
-            ) : null}
           </ul>
-        </CardContent>
-      </Card>
+        )}
+      </section>
     </div>
   );
 }

--- a/components/crm/crm-insights-content.tsx
+++ b/components/crm/crm-insights-content.tsx
@@ -1,10 +1,52 @@
 "use client";
 
+import { useState } from "react";
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { fetchJson } from "@/lib/api-client";
+import { Alert, Badge, Card, EmptyState, Skeleton, StatHero } from "@corelithzw/react";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { CRM_CHANNEL_LABELS } from "@/lib/crm/sources";
+import { REPORT_RANGES, formatRate, type ReportRange } from "@/lib/crm/reports";
+
+type FunnelStage = {
+  key: string;
+  label: string;
+  reached: number;
+  value: number;
+  shareOfTotal: number;
+  conversionFromPrevious: number;
+  droppedFromPrevious: number;
+};
+
+type GroupRow = {
+  key: string;
+  label: string;
+  won: number;
+  lost: number;
+  open: number;
+  wonValue: number;
+  openValue: number;
+  winRate: number;
+};
+
+type ReportData = {
+  range: ReportRange;
+  from: string;
+  to: string;
+  scope: "TEAM" | "MINE";
+  funnel: FunnelStage[];
+  counts: { won: number; lost: number; open: number };
+  winRate: number;
+  medianCycleDays: number | null;
+  forecast: { weighted: number; unweighted: number };
+  byOwner: GroupRow[];
+  bySource: GroupRow[];
+  activity: Array<{ label: string; start: string; count: number }>;
+  leads: { created: number; converted: number };
+};
 
 type RepRow = {
   repId: string;
@@ -27,148 +69,321 @@ type SourceRow = {
   conversionRate: number;
 };
 
-type ChannelRow = {
-  channel: string;
-  leads: number;
-  won: number;
-  conversionRate: number;
+type ChannelRow = { channel: string; leads: number; won: number; conversionRate: number };
+
+const RANGE_LABELS: Record<ReportRange, string> = {
+  "7d": "7 days",
+  "30d": "30 days",
+  "90d": "90 days",
+  "12m": "12 months",
 };
 
-const CHANNEL_LABELS: Record<string, string> = CRM_CHANNEL_LABELS;
+function money(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
 
+/** The stage that loses the most of what reached the one before it. */
+function biggestLeakStage(funnel: FunnelStage[]): FunnelStage | null {
+  let worst: FunnelStage | null = null;
+  for (const stage of funnel.slice(1)) {
+    if (stage.reached === 0 && stage.droppedFromPrevious === 0) continue;
+    // `>=` so a tie breaks toward the later stage — the one closer to the money.
+    if (!worst || stage.droppedFromPrevious >= worst.droppedFromPrevious) worst = stage;
+  }
+  return worst && worst.droppedFromPrevious > 0 ? worst : null;
+}
+
+/**
+ * Insights.
+ *
+ * The reporting engine — funnel with per-stage conversion, win rate, median
+ * cycle, weighted forecast, activity trend and grouped performance — already
+ * existed behind `/api/v2/crm/reports` and nothing rendered it; the page only
+ * showed two flat tables. This reads the whole report, and every number is a
+ * question someone actually asks: where are we losing them, how long does a
+ * deal take, what is realistically going to land, and who or what is bringing
+ * the work in.
+ */
 export function CrmInsightsContent() {
+  const [range, setRange] = useState<ReportRange>("90d");
+
+  const report = useQuery({
+    queryKey: ["crm-report", range],
+    queryFn: () => fetchJson<ReportData>(`/api/v2/crm/reports?range=${range}`),
+    placeholderData: (previous) => previous,
+  });
+
   const reps = useQuery({
     queryKey: ["crm-insights-reps"],
-    queryFn: () => fetchJson<{ data: RepRow[] }>("/api/v2/crm/insights/reps").then((r) => r.data),
+    queryFn: () => fetchJson<{ data: RepRow[] }>("/api/v2/crm/insights/reps"),
   });
+
   const sources = useQuery({
     queryKey: ["crm-insights-sources"],
     queryFn: () =>
       fetchJson<{ sources: SourceRow[]; channels: ChannelRow[] }>("/api/v2/crm/insights/sources"),
   });
 
+  if (report.error) {
+    return (
+      <Alert tone="danger" title="Couldn't build the report">
+        {getApiErrorMessage(report.error)}
+      </Alert>
+    );
+  }
+
+  const data = report.data;
+  const leak = data ? biggestLeakStage(data.funnel) : null;
+  const decided = data ? data.counts.won + data.counts.lost : 0;
+  const peakActivity = data ? Math.max(1, ...data.activity.map((point) => point.count)) : 1;
+
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Per-rep performance</CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-sm">
-            <thead>
-              <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
-                <th className="p-3">Rep</th>
-                <th className="p-3 text-right">Leads</th>
-                <th className="p-3 text-right">Quotes</th>
-                <th className="p-3 text-right">Win %</th>
-                <th className="p-3 text-right">Invoiced</th>
-                <th className="p-3 text-right">Collected</th>
-                <th className="p-3 text-right">Avg response</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(reps.data ?? []).map((r) => (
-                <tr key={r.repId} className="border-b border-[var(--border)]">
-                  <td className="p-3 font-medium">{r.name}</td>
-                  <td className="p-3 text-right">{r.leads}</td>
-                  <td className="p-3 text-right">{r.quotes}</td>
-                  <td className="p-3 text-right">{r.winRate}%</td>
-                  <td className="p-3 text-right">${r.invoicedAmount.toLocaleString()}</td>
-                  <td className="p-3 text-right">${r.collectedAmount.toLocaleString()}</td>
-                  <td className="p-3 text-right">{r.avgResponseHours != null ? `${r.avgResponseHours}h` : "—"}</td>
-                </tr>
-              ))}
-              {reps.data && reps.data.length === 0 ? (
-                <tr>
-                  <td className="p-3 text-[var(--text-muted)]" colSpan={7}>
-                    No data yet.
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-          </div>
-        </CardContent>
-      </Card>
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SegmentedControl
+          value={range}
+          onValueChange={(value) => setRange(value as ReportRange)}
+          size="sm"
+          ariaLabel="Report period"
+          options={REPORT_RANGES.map((value) => ({ value, label: RANGE_LABELS[value] }))}
+        />
+        {data ? (
+          <Badge tone="neutral" size="sm">
+            {data.scope === "TEAM" ? "Whole team" : "Your deals only"}
+          </Badge>
+        ) : null}
+      </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Lead channels</CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-          <table className="w-full min-w-[420px] text-sm">
-            <thead>
-              <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
-                <th className="p-3">Channel</th>
-                <th className="p-3 text-right">Leads</th>
-                <th className="p-3 text-right">Won</th>
-                <th className="p-3 text-right">Conversion</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(sources.data?.channels ?? []).map((c) => (
-                <tr key={c.channel} className="border-b border-[var(--border)]">
-                  <td className="p-3 font-medium">{CHANNEL_LABELS[c.channel] ?? c.channel}</td>
-                  <td className="p-3 text-right">{c.leads}</td>
-                  <td className="p-3 text-right">{c.won}</td>
-                  <td className="p-3 text-right">{c.conversionRate}%</td>
-                </tr>
-              ))}
-              {sources.data && sources.data.channels.length === 0 ? (
-                <tr>
-                  <td className="p-3 text-[var(--text-muted)]" colSpan={4}>
-                    No leads captured yet.
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
-          </div>
-        </CardContent>
-      </Card>
+      {!data ? (
+        <div className="space-y-4" aria-busy="true" aria-live="polite">
+          <Skeleton height={128} />
+          <Skeleton height={240} />
+        </div>
+      ) : decided === 0 && data.counts.open === 0 ? (
+        <EmptyState
+          title="Nothing to report on this period yet"
+          body="Once deals are opened and closed, this page shows where they are lost, how long they take and what is likely to land."
+        />
+      ) : (
+        <>
+          <StatHero
+            label="Weighted forecast"
+            value={money(data.forecast.weighted)}
+            subtitle={`${money(data.forecast.unweighted)} if every open deal lands · ${data.counts.open} open`}
+            change={
+              decided === 0
+                ? "Nothing decided in this period yet"
+                : `${formatRate(data.winRate)} win rate across ${decided} decided deal${decided === 1 ? "" : "s"}`
+            }
+            trend={data.winRate >= 0.5 ? "up" : data.winRate > 0 ? "down" : "neutral"}
+          />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Source & campaign attribution</CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-sm">
-            <thead>
-              <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
-                <th className="p-3">Source</th>
-                <th className="p-3">Channel</th>
-                <th className="p-3">Campaign</th>
-                <th className="p-3 text-right">Leads</th>
-                <th className="p-3 text-right">Won</th>
-                <th className="p-3 text-right">Conversion</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(sources.data?.sources ?? []).map((s, index) => (
-                <tr key={index} className="border-b border-[var(--border)]">
-                  <td className="p-3 font-medium">{s.source}</td>
-                  <td className="p-3 text-[var(--text-muted)]">{CHANNEL_LABELS[s.channel] ?? s.channel}</td>
-                  <td className="p-3 text-[var(--text-muted)]">{s.campaign ?? "—"}</td>
-                  <td className="p-3 text-right">{s.leads}</td>
-                  <td className="p-3 text-right">{s.won}</td>
-                  <td className="p-3 text-right">{s.conversionRate}%</td>
-                </tr>
-              ))}
-              {sources.data && sources.data.sources.length === 0 ? (
-                <tr>
-                  <td className="p-3 text-[var(--text-muted)]" colSpan={6}>
-                    No leads captured yet.
-                  </td>
-                </tr>
-              ) : null}
-            </tbody>
-          </table>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Card title="Median time to close">
+              <p className="text-2xl font-semibold">
+                {data.medianCycleDays === null ? "—" : `${data.medianCycleDays} days`}
+              </p>
+              <p className="text-sm text-[var(--text-muted)]">
+                {data.medianCycleDays === null
+                  ? "No deal has closed in this period."
+                  : "From opening the deal to winning or losing it."}
+              </p>
+            </Card>
+            <Card title="Biggest leak">
+              <p className="text-2xl font-semibold">{leak ? leak.label : "—"}</p>
+              <p className="text-sm text-[var(--text-muted)]">
+                {leak
+                  ? `${leak.droppedFromPrevious} dropped before reaching it — ${formatRate(leak.conversionFromPrevious)} of the previous stage carried through.`
+                  : "Nothing is falling out between stages."}
+              </p>
+            </Card>
+            <Card title="Leads converted">
+              <p className="text-2xl font-semibold">
+                {data.leads.converted}
+                <span className="text-base font-normal text-[var(--text-muted)]">
+                  {" "}
+                  / {data.leads.created}
+                </span>
+              </p>
+              <p className="text-sm text-[var(--text-muted)]">
+                {data.leads.created === 0
+                  ? "No leads captured in this period."
+                  : `${formatRate(data.leads.converted / data.leads.created)} of new leads became a deal.`}
+              </p>
+            </Card>
           </div>
-        </CardContent>
-      </Card>
+
+          <Card title="Where deals fall out">
+            {data.funnel.length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">No stages configured.</p>
+            ) : (
+              <ul className="space-y-3">
+                {data.funnel.map((stage, index) => (
+                  <li key={stage.key} className="space-y-1">
+                    <div className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
+                      <span className="font-medium">{stage.label}</span>
+                      <span className="font-mono text-xs text-[var(--text-muted)]">
+                        {stage.reached} reached · {money(stage.value)}
+                        {index > 0
+                          ? ` · ${formatRate(stage.conversionFromPrevious)} carried through`
+                          : ""}
+                      </span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-[var(--surface-muted)]">
+                      <div
+                        className="h-2 rounded-full bg-[var(--brand)]"
+                        style={{ width: `${Math.max(stage.shareOfTotal * 100, stage.reached > 0 ? 2 : 0)}%` }}
+                        aria-hidden="true"
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+
+          <Card title="Activity">
+            {data.activity.length === 0 ? (
+              <p className="text-sm text-[var(--text-muted)]">Nothing logged in this period.</p>
+            ) : (
+              <>
+                <div className="scroll-rail flex h-28 items-end gap-1 overflow-x-auto">
+                  {data.activity.map((point, index) => (
+                    <div
+                      key={`${point.start}-${index}`}
+                      className="flex min-w-2 flex-1 flex-col justify-end"
+                      title={`${point.label}: ${point.count}`}
+                    >
+                      <div
+                        className="rounded-t bg-[var(--brand)]"
+                        style={{ height: `${(point.count / peakActivity) * 100}%` }}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <p className="mt-2 text-xs text-[var(--text-muted)]">
+                  Calls, notes, emails and meetings logged. Peak {peakActivity} in a single period.
+                </p>
+              </>
+            )}
+          </Card>
+
+          <Tabs defaultValue="owner" variant="underline">
+            <TabsList aria-label="Performance breakdown">
+              <TabsTrigger value="owner">By owner</TabsTrigger>
+              <TabsTrigger value="source">By source</TabsTrigger>
+              <TabsTrigger value="rep">Rep scorecard</TabsTrigger>
+              <TabsTrigger value="channel">Channels</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="owner">
+              <GroupTable rows={data.byOwner} firstHeader="Owner" />
+            </TabsContent>
+
+            <TabsContent value="source">
+              <GroupTable rows={data.bySource} firstHeader="Source" />
+            </TabsContent>
+
+            <TabsContent value="rep">
+              {reps.data?.data.length ? (
+                <div className="scroll-rail overflow-x-auto">
+                  <table className="w-full min-w-[680px] text-sm">
+                    <thead>
+                      <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
+                        <th className="p-3">Rep</th>
+                        <th className="p-3 text-right">Leads</th>
+                        <th className="p-3 text-right">Quotes</th>
+                        <th className="p-3 text-right">Win %</th>
+                        <th className="p-3 text-right">Invoiced</th>
+                        <th className="p-3 text-right">Collected</th>
+                        <th className="p-3 text-right">Avg response</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {reps.data.data.map((row) => (
+                        <tr key={row.repId} className="border-b border-[var(--border-subtle)]">
+                          <td className="p-3 font-medium">{row.name}</td>
+                          <td className="p-3 text-right font-mono">{row.leads}</td>
+                          <td className="p-3 text-right font-mono">{row.quotes}</td>
+                          <td className="p-3 text-right font-mono">{row.winRate}%</td>
+                          <td className="p-3 text-right font-mono">{money(row.invoicedAmount)}</td>
+                          <td className="p-3 text-right font-mono">{money(row.collectedAmount)}</td>
+                          <td className="p-3 text-right font-mono">
+                            {row.avgResponseHours != null ? `${row.avgResponseHours}h` : "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <EmptyState title="No rep activity yet" />
+              )}
+            </TabsContent>
+
+            <TabsContent value="channel">
+              {sources.data?.channels.length ? (
+                <ul className="divide-y divide-[var(--border-subtle)]">
+                  {sources.data.channels.map((row) => (
+                    <li
+                      key={row.channel}
+                      className="flex flex-wrap items-center justify-between gap-2 p-3 text-sm"
+                    >
+                      <Link
+                        href={`/crm/leads?channels=${row.channel}`}
+                        className="font-medium hover:underline"
+                      >
+                        {(CRM_CHANNEL_LABELS as Record<string, string>)[row.channel] ?? row.channel}
+                      </Link>
+                      <span className="font-mono text-xs text-[var(--text-muted)]">
+                        {row.leads} leads · {row.won} won · {row.conversionRate}%
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState title="No lead channels recorded yet" />
+              )}
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Shared shape for the owner and source breakdowns — same columns, same maths. */
+function GroupTable({ rows, firstHeader }: { rows: GroupRow[]; firstHeader: string }) {
+  if (!rows.length) return <EmptyState title={`Nothing to break down by ${firstHeader.toLowerCase()} yet`} />;
+
+  return (
+    <div className="scroll-rail overflow-x-auto">
+      <table className="w-full min-w-[560px] text-sm">
+        <thead>
+          <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
+            <th className="p-3">{firstHeader}</th>
+            <th className="p-3 text-right">Open</th>
+            <th className="p-3 text-right">Won</th>
+            <th className="p-3 text-right">Lost</th>
+            <th className="p-3 text-right">Win %</th>
+            <th className="p-3 text-right">Won value</th>
+            <th className="p-3 text-right">Open value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key} className="border-b border-[var(--border-subtle)]">
+              <td className="p-3 font-medium">{row.label}</td>
+              <td className="p-3 text-right font-mono">{row.open}</td>
+              <td className="p-3 text-right font-mono">{row.won}</td>
+              <td className="p-3 text-right font-mono">{row.lost}</td>
+              <td className="p-3 text-right font-mono">{formatRate(row.winRate)}</td>
+              <td className="p-3 text-right font-mono">{money(row.wonValue)}</td>
+              <td className="p-3 text-right font-mono">{money(row.openValue)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/components/crm/leads/leads-board.tsx
+++ b/components/crm/leads/leads-board.tsx
@@ -107,12 +107,9 @@ export function LeadsBoard({ filters }: { filters: LeadViewFilters }) {
     }) => updateCrmLeadStage(leadId, stage, lostReason),
     onMutate: async ({ leadId, stage }) => {
       await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData<{ data: BoardData }>(queryKey);
+      const previous = queryClient.getQueryData<BoardData>(queryKey);
       if (previous) {
-        queryClient.setQueryData(queryKey, {
-          ...previous,
-          data: moveCardInCache(previous.data, leadId, stage),
-        });
+        queryClient.setQueryData(queryKey, moveCardInCache(previous, leadId, stage));
       }
       return { previous };
     },
@@ -133,7 +130,7 @@ export function LeadsBoard({ filters }: { filters: LeadViewFilters }) {
     },
   });
 
-  const columns = boardQuery.data?.data.columns ?? [];
+  const columns = boardQuery.data?.columns ?? [];
 
   const resolveDropStage = (overId: string): CrmLeadStage | null => {
     if (overId.startsWith("column:")) return overId.slice("column:".length) as CrmLeadStage;

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -79,7 +79,7 @@ export function LeadsWorkspace({
     [sourcesQuery.data],
   );
   const savedViews = useMemo<CrmSavedViewRecord[]>(
-    () => savedViewsQuery.data?.data.data ?? [],
+    () => savedViewsQuery.data?.data ?? [],
     [savedViewsQuery.data],
   );
 
@@ -134,7 +134,7 @@ export function LeadsWorkspace({
   );
 
   const leads = leadsQuery.data?.data ?? [];
-  const total = leadsQuery.data?.total ?? leads.length;
+  const total = leadsQuery.data?.pagination?.total ?? leads.length;
 
   return (
     <div className="space-y-4">

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -31,7 +31,7 @@ type PendingLostBulk = { ids: string[]; done: () => void };
 
 export function LeadsWorkspace({
   initialFilters = {},
-  initialView = "TABLE",
+  initialView = "BOARD",
 }: {
   /** Parsed from the page's query string, so links like /crm/leads?stages=QUOTED land pre-filtered. */
   initialFilters?: LeadViewFilters;

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -53,7 +53,7 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
   });
 
   const rows = useMemo(() => companiesQuery.data?.data ?? [], [companiesQuery.data]);
-  const total = companiesQuery.data?.total ?? rows.length;
+  const total = companiesQuery.data?.pagination?.total ?? rows.length;
 
   const columns = useMemo<ColumnDef<CrmCompanyRecord>[]>(
     () => [

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -160,6 +160,9 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
       error={companiesQuery.error}
     >
       <DataTable
+        // The shell above owns search; a second box in the table toolbar is the
+        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
+        features={{ globalFilter: false }}
         data={rows}
         columns={columns}
         edgeToEdge

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -107,7 +107,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
     queryFn: () => fetchCrmFieldDefinitions("COMPANY"),
   });
 
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const company = companyQuery.data?.data;
 
   if (companyQuery.isLoading) {

--- a/components/crm/records/company-form-sheet.tsx
+++ b/components/crm/records/company-form-sheet.tsx
@@ -162,7 +162,7 @@ export function CompanyFormSheet({
     [companiesQuery.data],
   );
   const owners = teamQuery.data?.data ?? [];
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
 
   const buildBody = (force: boolean) => ({
     name: form.name.trim(),

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -135,7 +135,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
   });
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const deal = dealQuery.data?.data;
 
   if (dealQuery.isLoading) {

--- a/components/crm/records/deal-form-sheet.tsx
+++ b/components/crm/records/deal-form-sheet.tsx
@@ -123,7 +123,7 @@ export function DealFormSheet({
     enabled: open,
   });
 
-  const pipelines = useMemo(() => pipelinesQuery.data?.data.data ?? [], [pipelinesQuery.data]);
+  const pipelines = useMemo(() => pipelinesQuery.data?.data ?? [], [pipelinesQuery.data]);
   const selectedPipeline = pipelines.find((pipeline) => pipeline.id === form.pipelineId);
   const openStages = useMemo(
     () => (selectedPipeline?.stages ?? []).filter((stage) => stage.status === "OPEN"),
@@ -179,7 +179,7 @@ export function DealFormSheet({
     [sitesQuery.data],
   );
   const owners = teamQuery.data?.data ?? [];
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
 
   const save = useMutation({
     mutationFn: () =>

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -60,7 +60,8 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
   });
 
   const rows = useMemo(() => dealsQuery.data?.data ?? [], [dealsQuery.data]);
-  const total = dealsQuery.data?.total ?? rows.length;
+  const total = dealsQuery.data?.pagination?.total ?? rows.length;
+  const pipelineCount = pipelinesQuery.data?.data.length ?? 0;
 
   const columns = useMemo<ColumnDef<CrmDealRecord>[]>(
     () => [
@@ -198,8 +199,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
           />
           <Button asChild size="sm" variant="outline">
             <Link href="/crm/settings?tab=pipelines">
-              {pipelinesQuery.data?.data.data.length ?? 0} pipeline
-              {(pipelinesQuery.data?.data.data.length ?? 0) === 1 ? "" : "s"}
+              {pipelineCount} pipeline{pipelineCount === 1 ? "" : "s"}
             </Link>
           </Button>
         </>

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -206,6 +206,9 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
       }
     >
       <DataTable
+        // The shell above owns search; a second box in the table toolbar is the
+        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
+        features={{ globalFilter: false }}
         data={rows}
         columns={columns}
         edgeToEdge

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -141,6 +141,9 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
       error={peopleQuery.error}
     >
       <DataTable
+        // The shell above owns search; a second box in the table toolbar is the
+        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
+        features={{ globalFilter: false }}
         data={rows}
         columns={columns}
         edgeToEdge

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -40,7 +40,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
   });
 
   const rows = useMemo(() => peopleQuery.data?.data ?? [], [peopleQuery.data]);
-  const total = peopleQuery.data?.total ?? rows.length;
+  const total = peopleQuery.data?.pagination?.total ?? rows.length;
 
   const columns = useMemo<ColumnDef<CrmPersonRecord>[]>(
     () => [

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -110,7 +110,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
     queryFn: () => fetchCrmFieldDefinitions("PERSON"),
   });
 
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const person = personQuery.data?.data;
 
   if (personQuery.isLoading) {

--- a/components/crm/records/person-form-sheet.tsx
+++ b/components/crm/records/person-form-sheet.tsx
@@ -144,7 +144,7 @@ export function PersonFormSheet({
     [companiesQuery.data],
   );
   const owners = teamQuery.data?.data ?? [];
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
 
   const buildBody = (force: boolean) => ({
     firstName: form.firstName.trim(),

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -71,7 +71,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
     queryFn: () => fetchCrmFieldDefinitions("SITE"),
   });
 
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const site = siteQuery.data?.data;
 
   if (siteQuery.isLoading) {

--- a/components/crm/records/site-form-sheet.tsx
+++ b/components/crm/records/site-form-sheet.tsx
@@ -121,7 +121,7 @@ export function SiteFormSheet({
       })),
     [peopleQuery.data],
   );
-  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data.data ?? [];
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
 
   const save = useMutation({
     mutationFn: () =>

--- a/components/crm/records/sites-content.tsx
+++ b/components/crm/records/sites-content.tsx
@@ -27,7 +27,7 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
   });
 
   const rows = useMemo(() => sitesQuery.data?.data ?? [], [sitesQuery.data]);
-  const total = sitesQuery.data?.total ?? rows.length;
+  const total = sitesQuery.data?.pagination?.total ?? rows.length;
 
   const columns = useMemo<ColumnDef<CrmSiteRecord>[]>(
     () => [

--- a/components/crm/records/sites-content.tsx
+++ b/components/crm/records/sites-content.tsx
@@ -121,6 +121,9 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
       error={sitesQuery.error}
     >
       <DataTable
+        // The shell above owns search; a second box in the table toolbar is the
+        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
+        features={{ globalFilter: false }}
         data={rows}
         columns={columns}
         edgeToEdge

--- a/components/crm/settings/automations-panel.tsx
+++ b/components/crm/settings/automations-panel.tsx
@@ -75,10 +75,10 @@ export function AutomationsPanel() {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["crm-automations"],
-    queryFn: () => fetchJson<{ data: { data: AutomationRecord[] } }>("/api/v2/crm/automations"),
+    queryFn: () => fetchJson<{ data: AutomationRecord[] }>("/api/v2/crm/automations"),
   });
 
-  const rules = data?.data.data ?? [];
+  const rules = data?.data ?? [];
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["crm-automations"] });
 
   const toggle = useMutation({

--- a/components/crm/settings/custom-fields-panel.tsx
+++ b/components/crm/settings/custom-fields-panel.tsx
@@ -64,7 +64,7 @@ export function CustomFieldsPanel() {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = useMemo(
-    () => fieldsQuery.data?.data.data ?? [],
+    () => fieldsQuery.data?.data ?? [],
     [fieldsQuery.data],
   );
 

--- a/components/crm/settings/pipelines-panel.tsx
+++ b/components/crm/settings/pipelines-panel.tsx
@@ -316,7 +316,7 @@ export function PipelinesPanel() {
     queryFn: () => fetchCrmPipelines(),
   });
 
-  const pipelines = pipelinesQuery.data?.data.data ?? [];
+  const pipelines = pipelinesQuery.data?.data ?? [];
 
   const create = useMutation({
     mutationFn: () =>

--- a/components/inventory/catalogue-panel.tsx
+++ b/components/inventory/catalogue-panel.tsx
@@ -32,7 +32,8 @@ import { Plus } from "@/lib/icons";
 import { ProductSheet, type ProductRecord } from "./product-sheet";
 
 type CatalogueResponse = {
-  data: { data: ProductRecord[]; priceList: { id: string; name: string } | null };
+  data: ProductRecord[];
+  priceList: { id: string; name: string } | null;
 };
 
 const KIND_FILTERS = [
@@ -66,8 +67,8 @@ export function CataloguePanel() {
       ),
   });
 
-  const products = data?.data.data ?? [];
-  const priceList = data?.data.priceList ?? null;
+  const products = data?.data ?? [];
+  const priceList = data?.priceList ?? null;
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["inventory-products"] });
 
   const archive = useMutation({

--- a/components/layout/global-search.tsx
+++ b/components/layout/global-search.tsx
@@ -21,10 +21,12 @@ import {
   Building2,
   Funnel,
   MapPin,
+  Package,
   Plus,
   Receipt,
   Search,
   Users,
+  Wallet,
 } from "@/lib/icons";
 import type { SearchResult, SearchResultType } from "@/lib/crm/search";
 import { cn } from "@/lib/utils";
@@ -40,6 +42,8 @@ const TYPE_ICONS: Record<SearchResultType, typeof Users> = {
   QUOTATION: Receipt,
   INVOICE: Receipt,
   RECEIPT: Receipt,
+  PRODUCT: Package,
+  CUSTOMER: Wallet,
 };
 
 const RECENT_KEY = "crm.search.recent";
@@ -78,12 +82,17 @@ const QUICK_CREATE: Array<{ label: string; href: string }> = [
 ];
 
 /**
- * One search for the whole CRM, opened with ⌘K from any page.
+ * One search for the whole workspace, opened with ⌘K from any page.
+ *
+ * It lives in the navbar rather than on a module layout because "find the
+ * thing" is not a CRM-shaped need: the same box reaches people, companies,
+ * deals, leads, sites, quotations, invoices, receipts, the shared catalogue
+ * and accounting customers.
  *
  * Shows recently viewed records before anything is typed, so the common case
  * — going back to the thing you were just looking at — takes no typing at all.
  */
-export function GlobalSearch() {
+export function GlobalSearch({ compact = false }: { compact?: boolean }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -119,7 +128,7 @@ export function GlobalSearch() {
   }, [query]);
 
   const searchQuery = useQuery({
-    queryKey: ["crm", "search", debounced],
+    queryKey: ["global-search", debounced],
     queryFn: () =>
       fetchJson<{ groups: SearchGroup[]; total: number }>(
         `/api/v2/crm/search?q=${encodeURIComponent(debounced)}`,
@@ -148,28 +157,35 @@ export function GlobalSearch() {
 
   return (
     <>
+      {/* `compact` is the phone navbar, where the row is already tight and an
+          icon reads better than a labelled button. */}
       <Button
         variant="outline"
         size="sm"
-        className="gap-2 text-[var(--text-muted)]"
+        className={cn(
+          "gap-2 text-[var(--text-muted)]",
+          compact ? "px-2" : "min-w-56 justify-start",
+        )}
         onClick={() => setOpen(true)}
-        aria-label="Search the CRM"
+        aria-label="Search"
       >
-        <Search className="h-4 w-4" />
-        <span className="hidden sm:inline">Search</span>
-        <kbd className="hidden rounded border border-[var(--border)] px-1 text-[10px] sm:inline">
-          ⌘K
-        </kbd>
+        <Search className="h-4 w-4 shrink-0" />
+        {compact ? null : (
+          <>
+            <span className="flex-1 text-left">Search everything</span>
+            <kbd className="rounded border border-[var(--border)] px-1 text-[10px]">⌘K</kbd>
+          </>
+        )}
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="overflow-hidden p-0">
-          <DialogTitle className="sr-only">Search the CRM</DialogTitle>
+          <DialogTitle className="sr-only">Search</DialogTitle>
           <Command shouldFilter={false}>
             <CommandInput
               value={query}
               onValueChange={setQuery}
-              placeholder="Search people, companies, deals, quotes…"
+              placeholder="Search records, documents, catalogue…"
             />
             <CommandList className="max-h-96">
               {noResults ? (

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -24,6 +24,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { usePageActions } from "@/components/layout/page-actions";
+import { GlobalSearch } from "@/components/layout/global-search";
 import { NotificationCenter } from "@/components/notifications/notification-center";
 import { MoreHorizontal } from "@/lib/icons";
 import { canAccessCapabilityWithToken } from "@/lib/platform/gating/token-check";
@@ -55,6 +56,7 @@ export function Navbar() {
                 {currentTitle}
               </p>
             </div>
+            <GlobalSearch compact />
             {showNotificationCenter ? <NotificationCenter /> : null}
             <MobileNavbarActions actions={actions} />
           </div>
@@ -69,6 +71,7 @@ export function Navbar() {
             </div>
 
             <div className="flex items-center gap-3">
+              <GlobalSearch />
               {showNotificationCenter ? <NotificationCenter /> : null}
               {actions ? (
                 <div className="flex items-center gap-2">{actions}</div>

--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -80,8 +80,8 @@ export function SegmentedControl<V extends string>({
       className={cn(
         "items-stretch rounded-md p-0.5",
         fullWidth ? "flex w-full" : "inline-flex",
-        variant === "default" && "bg-[--surface-muted]",
-        variant === "border" && "border border-[--border] bg-[--surface-muted]",
+        variant === "default" && "bg-[var(--surface-muted)]",
+        variant === "border" && "border border-[var(--border)] bg-[var(--surface-muted)]",
         className,
       )}
     >
@@ -108,9 +108,9 @@ export function SegmentedControl<V extends string>({
               size === "sm" && "h-6 px-2 text-[11px]",
               size === "md" && "h-7 px-3 text-xs",
               active
-                ? "bg-[--surface-base] text-[--text-strong] shadow-[0_1px_0_0_var(--border)]"
-                : "text-[--text-muted] hover:text-[--text-body]",
-              opt.disabled && "cursor-not-allowed opacity-50 hover:text-[--text-muted]",
+                ? "bg-[var(--surface-base)] text-[var(--text-strong)] shadow-[0_1px_0_0_var(--border)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-body)]",
+              opt.disabled && "cursor-not-allowed opacity-50 hover:text-[var(--text-muted)]",
             )}
           >
             <span className="truncate">{opt.label}</span>
@@ -119,8 +119,8 @@ export function SegmentedControl<V extends string>({
                 className={cn(
                   "rounded px-1 text-[10px] tabular-nums",
                   active
-                    ? "bg-[--surface-muted] text-[--text-muted]"
-                    : "bg-[--surface-base] text-[--text-subtle]",
+                    ? "bg-[var(--surface-muted)] text-[var(--text-muted)]"
+                    : "bg-[var(--surface-base)] text-[var(--text-subtle)]",
                 )}
               >
                 {opt.count > 99 ? "99+" : opt.count}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -157,8 +157,8 @@ const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
         className={cn(
           "peer group/sidebar relative flex h-[100dvh] min-h-[100dvh] flex-col bg-sidebar text-sidebar-foreground shadow-[inset_-1px_0_0_0_var(--sidebar-border)] transition-[width,background-color] duration-[var(--motion-duration-base)] ease-[var(--motion-ease-standard)]",
           collapsible === "icon" && state === "collapsed"
-            ? "w-[--sidebar-width-icon]"
-            : "w-[--sidebar-width]",
+            ? "w-[var(--sidebar-width-icon)]"
+            : "w-[var(--sidebar-width)]",
           className,
         )}
         {...props}
@@ -176,7 +176,7 @@ const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
         <Sheet open={openMobile} onOpenChange={setOpenMobile}>
           <SheetContent
             side="left"
-            className="w-[--sidebar-width] max-w-[--sidebar-width] p-0"
+            className="w-[var(--sidebar-width)] max-w-[var(--sidebar-width)] p-0"
             style={
               { "--sidebar-width": SIDEBAR_WIDTH_MOBILE } as React.CSSProperties
             }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,66 +1,62 @@
 "use client";
 
 import * as React from "react";
-import * as TabsPrimitive from "@radix-ui/react-tabs";
+import {
+  Tabs as DsTabs,
+  TabsContent as DsTabsContent,
+  TabsList as DsTabsList,
+  TabsTrigger as DsTabsTrigger,
+} from "@corelithzw/react";
 
 import { cn } from "@/lib/utils";
 
-const Tabs = TabsPrimitive.Root;
+/**
+ * Tabs — a shim onto the design system's Tabs primitive.
+ *
+ * This used to be Radix plus a wall of Tailwind, which meant every tab strip
+ * in the app was a second opinion on what a tab looks like. The design system
+ * exports the real thing — roving tabindex, arrow-key cycling, Home/End, and
+ * the four documented variants — so this file only keeps the prop names the
+ * existing call sites already pass.
+ *
+ * One difference worth knowing: the DS primitive is `variant`-driven and
+ * defaults to `underline`. The local component always drew the segmented look,
+ * so `segmented` is the default here and existing screens keep their shape.
+ * Pass `variant="underline"` for page-level navigation — that is what the
+ * design system intends above page content.
+ */
+
+type DsVariant = "underline" | "segmented" | "pill" | "vertical";
+
+/** The DS root is a plain function component, so there is no ref to forward. */
+function Tabs({ variant = "segmented", ...props }: React.ComponentProps<typeof DsTabs>) {
+  return <DsTabs variant={variant as DsVariant} {...props} />;
+}
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    data-slot="tabs-list"
-    className={cn(
-      "inline-flex h-9 max-w-full items-center gap-1 overflow-x-auto rounded-[10px] bg-[var(--surface-muted)] p-1 text-[var(--text-muted)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+  React.ComponentRef<typeof DsTabsList>,
+  React.ComponentPropsWithoutRef<typeof DsTabsList>
+>(function TabsList({ className, ...props }, ref) {
+  return <DsTabsList ref={ref} className={cn(className)} data-slot="tabs-list" {...props} />;
+});
+TabsList.displayName = "TabsList";
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
-    asChild?: boolean;
-  }
->(({ className, asChild, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    asChild={asChild}
-    data-slot="tabs-trigger"
-    className={cn(
-      "inline-flex h-7 shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[7px] px-3 text-[13px] font-medium transition-[background-color,color] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-default)]",
-      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-offset-0",
-      "hover:text-[var(--text-strong)]",
-      "disabled:pointer-events-none disabled:opacity-50",
-      "data-[state=active]:bg-[var(--surface)] data-[state=active]:font-semibold data-[state=active]:text-[var(--text-strong)] data-[state=active]:shadow-[var(--shadow-rest)]",
-      "[&_svg]:size-4 [&_svg]:shrink-0",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+  React.ComponentRef<typeof DsTabsTrigger>,
+  React.ComponentPropsWithoutRef<typeof DsTabsTrigger>
+>(function TabsTrigger({ className, ...props }, ref) {
+  return <DsTabsTrigger ref={ref} className={cn(className)} {...props} />;
+});
+TabsTrigger.displayName = "TabsTrigger";
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    data-slot="tabs-content"
-    className={cn(
-      "mt-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--focus-ring-offset)]",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+  React.ComponentRef<typeof DsTabsContent>,
+  React.ComponentPropsWithoutRef<typeof DsTabsContent>
+>(function TabsContent({ className, ...props }, ref) {
+  return (
+    <DsTabsContent ref={ref} className={cn("mt-4", className)} data-slot="tabs-content" {...props} />
+  );
+});
+TabsContent.displayName = "TabsContent";
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/docs/design-system/08-cookbook-patterns.md
+++ b/docs/design-system/08-cookbook-patterns.md
@@ -1,0 +1,86 @@
+# Cookbook patterns — the shapes to build to
+
+Distilled from the recipes at `https://design.corelith.co.zw/cookbook/`, pinned because these are
+the patterns this repo's screens are expected to match. `06-reference-urls.md` is the full index;
+this file is the part worth carrying between tasks so the page is right the first time.
+
+**These are examples, not templates.** Adapt them to the screen. The rule that never bends is the
+source-of-truth order from `README.md`: `index.d.ts` > `styles.css` > these docs > the website.
+
+---
+
+## Universal rules
+
+- **One search box per screen.** Search lives in the toolbar, feeds one `filters` object
+  (`{ search, status, sort, page }`), and is URL-synced. A page-level search plus a table-level
+  search is the failure this rule exists to prevent — route every change through one hook and the
+  temptation disappears.
+- **Debounce search 300ms.** Filter chips fire immediately; only the text input waits.
+- **Mobile is a different shell, not a hidden one.** Render the list *or* the table, never both
+  with `display: none` — duplicated DOM confuses screen readers. Switch at **720px** using
+  `matchMedia` with a listener, not `window.innerWidth`.
+- **Define column metadata once** (key, label, format, `showOnMobile`) and feed both shells from
+  it, so the card list and the table cannot drift.
+- **The whole row is the link**, not the chevron — a 44pt thumb target has to survive.
+- Interactive things are `<button>`, never `<div onClick>`. Tab order follows reading order.
+
+---
+
+## Dashboards — KPI hero + drilldown
+
+The shape: **StatHero → KpiGrid → RowCard list → EmptyState.**
+
+- One brand-tinted hero KPI carrying a delta and a sparkline. Two heroes side by side
+  (`grid-template-columns: 1fr 1fr`) only when the two numbers are genuinely equal in weight.
+- Three secondary metrics under it in neutral tone.
+- Then the drill targets: `RowCard`s with live values and a chevron, each linking somewhere real.
+- **Compute deltas against one snapshot, once.** Three views computing their own deltas is how
+  they end up disagreeing.
+- A missing baseline renders `—`, never `0%`.
+- Label is an `h2` with the value as a descendant, so screen readers announce them together.
+- Loading: `Skeleton` with `aria-busy="true"` in a polite live region.
+- Empty: keep the page's shape — a muted hero shell plus one focusable primary CTA.
+
+## Kanban board
+
+- Columns are real `role="list"` regions; each card is `role="listitem"`.
+- `KanbanBoard` › `Column` › `RowCard`, with a `Menu` on each card offering "move to…" so the
+  board is usable without dragging (and on a touch screen).
+- WIP limits render as a badge in the column header (`4/3` form).
+- Add/edit happens in a `Drawer`, not inline.
+
+## Filterable data table
+
+- Toolbar has three zones: search input, filter chips, and a bulk-action zone.
+- **The toolbar morphs on selection** — chips collapse and bulk actions take their place. It does
+  not grow a second row.
+- Toolbar is sticky on scroll.
+- Per-row actions live in a kebab menu; cross-row actions live in the morphed toolbar.
+
+## Command palette (⌘K)
+
+- Trigger lives in the **top bar**, `aria-label="Open command palette"` — keyboard and touch parity.
+- Every entry — page, action, recent, doc — is the same record shape, grouped by `kind`.
+- Empty query shows recents; **recents are an MRU cap of five in localStorage, never
+  frequency-ranked.** A palette that quietly reorders itself is worse than one that doesn't.
+- ⌘K toggles, ↑↓ move, ↵ runs, Esc closes. **Tab is deliberately unbound** — the palette is one
+  focus surface.
+- The global keybinding ignores keystrokes inside text inputs, except ⌘K itself.
+
+## Grouped lists
+
+- `<section aria-labelledby>` per group, `<nav aria-label>` around any jump strip.
+- Sticky group headers are constrained to the **scrolling parent**, not the viewport, or they
+  collide with page chrome.
+- Bucket with a `Map` to preserve insertion order; sort first, then group.
+- Announce the item count per section.
+- Worth the overhead only past ~30 items with a natural alphabetical or categorical anchor.
+
+## Save bar
+
+- `.p-save-bar`, with a `.dirty` modifier; `role="region" aria-label="Unsaved changes"`.
+- Sticky to the bottom **inside the scrolling form**, `12px 16px` plus safe-area inset.
+- Appears the instant the form goes dirty — that is what tells someone their edits are tracked.
+- Use the summary slot to say what changed ("3 fields edited").
+- Save stays **visible but disabled** while validation fails; it never disappears.
+- Discard is ghost, Save is primary. Destructive discards confirm through an alert dialog.

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -224,7 +224,9 @@ export function fetchCrmLeads(
 
 export function fetchCrmLeadsBoard(filters: LeadViewFilters = {}) {
   const query = qs(leadFiltersToParams(filters));
-  return fetchJson<Envelope<{ columns: CrmBoardColumn[]; cardsPerColumn: number }>>(
+  // The route answers `{ columns, cardsPerColumn }` — no envelope. Declaring
+  // one here is what made the board throw the moment it was switched to.
+  return fetchJson<{ columns: CrmBoardColumn[]; cardsPerColumn: number }>(
     `/api/v2/crm/leads/board${query}`,
   );
 }

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -160,7 +160,15 @@ export type CrmVisitReportRecord = CrmAppointmentRecord & {
   visitItems: CrmVisitItemRecord[];
 };
 
-type ListResponse<T> = { data: T[]; total?: number; page?: number; limit?: number };
+/**
+ * The shape every paginated CRM route actually returns. It used to be declared
+ * with a top-level `total`, which no route has ever sent — so `?? rows.length`
+ * fired on every list and each one reported a single page regardless of size.
+ */
+type ListResponse<T> = {
+  data: T[];
+  pagination?: { page: number; limit: number; total: number; pages: number; hasMore: boolean };
+};
 type Envelope<T> = { data: T };
 
 function qs(params: Record<string, string | number | boolean | null | undefined>): string {
@@ -232,7 +240,7 @@ export function bulkUpdateCrmLeads(body: CrmBulkLeadAction) {
 }
 
 export function fetchCrmSavedViews() {
-  return fetchJson<Envelope<{ data: CrmSavedViewRecord[] }>>(`/api/v2/crm/saved-views`);
+  return fetchJson<Envelope<CrmSavedViewRecord[]>>(`/api/v2/crm/saved-views`);
 }
 
 export function createCrmSavedView(body: {
@@ -571,11 +579,11 @@ export function fetchCrmSites(
 }
 
 export function fetchCrmPipelines() {
-  return fetchJson<Envelope<{ data: CrmPipelineRecord[] }>>(`/api/v2/crm/pipelines`);
+  return fetchJson<Envelope<CrmPipelineRecord[]>>(`/api/v2/crm/pipelines`);
 }
 
 export function fetchCrmFieldDefinitions(entity?: string) {
-  return fetchJson<Envelope<{ data: CrmFieldDefinitionRecord[] }>>(
+  return fetchJson<Envelope<CrmFieldDefinitionRecord[]>>(
     `/api/v2/crm/field-definitions${qs({ entity })}`,
   );
 }

--- a/lib/crm/search.ts
+++ b/lib/crm/search.ts
@@ -12,6 +12,7 @@
 import type { Prisma } from "@prisma/client";
 
 import { normalizePhoneE164 } from "@/lib/crm/phone";
+import { PRODUCT_KIND_LABELS, UNIT_LABELS } from "@/lib/inventory/catalogue";
 
 type Tx = Prisma.TransactionClient;
 
@@ -23,7 +24,9 @@ export type SearchResultType =
   | "SITE"
   | "QUOTATION"
   | "INVOICE"
-  | "RECEIPT";
+  | "RECEIPT"
+  | "PRODUCT"
+  | "CUSTOMER";
 
 export type SearchResult = {
   type: SearchResultType;
@@ -45,6 +48,8 @@ export const SEARCH_TYPE_LABELS: Record<SearchResultType, string> = {
   QUOTATION: "Quotations",
   INVOICE: "Invoices",
   RECEIPT: "Receipts",
+  PRODUCT: "Catalogue",
+  CUSTOMER: "Accounts",
 };
 
 /** Order groups appear in: the records people look for most, first. */
@@ -54,9 +59,11 @@ export const SEARCH_TYPE_ORDER: SearchResultType[] = [
   "COMPANY",
   "LEAD",
   "SITE",
+  "PRODUCT",
   "QUOTATION",
   "INVOICE",
   "RECEIPT",
+  "CUSTOMER",
 ];
 
 const PER_TYPE_LIMIT = 5;
@@ -71,8 +78,13 @@ function pluralise(count: number, singular: string): string {
 }
 
 /**
- * Search across the CRM. Every query is tenant-scoped; the caller supplies the
- * companyId and no result can cross that boundary.
+ * Search across the workspace. Every query is tenant-scoped; the caller
+ * supplies the companyId and no result can cross that boundary.
+ *
+ * Deliberately not CRM-only. Someone typing a product code is looking for the
+ * item in the shared catalogue whether they are quoting from the CRM, ringing
+ * it up in Retail or costing a work order — and someone typing a customer name
+ * should find the accounting account as readily as the CRM company.
  */
 export async function searchCrm(
   db: Tx,
@@ -86,7 +98,18 @@ export async function searchCrm(
   const phoneE164 = normalizePhoneE164(query);
   const companyId = input.companyId;
 
-  const [people, companies, leads, deals, sites, quotations, invoices, receipts] =
+  const [
+    people,
+    companies,
+    leads,
+    deals,
+    sites,
+    quotations,
+    invoices,
+    receipts,
+    products,
+    customers,
+  ] =
     await Promise.all([
       db.crmPerson.findMany({
         where: {
@@ -245,6 +268,28 @@ export async function searchCrm(
         },
         take,
       }),
+
+      // The shared catalogue — the same rows Retail lists and the CRM quotes.
+      db.product.findMany({
+        where: {
+          companyId,
+          archivedAt: null,
+          OR: [{ name: contains }, { code: contains }, { description: contains }],
+        },
+        select: { id: true, code: true, name: true, kind: true, unit: true, isActive: true },
+        take,
+      }),
+
+      // Accounting customers. A CRM company and an accounting account are two
+      // records for one relationship, and people search for either by name.
+      db.customer.findMany({
+        where: {
+          companyId,
+          OR: [{ name: contains }, { email: contains }, { contactName: contains }],
+        },
+        select: { id: true, name: true, email: true, contactName: true },
+        take,
+      }),
     ]);
 
   const results: SearchResult[] = [];
@@ -358,6 +403,36 @@ export async function searchCrm(
       title: doc.receipt?.receiptNumber ?? "Receipt",
       subtitle: `${doc.currency} ${doc.amount.toLocaleString()}`,
       href: documentHref(doc),
+    });
+  }
+
+  for (const product of products) {
+    results.push({
+      type: "PRODUCT",
+      id: product.id,
+      reference: product.code,
+      title: product.name,
+      subtitle: [
+        PRODUCT_KIND_LABELS[product.kind],
+        `per ${UNIT_LABELS[product.unit]}`,
+        product.isActive ? null : "archived",
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      href: `/stores/catalogue?product=${product.id}`,
+    });
+  }
+
+  for (const customer of customers) {
+    results.push({
+      type: "CUSTOMER",
+      id: customer.id,
+      reference: null,
+      title: customer.name,
+      subtitle: [customer.contactName, customer.email].filter(Boolean).join(" · ") || null,
+      // The accounting account has no page of its own; its sales history is
+      // the useful destination.
+      href: `/accounting/sales?customerId=${customer.id}`,
     });
   }
 

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -302,6 +302,7 @@ export const Pencil = createPhosphorIcon("PencilSimple", "Pencil");
 export const Phone = createPhosphorIcon("Phone", "Phone");
 export const Play = createPhosphorIcon("Play", "Play");
 export const Plus = createPhosphorIcon("Plus", "Plus");
+export const CopyLink = createPhosphorIcon("Copy", "CopyLink");
 export const PlusCircle = createPhosphorIcon("PlusCircle", "PlusCircle");
 export const QrCode = createPhosphorIcon("QrCode", "QrCode");
 export const Radio = createPhosphorIcon("Radio", "Radio");


### PR DESCRIPTION
Follow-up to #128, working through the defects reported against it. Every fix below was reproduced in a real browser against a seeded local database before and after — not reasoned about from the code.

## Two root causes behind most of the reported symptoms

**1. The API envelopes were mistyped.** The CRM fetchers declared `Envelope<{ data: T[] }>` for routes that answer `{ data: [...] }`. Nothing caught it because the declared type was simply wrong, so every consumer reached through `.data.data` and got `undefined`. Pipelines, field definitions, saved views, automations and the shared product catalogue all silently resolved to nothing — which is why **the deal form offered no pipeline and no starting stage**, why **Custom Fields rendered an empty box**, and why Deals showed **"0 pipelines"**. On Deals it was fatal: `.length` was read without a guard and threw during render. The kanban board had the same fault in its own fetcher, which is what **crashed the app on switching to Board**.

`ListResponse` was wrong in the other direction — a top-level `total` that no route has ever sent — so every CRM list fell back to `rows.length` and reported a single page regardless of size. Both types now describe what the routes actually return, which turns this class of bug into a compile error instead of a blank screen.

**2. The cascade layer order was inverted.** `app/layout.tsx` imported frappe-ui's theme before `app/globals.css`. Layer order is fixed by the first `@layer` statement in the document and unknown names are appended at the end, so frappe's build established `theme, base, components, utilities` and our `corelith` and `app` layers landed *after* `utilities`. Every Tailwind utility in the app then lost to the design system's element resets: `button { padding: 0 }` beat `px-2`, and `* { border-border }` in the `app` layer beat `border-transparent`. That one ordering bug produced **segmented controls rendering as run-together text**, **menu options each drawing their own outline**, and **combo boxes showing a stray border and ring with squared-off radii**.

## The design system ships components without their CSS

`@corelithzw/react@0.3.4` builds `dist/styles.css` from a subset of its stylesheets, and several exported components were left out. Their JSX emits the right class names and nothing styles them. I audited the package's own sources against its stylesheet rather than guessing; of the 38 components this app imports, eleven are affected. 0.3.4 is the latest published version, so there is no upgrade to take.

- **`Tabs`** — renders `.utabs/.stabs/.ptabs/.vtabs` with `.utab/.stab/.ptab/.vtab` triggers. **None of those eight names exists** in the package bundle *or* in the docs site's own `components.css`; the component's class names outran its CSS. The stylesheet does carry `.under-tabs`, `.seg-tabs` and `.iconstrip`, which `p-tabs.html` names as the three variants, so the replacement reproduces those looks at the documented heights (40/36/32). `components/ui/tabs.tsx` was Radix plus a wall of Tailwind — a second opinion on what a tab looks like — and is now a shim onto the DS primitive, so every call site gets roving tabindex and arrow-key cycling for free.
- **`PageHeader`** — its source says it "maps to `.dash-page-h` in dash.css", and dash.css is not in the bundle. Every page title in the app was a bare `<h1>`, which Tailwind's preflight resets to inherit: 14px at weight 400, identical to body text. **This is the "headings are small text" bug.**
- `Field`, `Drawer`, `TextArea`, `EmptyState`, `KpiGrid`, `RowCard`, and parts of `Button`, `Card` and `DataToolbar`.

The replacement lives in `app/themes/corelith-missing.css`, written to the package's conventions — tokens only, same selector shapes — and imported into `layer(corelith)`, exactly where the package's stylesheet would have put it. It can be deleted wholesale when a release ships the real thing.

## Reported items

| Reported | What was done |
|---|---|
| Kanban must be the default view | Board is now the default for Leads & Pipeline; `?view=table` still opens the table for filtering and bulk edits |
| Switching table → kanban crashes | Board fetcher declared an envelope the route does not send; the optimistic-move cache writer was a level too deep as well |
| Dashboard must show everything at a glance | Rebuilt to the KPI-hero-and-drilldown recipe on a new aggregate endpoint |
| Menus show an outline per item | Cascade layer order — `* { border-border }` was beating `border-transparent` |
| Typography wrong, headings are small text | `PageHeader` had no CSS at all; titles now render at the page-title ramp |
| Choosing pipeline / starting stage does nothing | Envelope fix — the pickers were being handed `undefined` |
| Combo boxes: outline, ring, overflow, square borders | Cascade layer order; verified `justify-content: space-between` and full width in the browser |
| Tabs have no styling | Wrote the CSS for all four variants and shimmed the local component onto the DS primitive |
| Search must be truly global, in the navbar | Moved out of the CRM layout into the navbar on every page, and widened past the CRM |
| Follow-ups is blank | Rebuilt on the real task infrastructure |
| Intake forms feel out of place | Rebuilt around the numbers that make a form a lead source |
| Insights have no depth | Now renders the reporting engine that already existed and was never wired up |

## Search

Search was mounted on the CRM layout, so "find anything" was a CRM-only affordance sitting awkwardly above each page's own header. It now lives in the navbar — labelled on desktop, icon-only in the phone row — which is where the command-palette recipe puts it.

It also reaches past the CRM. The **shared catalogue** is in scope, so a product code finds the item whether you are quoting from the CRM, ringing it up in Retail or costing a work order; **accounting customers** are too, since a CRM company and an accounting account are two records for one relationship. The shared catalogue also gains its own page under Stock & Inventory — it was only reachable through CRM settings, which is the wrong door for a Retail user.

## Follow-ups

It was a bare list against the legacy `CrmFollowUp` model and rendered empty whether or not work was outstanding. It now runs on the same task infrastructure the record pages use: overdue/today/upcoming counts, the full set of queues, completion with an outcome, and recurrence. Legacy lead reminders are surfaced in their own labelled section rather than left invisible, so nothing already raised disappears.

## Dashboard

One hero number, four KPIs, then rows that lead somewhere. It reads from a new aggregate endpoint covering the whole lifecycle — pipeline by stage, deals going stale against each stage's own inactivity budget, quotes waiting on a customer or a manager, invoices to collect with an ageing split, work orders and site visits booked. Deltas are computed against one period boundary in the route, so the dashboard and the report cannot disagree, and a missing baseline renders as nothing rather than a fabricated +100%.

## Insights

The reporting engine — funnel with per-stage conversion, win rate, median cycle, weighted forecast, activity trend and grouped performance — already existed behind `/api/v2/crm/reports` and **nothing rendered it**; the page showed two flat tables from a thinner endpoint. It now reads the whole report against a selectable period: weighted forecast against the unweighted ceiling, median time to close, the stage losing the most of what reached the one before it, and lead-to-deal conversion, with owner/source/rep/channel breakdowns behind tabs.

One trap worth naming for future work: `lib/crm/reports` reports rates as 0–1 fractions and `formatRate` scales them, while `lib/crm/insights` already returns percentages. Mixing the two silently renders 7100%. Both call sites are now explicit about which they are handling.

## Intake forms

A form is a lead source, so the list is built around the numbers that make it one: submissions, how many became leads, and when it last did anything. The list route now returns those per form; the page adds a live/paused state, a preview link, and a feed of the latest submissions showing which converted. The previous version listed names and a copy link, which cannot tell a form nobody has ever used from one bringing work in every day.

## Caveats

- **Only the CRM, the Stock & Inventory catalogue and shared layout surfaces were re-verified in a browser.** The layer-order and tabs fixes are global and improve every module, but the other modules were not swept page by page.
- **`app/themes/corelith-missing.css` is a workaround, not a fix.** The right resolution is a design-system release that bundles the CSS for the components it exports. The file is scoped to the components this app imports; other consumers of 0.3.4 will hit the same wall.
- The catalogue is now reachable from two places (Stock & Inventory, and the CRM settings tab). Both render the same panel, but the CRM tab is arguably now redundant.
- Legacy `CrmFollowUp` and the newer `CrmTask` still coexist. Follow-ups shows both, clearly labelled, but consolidating onto one model is unfinished work.
- `docs/design-system/08-cookbook-patterns.md` records the pinned cookbook recipes so the shapes are applied without re-fetching the site. The mobile table→cards rule is written down there but **not yet applied** across the CRM's tables.

## Verification

`tsc --noEmit` clean, `eslint` clean over the changed areas, and **679/679 tests pass** (the suite needs `DATABASE_URL_TEST` set; without it fourteen DB-backed files fail for want of credentials, unrelated to this change). Both Vercel previews build.

Every screen above was driven in Chromium against a seeded local Postgres — logged in, with real pipelines, deals, companies and people — and checked before and after each fix. Computed styles were read from the DOM rather than eyeballed: `.btn-primary` background, button padding, heading size and weight, segmented-control strip, tab strip and combo-box alignment.
