### PR TITLE
fix(crm): repair the crashes, add record editing, and restructure the module

### DIFF
--- a/app/crm/appointments/page.tsx
+++ b/app/crm/appointments/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmAppointmentsContent } from "@/components/crm/crm-appointments-content";
@@ -8,9 +9,9 @@ export default async function CrmAppointmentsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6">
+    <CrmPage>
       <PageHeading title="Site Visits" />
       <CrmAppointmentsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/collections/page.tsx
+++ b/app/crm/collections/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PageHeading } from "@/components/layout/page-heading";
@@ -9,12 +10,12 @@ export default async function CrmCollectionsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-6">
+    <CrmPage>
       <PageHeading
         title="Collections"
         description="Who owes what, who promised when, and who to ring first."
       />
       <CollectionsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/companies/[id]/page.tsx
+++ b/app/crm/companies/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { CompanyDetailPage } from "@/components/crm/records/company-detail-page";
@@ -9,8 +10,8 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-[100rem]">
+    <CrmPage width="detail">
       <CompanyDetailPage companyId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/companies/page.tsx
+++ b/app/crm/companies/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { CompaniesContent } from "@/components/crm/records/companies-content";
@@ -11,8 +12,8 @@ export default async function CrmCompaniesPage({ searchParams }: { searchParams:
   if (!session?.user) redirect("/login");
   const params = await searchParams;
   return (
-    <div className="mx-auto w-full max-w-[110rem]">
+    <CrmPage>
       <CompaniesContent openCreate={params.new === "1"} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/deals/[id]/page.tsx
+++ b/app/crm/deals/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { DealDetailPage } from "@/components/crm/records/deal-detail-page";
@@ -9,8 +10,8 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-[100rem]">
+    <CrmPage width="detail">
       <DealDetailPage dealId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/deals/page.tsx
+++ b/app/crm/deals/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { DealsContent } from "@/components/crm/records/deals-content";
@@ -11,8 +12,8 @@ export default async function CrmDealsPage({ searchParams }: { searchParams: Sea
   if (!session?.user) redirect("/login");
   const params = await searchParams;
   return (
-    <div className="mx-auto w-full max-w-[110rem]">
+    <CrmPage>
       <DealsContent openCreate={params.new === "1"} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/follow-ups/page.tsx
+++ b/app/crm/follow-ups/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmFollowUpsContent } from "@/components/crm/crm-follow-ups-content";
@@ -8,12 +9,12 @@ export default async function CrmFollowUpsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6">
+    <CrmPage>
       <PageHeading
         title="Follow-ups"
         description="Everything owed to a customer, across leads, deals, companies and sites."
       />
       <CrmFollowUpsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/forms/[id]/page.tsx
+++ b/app/crm/forms/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { CrmFormBuilderContent } from "@/components/crm/crm-form-builder-content";
 import { authOptions } from "@/lib/auth";
@@ -8,8 +9,8 @@ export default async function CrmFormBuilderPage({ params }: { params: Promise<{
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6">
+    <CrmPage width="detail">
       <CrmFormBuilderContent formId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/forms/page.tsx
+++ b/app/crm/forms/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmFormsContent } from "@/components/crm/crm-forms-content";
@@ -8,9 +9,9 @@ export default async function CrmFormsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6">
+    <CrmPage>
       <PageHeading title="Intake Forms" />
       <CrmFormsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/import/page.tsx
+++ b/app/crm/import/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PageHeading } from "@/components/layout/page-heading";
@@ -14,12 +15,12 @@ export default async function CrmImportPage() {
   if (!hasCrmFullAccess(session.user.role)) redirect("/crm");
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6">
+    <CrmPage width="narrow">
       <PageHeading
         title="Import"
         description="Bring people, companies or leads in from a spreadsheet."
       />
       <ImportWizard />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/insights/page.tsx
+++ b/app/crm/insights/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmInsightsContent } from "@/components/crm/crm-insights-content";
@@ -8,9 +9,9 @@ export default async function CrmInsightsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6">
+    <CrmPage>
       <PageHeading title="CRM Insights" />
       <CrmInsightsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/leads/[id]/page.tsx
+++ b/app/crm/leads/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { LeadDetailPage } from "@/components/crm/lead-detail/lead-detail-page";
 import { authOptions } from "@/lib/auth";
@@ -8,8 +9,8 @@ export default async function CrmLeadDetailPage({ params }: { params: Promise<{ 
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-[100rem]">
+    <CrmPage width="detail">
       <LeadDetailPage leadId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/leads/page.tsx
+++ b/app/crm/leads/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { LeadsWorkspace } from "@/components/crm/leads/leads-workspace";
@@ -23,7 +24,7 @@ export default async function CrmLeadsPage({ searchParams }: { searchParams: Sea
   const view = params.get("view") === "table" ? "TABLE" : "BOARD";
 
   return (
-    <div className="mx-auto w-full max-w-[110rem] space-y-6">
+    <CrmPage>
       <PageHeading
         title="Leads & Pipeline"
         description="Every enquiry in flight, and the stage it is sitting in."
@@ -32,6 +33,6 @@ export default async function CrmLeadsPage({ searchParams }: { searchParams: Sea
         initialFilters={parseLeadFiltersFromParams(params)}
         initialView={view}
       />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/page.tsx
+++ b/app/crm/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmDashboardContent } from "@/components/crm/crm-dashboard-content";
@@ -9,9 +10,9 @@ export default async function CrmDashboardPage() {
   if (!session?.user) redirect("/login");
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6">
+    <CrmPage>
       <PageHeading title="CRM" />
       <CrmDashboardContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/people/[id]/page.tsx
+++ b/app/crm/people/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PersonDetailPage } from "@/components/crm/records/person-detail-page";
@@ -9,8 +10,8 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-[100rem]">
+    <CrmPage width="detail">
       <PersonDetailPage personId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/people/page.tsx
+++ b/app/crm/people/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PeopleContent } from "@/components/crm/records/people-content";
@@ -11,8 +12,8 @@ export default async function CrmPeoplePage({ searchParams }: { searchParams: Se
   if (!session?.user) redirect("/login");
   const params = await searchParams;
   return (
-    <div className="mx-auto w-full max-w-[110rem]">
+    <CrmPage>
       <PeopleContent openCreate={params.new === "1"} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/reports/page.tsx
+++ b/app/crm/reports/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PageHeading } from "@/components/layout/page-heading";
@@ -9,12 +10,12 @@ export default async function CrmReportsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-6">
+    <CrmPage>
       <PageHeading
         title="Sales reports"
         description="Where the pipeline leaks, who is closing, and what is likely to land."
       />
       <ReportsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/settings/page.tsx
+++ b/app/crm/settings/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 import { PageHeading } from "@/components/layout/page-heading";
 import { CrmSettingsContent } from "@/components/crm/crm-settings-content";
@@ -8,9 +9,9 @@ export default async function CrmSettingsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-6">
+    <CrmPage>
       <PageHeading title="CRM Settings" />
       <CrmSettingsContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/sites/[id]/page.tsx
+++ b/app/crm/sites/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { SiteDetailPage } from "@/components/crm/records/site-detail-page";
@@ -9,8 +10,8 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   if (!session?.user) redirect("/login");
   const { id } = await params;
   return (
-    <div className="mx-auto w-full max-w-[100rem]">
+    <CrmPage width="detail">
       <SiteDetailPage siteId={id} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/sites/page.tsx
+++ b/app/crm/sites/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { SitesContent } from "@/components/crm/records/sites-content";
@@ -11,8 +12,8 @@ export default async function CrmSitesPage({ searchParams }: { searchParams: Sea
   if (!session?.user) redirect("/login");
   const params = await searchParams;
   return (
-    <div className="mx-auto w-full max-w-[110rem]">
+    <CrmPage>
       <SitesContent openCreate={params.new === "1"} />
-    </div>
+    </CrmPage>
   );
 }

--- a/app/crm/tasks/page.tsx
+++ b/app/crm/tasks/page.tsx
@@ -1,20 +1,12 @@
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
-import { PageHeading } from "@/components/layout/page-heading";
-import { TaskQueueContent } from "@/components/crm/tasks/task-queue-content";
-import { authOptions } from "@/lib/auth";
-
-export default async function CrmTasksPage() {
-  const session = await getServerSession(authOptions);
-  if (!session?.user) redirect("/login");
-  return (
-    <div className="mx-auto w-full max-w-5xl space-y-6">
-      <PageHeading
-        title="Tasks"
-        description="What needs doing, and what happened when it was done."
-      />
-      <TaskQueueContent />
-    </div>
-  );
+/**
+ * Tasks and Follow-ups were two doors onto the same queue.
+ *
+ * Follow-ups now runs on this exact task infrastructure and additionally
+ * surfaces the legacy lead reminders, so it is strictly the better of the two.
+ * The route stays so existing links and bookmarks keep working.
+ */
+export default function CrmTasksPage() {
+  redirect("/crm/follow-ups");
 }

--- a/app/crm/work-orders/page.tsx
+++ b/app/crm/work-orders/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "next-auth";
+import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
 import { PageHeading } from "@/components/layout/page-heading";
@@ -9,12 +10,12 @@ export default async function CrmWorkOrdersPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6">
+    <CrmPage>
       <PageHeading
         title="Jobs"
         description="What the crews are doing today, and what the customer signed for."
       />
       <WorkOrdersContent />
-    </div>
+    </CrmPage>
   );
 }

--- a/components/crm/collaboration/comment-thread.tsx
+++ b/components/crm/collaboration/comment-thread.tsx
@@ -78,9 +78,9 @@ export function CommentThread({
     queryFn: () => fetchCrmFollowers(entity, recordId),
   });
 
-  const comments = data?.data ?? [];
-  const followers = followerData?.data.followers ?? [];
-  const isFollowing = followerData?.data.isFollowing ?? false;
+  const comments = data ?? [];
+  const followers = followerData?.followers ?? [];
+  const isFollowing = followerData?.isFollowing ?? false;
 
   const refresh = () => {
     queryClient.invalidateQueries({ queryKey: commentsKey });

--- a/components/crm/collections/collections-content.tsx
+++ b/components/crm/collections/collections-content.tsx
@@ -185,9 +185,13 @@ function ChaseDialog({
   const [notes, setNotes] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const [seededFor, setSeededFor] = useState<string | null>(row?.documentId ?? null);
-  if (row?.documentId !== seededFor) {
-    setSeededFor(row?.documentId ?? null);
+  // Normalise before comparing: `row?.documentId` is `undefined` with no row
+  // while the state holds `null`, and an un-normalised guard never converges —
+  // it re-runs every render and React aborts with "Too many re-renders".
+  const currentDocumentId = row?.documentId ?? null;
+  const [seededFor, setSeededFor] = useState<string | null>(currentDocumentId);
+  if (currentDocumentId !== seededFor) {
+    setSeededFor(currentDocumentId);
     setOutcome("NO_ANSWER");
     setPromisedAt("");
     setNotes("");

--- a/components/crm/crm-page.tsx
+++ b/components/crm/crm-page.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The container every CRM page sits in.
+ *
+ * Page widths had drifted to six different values across the module —
+ * `max-w-4xl` through `max-w-[110rem]` — so moving between pages shifted the
+ * content under you. Three widths, named for what they hold, and one place to
+ * change them:
+ *
+ *   list    the default: a record list or a dashboard
+ *   detail  a record page carrying a side rail, so it needs the room
+ *   narrow  a single column of form — an import wizard, a form builder
+ */
+const WIDTH = {
+  list: "max-w-7xl",
+  detail: "max-w-[100rem]",
+  narrow: "max-w-3xl",
+} as const;
+
+export function CrmPage({
+  width = "list",
+  className,
+  children,
+}: {
+  width?: keyof typeof WIDTH;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("mx-auto w-full space-y-6", WIDTH[width], className)}>{children}</div>
+  );
+}

--- a/components/crm/crm-settings-content.tsx
+++ b/components/crm/crm-settings-content.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
@@ -8,13 +10,13 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { CRM_CHANNEL_LABELS, CRM_LEAD_CHANNELS } from "@/lib/crm/sources";
 import { CustomFieldsPanel } from "@/components/crm/settings/custom-fields-panel";
 import { PipelinesPanel } from "@/components/crm/settings/pipelines-panel";
 import { PermissionsPanel } from "@/components/crm/settings/permissions-panel";
 import { AutomationsPanel } from "@/components/crm/settings/automations-panel";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
 import { CataloguePanel } from "@/components/inventory/catalogue-panel";
 import type { CrmLeadChannel } from "@prisma/client";
 
@@ -367,45 +369,111 @@ function CommissionsPanel() {
   );
 }
 
+/**
+ * CRM settings, on the settings shell rather than a tab strip.
+ *
+ * Eight tabs in a scrolling strip is the shape the pattern exists to replace:
+ * the rail is the map and the content is one page deep, so you can see every
+ * section at once instead of discovering them by scrolling sideways. The
+ * active section lives in the URL, so a link to Pipelines opens Pipelines.
+ *
+ * Each panel saves inline. There is deliberately no sticky unsaved bar —
+ * settings are individually committed, not a form you submit.
+ */
+
+type SettingsSection = {
+  id: string;
+  label: string;
+  description: string;
+  render: () => ReactNode;
+};
+
+const SECTIONS: SettingsSection[] = [
+  {
+    id: "pipelines",
+    label: "Pipelines",
+    description: "The stages a deal moves through, and what each one requires.",
+    render: () => <PipelinesPanel />,
+  },
+  {
+    id: "fields",
+    label: "Custom fields",
+    description: "Extra fields for your business, on the form and the record page.",
+    render: () => <CustomFieldsPanel />,
+  },
+  {
+    id: "sources",
+    label: "Lead sources",
+    description: "Where enquiries come from, so attribution has something to count.",
+    render: () => <LeadSourcesPanel />,
+  },
+  {
+    id: "catalogue",
+    label: "Catalogue",
+    description: "What the business sells — shared with Stock & Inventory and Retail.",
+    render: () => <CataloguePanel />,
+  },
+  {
+    id: "automations",
+    label: "Automations",
+    description: "Small rules that do the obvious thing when something changes.",
+    render: () => <AutomationsPanel />,
+  },
+  {
+    id: "commissions",
+    label: "Commissions",
+    description: "Who earns what, and at which thresholds.",
+    render: () => <CommissionsPanel />,
+  },
+  {
+    id: "permissions",
+    label: "Permissions",
+    description: "What each CRM role can see and change.",
+    render: () => <PermissionsPanel />,
+  },
+  {
+    id: "keys",
+    label: "API keys",
+    description: "Credentials for webhook and intake-form integrations.",
+    render: () => <ApiKeysPanel />,
+  },
+];
+
 export function CrmSettingsContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const requested = searchParams.get("tab");
+  const active = SECTIONS.find((section) => section.id === requested) ?? SECTIONS[0];
+
+  const select = (id: string) => {
+    // Replace rather than push: flipping between settings sections is not
+    // navigation you want to walk back through one at a time.
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", id);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
   return (
-    <Tabs defaultValue="pipelines">
-      <div className="scroll-rail max-w-full">
-        <TabsList>
-          <TabsTrigger value="pipelines">Pipelines</TabsTrigger>
-          <TabsTrigger value="fields">Custom Fields</TabsTrigger>
-          <TabsTrigger value="keys">API Keys</TabsTrigger>
-          <TabsTrigger value="sources">Lead Sources</TabsTrigger>
-          <TabsTrigger value="commissions">Commissions</TabsTrigger>
-          <TabsTrigger value="catalogue">Catalogue</TabsTrigger>
-          <TabsTrigger value="automations">Automations</TabsTrigger>
-          <TabsTrigger value="permissions">Permissions</TabsTrigger>
-        </TabsList>
-      </div>
-      <TabsContent value="catalogue">
-        <CataloguePanel />
-      </TabsContent>
-      <TabsContent value="automations">
-        <AutomationsPanel />
-      </TabsContent>
-      <TabsContent value="permissions">
-        <PermissionsPanel />
-      </TabsContent>
-      <TabsContent value="pipelines">
-        <PipelinesPanel />
-      </TabsContent>
-      <TabsContent value="fields">
-        <CustomFieldsPanel />
-      </TabsContent>
-      <TabsContent value="keys">
-        <ApiKeysPanel />
-      </TabsContent>
-      <TabsContent value="sources">
-        <LeadSourcesPanel />
-      </TabsContent>
-      <TabsContent value="commissions">
-        <CommissionsPanel />
-      </TabsContent>
-    </Tabs>
+    <div className="settings-layout">
+      <NavRail label="CRM settings sections" orientation="responsive">
+        {SECTIONS.map((section) => (
+          <NavRailItem
+            key={section.id}
+            active={section.id === active.id}
+            onClick={() => select(section.id)}
+          >
+            {section.label}
+          </NavRailItem>
+        ))}
+      </NavRail>
+
+      <section className="min-w-0 space-y-4">
+        <header>
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">{active.label}</h2>
+          <p className="text-sm text-[var(--text-muted)]">{active.description}</p>
+        </header>
+        {active.render()}
+      </section>
+    </div>
   );
 }

--- a/components/crm/documents/document-builder-sheet.tsx
+++ b/components/crm/documents/document-builder-sheet.tsx
@@ -106,7 +106,7 @@ export function DocumentBuilderSheet({
       }
 
       const endpoint = mode === "quotation" ? "quotation" : "invoice";
-      return fetchJson<{ data: { total?: number } }>(
+      return fetchJson<{ total?: number }>(
         `${basePath}/${endpoint}`,
         {
           method: "POST",
@@ -133,8 +133,8 @@ export function DocumentBuilderSheet({
         // Report the server's total, not the preview — per-line rounding can
         // put the two a cent apart, and money should never look uncertain.
         description:
-          typeof result.data.total === "number"
-            ? formatMoney(result.data.total, currency)
+          typeof result.total === "number"
+            ? formatMoney(result.total, currency)
             : undefined,
       });
       onOpenChange(false);

--- a/components/crm/import/import-wizard.tsx
+++ b/components/crm/import/import-wizard.tsx
@@ -74,7 +74,7 @@ export function ImportWizard() {
   const dryRun = useMutation({
     mutationFn: () => previewCrmImport({ entity, mapping, onDuplicate, csv }),
     onSuccess: (result) => {
-      setPreview(result.data);
+      setPreview(result);
       setError(null);
     },
     onError: (err) => setError(getApiErrorMessage(err)),
@@ -83,7 +83,7 @@ export function ImportWizard() {
   const commit = useMutation({
     mutationFn: () => commitCrmImport({ entity, mapping, onDuplicate, csv }),
     onSuccess: (result) => {
-      const { created, updated, failed } = result.data;
+      const { created, updated, failed } = result;
       toast({
         title: `Imported ${created + updated} record${created + updated === 1 ? "" : "s"}`,
         description: failed.length ? `${failed.length} row(s) couldn't be saved.` : undefined,

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -87,7 +87,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
 
   const leadQuery = useQuery({
     queryKey: ["crm-lead", leadId],
-    queryFn: () => fetchJson<{ data: LeadDetail }>(`/api/v2/crm/leads/${leadId}`),
+    queryFn: () => fetchJson<LeadDetail>(`/api/v2/crm/leads/${leadId}`),
   });
 
   const teamQuery = useQuery({
@@ -96,7 +96,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   });
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
-  const lead = leadQuery.data?.data;
+  const lead = leadQuery.data;
 
   const changeStage = useMutation({
     mutationFn: ({ stage, lostReason }: { stage: CrmLeadStage; lostReason?: string }) =>

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -133,11 +133,11 @@ export function ConvertLeadSheet({
 
   const prepQuery = useQuery({
     queryKey: ["crm", "lead-convert", leadId],
-    queryFn: () => fetchJson<{ data: ConvertPayload }>(`/api/v2/crm/leads/${leadId}/convert`),
+    queryFn: () => fetchJson<ConvertPayload>(`/api/v2/crm/leads/${leadId}/convert`),
     enabled: open,
   });
 
-  const prep = prepQuery.data?.data;
+  const prep = prepQuery.data;
 
   // Seed the form from the preparation payload the first time it arrives,
   // adjusting state during render so the fields are already filled on the
@@ -156,7 +156,7 @@ export function ConvertLeadSheet({
 
   const convert = useMutation({
     mutationFn: () =>
-      fetchJson<{ data: { dealId: string; dealNo: string } }>(
+      fetchJson<{ dealId: string; dealNo: string }>(
         `/api/v2/crm/leads/${leadId}/convert`,
         {
           method: "POST",
@@ -176,10 +176,10 @@ export function ConvertLeadSheet({
       queryClient.invalidateQueries({ queryKey: ["crm", "deals"] });
       toast({
         title: "Lead converted",
-        description: `Deal ${result.data.dealNo} is ready.`,
+        description: `Deal ${result.dealNo} is ready.`,
       });
       onOpenChange(false);
-      router.push(`/crm/deals/${result.data.dealId}`);
+      router.push(`/crm/deals/${result.dealId}`);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });

--- a/components/crm/leads/lead-form-sheet.tsx
+++ b/components/crm/leads/lead-form-sheet.tsx
@@ -197,14 +197,14 @@ export function LeadFormSheet({
 
   const createClient = useMutation({
     mutationFn: (name: string) =>
-      fetchJson<{ data: ClientOption }>("/api/v2/crm/clients", {
+      fetchJson<ClientOption>("/api/v2/crm/clients", {
         method: "POST",
         body: JSON.stringify({ name }),
       }),
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["crm", "clients", "options"] });
-      setForm((prev) => ({ ...prev, clientId: result.data.id }));
-      toast({ title: "Client created", description: `${result.data.name} is now on file.` });
+      setForm((prev) => ({ ...prev, clientId: result.id }));
+      toast({ title: "Client created", description: `${result.name} is now on file.` });
     },
     onError: (error) =>
       toast({
@@ -231,7 +231,7 @@ export function LeadFormSheet({
         assignedToId: form.assignedToId || null,
       };
       if (isEdit) {
-        return fetchJson<{ data: { id: string } }>(`/api/v2/crm/leads/${initial?.id}`, {
+        return fetchJson<{ id: string }>(`/api/v2/crm/leads/${initial?.id}`, {
           method: "PATCH",
           body: JSON.stringify({
             ...body,
@@ -239,7 +239,7 @@ export function LeadFormSheet({
           }),
         });
       }
-      return fetchJson<{ data: { id: string } }>("/api/v2/crm/leads", {
+      return fetchJson<{ id: string }>("/api/v2/crm/leads", {
         method: "POST",
         body: JSON.stringify(body),
       });
@@ -250,7 +250,7 @@ export function LeadFormSheet({
       if (isEdit) queryClient.invalidateQueries({ queryKey: ["crm-lead", initial?.id] });
       toast({ title: isEdit ? "Lead updated" : "Lead created" });
       onOpenChange(false);
-      onSaved?.(result.data.id);
+      onSaved?.(result.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -97,7 +97,7 @@ export function LeadsWorkspace({
     mutationFn: bulkUpdateCrmLeads,
     onSuccess: (result) => {
       refreshLeadLists();
-      const { updated, skipped } = result.data;
+      const { updated, skipped } = result;
       toast({
         title: `${updated} lead${updated === 1 ? "" : "s"} updated`,
         description:

--- a/components/crm/leads/lost-reason-dialog.tsx
+++ b/components/crm/leads/lost-reason-dialog.tsx
@@ -46,7 +46,10 @@ export function LostReasonDialog({
   const [reason, setReason] = useState("");
   // Clear the box each time the dialog opens, adjusting state during render
   // rather than in an effect so there's no flash of the previous reason.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) setReason("");

--- a/components/crm/leads/saved-views-bar.tsx
+++ b/components/crm/leads/saved-views-bar.tsx
@@ -97,8 +97,8 @@ export function SavedViewsBar({
       setDraftName("");
       setDraftShared(false);
       refresh();
-      onSelectView({ id: result.data.id, filters: result.data.filters, sort: result.data.sort });
-      toast({ title: "View saved", description: `"${result.data.name}" is ready to reuse.` });
+      onSelectView({ id: result.id, filters: result.filters, sort: result.sort });
+      toast({ title: "View saved", description: `"${result.name}" is ready to reuse.` });
     },
     onError: failed("Could not save view"),
   });

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
 
-import { Badge } from "@/components/ui/badge";
-import { DataTable } from "@/components/ui/data-table";
+import { Badge, Button } from "@corelithzw/react";
 import { StatusChip } from "@/components/ui/status-chip";
-import { fetchCrmCompanies, type CrmCompanyRecord } from "@/lib/crm/crm-v2";
+import { fetchCrmCompanies } from "@/lib/crm/crm-v2";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { useDebounced } from "@/hooks/use-debounced";
 
 import { CompanyFormSheet } from "./company-form-sheet";
+import { RecordList, RecordListPager, type RecordListRow } from "./record-list";
 import { RecordListShell } from "./record-list-shell";
 
 const PAGE_SIZE = 50;
@@ -47,108 +45,47 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
 
   const companiesQuery = useQuery({
     queryKey: ["crm", "companies", debouncedSearch, page],
-    queryFn: () =>
-      fetchCrmCompanies({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
+    queryFn: () => fetchCrmCompanies({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
     placeholderData: (previous) => previous,
   });
 
-  const rows = useMemo(() => companiesQuery.data?.data ?? [], [companiesQuery.data]);
-  const total = companiesQuery.data?.pagination?.total ?? rows.length;
+  const companies = useMemo(() => companiesQuery.data?.data ?? [], [companiesQuery.data]);
+  const total = companiesQuery.data?.pagination?.total ?? companies.length;
 
-  const columns = useMemo<ColumnDef<CrmCompanyRecord>[]>(
-    () => [
-      {
-        id: "name",
-        header: "Company",
-        size: 240,
-        cell: ({ row }) => (
-          <Link
-            href={`/crm/companies/${row.original.id}`}
-            className="block min-w-0 hover:underline"
-          >
-            <div className="truncate font-medium">{row.original.name}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {[row.original.clientNo, row.original.tradingName].filter(Boolean).join(" · ")}
-            </div>
-          </Link>
+  const rows = useMemo<RecordListRow[]>(
+    () =>
+      companies.map((company) => ({
+        id: company.id,
+        href: `/crm/companies/${company.id}`,
+        title: company.name,
+        subtitle:
+          [company.clientNo, [company.city, company.country].filter(Boolean).join(", ")]
+            .filter(Boolean)
+            .join(" · "),
+        status: (
+          <>
+            <StatusChip
+              status={ACCOUNT_STATUS_PRESENTATION[company.accountStatus] ?? "pending"}
+              label={ACCOUNT_STATUS_LABELS[company.accountStatus] ?? company.accountStatus}
+            />
+            <Badge tone="neutral" size="sm">
+              {COMPANY_TYPE_LABELS[company.companyType] ?? company.companyType}
+            </Badge>
+          </>
         ),
-      },
-      {
-        id: "type",
-        header: "Type",
-        size: 130,
-        cell: ({ row }) => (
-          <Badge variant="outline">
-            {COMPANY_TYPE_LABELS[row.original.companyType] ?? row.original.companyType}
-          </Badge>
-        ),
-      },
-      {
-        id: "contact",
-        header: "Contact",
-        size: 220,
-        cell: ({ row }) => (
-          <div className="min-w-0 text-sm">
-            <div className="truncate">{row.original.email ?? "—"}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {row.original.phone ?? ""}
-            </div>
-          </div>
-        ),
-      },
-      {
-        id: "location",
-        header: "Location",
-        size: 180,
-        cell: ({ row }) => (
-          <span className="truncate text-sm">
-            {[row.original.city, row.original.country].filter(Boolean).join(", ") || "—"}
-          </span>
-        ),
-      },
-      {
-        id: "people",
-        header: "People",
-        size: 80,
-        cell: ({ row }) => (
-          <span className="font-mono text-sm">{row.original._count?.people ?? 0}</span>
-        ),
-      },
-      {
-        id: "deals",
-        header: "Deals",
-        size: 80,
-        cell: ({ row }) => (
-          <span className="font-mono text-sm">{row.original._count?.deals ?? 0}</span>
-        ),
-      },
-      {
-        id: "status",
-        header: "Status",
-        size: 140,
-        cell: ({ row }) => (
-          <StatusChip
-            status={ACCOUNT_STATUS_PRESENTATION[row.original.accountStatus] ?? "pending"}
-            label={ACCOUNT_STATUS_LABELS[row.original.accountStatus] ?? row.original.accountStatus}
-          />
-        ),
-      },
-      {
-        id: "owner",
-        header: "Owner",
-        size: 150,
-        cell: ({ row }) => (
-          <span className="truncate text-sm">{row.original.assignedTo?.name ?? "Unassigned"}</span>
-        ),
-      },
-    ],
-    [],
+        facts: [
+          { label: "People", value: company._count?.people ?? 0, mono: true },
+          { label: "Deals", value: company._count?.deals ?? 0, mono: true },
+          { label: "Owner", value: company.assignedTo?.name ?? "Unassigned" },
+        ],
+      })),
+    [companies],
   );
 
   return (
     <RecordListShell
       title="Companies"
-      description="Customer organisations, suppliers and partners."
+      description="Every organisation you sell to, with its people, sites and deals in one place."
       search={search}
       onSearchChange={(value) => {
         setSearch(value);
@@ -159,44 +96,23 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
       onCreate={() => setCreateOpen(true)}
       error={companiesQuery.error}
     >
-      <DataTable
-        // The shell above owns search; a second box in the table toolbar is the
-        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
-        features={{ globalFilter: false }}
-        data={rows}
-        columns={columns}
-        edgeToEdge
-        stickyHeader
-        queryState={{ mode: "paginated", page, pageSize: PAGE_SIZE }}
-        onQueryStateChange={(next) => {
-          if (next.page && next.page !== page) setPage(next.page);
-        }}
-        pagination={{
-          enabled: true,
-          server: true,
-          total,
-          totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-        }}
-        mobileCardRenderer={({ row }) => (
-          <Link
-            href={`/crm/companies/${row.id}`}
-            className="flex flex-col gap-1 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
-          >
-            <span className="font-medium">{row.name}</span>
-            <span className="text-xs text-[var(--text-muted)]">
-              {[row.clientNo, [row.city, row.country].filter(Boolean).join(", ")]
-                .filter(Boolean)
-                .join(" · ")}
-            </span>
-            <span className="text-sm">{row.email ?? row.phone ?? ""}</span>
-          </Link>
-        )}
-        emptyState={
-          companiesQuery.isLoading
-            ? "Loading companies…"
-            : "No companies yet. Add one, or convert a lead."
+      <RecordList
+        rows={rows}
+        isLoading={companiesQuery.isLoading}
+        emptyTitle={debouncedSearch ? "No companies match that search" : "No companies yet"}
+        emptyBody={
+          debouncedSearch ? undefined : "Add one, or convert a lead and its company comes with it."
+        }
+        emptyAction={
+          debouncedSearch ? undefined : (
+            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+              Add the first company
+            </Button>
+          )
         }
       />
+
+      <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
 
       <CompanyFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </RecordListShell>

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -20,6 +20,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
+import { CompanyFormSheet } from "./company-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
 
@@ -49,7 +50,12 @@ type CompanyDetail = {
   email: string | null;
   phone: string | null;
   city: string | null;
+  country: string | null;
+  addressLine: string | null;
+  billingAddress: string | null;
+  companyType: string;
   accountStatus: string;
+  notes: string | null;
   parentRelation: string | null;
   customFields: Record<string, unknown> | null;
   assignedTo: { id: string; name: string | null } | null;
@@ -96,6 +102,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   const router = useRouter();
   const { data: session } = useSession();
   const [mergeOpen, setMergeOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const [tab, setTab] = useState("people");
 
   const companyQuery = useQuery({
@@ -167,7 +174,10 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
     <RecordPageShell
       backHref="/crm/companies"
       backLabel="All companies"
-      actions={[{ label: "Merge a duplicate", onSelect: () => setMergeOpen(true) }]}
+      actions={[
+        { label: "Edit", onSelect: () => setEditOpen(true) },
+        { label: "Merge a duplicate", onSelect: () => setMergeOpen(true) },
+      ]}
       title={company.name}
       reference={company.clientNo}
       status={ACCOUNT_STATUS_PRESENTATION[company.accountStatus] ?? null}
@@ -325,6 +335,33 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
           <CustomFieldDisplay definitions={definitions} values={company.customFields} />
         </>
       }
+    />
+
+    <CompanyFormSheet
+      open={editOpen}
+      onOpenChange={setEditOpen}
+      record={{
+        id: company.id,
+        name: company.name,
+        tradingName: company.tradingName ?? "",
+        companyType: company.companyType,
+        registrationNumber: company.registrationNumber ?? "",
+        taxNumber: company.taxNumber ?? "",
+        website: company.website ?? "",
+        industry: company.industry ?? "",
+        email: company.email ?? "",
+        phone: company.phone ?? "",
+        addressLine: company.addressLine ?? "",
+        city: company.city ?? "",
+        country: company.country ?? "",
+        billingAddress: company.billingAddress ?? "",
+        accountStatus: company.accountStatus,
+        parentClientId: company.parent?.id ?? "",
+        parentRelation: company.parentRelation ?? "",
+        notes: company.notes ?? "",
+        assignedToId: company.assignedTo?.id ?? "",
+      }}
+      onSaved={() => companyQuery.refetch()}
     />
 
     <MergeDialog

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -100,7 +100,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
 
   const companyQuery = useQuery({
     queryKey: ["crm", "company", companyId],
-    queryFn: () => fetchJson<{ data: CompanyDetail }>(`/api/v2/crm/companies/${companyId}`),
+    queryFn: () => fetchJson<CompanyDetail>(`/api/v2/crm/companies/${companyId}`),
   });
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "COMPANY"],
@@ -108,7 +108,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
-  const company = companyQuery.data?.data;
+  const company = companyQuery.data;
 
   if (companyQuery.isLoading) {
     return (

--- a/components/crm/records/company-form-sheet.tsx
+++ b/components/crm/records/company-form-sheet.tsx
@@ -100,19 +100,38 @@ const EMPTY: FormState = {
   assignedToId: "",
 };
 
+/** Only the keys the form owns; anything else on the record is ignored. */
+function seedFrom(record: CompanyFormRecord): Partial<FormState> {
+  const seed: Partial<FormState> = {};
+  for (const key of Object.keys(EMPTY) as (keyof FormState)[]) {
+    const value = record[key];
+    if (value !== undefined && value !== null) seed[key] = value as never;
+  }
+  return seed;
+}
+
 type SaveResult =
   | { duplicates: DuplicateEntry[] }
   | { company: { id: string; name: string } };
+
+/** The subset of a company this form can edit, as the detail page holds it. */
+export type CompanyFormRecord = { id: string } & Partial<FormState>;
 
 export function CompanyFormSheet({
   open,
   onOpenChange,
   onCreated,
+  record,
+  onSaved,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated?: (companyId: string) => void;
+  /** Pass a record to edit it. Omit to create a new one. */
+  record?: CompanyFormRecord | null;
+  onSaved?: () => void;
 }) {
+  const isEdit = Boolean(record?.id);
   const router = useRouter();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -123,11 +142,14 @@ export function CompanyFormSheet({
 
   // Reset as the sheet opens, adjusting state during render rather than in an
   // effect so there is no flash of the previous record's details.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {
-      setForm(EMPTY);
+      setForm(record ? { ...EMPTY, ...seedFrom(record) } : EMPTY);
       setCustomValues({});
       setErrors([]);
       setDuplicates(null);
@@ -191,16 +213,21 @@ export function CompanyFormSheet({
 
   const save = useMutation({
     mutationFn: async (force: boolean): Promise<SaveResult> => {
-      const response = await fetch("/api/v2/crm/companies", {
-        method: "POST",
+      const response = await fetch(
+        isEdit ? `/api/v2/crm/companies/${record?.id}` : "/api/v2/crm/companies",
+        {
+        method: isEdit ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(buildBody(force)),
-      });
+        },
+      );
       const payload = await response.json();
       if (response.status === 409 && payload?.code === "DUPLICATE_CANDIDATES") {
         return { duplicates: (payload.duplicates ?? []) as DuplicateEntry[] };
       }
-      if (!response.ok) throw new Error(payload?.error ?? "Failed to create company");
+      if (!response.ok) {
+        throw new Error(payload?.error ?? `Failed to ${isEdit ? "save" : "create"} company`);
+      }
       return { company: payload as { id: string; name: string } };
     },
     onSuccess: (result) => {
@@ -209,10 +236,15 @@ export function CompanyFormSheet({
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["crm", "companies"] });
-      toast({ title: "Company created", description: result.company.name });
+      if (isEdit) queryClient.invalidateQueries({ queryKey: ["crm", "company", record?.id] });
+      toast({
+        title: isEdit ? "Company saved" : "Company created",
+        description: result.company.name,
+      });
       setDuplicates(null);
       onOpenChange(false);
-      onCreated?.(result.company.id);
+      onSaved?.();
+      if (!isEdit) onCreated?.(result.company.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });
@@ -233,7 +265,7 @@ export function CompanyFormSheet({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent size="lg" className="w-full overflow-y-auto p-6">
           <SheetHeader>
-            <SheetTitle>New company</SheetTitle>
+            <SheetTitle>{isEdit ? "Edit company" : "New company"}</SheetTitle>
             <SheetDescription>
               The account everything else hangs off — people, sites, deals and invoices.
             </SheetDescription>
@@ -256,7 +288,7 @@ export function CompanyFormSheet({
                     Cancel
                   </Button>
                   <Button type="submit" disabled={save.isPending}>
-                    {save.isPending ? "Saving…" : "Create company"}
+                    {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create company"}
                   </Button>
                 </>
               }

--- a/components/crm/records/company-form-sheet.tsx
+++ b/components/crm/records/company-form-sheet.tsx
@@ -201,7 +201,7 @@ export function CompanyFormSheet({
         return { duplicates: (payload.duplicates ?? []) as DuplicateEntry[] };
       }
       if (!response.ok) throw new Error(payload?.error ?? "Failed to create company");
-      return { company: payload.data as { id: string; name: string } };
+      return { company: payload as { id: string; name: string } };
     },
     onSuccess: (result) => {
       if ("duplicates" in result) {

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -123,7 +123,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
 
   const dealQuery = useQuery({
     queryKey: ["crm", "deal", dealId],
-    queryFn: () => fetchJson<{ data: DealDetail }>(`/api/v2/crm/deals/${dealId}`),
+    queryFn: () => fetchJson<DealDetail>(`/api/v2/crm/deals/${dealId}`),
   });
   const teamQuery = useQuery({
     queryKey: ["crm", "team"],
@@ -136,7 +136,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
-  const deal = dealQuery.data?.data;
+  const deal = dealQuery.data;
 
   if (dealQuery.isLoading) {
     return (

--- a/components/crm/records/deal-form-sheet.tsx
+++ b/components/crm/records/deal-form-sheet.tsx
@@ -132,7 +132,10 @@ export function DealFormSheet({
 
   // Reset as the sheet opens, adjusting state during render rather than in an
   // effect so there is no flash of the previous deal's details.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {

--- a/components/crm/records/deal-form-sheet.tsx
+++ b/components/crm/records/deal-form-sheet.tsx
@@ -183,7 +183,7 @@ export function DealFormSheet({
 
   const save = useMutation({
     mutationFn: () =>
-      fetchJson<{ data: { id: string; dealNo: string } }>("/api/v2/crm/deals", {
+      fetchJson<{ id: string; dealNo: string }>("/api/v2/crm/deals", {
         method: "POST",
         body: JSON.stringify({
           title: form.title.trim(),
@@ -204,9 +204,9 @@ export function DealFormSheet({
       }),
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["crm", "deals"] });
-      toast({ title: "Deal created", description: result.data.dealNo });
+      toast({ title: "Deal created", description: result.dealNo });
       onOpenChange(false);
-      onCreated?.(result.data.id);
+      onCreated?.(result.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });

--- a/components/crm/records/merge-dialog.tsx
+++ b/components/crm/records/merge-dialog.tsx
@@ -103,7 +103,7 @@ export function MergeDialog({
   const preview = useMutation({
     mutationFn: (id: string) => previewCrmMerge(entity, survivorId, id),
     onSuccess: (result) => {
-      setPlan(result.data);
+      setPlan(result);
       setChoices({});
       setError(null);
     },

--- a/components/crm/records/merge-dialog.tsx
+++ b/components/crm/records/merge-dialog.tsx
@@ -77,7 +77,10 @@ export function MergeDialog({
   const [error, setError] = useState<string | null>(null);
 
   // Reset during render as the dialog opens rather than in an effect.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
 
-import { Badge } from "@/components/ui/badge";
-import { DataTable } from "@/components/ui/data-table";
-import { ClientDate } from "@/components/ui/client-date";
-import { fetchCrmPeople, type CrmPersonRecord } from "@/lib/crm/crm-v2";
+import { Badge, Button } from "@corelithzw/react";
+import { fetchCrmPeople } from "@/lib/crm/crm-v2";
 import { useDebounced } from "@/hooks/use-debounced";
 
 import { PersonFormSheet } from "./person-form-sheet";
+import { RecordList, RecordListPager, type RecordListRow } from "./record-list";
 import { RecordListShell } from "./record-list-shell";
 
 const PAGE_SIZE = 50;
@@ -26,6 +23,16 @@ const CONTACT_TYPE_LABELS: Record<string, string> = {
   OTHER: "Other",
 };
 
+/** Two letters is enough to tell rows apart while you scan. */
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
 export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
@@ -34,96 +41,39 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
 
   const peopleQuery = useQuery({
     queryKey: ["crm", "people", debouncedSearch, page],
-    queryFn: () =>
-      fetchCrmPeople({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
+    queryFn: () => fetchCrmPeople({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
     placeholderData: (previous) => previous,
   });
 
-  const rows = useMemo(() => peopleQuery.data?.data ?? [], [peopleQuery.data]);
-  const total = peopleQuery.data?.pagination?.total ?? rows.length;
+  const people = useMemo(() => peopleQuery.data?.data ?? [], [peopleQuery.data]);
+  const total = peopleQuery.data?.pagination?.total ?? people.length;
 
-  const columns = useMemo<ColumnDef<CrmPersonRecord>[]>(
-    () => [
-      {
-        id: "name",
-        header: "Name",
-        size: 220,
-        cell: ({ row }) => (
-          <Link href={`/crm/people/${row.original.id}`} className="block min-w-0 hover:underline">
-            <div className="truncate font-medium">{row.original.fullName}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {row.original.jobTitle ?? row.original.personNo}
-            </div>
-          </Link>
-        ),
-      },
-      {
-        id: "company",
-        header: "Company",
-        size: 200,
-        cell: ({ row }) =>
-          row.original.client ? (
-            <Link
-              href={`/crm/companies/${row.original.client.id}`}
-              className="truncate text-sm hover:underline"
-            >
-              {row.original.client.name}
-            </Link>
-          ) : (
-            <span className="text-sm text-[var(--text-muted)]">—</span>
-          ),
-      },
-      {
-        id: "contact",
-        header: "Contact",
-        size: 220,
-        cell: ({ row }) => (
-          <div className="min-w-0 text-sm">
-            <div className="truncate">{row.original.email ?? "—"}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {row.original.phone ?? ""}
-            </div>
-          </div>
-        ),
-      },
-      {
-        id: "type",
-        header: "Type",
-        size: 140,
-        cell: ({ row }) => (
-          <Badge variant="outline">
-            {CONTACT_TYPE_LABELS[row.original.contactType] ?? row.original.contactType}
-          </Badge>
-        ),
-      },
-      {
-        id: "deals",
-        header: "Deals",
-        size: 80,
-        cell: ({ row }) => (
-          <span className="font-mono text-sm">{row.original._count?.dealContacts ?? 0}</span>
-        ),
-      },
-      {
-        id: "owner",
-        header: "Owner",
-        size: 150,
-        cell: ({ row }) => (
-          <span className="truncate text-sm">{row.original.assignedTo?.name ?? "Unassigned"}</span>
-        ),
-      },
-      {
-        id: "updated",
-        header: "Updated",
-        size: 130,
-        cell: ({ row }) => (
-          <span className="text-sm text-[var(--text-muted)]">
-            <ClientDate value={row.original.updatedAt} mode="date" />
+  const rows = useMemo<RecordListRow[]>(
+    () =>
+      people.map((person) => ({
+        id: person.id,
+        href: `/crm/people/${person.id}`,
+        leading: (
+          <span className="flex size-9 items-center justify-center rounded-full bg-[var(--surface-muted)] text-xs font-medium text-[var(--text-muted)]">
+            {initials(person.fullName)}
           </span>
         ),
-      },
-    ],
-    [],
+        title: person.fullName,
+        subtitle:
+          [person.jobTitle, person.client?.name, person.email ?? person.phone]
+            .filter(Boolean)
+            .join(" · ") || person.personNo,
+        status: (
+          <Badge tone="neutral" size="sm">
+            {CONTACT_TYPE_LABELS[person.contactType] ?? person.contactType}
+          </Badge>
+        ),
+        facts: [
+          { label: "Deals", value: person._count?.dealContacts ?? 0, mono: true },
+          { label: "Owner", value: person.assignedTo?.name ?? "Unassigned" },
+        ],
+      })),
+    [people],
   );
 
   return (
@@ -140,40 +90,25 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
       onCreate={() => setCreateOpen(true)}
       error={peopleQuery.error}
     >
-      <DataTable
-        // The shell above owns search; a second box in the table toolbar is the
-        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
-        features={{ globalFilter: false }}
-        data={rows}
-        columns={columns}
-        edgeToEdge
-        stickyHeader
-        queryState={{ mode: "paginated", page, pageSize: PAGE_SIZE }}
-        onQueryStateChange={(next) => {
-          if (next.page && next.page !== page) setPage(next.page);
-        }}
-        pagination={{
-          enabled: true,
-          server: true,
-          total,
-          totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-        }}
-        mobileCardRenderer={({ row }) => (
-          <Link
-            href={`/crm/people/${row.id}`}
-            className="flex flex-col gap-1 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
-          >
-            <span className="font-medium">{row.fullName}</span>
-            <span className="text-xs text-[var(--text-muted)]">
-              {[row.jobTitle, row.client?.name].filter(Boolean).join(" · ") || row.personNo}
-            </span>
-            <span className="text-sm">{row.email ?? row.phone ?? ""}</span>
-          </Link>
-        )}
-        emptyState={
-          peopleQuery.isLoading ? "Loading people…" : "No people yet. Add one, or convert a lead."
+      <RecordList
+        rows={rows}
+        isLoading={peopleQuery.isLoading}
+        emptyTitle={debouncedSearch ? "No people match that search" : "No people yet"}
+        emptyBody={
+          debouncedSearch
+            ? undefined
+            : "Add someone, or convert a lead and its contact comes with it."
+        }
+        emptyAction={
+          debouncedSearch ? undefined : (
+            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+              Add the first person
+            </Button>
+          )
         }
       />
+
+      <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
 
       <PersonFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </RecordListShell>

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -19,6 +19,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
+import { PersonFormSheet } from "./person-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
 
@@ -54,7 +55,12 @@ type PersonDetail = {
   id: string;
   personNo: string;
   fullName: string;
+  firstName: string;
+  lastName: string | null;
   jobTitle: string | null;
+  addressLine: string | null;
+  city: string | null;
+  notes: string | null;
   email: string | null;
   phone: string | null;
   contactType: string;
@@ -99,6 +105,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
   const router = useRouter();
   const { data: session } = useSession();
   const [mergeOpen, setMergeOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const [tab, setTab] = useState("timeline");
 
   const personQuery = useQuery({
@@ -270,6 +277,26 @@ export function PersonDetailPage({ personId }: { personId: string }) {
           <CustomFieldDisplay definitions={definitions} values={person.customFields} />
         </>
       }
+    />
+
+    <PersonFormSheet
+      open={editOpen}
+      onOpenChange={setEditOpen}
+      record={{
+        id: person.id,
+        firstName: person.firstName,
+        lastName: person.lastName ?? "",
+        jobTitle: person.jobTitle ?? "",
+        email: person.email ?? "",
+        phone: person.phone ?? "",
+        contactType: person.contactType,
+        addressLine: person.addressLine ?? "",
+        city: person.city ?? "",
+        notes: person.notes ?? "",
+        clientId: person.client?.id ?? "",
+        assignedToId: person.assignedTo?.id ?? "",
+      }}
+      onSaved={() => personQuery.refetch()}
     />
 
     <MergeDialog

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -103,7 +103,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
 
   const personQuery = useQuery({
     queryKey: ["crm", "person", personId],
-    queryFn: () => fetchJson<{ data: PersonDetail }>(`/api/v2/crm/people/${personId}`),
+    queryFn: () => fetchJson<PersonDetail>(`/api/v2/crm/people/${personId}`),
   });
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "PERSON"],
@@ -111,7 +111,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
-  const person = personQuery.data?.data;
+  const person = personQuery.data;
 
   if (personQuery.isLoading) {
     return (

--- a/components/crm/records/person-form-sheet.tsx
+++ b/components/crm/records/person-form-sheet.tsx
@@ -84,17 +84,36 @@ const EMPTY: FormState = {
   assignedToId: "",
 };
 
+/** The subset of a person this form can edit, as the detail page holds it. */
+export type PersonFormRecord = { id: string } & Partial<FormState>;
+
+/** Only the keys the form owns; anything else on the record is ignored. */
+function seedFrom(record: PersonFormRecord): Partial<FormState> {
+  const seed: Partial<FormState> = {};
+  for (const key of Object.keys(EMPTY) as (keyof FormState)[]) {
+    const value = record[key];
+    if (value !== undefined && value !== null) seed[key] = value as never;
+  }
+  return seed;
+}
+
 export function PersonFormSheet({
   open,
   onOpenChange,
   defaultClientId,
   onCreated,
+  record,
+  onSaved,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   defaultClientId?: string;
   onCreated?: (personId: string) => void;
+  /** Pass a record to edit it. Omit to create a new one. */
+  record?: PersonFormRecord | null;
+  onSaved?: () => void;
 }) {
+  const isEdit = Boolean(record?.id);
   const router = useRouter();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -105,11 +124,18 @@ export function PersonFormSheet({
 
   // Reset as the sheet opens, adjusting state during render rather than in an
   // effect so there is no flash of the previous person's details.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {
-      setForm({ ...EMPTY, clientId: defaultClientId ?? "" });
+      setForm(
+        record
+          ? { ...EMPTY, ...seedFrom(record) }
+          : { ...EMPTY, clientId: defaultClientId ?? "" },
+      );
       setCustomValues({});
       setErrors([]);
       setDuplicates(null);
@@ -165,16 +191,21 @@ export function PersonFormSheet({
 
   const save = useMutation({
     mutationFn: async (force: boolean) => {
-      const response = await fetch("/api/v2/crm/people", {
-        method: "POST",
+      const response = await fetch(
+        isEdit ? `/api/v2/crm/people/${record?.id}` : "/api/v2/crm/people",
+        {
+        method: isEdit ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(buildBody(force)),
-      });
+        },
+      );
       const payload = await response.json();
       if (response.status === 409 && payload?.code === "DUPLICATE_CANDIDATES") {
         return { kind: "duplicates" as const, duplicates: (payload.duplicates ?? []) as DuplicateEntry[] };
       }
-      if (!response.ok) throw new Error(payload?.error ?? "Failed to create person");
+      if (!response.ok) {
+        throw new Error(payload?.error ?? `Failed to ${isEdit ? "save" : "create"} person`);
+      }
       return { kind: "created" as const, record: payload as { id: string; fullName: string } };
     },
     onSuccess: (result) => {
@@ -183,10 +214,15 @@ export function PersonFormSheet({
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["crm", "people"] });
-      toast({ title: "Person created", description: result.record.fullName });
+      if (isEdit) queryClient.invalidateQueries({ queryKey: ["crm", "person", record?.id] });
+      toast({
+        title: isEdit ? "Person saved" : "Person created",
+        description: result.record.fullName,
+      });
       setDuplicates(null);
       onOpenChange(false);
-      onCreated?.(result.record.id);
+      onSaved?.();
+      if (!isEdit) onCreated?.(result.record.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });
@@ -207,7 +243,7 @@ export function PersonFormSheet({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent size="lg" className="w-full overflow-y-auto p-6">
           <SheetHeader>
-            <SheetTitle>New person</SheetTitle>
+            <SheetTitle>{isEdit ? "Edit person" : "New person"}</SheetTitle>
             <SheetDescription>
               A contact you can attach to any number of deals and sites without re-typing them.
             </SheetDescription>
@@ -230,7 +266,7 @@ export function PersonFormSheet({
                     Cancel
                   </Button>
                   <Button type="submit" disabled={save.isPending}>
-                    {save.isPending ? "Saving…" : "Create person"}
+                    {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create person"}
                   </Button>
                 </>
               }

--- a/components/crm/records/person-form-sheet.tsx
+++ b/components/crm/records/person-form-sheet.tsx
@@ -175,7 +175,7 @@ export function PersonFormSheet({
         return { kind: "duplicates" as const, duplicates: (payload.duplicates ?? []) as DuplicateEntry[] };
       }
       if (!response.ok) throw new Error(payload?.error ?? "Failed to create person");
-      return { kind: "created" as const, record: payload.data as { id: string; fullName: string } };
+      return { kind: "created" as const, record: payload as { id: string; fullName: string } };
     },
     onSuccess: (result) => {
       if (result.kind === "duplicates") {

--- a/components/crm/records/record-list.tsx
+++ b/components/crm/records/record-list.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+import { Button, EmptyState, Skeleton } from "@corelithzw/react";
+import { ChevronRight } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * The CRM record list.
+ *
+ * People, companies, sites, collections and the rest are lists of things you
+ * open, not grids of numbers you compare — so they get the list pattern rather
+ * than a data table. Each row is a title, a supporting line, and a small
+ * cluster of facts on the right; the whole row is the link, which is what makes
+ * it work with a thumb as well as a mouse.
+ *
+ * DataTable is still the right answer for a comparison surface — sortable
+ * columns, bulk selection, money you scan down a column. It is the wrong
+ * answer for "find the company and open it", where it spends a header row and
+ * six columns saying what one line of text would.
+ */
+
+export type RecordListFact = {
+  /** Short label. Hidden on narrow screens where only the value fits. */
+  label?: string;
+  value: ReactNode;
+  /** Numerals line up when this is set — codes, money, counts. */
+  mono?: boolean;
+};
+
+export type RecordListRow = {
+  id: string;
+  href: string;
+  title: ReactNode;
+  /** One line under the title: the thing that tells two similar rows apart. */
+  subtitle?: ReactNode;
+  /** Leading avatar, icon or initials. */
+  leading?: ReactNode;
+  /** Status chip or badge, shown beside the title. */
+  status?: ReactNode;
+  /** Up to three facts, right-aligned. Dropped below `sm`. */
+  facts?: RecordListFact[];
+  /** Row-level actions. Rendered outside the link so they stay clickable. */
+  actions?: ReactNode;
+};
+
+export function RecordList({
+  rows,
+  isLoading,
+  emptyTitle = "Nothing here yet",
+  emptyBody,
+  emptyAction,
+  className,
+}: {
+  rows: RecordListRow[];
+  isLoading?: boolean;
+  emptyTitle?: string;
+  emptyBody?: string;
+  emptyAction?: ReactNode;
+  className?: string;
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2" aria-busy="true" aria-live="polite">
+        <Skeleton height={64} />
+        <Skeleton height={64} />
+        <Skeleton height={64} />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return <EmptyState title={emptyTitle} body={emptyBody} action={emptyAction} />;
+  }
+
+  return (
+    <ul
+      className={cn(
+        "divide-y divide-[var(--border-subtle)] overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface)]",
+        className,
+      )}
+    >
+      {rows.map((row) => (
+        <li key={row.id} className="relative flex items-center gap-3 pr-3">
+          <Link
+            href={row.href}
+            className="flex min-w-0 flex-1 items-center gap-3 px-3 py-3 hover:bg-[var(--surface-muted)]"
+          >
+            {row.leading ? <span className="flex-none">{row.leading}</span> : null}
+
+            <span className="min-w-0 flex-1">
+              <span className="flex flex-wrap items-center gap-2">
+                <span className="truncate text-sm font-medium text-[var(--text-strong)]">
+                  {row.title}
+                </span>
+                {row.status}
+              </span>
+              {row.subtitle ? (
+                <span className="mt-0.5 block truncate text-sm text-[var(--text-muted)]">
+                  {row.subtitle}
+                </span>
+              ) : null}
+            </span>
+
+            {/* Facts are supporting detail, so they are the first thing to go
+                when the row runs out of room. */}
+            {row.facts?.length ? (
+              <span className="hidden flex-none items-center gap-6 sm:flex">
+                {row.facts.map((fact, index) => (
+                  <span key={index} className="text-right">
+                    {fact.label ? (
+                      <span className="block text-[11px] uppercase tracking-wide text-[var(--text-subtle)]">
+                        {fact.label}
+                      </span>
+                    ) : null}
+                    <span
+                      className={cn(
+                        "block text-sm text-[var(--text-body)]",
+                        fact.mono ? "font-mono tabular-nums" : "",
+                      )}
+                    >
+                      {fact.value}
+                    </span>
+                  </span>
+                ))}
+              </span>
+            ) : null}
+
+            <ChevronRight className="size-4 flex-none text-[var(--text-subtle)]" />
+          </Link>
+
+          {row.actions ? <span className="flex-none">{row.actions}</span> : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * "Showing 20 of 340" plus a pair of page buttons.
+ *
+ * A list does not need a table's pagination bar — page size, jump-to-page and
+ * a row-count select are controls for a grid you are working through, not a
+ * list you are scanning.
+ */
+export function RecordListPager({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}) {
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  if (total <= pageSize) return null;
+
+  const from = (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <p className="text-sm text-[var(--text-muted)]">
+        Showing <span className="font-mono">{from}</span>–<span className="font-mono">{to}</span> of{" "}
+        <span className="font-mono">{total}</span>
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={page <= 1}
+          onClick={() => onPageChange(page - 1)}
+        >
+          Previous
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={page >= pages}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -64,7 +64,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
 
   const siteQuery = useQuery({
     queryKey: ["crm", "site", siteId],
-    queryFn: () => fetchJson<{ data: SiteDetail }>(`/api/v2/crm/sites/${siteId}`),
+    queryFn: () => fetchJson<SiteDetail>(`/api/v2/crm/sites/${siteId}`),
   });
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "SITE"],
@@ -72,7 +72,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
-  const site = siteQuery.data?.data;
+  const site = siteQuery.data;
 
   if (siteQuery.isLoading) {
     return (

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -18,6 +18,7 @@ import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
+import { SiteFormSheet } from "./site-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
 
 const VISIT_STATUS: Record<string, { label: string; status: CanonicalUiStatus }> = {
@@ -61,6 +62,7 @@ type SiteDetail = {
 export function SiteDetailPage({ siteId }: { siteId: string }) {
   const { data: session } = useSession();
   const [tab, setTab] = useState("visits");
+  const [editOpen, setEditOpen] = useState(false);
 
   const siteQuery = useQuery({
     queryKey: ["crm", "site", siteId],
@@ -104,8 +106,10 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
       : null;
 
   return (
-    <RecordPageShell
+    <>
+      <RecordPageShell
       backHref="/crm/sites"
+      actions={[{ label: "Edit", onSelect: () => setEditOpen(true) }]}
       backLabel="All sites"
       title={site.name}
       reference={site.siteNo}
@@ -236,6 +240,30 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           <CustomFieldDisplay definitions={definitions} values={site.customFields} />
         </>
       }
-    />
+      />
+
+      <SiteFormSheet
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        // The detail record holds related objects and numeric coordinates; the
+        // form holds ids and strings. Map rather than loosen the form's type.
+        record={{
+          id: site.id,
+          name: site.name,
+          clientId: site.client?.id ?? "",
+          addressLine: site.addressLine ?? "",
+          city: site.city ?? "",
+          country: site.country ?? "",
+          latitude: site.latitude === null ? "" : String(site.latitude),
+          longitude: site.longitude === null ? "" : String(site.longitude),
+          primaryContactId: site.primaryContact?.id ?? "",
+          accessInstructions: site.accessInstructions ?? "",
+          siteConditions: site.siteConditions ?? "",
+        }}
+        onSaved={() => siteQuery.refetch()}
+      />
+    </>
   );
 }
+
+

--- a/components/crm/records/site-form-sheet.tsx
+++ b/components/crm/records/site-form-sheet.tsx
@@ -125,7 +125,7 @@ export function SiteFormSheet({
 
   const save = useMutation({
     mutationFn: () =>
-      fetchJson<{ data: { id: string; name: string } }>("/api/v2/crm/sites", {
+      fetchJson<{ id: string; name: string }>("/api/v2/crm/sites", {
         method: "POST",
         body: JSON.stringify({
           name: form.name.trim(),
@@ -144,9 +144,9 @@ export function SiteFormSheet({
       }),
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["crm", "sites"] });
-      toast({ title: "Site created", description: result.data.name });
+      toast({ title: "Site created", description: result.name });
       onOpenChange(false);
-      onCreated?.(result.data.id);
+      onCreated?.(result.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });

--- a/components/crm/records/site-form-sheet.tsx
+++ b/components/crm/records/site-form-sheet.tsx
@@ -55,17 +55,36 @@ const EMPTY: FormState = {
   notes: "",
 };
 
+/** The subset of a site this form can edit, as the detail page holds it. */
+export type SiteFormRecord = { id: string } & Partial<FormState>;
+
+/** Only the keys the form owns; anything else on the record is ignored. */
+function seedFrom(record: SiteFormRecord): Partial<FormState> {
+  const seed: Partial<FormState> = {};
+  for (const key of Object.keys(EMPTY) as (keyof FormState)[]) {
+    const value = record[key];
+    if (value !== undefined && value !== null) seed[key] = value as never;
+  }
+  return seed;
+}
+
 export function SiteFormSheet({
   open,
   onOpenChange,
   defaultClientId,
   onCreated,
+  record,
+  onSaved,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   defaultClientId?: string;
   onCreated?: (siteId: string) => void;
+  /** Pass a record to edit it. Omit to create a new one. */
+  record?: SiteFormRecord | null;
+  onSaved?: () => void;
 }) {
+  const isEdit = Boolean(record?.id);
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [form, setForm] = useState<FormState>(EMPTY);
@@ -74,11 +93,18 @@ export function SiteFormSheet({
 
   // Reset as the sheet opens, adjusting state during render rather than in an
   // effect so there is no flash of the previous record's details.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {
-      setForm({ ...EMPTY, clientId: defaultClientId ?? "" });
+      setForm(
+        record
+          ? { ...EMPTY, ...seedFrom(record) }
+          : { ...EMPTY, clientId: defaultClientId ?? "" },
+      );
       setCustomValues({});
       setErrors([]);
     }
@@ -125,8 +151,10 @@ export function SiteFormSheet({
 
   const save = useMutation({
     mutationFn: () =>
-      fetchJson<{ id: string; name: string }>("/api/v2/crm/sites", {
-        method: "POST",
+      fetchJson<{ id: string; name: string }>(
+        isEdit ? `/api/v2/crm/sites/${record?.id}` : "/api/v2/crm/sites",
+        {
+        method: isEdit ? "PATCH" : "POST",
         body: JSON.stringify({
           name: form.name.trim(),
           clientId: form.clientId || null,
@@ -144,9 +172,11 @@ export function SiteFormSheet({
       }),
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["crm", "sites"] });
-      toast({ title: "Site created", description: result.name });
+      if (isEdit) queryClient.invalidateQueries({ queryKey: ["crm", "site", record?.id] });
+      toast({ title: isEdit ? "Site saved" : "Site created", description: result.name });
       onOpenChange(false);
-      onCreated?.(result.id);
+      onSaved?.();
+      if (!isEdit) onCreated?.(result.id);
     },
     onError: (error) => setErrors([getApiErrorMessage(error)]),
   });
@@ -175,7 +205,7 @@ export function SiteFormSheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent size="lg" className="w-full overflow-y-auto p-6">
         <SheetHeader>
-          <SheetTitle>New site</SheetTitle>
+          <SheetTitle>{isEdit ? "Edit site" : "New site"}</SheetTitle>
           <SheetDescription>
             A place your crew actually goes to. Whatever you record here is what they&apos;ll read
             on the way there.
@@ -199,7 +229,7 @@ export function SiteFormSheet({
                   Cancel
                 </Button>
                 <Button type="submit" disabled={save.isPending}>
-                  {save.isPending ? "Saving…" : "Create site"}
+                  {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create site"}
                 </Button>
               </>
             }

--- a/components/crm/records/sites-content.tsx
+++ b/components/crm/records/sites-content.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
 
-import { DataTable } from "@/components/ui/data-table";
-import { fetchCrmSites, type CrmSiteRecord } from "@/lib/crm/crm-v2";
+import { Button } from "@corelithzw/react";
+import { fetchCrmSites } from "@/lib/crm/crm-v2";
 import { useDebounced } from "@/hooks/use-debounced";
 
 import { SiteFormSheet } from "./site-form-sheet";
+import { RecordList, RecordListPager, type RecordListRow } from "./record-list";
 import { RecordListShell } from "./record-list-shell";
 
 const PAGE_SIZE = 50;
@@ -26,136 +25,65 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
     placeholderData: (previous) => previous,
   });
 
-  const rows = useMemo(() => sitesQuery.data?.data ?? [], [sitesQuery.data]);
-  const total = sitesQuery.data?.pagination?.total ?? rows.length;
+  const sites = useMemo(() => sitesQuery.data?.data ?? [], [sitesQuery.data]);
+  const total = sitesQuery.data?.pagination?.total ?? sites.length;
 
-  const columns = useMemo<ColumnDef<CrmSiteRecord>[]>(
-    () => [
-      {
-        id: "name",
-        header: "Site",
-        size: 220,
-        cell: ({ row }) => (
-          <Link href={`/crm/sites/${row.original.id}`} className="block min-w-0 hover:underline">
-            <div className="truncate font-medium">{row.original.name}</div>
-            <div className="truncate font-mono text-xs text-[var(--text-muted)]">
-              {row.original.siteNo}
-            </div>
-          </Link>
-        ),
-      },
-      {
-        id: "company",
-        header: "Company",
-        size: 200,
-        cell: ({ row }) =>
-          row.original.client ? (
-            <Link
-              href={`/crm/companies/${row.original.client.id}`}
-              className="truncate text-sm hover:underline"
-            >
-              {row.original.client.name}
-            </Link>
-          ) : (
-            <span className="text-sm text-[var(--text-muted)]">—</span>
-          ),
-      },
-      {
-        id: "address",
-        header: "Address",
-        size: 240,
-        cell: ({ row }) => (
-          <div className="min-w-0 text-sm">
-            <div className="truncate">{row.original.addressLine ?? "—"}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {row.original.city ?? ""}
-            </div>
-          </div>
-        ),
-      },
-      {
-        id: "contact",
-        header: "Contact",
-        size: 200,
-        cell: ({ row }) => (
-          <div className="min-w-0 text-sm">
-            <div className="truncate">{row.original.primaryContact?.fullName ?? "—"}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
-              {row.original.primaryContact?.phone ?? ""}
-            </div>
-          </div>
-        ),
-      },
-      {
-        id: "deals",
-        header: "Deals",
-        size: 80,
-        cell: ({ row }) => (
-          <span className="font-mono text-sm">{row.original._count?.deals ?? 0}</span>
-        ),
-      },
-      {
-        id: "visits",
-        header: "Visits",
-        size: 80,
-        cell: ({ row }) => (
-          <span className="font-mono text-sm">{row.original._count?.appointments ?? 0}</span>
-        ),
-      },
-    ],
-    [],
+  const rows = useMemo<RecordListRow[]>(
+    () =>
+      sites.map((site) => ({
+        id: site.id,
+        href: `/crm/sites/${site.id}`,
+        title: site.name,
+        subtitle:
+          [
+            site.siteNo,
+            site.client?.name,
+            [site.addressLine, site.city, site.country].filter(Boolean).join(", "),
+          ]
+            .filter(Boolean)
+            .join(" · "),
+        facts: [
+          { label: "Contact", value: site.primaryContact?.fullName ?? "—" },
+          { label: "Deals", value: site._count?.deals ?? 0, mono: true },
+          { label: "Visits", value: site._count?.appointments ?? 0, mono: true },
+        ],
+      })),
+    [sites],
   );
 
   return (
     <RecordListShell
       title="Sites"
-      description="Places where work happens — addresses, access notes and past measurements, entered once."
+      description="Where the work happens — addresses, access notes and who to ask for."
       search={search}
       onSearchChange={(value) => {
         setSearch(value);
         setPage(1);
       }}
-      searchPlaceholder="Search sites by name, address or city"
+      searchPlaceholder="Search sites by name, number or address"
       createLabel="New site"
       onCreate={() => setCreateOpen(true)}
       error={sitesQuery.error}
     >
-      <DataTable
-        // The shell above owns search; a second box in the table toolbar is the
-        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
-        features={{ globalFilter: false }}
-        data={rows}
-        columns={columns}
-        edgeToEdge
-        stickyHeader
-        queryState={{ mode: "paginated", page, pageSize: PAGE_SIZE }}
-        onQueryStateChange={(next) => {
-          if (next.page && next.page !== page) setPage(next.page);
-        }}
-        pagination={{
-          enabled: true,
-          server: true,
-          total,
-          totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-        }}
-        mobileCardRenderer={({ row }) => (
-          <Link
-            href={`/crm/sites/${row.id}`}
-            className="flex flex-col gap-1 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
-          >
-            <span className="font-medium">{row.name}</span>
-            <span className="text-xs text-[var(--text-muted)]">
-              {[row.client?.name, row.city].filter(Boolean).join(" · ") || row.siteNo}
-            </span>
-            <span className="text-sm">{row.addressLine ?? ""}</span>
-          </Link>
-        )}
-        emptyState={
-          sitesQuery.isLoading
-            ? "Loading sites…"
-            : "No sites yet. Add the places you work at so nobody re-types an address."
+      <RecordList
+        rows={rows}
+        isLoading={sitesQuery.isLoading}
+        emptyTitle={debouncedSearch ? "No sites match that search" : "No sites yet"}
+        emptyBody={
+          debouncedSearch
+            ? undefined
+            : "A site is an address you keep going back to — add one and visits and deals can point at it."
+        }
+        emptyAction={
+          debouncedSearch ? undefined : (
+            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+              Add the first site
+            </Button>
+          )
         }
       />
+
+      <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
 
       <SiteFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </RecordListShell>

--- a/components/crm/settings/automations-panel.tsx
+++ b/components/crm/settings/automations-panel.tsx
@@ -227,7 +227,10 @@ function AutomationFormSheet({
   const [actions, setActions] = useState<AutomationAction[]>([defaultAction("CREATE_TASK")]);
   const [errors, setErrors] = useState<string[]>([]);
 
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {

--- a/components/crm/tasks/complete-task-dialog.tsx
+++ b/components/crm/tasks/complete-task-dialog.tsx
@@ -39,9 +39,17 @@ export function CompleteTaskDialog({
   const [notes, setNotes] = useState("");
 
   // Clear as a new task arrives, during render rather than in an effect.
-  const [seededFor, setSeededFor] = useState<string | null>(task?.id ?? null);
-  if (task?.id !== seededFor) {
-    setSeededFor(task?.id ?? null);
+  //
+  // Both sides have to be normalised. `task?.id` is `undefined` when there is
+  // no task while the state holds `null`, so comparing them directly is always
+  // unequal: the guard re-runs every render, sets the same value, and React
+  // gives up with "Too many re-renders". The dialog is mounted by TaskList
+  // whenever there are tasks to show, so this took down every page with a task
+  // on it — and only those, which is why an empty CRM looked fine.
+  const currentTaskId = task?.id ?? null;
+  const [seededFor, setSeededFor] = useState<string | null>(currentTaskId);
+  if (currentTaskId !== seededFor) {
+    setSeededFor(currentTaskId);
     setOutcome("");
     setNotes("");
   }

--- a/components/crm/tasks/task-form-sheet.tsx
+++ b/components/crm/tasks/task-form-sheet.tsx
@@ -91,7 +91,10 @@ export function TaskFormSheet({
 
   // Reset during render as the sheet opens, so there's no flash of the last
   // task's details.
-  const [wasOpen, setWasOpen] = useState(open);
+  // Starts at `false`, not `open`: a sheet that mounts already open would
+  // otherwise record itself as having always been open, the transition below
+  // would never fire, and the form would never seed.
+  const [wasOpen, setWasOpen] = useState(false);
   if (open !== wasOpen) {
     setWasOpen(open);
     if (open) {

--- a/components/crm/tasks/task-list.tsx
+++ b/components/crm/tasks/task-list.tsx
@@ -62,15 +62,15 @@ export function TaskList({
     onSuccess: (result) => {
       refresh();
       setCompleting(null);
-      if (result.data.recurredTask) {
+      if (result.recurredTask) {
         toast({
           title: "Task completed",
           description: "The next one is booked in.",
         });
-      } else if (result.data.suggestsFollowUp) {
+      } else if (result.suggestsFollowUp) {
         // The outcome says the conversation isn't over, so offer the next step
         // while the context is still in front of the person.
-        const source = tasks.find((task) => task.id === result.data.id) ?? null;
+        const source = tasks.find((task) => task.id === result.id) ?? null;
         setFollowUpFor(source);
       } else {
         toast({ title: "Task completed" });

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -94,7 +94,7 @@ export function VisitReportSheet({
     enabled: open && Boolean(appointmentId),
   });
 
-  const report = reportQuery.data?.data;
+  const report = reportQuery.data;
 
   useEffect(() => {
     if (!report) return;

--- a/components/crm/work-orders/work-order-sheet.tsx
+++ b/components/crm/work-orders/work-order-sheet.tsx
@@ -111,10 +111,10 @@ export function WorkOrderSheet({
   const { data, isLoading } = useQuery({
     queryKey: ["crm-work-order", workOrderId],
     enabled: Boolean(workOrderId),
-    queryFn: () => fetchJson<{ data: WorkOrderRecord }>(`/api/v2/crm/work-orders/${workOrderId}`),
+    queryFn: () => fetchJson<WorkOrderRecord>(`/api/v2/crm/work-orders/${workOrderId}`),
   });
 
-  const order = data?.data;
+  const order = data;
 
   const refresh = () => {
     queryClient.invalidateQueries({ queryKey: ["crm-work-orders"] });
@@ -123,14 +123,14 @@ export function WorkOrderSheet({
 
   const update = useMutation({
     mutationFn: (body: Record<string, unknown>) =>
-      fetchJson<{ data: WorkOrderRecord }>(`/api/v2/crm/work-orders/${workOrderId}`, {
+      fetchJson<WorkOrderRecord>(`/api/v2/crm/work-orders/${workOrderId}`, {
         method: "PATCH",
         body: JSON.stringify(body),
       }),
     onSuccess: (result) => {
       setBlockers([]);
       setError(null);
-      toast({ title: `Job is now ${WORK_ORDER_STATUS_LABELS[result.data.status].toLowerCase()}` });
+      toast({ title: `Job is now ${WORK_ORDER_STATUS_LABELS[result.status].toLowerCase()}` });
       refresh();
     },
     onError: (err: unknown) => {

--- a/components/layout/app-sidebar/sidebar-nav-sections.tsx
+++ b/components/layout/app-sidebar/sidebar-nav-sections.tsx
@@ -27,6 +27,33 @@ import {
   isFlatLinkSection,
 } from "./sidebar-helpers";
 
+type NavBand = { id: string | null; label: string | null; items: NavItem[] };
+
+/**
+ * Split a section's items into its declared groups.
+ *
+ * Ungrouped items lead, unlabelled — so a section that declares no groups
+ * comes back as one anonymous band and renders exactly as it always has.
+ * Order follows `section.groups`, not the order items happen to appear in.
+ */
+function groupItems(section: WorkspaceNavSection): NavBand[] {
+  const groups = section.groups ?? [];
+  if (groups.length === 0) {
+    return [{ id: null, label: null, items: section.items }];
+  }
+
+  const ungrouped = section.items.filter((item) => !item.group);
+  const bands: NavBand[] = ungrouped.length
+    ? [{ id: null, label: null, items: ungrouped }]
+    : [];
+
+  for (const group of groups) {
+    const items = section.items.filter((item) => item.group === group.id);
+    if (items.length > 0) bands.push({ id: group.id, label: group.label, items });
+  }
+  return bands;
+}
+
 function SidebarNavLink({
   item,
   isActive,
@@ -174,13 +201,25 @@ function SidebarExpandableSection({
           <div className="overflow-hidden">
             <SidebarGroupContent className="mt-0 pl-4 pr-0.5">
               <SidebarMenu className="relative ml-2 gap-1 pl-2.5">
-                {section.items.map((item) => (
-                  <SidebarNavLink
-                    key={item.href}
-                    item={item}
-                    isActive={item.href === activeHref}
-                    className="h-10 rounded-[8px] px-2 text-[14px] lg:h-8"
-                  />
+                {groupItems(section).map((band) => (
+                  <React.Fragment key={band.id ?? "__ungrouped"}>
+                    {band.label ? (
+                      <li
+                        className="px-2 pb-0.5 pt-2 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+                        aria-hidden="true"
+                      >
+                        {band.label}
+                      </li>
+                    ) : null}
+                    {band.items.map((item) => (
+                      <SidebarNavLink
+                        key={item.href}
+                        item={item}
+                        isActive={item.href === activeHref}
+                        className="h-10 rounded-[8px] px-2 text-[14px] lg:h-8"
+                      />
+                    ))}
+                  </React.Fragment>
                 ))}
               </SidebarMenu>
             </SidebarGroupContent>

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -169,6 +169,18 @@ type ListResponse<T> = {
   data: T[];
   pagination?: { page: number; limit: number; total: number; pages: number; hasMore: boolean };
 };
+/**
+ * `{ data: T }` — and only for the handful of list GETs that literally call
+ * `successResponse({ data: rows })`.
+ *
+ * `successResponse(x)` sends `x` as the body; it adds no envelope of its own.
+ * Every `[id]` route, every POST and every PATCH in the CRM answers with the
+ * record or result itself, so wrapping those in `Envelope` describes a shape
+ * that never arrives — and because the declaration is a lie the compiler
+ * accepts, the failure surfaces as `undefined` at runtime: a detail page that
+ * says "not found", a toast naming nothing, a callback handed no id. Check the
+ * route before reaching for this type.
+ */
 type Envelope<T> = { data: T };
 
 function qs(params: Record<string, string | number | boolean | null | undefined>): string {
@@ -237,7 +249,7 @@ export type CrmBulkLeadAction =
 
 export function bulkUpdateCrmLeads(body: CrmBulkLeadAction) {
   return fetchJson<
-    Envelope<{ updated: number; unchanged?: number; skipped: number; notFound: number }>
+    { updated: number; unchanged?: number; skipped: number; notFound: number }
   >(`/api/v2/crm/leads/bulk`, { method: "POST", body: JSON.stringify(body) });
 }
 
@@ -252,7 +264,7 @@ export function createCrmSavedView(body: {
   sort?: LeadSort | null;
   isShared?: boolean;
 }) {
-  return fetchJson<Envelope<CrmSavedViewRecord>>(`/api/v2/crm/saved-views`, {
+  return fetchJson<CrmSavedViewRecord>(`/api/v2/crm/saved-views`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -268,26 +280,26 @@ export function updateCrmSavedView(
     isShared: boolean;
   }>,
 ) {
-  return fetchJson<Envelope<CrmSavedViewRecord>>(`/api/v2/crm/saved-views/${id}`, {
+  return fetchJson<CrmSavedViewRecord>(`/api/v2/crm/saved-views/${id}`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });
 }
 
 export function deleteCrmSavedView(id: string) {
-  return fetchJson<Envelope<{ id: string }>>(`/api/v2/crm/saved-views/${id}`, {
+  return fetchJson<{ id: string }>(`/api/v2/crm/saved-views/${id}`, {
     method: "DELETE",
   });
 }
 
 export function fetchCrmVisitReport(appointmentId: string) {
-  return fetchJson<Envelope<CrmVisitReportRecord>>(
+  return fetchJson<CrmVisitReportRecord>(
     `/api/v2/crm/appointments/${appointmentId}/report`,
   );
 }
 
 export function saveCrmVisitReport(appointmentId: string, body: SiteVisitReportInput) {
-  return fetchJson<Envelope<CrmVisitReportRecord>>(
+  return fetchJson<CrmVisitReportRecord>(
     `/api/v2/crm/appointments/${appointmentId}/report`,
     { method: "PUT", body: JSON.stringify(body) },
   );
@@ -303,25 +315,25 @@ export function updateCrmFollowUp(
     assignedToId: string;
   }>,
 ) {
-  return fetchJson<Envelope<CrmFollowUpRecord>>(`/api/v2/crm/follow-ups/${id}`, {
+  return fetchJson<CrmFollowUpRecord>(`/api/v2/crm/follow-ups/${id}`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });
 }
 
 export function fetchCrmLead(id: string) {
-  return fetchJson<Envelope<CrmLeadRecord & Record<string, unknown>>>(`/api/v2/crm/leads/${id}`);
+  return fetchJson<CrmLeadRecord & Record<string, unknown>>(`/api/v2/crm/leads/${id}`);
 }
 
 export function createCrmLead(body: Partial<CrmLeadRecord> & { title?: string }) {
-  return fetchJson<Envelope<CrmLeadRecord>>(`/api/v2/crm/leads`, {
+  return fetchJson<CrmLeadRecord>(`/api/v2/crm/leads`, {
     method: "POST",
     body: JSON.stringify(body),
   });
 }
 
 export function updateCrmLeadStage(id: string, stage: CrmLeadStage, lostReason?: string) {
-  return fetchJson<Envelope<CrmLeadRecord>>(`/api/v2/crm/leads/${id}/stage`, {
+  return fetchJson<CrmLeadRecord>(`/api/v2/crm/leads/${id}/stage`, {
     method: "POST",
     body: JSON.stringify({ stage, lostReason }),
   });
@@ -332,7 +344,7 @@ export function fetchCrmClients(params: { q?: string; page?: number } = {}) {
 }
 
 export function createCrmClient(body: Partial<CrmClientRecord> & { name: string }) {
-  return fetchJson<Envelope<CrmClientRecord>>(`/api/v2/crm/clients`, {
+  return fetchJson<CrmClientRecord>(`/api/v2/crm/clients`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -347,7 +359,7 @@ export function fetchCrmAppointments(params: { from?: string; to?: string; assig
 }
 
 export function fetchCrmInsightsSummary(params: { from?: string; to?: string } = {}) {
-  return fetchJson<Envelope<Record<string, unknown>>>(`/api/v2/crm/insights/summary${qs(params)}`);
+  return fetchJson<Record<string, unknown>>(`/api/v2/crm/insights/summary${qs(params)}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -594,7 +606,7 @@ export function moveCrmDealStage(
   dealId: string,
   body: { stageId: string; lostReason?: string; force?: boolean },
 ) {
-  return fetchJson<Envelope<CrmDealRecord>>(`/api/v2/crm/deals/${dealId}/stage`, {
+  return fetchJson<CrmDealRecord>(`/api/v2/crm/deals/${dealId}/stage`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -658,7 +670,7 @@ export function fetchCrmTasks(
 }
 
 export function createCrmTask(body: Record<string, unknown>) {
-  return fetchJson<Envelope<CrmTaskRecord>>(`/api/v2/crm/tasks`, {
+  return fetchJson<CrmTaskRecord>(`/api/v2/crm/tasks`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -666,12 +678,12 @@ export function createCrmTask(body: Record<string, unknown>) {
 
 export function updateCrmTask(id: string, body: Record<string, unknown>) {
   return fetchJson<
-    Envelope<CrmTaskRecord & { recurredTask: { id: string; dueAt: string } | null; suggestsFollowUp: boolean }>
+    CrmTaskRecord & { recurredTask: { id: string; dueAt: string } | null; suggestsFollowUp: boolean }
   >(`/api/v2/crm/tasks/${id}`, { method: "PATCH", body: JSON.stringify(body) });
 }
 
 export function deleteCrmTask(id: string) {
-  return fetchJson<Envelope<{ id: string }>>(`/api/v2/crm/tasks/${id}`, { method: "DELETE" });
+  return fetchJson<{ id: string }>(`/api/v2/crm/tasks/${id}`, { method: "DELETE" });
 }
 
 export type CrmCommentAuthor = { id: string; name: string | null; email: string };
@@ -691,7 +703,7 @@ export type CrmCommentRecord = {
 };
 
 export function fetchCrmComments(entity: CollabEntity, recordId: string) {
-  return fetchJson<Envelope<CrmCommentRecord[]>>(
+  return fetchJson<CrmCommentRecord[]>(
     `/api/v2/crm/comments${qs({ entity, recordId })}`,
   );
 }
@@ -702,7 +714,7 @@ export function createCrmComment(body: {
   body: string;
   parentId?: string | null;
 }) {
-  return fetchJson<Envelope<CrmCommentRecord>>(`/api/v2/crm/comments`, {
+  return fetchJson<CrmCommentRecord>(`/api/v2/crm/comments`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -712,14 +724,14 @@ export function updateCrmComment(
   id: string,
   body: { body?: string; isPinned?: boolean; resolved?: boolean },
 ) {
-  return fetchJson<Envelope<CrmCommentRecord>>(`/api/v2/crm/comments/${id}`, {
+  return fetchJson<CrmCommentRecord>(`/api/v2/crm/comments/${id}`, {
     method: "PATCH",
     body: JSON.stringify(body),
   });
 }
 
 export function deleteCrmComment(id: string) {
-  return fetchJson<Envelope<{ id: string }>>(`/api/v2/crm/comments/${id}`, { method: "DELETE" });
+  return fetchJson<{ id: string }>(`/api/v2/crm/comments/${id}`, { method: "DELETE" });
 }
 
 export type CrmFollowerRecord = {
@@ -729,20 +741,20 @@ export type CrmFollowerRecord = {
 };
 
 export function fetchCrmFollowers(entity: CollabEntity, recordId: string) {
-  return fetchJson<Envelope<{ followers: CrmFollowerRecord[]; isFollowing: boolean }>>(
+  return fetchJson<{ followers: CrmFollowerRecord[]; isFollowing: boolean }>(
     `/api/v2/crm/followers${qs({ entity, recordId })}`,
   );
 }
 
 export function followCrmRecord(entity: CollabEntity, recordId: string, userId?: string) {
-  return fetchJson<Envelope<CrmFollowerRecord>>(`/api/v2/crm/followers`, {
+  return fetchJson<CrmFollowerRecord>(`/api/v2/crm/followers`, {
     method: "POST",
     body: JSON.stringify({ entity, recordId, userId }),
   });
 }
 
 export function unfollowCrmRecord(entity: CollabEntity, recordId: string, userId?: string) {
-  return fetchJson<Envelope<{ unfollowed: boolean }>>(
+  return fetchJson<{ unfollowed: boolean }>(
     `/api/v2/crm/followers${qs({ entity, recordId, userId })}`,
     { method: "DELETE" },
   );
@@ -763,7 +775,7 @@ export function previewCrmImport(body: {
   onDuplicate: "SKIP" | "UPDATE";
   csv: string;
 }) {
-  return fetchJson<Envelope<CrmImportPreview>>(`/api/v2/crm/import`, {
+  return fetchJson<CrmImportPreview>(`/api/v2/crm/import`, {
     method: "POST",
     body: JSON.stringify({ ...body, commit: false }),
   });
@@ -776,12 +788,12 @@ export function commitCrmImport(body: {
   csv: string;
 }) {
   return fetchJson<
-    Envelope<{
+    {
       created: number;
       updated: number;
       failed: { line: number; message: string }[];
       totals: { create: number; update: number; skip: number };
-    }>
+    }
   >(`/api/v2/crm/import`, { method: "POST", body: JSON.stringify({ ...body, commit: true }) });
 }
 
@@ -793,7 +805,7 @@ export type CrmMergePreview = {
 
 export function previewCrmMerge(entity: "PERSON" | "COMPANY", survivorId: string, loserId: string) {
   const base = entity === "PERSON" ? "people" : "companies";
-  return fetchJson<Envelope<CrmMergePreview>>(`/api/v2/crm/${base}/${survivorId}/merge`, {
+  return fetchJson<CrmMergePreview>(`/api/v2/crm/${base}/${survivorId}/merge`, {
     method: "POST",
     body: JSON.stringify({ loserId, commit: false }),
   });
@@ -806,7 +818,7 @@ export function commitCrmMerge(
   choices: Record<string, FieldChoice>,
 ) {
   const base = entity === "PERSON" ? "people" : "companies";
-  return fetchJson<Envelope<{ id: string }>>(`/api/v2/crm/${base}/${survivorId}/merge`, {
+  return fetchJson<{ id: string }>(`/api/v2/crm/${base}/${survivorId}/merge`, {
     method: "POST",
     body: JSON.stringify({ loserId, choices, commit: true }),
   });

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -55,6 +55,24 @@ export type NavItem = {
   label: string;
   icon: LucideIcon;
   roles?: UserRole[];
+  /**
+   * Which group inside the section this belongs to. Items with no group render
+   * first and unlabelled, which keeps every existing section rendering exactly
+   * as it did.
+   */
+  group?: string;
+};
+
+/**
+ * A labelled band of related items inside a section.
+ *
+ * Only worth it once a section is long enough that a flat list stops being
+ * scannable — a sixteen-item CRM reads as inventory rather than navigation.
+ * A group whose items are all gated away disappears with them.
+ */
+export type NavGroup = {
+  id: string;
+  label: string;
 };
 
 export type NavSection = {
@@ -62,6 +80,8 @@ export type NavSection = {
   title: string;
   description?: string;
   featureKey?: string;
+  /** Declares group order and labels. Groups with no visible items are dropped. */
+  groups?: NavGroup[];
   items: NavItem[];
 };
 
@@ -310,27 +330,44 @@ export const navSections: NavSection[] = [
     title: "CRM",
     description: "Leads, clients, site visits, and sales pipeline",
     featureKey: "crm.core",
+    // Grouped the way the work runs: win it, know who you are dealing with, do
+    // the work, get paid, then learn from it. Sixteen links in one column was
+    // an inventory of pages rather than a route through the job.
+    groups: [
+      { id: "sell", label: "Selling" },
+      { id: "records", label: "Who we deal with" },
+      { id: "work", label: "Doing the work" },
+      { id: "money", label: "Getting paid" },
+      { id: "learn", label: "Understanding it" },
+      { id: "setup", label: "Setup" },
+    ],
     items: [
       { href: "/crm", icon: Dashboard, label: "Overview" },
-      { href: "/crm/leads", icon: Funnel, label: "Leads" },
-      { href: "/crm/deals", icon: Funnel, label: "Deals & Pipeline" },
-      { href: "/crm/people", icon: Users, label: "People" },
-      { href: "/crm/companies", icon: Building2, label: "Companies" },
-      { href: "/crm/sites", icon: MapPin, label: "Sites" },
-      { href: "/crm/appointments", icon: CalendarCheck, label: "Site Visits" },
-      { href: "/crm/tasks", icon: Checklist, label: "Tasks" },
-      { href: "/crm/follow-ups", icon: Checklist, label: "Follow-ups" },
-      { href: "/crm/forms", icon: NoteAdd, label: "Intake Forms" },
-      { href: "/crm/import", icon: Upload, label: "Import" },
-      { href: "/crm/insights", icon: BarChart3, label: "Insights" },
-      { href: "/crm/reports", icon: ChartLine, label: "Sales Reports" },
-      { href: "/crm/work-orders", icon: Wrench, label: "Jobs" },
-      { href: "/crm/collections", icon: ReceiptLong, label: "Collections" },
+
+      { href: "/crm/leads", icon: Funnel, label: "Leads", group: "sell" },
+      { href: "/crm/deals", icon: Funnel, label: "Deals", group: "sell" },
+      { href: "/crm/forms", icon: NoteAdd, label: "Intake forms", group: "sell" },
+
+      { href: "/crm/people", icon: Users, label: "People", group: "records" },
+      { href: "/crm/companies", icon: Building2, label: "Companies", group: "records" },
+      { href: "/crm/sites", icon: MapPin, label: "Sites", group: "records" },
+
+      { href: "/crm/follow-ups", icon: Checklist, label: "Follow-ups", group: "work" },
+      { href: "/crm/appointments", icon: CalendarCheck, label: "Site visits", group: "work" },
+      { href: "/crm/work-orders", icon: Wrench, label: "Jobs", group: "work" },
+
+      { href: "/crm/collections", icon: ReceiptLong, label: "Collections", group: "money" },
+
+      { href: "/crm/insights", icon: BarChart3, label: "Insights", group: "learn" },
+      { href: "/crm/reports", icon: ChartLine, label: "Sales reports", group: "learn" },
+
+      { href: "/crm/import", icon: Upload, label: "Import", group: "setup" },
       {
         href: "/crm/settings",
         icon: ManageAccounts,
-        label: "CRM Settings",
+        label: "CRM settings",
         roles: ["SUPERADMIN", "MANAGER"],
+        group: "setup",
       },
     ],
   },

--- a/lib/platform/gating/nav-filter.ts
+++ b/lib/platform/gating/nav-filter.ts
@@ -32,9 +32,17 @@ export function filterNavSectionsByEnabledFeatures(
     .filter((section) =>
       section.featureKey ? hasTokenFeature(enabledFeatures, section.featureKey) : true,
     )
-    .map((section) => ({
-      ...section,
-      items: filterHrefItemsByEnabledFeatures(section.items, enabledFeatures),
-    }))
+    .map((section) => {
+      const items = filterHrefItemsByEnabledFeatures(section.items, enabledFeatures);
+      if (!section.groups) return { ...section, items };
+      // A group label with nothing under it is worse than no label, so groups
+      // whose every item was gated away go with them.
+      const surviving = new Set(items.map((item) => item.group).filter(Boolean));
+      return {
+        ...section,
+        items,
+        groups: section.groups.filter((group) => surviving.has(group.id)),
+      };
+    })
     .filter((section) => section.items.length > 0);
 }

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -1,7 +1,7 @@
 import { ACCOUNTING_OPERATIONS_SECTIONS, ACCOUNTING_TABS } from "@/lib/accounting/tab-config";
 import { filterAccountingTabsByFeatures } from "@/lib/accounting/visibility";
-import type { NavItem, NavSection } from "@/lib/navigation";
-import { getNavSectionsForRole } from "@/lib/navigation";
+import type { NavGroup, NavItem, NavSection } from "@/lib/navigation";
+import { getNavSectionsForRole, navSections } from "@/lib/navigation";
 import { normalizeFeatureKey } from "@/lib/platform/gating/catalog-utils";
 import { filterNavSectionsByEnabledFeatures } from "@/lib/platform/gating/nav-filter";
 import { getPrimaryQuickActions } from "@/lib/primary-actions";
@@ -77,6 +77,12 @@ type WorkspaceModuleDefinition = {
   label: string;
   homeHref: string | null;
   getItems: (context: WorkspaceBuildContext) => NavItem[];
+  /**
+   * The section's semantic groups, when it declares any. Carried through here
+   * because the sidebar assembles its own sections from module items and would
+   * otherwise drop the grouping the navigation model defines.
+   */
+  getGroups?: (context: WorkspaceBuildContext) => NavGroup[] | undefined;
 };
 
 type WorkspaceProfileSectionSpec = {
@@ -147,6 +153,9 @@ function createSectionModule(args: {
     homeHref: args.homeHref,
     getItems(context) {
       return context.navSectionById.get(args.sectionId)?.items ?? [];
+    },
+    getGroups(context) {
+      return context.navSectionById.get(args.sectionId)?.groups;
     },
   };
 }
@@ -625,6 +634,25 @@ function collectSectionHrefs(sections: WorkspaceNavSection[]): Set<string> {
   return new Set(sections.flatMap((section) => section.items.map((item) => item.href)));
 }
 
+/**
+ * The groups a module's own nav section declares.
+ *
+ * The sidebar reassembles sections from module items, which loses everything on
+ * the section but its items. Module ids and section ids line up for every
+ * `createSectionModule` module, so reading the declaration back is enough.
+ */
+function declaredGroups(moduleId: WorkspaceModuleId): NavGroup[] | undefined {
+  // Last match, not first: two sections share the id "crm" (the retail customer
+  // directory and the CRM module proper), and `navSectionById` — the map the
+  // module reads its items from — is built from this array, so a later entry
+  // wins there. Taking the first here would read groups off the other section.
+  let found: NavGroup[] | undefined;
+  for (const section of navSections) {
+    if (section.id === moduleId) found = section.groups;
+  }
+  return found;
+}
+
 function buildModuleSection(
   moduleId: WorkspaceModuleId,
   visibleModules: Map<WorkspaceModuleId, NavItem[]>,
@@ -634,9 +662,14 @@ function buildModuleSection(
   const items = (visibleModules.get(moduleId) ?? []).filter((item) => !excludedHrefs?.has(item.href));
   if (items.length === 0) return null;
 
+  // Drop any group left with nothing in it after gating and exclusions.
+  const present = new Set(items.map((item) => item.group).filter(Boolean));
+  const groups = declaredGroups(moduleId)?.filter((group) => present.has(group.id));
+
   return {
     id: moduleId,
     title: WORKSPACE_MODULES[moduleId].label,
+    ...(groups && groups.length > 0 ? { groups } : {}),
     items,
     workspaceGroup,
   };


### PR DESCRIPTION
Follow-up to #130. Everything below was reproduced in a browser against a seeded local database before and after — this round needed real tasks and deals in the database, because both crashes only appear once there is data.

## The crashes

**Tasks and collections: "Too many re-renders."** Both used the adjust-state-during-render pattern with an un-normalised guard — `task?.id !== seededFor`, where `task?.id` is `undefined` with no task while the state holds `null`. The comparison is therefore *always* unequal: the guard re-ran every render, set the same value again, and React gave up. The outcome dialog is mounted by `TaskList` whenever there are tasks to show, so every page with a task on it went down, and an empty CRM looked healthy.

**Every record detail page said "not found".** Each CRM `[id]` route answers with the record itself — `successResponse(record)` — and every detail page declared `Envelope<Rec>` and then unwrapped it. The record arrived, `.data.data` was `undefined`, and the page reported the record missing. **That is the missing company and person detail view**: the pages existed and were never able to show anything.

That turned out to be systemic. `successResponse(x)` sends `x`; only fifteen list GETs call it with `{ data: rows }`. **Twenty-seven fetchers** in the client SDK declared an envelope anyway, and a wrong type is one the compiler accepts, so each failed silently: creating a person or site toasted `undefined` and handed the caller no id, saving a view could not then select it, completing a task never noticed the recurrence it had just created, and comments, followers, the import preview, the merge plan and the site-visit report all read as empty. Types now match the routes, so `tsc` catches the next one.

## Record editing

The form sheets were create-only and the record pages offered no way in, so **a typo in a company name could not be corrected anywhere in the module**. Each sheet now takes an optional record: given one it seeds from it, PATCHes the `[id]` route, and says "Save changes". Record pages carry an Edit action. The detail types gain the fields the form owns — the routes use `include`, so those columns were already on the wire and simply not declared.

This uncovered a bug in the shared open-transition pattern affecting **every sheet in the module**: `useState(open)` seeds the previous-open flag from the current value, so a sheet that *mounts* already open records itself as having always been open — the transition never fires and the form never seeds or resets. It only surfaced now because a create sheet always mounts closed.

## Workspace structure

Sixteen CRM links in one flat column was an inventory of pages, not a route through the job. The section now declares semantic groups — **Selling / Who we deal with / Doing the work / Getting paid / Understanding it / Setup** — rendered as labelled bands.

Grouping lives in the navigation model rather than the renderer, so any section can adopt it; a section that declares no groups renders exactly as before.

**Entitlements decide the shape.** Per-item feature keys already existed in the route registry; what was missing is that a group whose every item is gated away now disappears with it, so nobody sees a heading over nothing. Verified: a tenant with only `crm.core` + `crm.leads` sees three groups and six links, not six groups and sixteen.

Tasks and Follow-ups were two doors onto the same queue — Follow-ups runs on the same task infrastructure *and* surfaces the legacy lead reminders — so Tasks redirects there and leaves the nav.

## Lists, not tables

People, companies and sites are lists of things you open, not grids of numbers you compare, and a data table spent a header row and seven columns saying what one line of text says better. They now use a shared record list: a title, the line that tells two similar rows apart, a small cluster of right-aligned facts, and the whole row as the link. The facts drop out below `sm` rather than being duplicated into a separate mobile renderer.

DataTable stays where it earns its place — leads and deals keep it for sorting, bulk selection and money you scan down a column.

## Containers and settings

Page widths had drifted to six values across the module (`max-w-4xl` through `max-w-[110rem]`), so moving between pages shifted the content under you. `CrmPage` offers three, named for what they hold: `list`, `detail` (a record page with a side rail), `narrow` (a single column of form).

CRM settings moves from eight horizontally scrolling tabs to the settings shell — the rail is the map, content is one page deep, every section visible at once, each with a line saying what it is for. The active section lives in the URL. Panels keep saving inline; no sticky unsaved bar, because settings are individually committed rather than a form you submit.

## Caveats

- **Deals and leads still use DataTable**, deliberately. If you want those on the list pattern too, say so — the shared list handles it, but a sortable value column and bulk stage changes are genuinely table work.
- **The deal form sheet takes the edit props but no detail page wires an Edit action to it yet.** People, companies and sites do. Deals edit through the stage bar and the attributes rail instead, which is a different interaction I did not want to duplicate without checking.
- Two nav sections share the id `"crm"` — the retail customer directory and the CRM module. `navSectionById` is built from the array so a later entry wins there; anything reading the array back has to match that or it silently reads the wrong section. Worth giving them distinct ids separately.
- The mobile list rule is applied to the converted pages; **the rest of the module's tables were not swept.**

## Verification

`tsc --noEmit` clean, `eslint` clean over the changed areas (one pre-existing unused-import warning), **679/679 tests pass**. Every screen was driven in Chromium against a seeded local Postgres with real pipelines, deals, people, companies and tasks — including opening the Edit sheet and confirming it comes up populated with the record rather than blank.


---
_Generated by [Claude Code](https://claude.ai/code/session_0165pkzEEY2bL2n1i4fL63kk)_