### PR TITLE
CRM: shell, typography and list corrections

### DIFF
--- a/app/api/v2/crm/dashboard/route.ts
+++ b/app/api/v2/crm/dashboard/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { hasCrmFullAccess } from "@/lib/crm/scope";
 import { ageingBucket } from "@/lib/crm/collections";
 import { ensureDefaultPipeline } from "@/lib/crm/pipelines";
+import { stageSla, workingMinutesBetween } from "@/lib/crm/sla";
 
 /**
  * Everything the CRM home needs, in one round trip.
@@ -57,6 +58,9 @@ export async function GET(request: NextRequest) {
       taskCounts,
       legacyOverdue,
       quotations,
+      quotesWithCustomers,
+      openLeads,
+      answeredLeads,
       openInvoices,
       workOrders,
       upcomingVisits,
@@ -121,6 +125,47 @@ export async function GET(request: NextRequest) {
         },
       }),
 
+      // Every quote still sitting with a customer, not just the ones raised
+      // inside the reporting window. A quote sent seven weeks ago and never
+      // answered is exactly the one worth chasing, and the 30-day cut was
+      // hiding it.
+      prisma.crmLeadDocument.findMany({
+        where: {
+          companyId,
+          type: "QUOTATION",
+          approval: { status: "PENDING" },
+        },
+        select: { id: true, amount: true, currency: true, createdAt: true },
+      }),
+
+      // Leads nobody has answered yet. Deliberately the first-contact clock
+      // and nothing else: later stages measure from when the lead entered
+      // them, which is only recoverable from the activity log, and a
+      // dashboard tile is not worth that join. This is the one the business
+      // actually runs on — a new enquiry gets answered inside the half hour.
+      prisma.crmLead.findMany({
+        where: {
+          companyId,
+          stage: { notIn: ["WON", "LOST"] },
+          firstContactAt: null,
+          ...scope,
+        },
+        select: { id: true, createdAt: true },
+      }),
+
+      // How fast we actually answered, over the period. Only leads that were
+      // answered count — an unanswered lead has no response time, and folding
+      // it in as a zero would flatter the number.
+      prisma.crmLead.findMany({
+        where: {
+          companyId,
+          createdAt: { gte: periodStart },
+          firstContactAt: { not: null },
+          ...scope,
+        },
+        select: { createdAt: true, firstContactAt: true },
+      }),
+
       prisma.salesInvoice.findMany({
         where: {
           companyId,
@@ -152,10 +197,6 @@ export async function GET(request: NextRequest) {
     ]);
 
     const grossValue = openDeals.reduce((sum, deal) => sum + (deal.value ?? 0), 0);
-    const weightedValue = openDeals.reduce(
-      (sum, deal) => sum + ((deal.value ?? 0) * (deal.probability ?? 0)) / 100,
-      0,
-    );
 
     // "Stale" is the stage's own inactivity budget, not a global number — a
     // deal can sit in Quoted for a fortnight and be fine, but three days in New
@@ -231,13 +272,43 @@ export async function GET(request: NextRequest) {
     const wonValue = wonThisPeriod._sum.value ?? 0;
     const previousWonValue = wonPreviousPeriod._sum.value ?? 0;
 
+    // Counted in working hours, so a lead that arrived at five on Friday is
+    // not half a week late by Monday morning.
+    const firstContactStates = openLeads.map((lead) => stageSla("NEW", lead.createdAt, now));
+    const breachedLeads = firstContactStates.filter((state) => state.breached);
+    const atRiskLeads = firstContactStates.filter((state) => state.atRisk);
+
+    // Median, not mean: one lead answered three weeks late drags an average
+    // somewhere no actual lead has ever been.
+    const responseMinutes = answeredLeads
+      .map((lead) =>
+        workingMinutesBetween(lead.createdAt, lead.firstContactAt as Date),
+      )
+      .sort((a, b) => a - b);
+    const medianResponseMinutes =
+      responseMinutes.length === 0
+        ? null
+        : Math.round(responseMinutes[Math.floor(responseMinutes.length / 2)]);
+
+    const closedThisPeriod = wonThisPeriod._count._all + lostThisPeriod;
+
+    // The currency most of the open money is actually in. Mixed books are
+    // possible but rare, and a bare number with no unit is worse than one
+    // labelled with the currency nearly everything is in.
+    const currencyTally = new Map<string, number>();
+    for (const doc of [...quotesWithCustomers, ...openInvoices]) {
+      currencyTally.set(doc.currency, (currencyTally.get(doc.currency) ?? 0) + 1);
+    }
+    const currency =
+      [...currencyTally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "USD";
+
     return successResponse({
       scope: isManager ? "TEAM" : "MINE",
       periodDays,
+      currency,
       pipeline: {
         openDeals: openDeals.length,
         grossValue,
-        weightedValue,
         byStage,
         stale: stale.length,
         closingThisWeek: closingThisWeek.length,
@@ -253,6 +324,20 @@ export async function GET(request: NextRequest) {
             ? Math.round(((wonValue - previousWonValue) / previousWonValue) * 100)
             : null,
         previousValue: previousWonValue,
+        // Of everything that actually closed in the period. Counting open
+        // deals in the denominator would make the rate fall every time
+        // somebody added a lead, which is the opposite of the truth.
+        winRatePercent:
+          closedThisPeriod > 0
+            ? Math.round((wonThisPeriod._count._all / closedThisPeriod) * 100)
+            : null,
+        closed: closedThisPeriod,
+      },
+      speed: {
+        breachedLeads: breachedLeads.length,
+        atRiskLeads: atRiskLeads.length,
+        medianResponseMinutes,
+        answered: answeredLeads.length,
       },
       tasks: {
         overdue: tasksOverdue,
@@ -263,7 +348,18 @@ export async function GET(request: NextRequest) {
       documents: {
         quotationsRaised: quotations.length,
         quotedValue: quotations.reduce((sum, doc) => sum + doc.amount, 0),
-        awaitingApproval: quotations.filter((doc) => doc.approval?.status === "PENDING").length,
+        awaitingApproval: quotesWithCustomers.length,
+        awaitingValue: quotesWithCustomers.reduce((sum, doc) => sum + doc.amount, 0),
+        // The oldest quote nobody has answered — the number that says whether
+        // "awaiting a decision" means "sent this morning" or "forgotten".
+        oldestAwaitingDays:
+          quotesWithCustomers.length === 0
+            ? null
+            : Math.floor(
+                (now.getTime() -
+                  Math.min(...quotesWithCustomers.map((doc) => doc.createdAt.getTime()))) /
+                  (24 * 3600 * 1000),
+              ),
         pendingDiscountApprovals: pendingApprovals,
       },
       collections: {

--- a/app/stores/fuel/page.tsx
+++ b/app/stores/fuel/page.tsx
@@ -244,7 +244,7 @@ export default function StoresFuelPage() {
                         </TableCell>
                         <TableCell className="p-3 text-sm">
                           <span
-                            className={`px-2 py-1 rounded-full text-xs font-semibold ${
+                            className={`px-2 py-1 rounded-full text-sm font-semibold ${
                               isReceipt
                                 ? "bg-green-100 text-green-800"
                                 : "bg-red-100 text-red-800"
@@ -290,7 +290,7 @@ export default function StoresFuelPage() {
               { label: "Total movements", value: String(ledgerRows.length) },
             ]}
           >
-            <table className="w-full text-xs">
+            <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-200 text-left">
                   <th className="py-2">Date</th>

--- a/app/stores/inventory/page.tsx
+++ b/app/stores/inventory/page.tsx
@@ -900,7 +900,7 @@ export default function StoresInventoryPage() {
                         </TableCell>
                         <TableCell className="p-3 text-center">
                           <span
-                            className={`px-2 py-1 rounded-full text-xs font-semibold ${
+                            className={`px-2 py-1 rounded-full text-sm font-semibold ${
                               isLow
                                 ? "bg-yellow-100 text-yellow-800"
                                 : "bg-green-100 text-green-800"
@@ -983,7 +983,7 @@ export default function StoresInventoryPage() {
                         className="h-64 w-64 rounded border object-contain"
                       />
                     </div>
-                    <p className="text-xs text-muted-foreground break-all">
+                    <p className="text-sm text-muted-foreground break-all">
                       {qrPreviewPayload}
                     </p>
                   </div>
@@ -1037,7 +1037,7 @@ export default function StoresInventoryPage() {
                       }
                       required
                     />
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="mt-1 text-sm text-muted-foreground">
                       {editingItemId
                         ? "Item code is immutable."
                         : reserveInventoryCodeError ??
@@ -1245,7 +1245,7 @@ export default function StoresInventoryPage() {
               { label: "Total value", value: `$${totalValue.toFixed(2)}` },
             ]}
           >
-            <div className="space-y-6 text-xs">
+            <div className="space-y-6 text-sm">
               <div>
                 <h2 className="text-sm font-semibold mb-2">Inventory Items</h2>
                 <table className="w-full">
@@ -1442,7 +1442,7 @@ export default function StoresInventoryPage() {
                     }
                     required
                   />
-                  <p className="mt-1 text-xs text-muted-foreground">
+                  <p className="mt-1 text-sm text-muted-foreground">
                     {editingLocationId
                       ? "Location code is immutable."
                       : reserveLocationCodeError ??

--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -324,11 +324,17 @@
      SIDEBAR
      ══════════════════════════════════════════════════════════════════════ */
 
-  --sidebar:                    var(--surface-muted);
+  /* The sidebar is the page's own surface, not a tinted panel beside it. A
+     muted background made it read as a separate application chrome; flat white
+     lets the nav sit in the same plane as the content and puts all the visual
+     weight on the one item that is selected. */
+  --sidebar:                    var(--surface);
   --sidebar-foreground:         var(--text-body);
   --sidebar-primary:            var(--action-primary-bg);
   --sidebar-primary-foreground: var(--action-primary-fg);
-  --sidebar-accent:             var(--surface);
+  /* Hover has to darken now that the base is white — against `--surface` the
+     old value was invisible. */
+  --sidebar-accent:             var(--surface-muted);
   --sidebar-accent-foreground:  var(--text-strong);
   --sidebar-border:             var(--border);
   --sidebar-ring:               var(--focus-ring);

--- a/components/crm/collaboration/comment-thread.tsx
+++ b/components/crm/collaboration/comment-thread.tsx
@@ -146,14 +146,14 @@ export function CommentThread({
       >
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2">
-            <span className="flex size-7 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-xs font-medium">
+            <span className="flex size-7 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-sm font-medium">
               {initials(comment.createdBy.name, comment.createdBy.email)}
             </span>
             <div className="leading-tight">
               <div className="text-sm font-medium">
                 {comment.createdBy.name ?? comment.createdBy.email}
               </div>
-              <div className="text-xs text-[var(--text-muted)]">
+              <div className="text-sm text-[var(--text-muted)]">
                 <ClientDate value={comment.createdAt} mode="datetime" />
                 {comment.editedAt ? " · edited" : null}
               </div>
@@ -203,7 +203,7 @@ export function CommentThread({
         </div>
 
         {resolved && comment.resolvedBy ? (
-          <div className="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
+          <div className="mt-2 flex items-center gap-1 text-sm text-[var(--text-muted)]">
             <Check className="size-3.5" />
             Resolved by {comment.resolvedBy.name ?? comment.resolvedBy.email}
           </div>
@@ -281,7 +281,7 @@ export function CommentThread({
                   <span
                     key={follower.id}
                     title={follower.user.name ?? follower.user.email}
-                    className="flex size-6 items-center justify-center rounded-full border border-[var(--surface-base)] bg-[var(--surface-subtle)] text-[10px] font-medium"
+                    className="flex size-6 items-center justify-center rounded-full border border-[var(--surface-base)] bg-[var(--surface-subtle)] text-sm font-medium"
                   >
                     {initials(follower.user.name, follower.user.email)}
                   </span>
@@ -316,7 +316,7 @@ export function CommentThread({
           onSubmit={() => body.trim() && post.mutate({ body: body.trim() })}
         />
         <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-muted)]">⌘↵ to post</span>
+          <span className="text-sm text-[var(--text-muted)]">⌘↵ to post</span>
           <Button
             type="button"
             size="sm"

--- a/components/crm/collaboration/mention-textarea.tsx
+++ b/components/crm/collaboration/mention-textarea.tsx
@@ -137,7 +137,7 @@ export function MentionTextarea({
                 )}
               >
                 <span className="font-medium">{user.name ?? user.email}</span>
-                <span className="text-xs text-[var(--text-muted)]">{user.email}</span>
+                <span className="text-sm text-[var(--text-muted)]">{user.email}</span>
               </button>
             </li>
           ))}

--- a/components/crm/collections/collections-content.tsx
+++ b/components/crm/collections/collections-content.tsx
@@ -54,12 +54,15 @@ type ChaseRow = {
   urgency: number;
 };
 
+/**
+ * The route answers this shape bare — `successResponse` adds no envelope.
+ * Wrapping it in another `data` made `report` the rows array instead of the
+ * report, so `report.ageing` was undefined and the page threw on open.
+ */
 type CollectionsResponse = {
-  data: {
-    data: ChaseRow[];
-    ageing: { bucket: AgeingBucket; label: string; count: number; amount: number }[];
-    totalOutstanding: number;
-  };
+  data: ChaseRow[];
+  ageing: { bucket: AgeingBucket; label: string; count: number; amount: number }[];
+  totalOutstanding: number;
 };
 
 export function CollectionsContent({ currency = "USD" }: { currency?: string }) {
@@ -70,7 +73,7 @@ export function CollectionsContent({ currency = "USD" }: { currency?: string }) 
     queryFn: () => fetchJson<CollectionsResponse>("/api/v2/crm/collections"),
   });
 
-  const report = data?.data;
+  const report = data;
 
   return (
     <div className="space-y-5">
@@ -124,7 +127,7 @@ export function CollectionsContent({ currency = "USD" }: { currency?: string }) 
                         </Link>
                       ) : null}
                     </div>
-                    <p className="text-xs text-[var(--text-muted)]">
+                    <p className="text-sm text-[var(--text-muted)]">
                       {row.daysOverdue > 0 ? (
                         <span className="font-medium text-[var(--status-error-text)]">
                           {row.daysOverdue} day{row.daysOverdue === 1 ? "" : "s"} late
@@ -269,7 +272,7 @@ function ChaseDialog({
                 value={promisedAt}
                 onChange={(event) => setPromisedAt(event.target.value)}
               />
-              <p className="text-xs text-[var(--text-muted)]">
+              <p className="text-sm text-[var(--text-muted)]">
                 A task lands on this date so somebody actually checks.
               </p>
             </div>

--- a/components/crm/crm-dashboard-content.tsx
+++ b/components/crm/crm-dashboard-content.tsx
@@ -280,7 +280,7 @@ export function CrmDashboardContent() {
                         style={{ width: `${Math.max(share, stage.count > 0 ? 3 : 0)}%` }}
                         aria-hidden="true"
                       />
-                      <span className="ml-auto shrink-0 font-mono text-xs text-[var(--text-muted)]">
+                      <span className="ml-auto shrink-0 font-mono text-sm text-[var(--text-muted)]">
                         {stage.count} · {money(stage.value)}
                       </span>
                     </Link>
@@ -306,7 +306,7 @@ export function CrmDashboardContent() {
                     className="flex items-center justify-between gap-3 text-sm"
                   >
                     <span>{AGEING_LABELS[bucket]}</span>
-                    <span className="font-mono text-xs text-[var(--text-muted)]">
+                    <span className="font-mono text-sm text-[var(--text-muted)]">
                       {row ? `${row.count} · ${money(row.value)}` : "—"}
                     </span>
                   </li>

--- a/components/crm/crm-dashboard-content.tsx
+++ b/components/crm/crm-dashboard-content.tsx
@@ -20,10 +20,10 @@ import {
 type DashboardData = {
   scope: "TEAM" | "MINE";
   periodDays: number;
+  currency: string;
   pipeline: {
     openDeals: number;
     grossValue: number;
-    weightedValue: number;
     byStage: Array<{ id: string; name: string; status: string; count: number; value: number }>;
     stale: number;
     closingThisWeek: number;
@@ -34,12 +34,22 @@ type DashboardData = {
     lost: number;
     valueDeltaPercent: number | null;
     previousValue: number;
+    winRatePercent: number | null;
+    closed: number;
+  };
+  speed: {
+    breachedLeads: number;
+    atRiskLeads: number;
+    medianResponseMinutes: number | null;
+    answered: number;
   };
   tasks: { overdue: number; today: number; open: number; legacyOverdue: number };
   documents: {
     quotationsRaised: number;
     quotedValue: number;
     awaitingApproval: number;
+    awaitingValue: number;
+    oldestAwaitingDays: number | null;
     pendingDiscountApprovals: number;
   };
   collections: {
@@ -51,8 +61,24 @@ type DashboardData = {
   delivery: { workOrders: Record<string, number>; upcomingVisits: number };
 };
 
-function money(value: number): string {
-  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+function money(value: number, currency: string): string {
+  // With the currency, always. A dashboard that says "6,168" has told you a
+  // digit string, not an amount.
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  });
+}
+
+/** "18m", "2h 10m", "3 days" — working time, in the largest unit that is true. */
+function duration(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  // Nine working hours to a day, matching the SLA clock.
+  if (hours < 9) return `${hours}h`;
+  const days = Math.round((minutes / (9 * 60)) * 10) / 10;
+  return `${days} working day${days === 1 ? "" : "s"}`;
 }
 
 /**
@@ -90,7 +116,8 @@ export function CrmDashboardContent() {
     );
   }
 
-  const { pipeline, won, tasks, documents, collections, delivery } = data;
+  const { pipeline, won, speed, tasks, documents, collections, delivery } = data;
+  const currency = data.currency;
   const needsAttention = tasks.overdue + tasks.legacyOverdue;
   const nothingYet = pipeline.openDeals === 0 && won.count === 0 && documents.quotationsRaised === 0;
 
@@ -113,17 +140,23 @@ export function CrmDashboardContent() {
 
   return (
     <div className="space-y-5">
-      {/* Hero: weighted pipeline is the one number that answers "how are we
-          doing". Gross sits underneath it because the two are always read
-          together and a weighted figure alone invites the wrong question. */}
+      {/* The hero used to be a probability-weighted pipeline figure. Nobody
+          sets those probabilities, so it was mostly the sum of whatever
+          defaults happened to be in the column — a number that changed for
+          reasons no one could explain and that nothing could be decided on.
+          What actually closed is a fact, and it compares to last month. */}
       <StatHero
-        label="Weighted pipeline"
-        value={money(pipeline.weightedValue)}
-        subtitle={`${pipeline.openDeals} open deal${pipeline.openDeals === 1 ? "" : "s"} · ${money(pipeline.grossValue)} gross`}
+        label={`Won in the last ${data.periodDays} days`}
+        value={money(won.value, currency)}
+        subtitle={
+          won.winRatePercent === null
+            ? `${won.count} deal${won.count === 1 ? "" : "s"} · nothing else closed to compare against`
+            : `${won.count} of ${won.closed} closed · ${won.winRatePercent}% win rate`
+        }
         change={
           won.valueDeltaPercent === null
-            ? `${money(won.value)} won in the last ${data.periodDays} days`
-            : `${won.valueDeltaPercent >= 0 ? "+" : ""}${won.valueDeltaPercent}% won vs the previous ${data.periodDays} days`
+            ? `${money(won.previousValue, currency)} in the previous ${data.periodDays} days`
+            : `${won.valueDeltaPercent >= 0 ? "+" : ""}${won.valueDeltaPercent}% against the previous ${data.periodDays} days`
         }
         trend={
           won.valueDeltaPercent === null
@@ -139,35 +172,54 @@ export function CrmDashboardContent() {
         }
       />
 
+      {/* Four questions, in the order they cost you money: are we answering
+          people, is anything sitting with a customer unanswered, what is in
+          flight, and what have we not been paid for. */}
       <KpiGrid cols={4}>
         <KpiGrid.Item
-          label="Needs chasing"
-          value={needsAttention}
-          delta={tasks.today > 0 ? `${tasks.today} due today` : "nothing due today"}
-          tone={needsAttention > 0 ? "danger" : "neutral"}
-          onClick={() => router.push("/crm/follow-ups")}
+          label="Waiting on a first call"
+          value={speed.breachedLeads}
+          delta={
+            speed.medianResponseMinutes === null
+              ? "no answered leads yet"
+              : `usually answered in ${duration(speed.medianResponseMinutes)}`
+          }
+          tone={speed.breachedLeads > 0 ? "danger" : speed.atRiskLeads > 0 ? "warn" : "success"}
+          onClick={() => router.push("/crm/leads")}
         />
         <KpiGrid.Item
-          label="Quoted"
-          value={money(documents.quotedValue)}
-          delta={`${documents.quotationsRaised} in ${data.periodDays} days`}
+          label="Out with customers"
+          value={money(documents.awaitingValue, currency)}
+          delta={
+            documents.awaitingApproval === 0
+              ? "no quotes waiting on a decision"
+              : documents.oldestAwaitingDays === null
+                ? `${documents.awaitingApproval} quote${documents.awaitingApproval === 1 ? "" : "s"}`
+                : `${documents.awaitingApproval} quote${documents.awaitingApproval === 1 ? "" : "s"} · oldest ${documents.oldestAwaitingDays} days`
+          }
+          tone={
+            documents.oldestAwaitingDays !== null && documents.oldestAwaitingDays > 7
+              ? "warn"
+              : "neutral"
+          }
+          onClick={() => router.push("/crm/quotes")}
+        />
+        <KpiGrid.Item
+          label="In the pipeline"
+          value={money(pipeline.grossValue, currency)}
+          delta={`${pipeline.openDeals} open · ${pipeline.closingThisWeek} due to close this week`}
           onClick={() => router.push("/crm/deals")}
         />
         <KpiGrid.Item
           label="Owed to us"
-          value={money(collections.outstanding)}
+          value={money(collections.outstanding, currency)}
           delta={
-            collections.overdue > 0 ? `${money(collections.overdue)} overdue` : "all within terms"
+            collections.overdue > 0
+              ? `${money(collections.overdue, currency)} overdue`
+              : "all within terms"
           }
           tone={collections.overdue > 0 ? "warn" : "neutral"}
           onClick={() => router.push("/crm/collections")}
-        />
-        <KpiGrid.Item
-          label="Won"
-          value={won.count}
-          delta={won.lost > 0 ? `${won.lost} lost` : "none lost"}
-          tone={won.count > 0 ? "success" : "neutral"}
-          onClick={() => router.push("/crm/insights")}
         />
       </KpiGrid>
 
@@ -222,7 +274,7 @@ export function CrmDashboardContent() {
             subtitle={
               collections.invoiceCount === 0
                 ? "Nothing outstanding from a CRM quote."
-                : `${collections.invoiceCount} open · ${money(collections.outstanding)} outstanding`
+                : `${collections.invoiceCount} open · ${money(collections.outstanding, currency)} outstanding`
             }
             status={<ChevronRight className="size-4 text-[var(--text-subtle)]" />}
             onClick={() => router.push("/crm/collections")}
@@ -281,7 +333,7 @@ export function CrmDashboardContent() {
                         aria-hidden="true"
                       />
                       <span className="ml-auto shrink-0 font-mono text-sm text-[var(--text-muted)]">
-                        {stage.count} · {money(stage.value)}
+                        {stage.count} · {money(stage.value, currency)}
                       </span>
                     </Link>
                   </li>
@@ -307,7 +359,7 @@ export function CrmDashboardContent() {
                   >
                     <span>{AGEING_LABELS[bucket]}</span>
                     <span className="font-mono text-sm text-[var(--text-muted)]">
-                      {row ? `${row.count} · ${money(row.value)}` : "—"}
+                      {row ? `${row.count} · ${money(row.value, currency)}` : "—"}
                     </span>
                   </li>
                 );

--- a/components/crm/crm-follow-ups-content.tsx
+++ b/components/crm/crm-follow-ups-content.tsx
@@ -181,7 +181,7 @@ export function CrmFollowUpsContent() {
                       Lead reminder
                     </Badge>
                   </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--text-muted)]">
                     <ClientDate value={row.dueAt} mode="datetime" />
                     <span>{row.assignedTo?.name ?? "Unassigned"}</span>
                     {row.lead ? (
@@ -192,7 +192,7 @@ export function CrmFollowUpsContent() {
                     {row.client ? <span>{row.client.name}</span> : null}
                   </div>
                   {row.notes ? (
-                    <p className="mt-1 text-xs text-[var(--text-muted)]">{row.notes}</p>
+                    <p className="mt-1 text-sm text-[var(--text-muted)]">{row.notes}</p>
                   ) : null}
                 </div>
                 <Button

--- a/components/crm/crm-form-builder-content.tsx
+++ b/components/crm/crm-form-builder-content.tsx
@@ -217,7 +217,7 @@ function FormBuilderEditor({ formId, initial }: { formId: string; initial: FormR
                   ))}
                 </SelectContent>
               </Select>
-              <label className="col-span-2 flex items-center gap-1 text-xs sm:col-span-1">
+              <label className="col-span-2 flex items-center gap-1 text-sm sm:col-span-1">
                 <input
                   type="checkbox"
                   checked={field.required}
@@ -239,7 +239,7 @@ function FormBuilderEditor({ formId, initial }: { formId: string; initial: FormR
               </Button>
             </div>
           ))}
-          <p className="text-xs text-[var(--text-muted)]">
+          <p className="text-sm text-[var(--text-muted)]">
             Name, email, phone (with country code), and photos are always included.
           </p>
         </CardContent>

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -173,16 +173,16 @@ export function CrmFormsContent() {
 
               <dl className="mt-3 grid grid-cols-3 gap-2 text-sm">
                 <div>
-                  <dt className="text-xs text-[var(--text-muted)]">Submissions</dt>
+                  <dt className="text-sm text-[var(--text-muted)]">Submissions</dt>
                   <dd className="font-mono">{form.submissionCount}</dd>
                 </div>
                 <div>
-                  <dt className="text-xs text-[var(--text-muted)]">Became leads</dt>
+                  <dt className="text-sm text-[var(--text-muted)]">Became leads</dt>
                   <dd className="font-mono">{form.convertedCount}</dd>
                 </div>
                 <div>
-                  <dt className="text-xs text-[var(--text-muted)]">Last one</dt>
-                  <dd className="text-xs">
+                  <dt className="text-sm text-[var(--text-muted)]">Last one</dt>
+                  <dd className="text-sm">
                     {form.lastSubmissionAt ? (
                       <ClientDate value={form.lastSubmissionAt} mode="date" />
                     ) : (
@@ -232,7 +232,7 @@ export function CrmFormsContent() {
                     via {submission.form?.name ?? "a form"}
                   </span>
                 </div>
-                <div className="flex items-center gap-3 text-xs text-[var(--text-muted)]">
+                <div className="flex items-center gap-3 text-sm text-[var(--text-muted)]">
                   <ClientDate value={submission.createdAt} mode="datetime" />
                   {submission.lead ? (
                     <Link href={`/crm/leads/${submission.lead.id}`} className="hover:underline">

--- a/components/crm/crm-insights-content.tsx
+++ b/components/crm/crm-insights-content.tsx
@@ -41,7 +41,7 @@ type ReportData = {
   counts: { won: number; lost: number; open: number };
   winRate: number;
   medianCycleDays: number | null;
-  forecast: { weighted: number; unweighted: number };
+  forecast: { weighted: number; unweighted: number; count: number; estimated: number };
   byOwner: GroupRow[];
   bySource: GroupRow[];
   activity: Array<{ label: string; start: string; count: number }>;
@@ -169,7 +169,11 @@ export function CrmInsightsContent() {
           <StatHero
             label="Weighted forecast"
             value={money(data.forecast.weighted)}
-            subtitle={`${money(data.forecast.unweighted)} if every open deal lands · ${data.counts.open} open`}
+            subtitle={
+              data.forecast.estimated === 0
+                ? `${money(data.forecast.unweighted)} if every open deal lands · ${data.counts.open} open`
+                : `${money(data.forecast.unweighted)} if every open deal lands · ${data.forecast.estimated} of ${data.forecast.count} open deals have no likelihood set, so they are counted at the default`
+            }
             change={
               decided === 0
                 ? "Nothing decided in this period yet"

--- a/components/crm/crm-insights-content.tsx
+++ b/components/crm/crm-insights-content.tsx
@@ -222,7 +222,7 @@ export function CrmInsightsContent() {
                   <li key={stage.key} className="space-y-1">
                     <div className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
                       <span className="font-medium">{stage.label}</span>
-                      <span className="font-mono text-xs text-[var(--text-muted)]">
+                      <span className="font-mono text-sm text-[var(--text-muted)]">
                         {stage.reached} reached · {money(stage.value)}
                         {index > 0
                           ? ` · ${formatRate(stage.conversionFromPrevious)} carried through`
@@ -261,7 +261,7 @@ export function CrmInsightsContent() {
                     </div>
                   ))}
                 </div>
-                <p className="mt-2 text-xs text-[var(--text-muted)]">
+                <p className="mt-2 text-sm text-[var(--text-muted)]">
                   Calls, notes, emails and meetings logged. Peak {peakActivity} in a single period.
                 </p>
               </>
@@ -335,7 +335,7 @@ export function CrmInsightsContent() {
                       >
                         {(CRM_CHANNEL_LABELS as Record<string, string>)[row.channel] ?? row.channel}
                       </Link>
-                      <span className="font-mono text-xs text-[var(--text-muted)]">
+                      <span className="font-mono text-sm text-[var(--text-muted)]">
                         {row.leads} leads · {row.won} won · {row.conversionRate}%
                       </span>
                     </li>

--- a/components/crm/crm-members.tsx
+++ b/components/crm/crm-members.tsx
@@ -76,14 +76,14 @@ export function CrmMembers({ className }: { className?: string }) {
             </span>
           ))}
           {overflow > 0 ? (
-            <span className="-ml-2 flex size-7 items-center justify-center rounded-full bg-[var(--surface-muted)] text-[11px] font-medium text-[var(--text-muted)] ring-2 ring-[var(--surface-base)]">
+            <span className="-ml-2 flex size-7 items-center justify-center rounded-full bg-[var(--surface-muted)] text-sm font-medium text-[var(--text-muted)] ring-2 ring-[var(--surface-base)]">
               +{overflow}
             </span>
           ) : null}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[16rem] p-1">
-        <p className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]">
+        <p className="px-2 py-1.5 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]">
           {members.length} in this workspace
         </p>
         <ul className="max-h-72 overflow-y-auto">
@@ -94,7 +94,7 @@ export function CrmMembers({ className }: { className?: string }) {
                 <span className="block truncate text-sm">
                   {member.name ?? member.email ?? "Unnamed"}
                 </span>
-                <span className="block truncate text-xs text-[var(--text-muted)]">
+                <span className="block truncate text-sm text-[var(--text-muted)]">
                   {ROLE_LABELS[member.role] ?? member.role}
                 </span>
               </span>

--- a/components/crm/crm-settings-content.tsx
+++ b/components/crm/crm-settings-content.tsx
@@ -106,7 +106,7 @@ function ApiKeysPanel() {
             Create key
           </Button>
         </div>
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-sm text-[var(--text-muted)]">
           Every lead captured with a key inherits its channel and source label — e.g. a &quot;Facebook Lead
           Ads&quot; key labels leads as Paid ads / facebook automatically.
         </p>
@@ -216,7 +216,7 @@ function LeadSourcesPanel() {
               </span>
               <span className="flex items-center gap-2">
                 <select
-                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-xs"
+                  className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-sm"
                   value={source.channel}
                   disabled={update.isPending}
                   onChange={(e) => update.mutate({ id: source.id, channel: e.target.value })}

--- a/components/crm/documents/document-builder-sheet.tsx
+++ b/components/crm/documents/document-builder-sheet.tsx
@@ -211,7 +211,7 @@ export function DocumentBuilderSheet({
               </p>
             ) : (
               <section className="space-y-3">
-                <div className="hidden gap-2 px-1 text-xs font-medium text-[var(--text-muted)] sm:grid sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem]">
+                <div className="hidden gap-2 px-1 text-sm font-medium text-[var(--text-muted)] sm:grid sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem]">
                   <span>Description</span>
                   <span className="text-right">Qty</span>
                   <span className="text-right">Unit price</span>

--- a/components/crm/documents/document-builder-sheet.tsx
+++ b/components/crm/documents/document-builder-sheet.tsx
@@ -8,14 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { Plus, Trash2 } from "@/lib/icons";
@@ -162,251 +155,239 @@ export function DocumentBuilderSheet({
   const isQuotation = mode === "quotation";
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="xl" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>{isQuotation ? "New quotation" : "New invoice"}</SheetTitle>
-          <SheetDescription>
-            {fromQuotationId
-              ? "Converting the accepted quotation — the lines carry over exactly as quoted."
-              : isQuotation
-                ? "Price up the work. The client can approve it from a link without signing in."
-                : "Bill the work. Payments recorded against this invoice produce receipts."}
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isQuotation ? "New quotation" : "New invoice"}
+      description={fromQuotationId
+      ? "Converting the accepted quotation — the lines carry over exactly as quoted."
+      : isQuotation
+        ? "Price up the work. The client can approve it from a link without signing in."
+        : "Bill the work. Payments recorded against this invoice produce receipts."}
+      size="xl"
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) create.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={create.isPending}>
+          {create.isPending
+            ? "Saving…"
+            : isQuotation
+              ? sendApproval
+                ? "Create & share"
+                : "Create quotation"
+              : "Issue invoice"}
+        </Button>
+      </>}
+    >
+      {fromQuotationId ? (
+        <p className="rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface-muted)]/50 p-3 text-sm">
+          Lines are taken from the source quotation and can&apos;t be edited here — that keeps
+          the invoice matching what the client accepted. Cancel and start a fresh invoice if
+          the scope has changed.
+        </p>
+      ) : (
+        <section className="space-y-3">
+          <div className="hidden gap-2 px-1 text-sm font-medium text-[var(--text-muted)] sm:grid sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem]">
+            <span>Description</span>
+            <span className="text-right">Qty</span>
+            <span className="text-right">Unit price</span>
+            <span className="text-right">Disc %</span>
+            <span className="text-right">Tax %</span>
+            <span className="text-right">Line total</span>
+            <span />
+          </div>
 
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            requiredHint="Every line needs a description, a quantity, and a unit price."
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) create.mutate();
-            }}
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={create.isPending}>
-                  {create.isPending
-                    ? "Saving…"
-                    : isQuotation
-                      ? sendApproval
-                        ? "Create & share"
-                        : "Create quotation"
-                      : "Issue invoice"}
-                </Button>
-              </>
-            }
-          >
-            {fromQuotationId ? (
-              <p className="rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface-muted)]/50 p-3 text-sm">
-                Lines are taken from the source quotation and can&apos;t be edited here — that keeps
-                the invoice matching what the client accepted. Cancel and start a fresh invoice if
-                the scope has changed.
-              </p>
-            ) : (
-              <section className="space-y-3">
-                <div className="hidden gap-2 px-1 text-sm font-medium text-[var(--text-muted)] sm:grid sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem]">
-                  <span>Description</span>
-                  <span className="text-right">Qty</span>
-                  <span className="text-right">Unit price</span>
-                  <span className="text-right">Disc %</span>
-                  <span className="text-right">Tax %</span>
-                  <span className="text-right">Line total</span>
-                  <span />
-                </div>
+          {lines.map((line, index) => {
+            const quantity = toNumber(line.quantity, 1);
+            const listPrice = toNumber(line.unitPrice);
+            const discount = Math.min(Math.max(toNumber(line.discountPercent), 0), 100);
+            const net = round2(quantity * round2(listPrice * (1 - discount / 100)));
 
-                {lines.map((line, index) => {
-                  const quantity = toNumber(line.quantity, 1);
-                  const listPrice = toNumber(line.unitPrice);
-                  const discount = Math.min(Math.max(toNumber(line.discountPercent), 0), 100);
-                  const net = round2(quantity * round2(listPrice * (1 - discount / 100)));
-
-                  return (
-                    <div
-                      key={index}
-                      className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem] sm:items-center"
-                    >
-                      <Input
-                        value={line.description}
-                        onChange={(event) => patchLine(index, { description: event.target.value })}
-                        placeholder="What are you charging for?"
-                        aria-label={`Line ${index + 1} description`}
-                        maxLength={300}
-                      />
-                      <Input
-                        value={line.quantity}
-                        onChange={(event) => patchLine(index, { quantity: event.target.value })}
-                        inputMode="decimal"
-                        className="text-right font-mono"
-                        aria-label={`Line ${index + 1} quantity`}
-                      />
-                      <Input
-                        value={line.unitPrice}
-                        onChange={(event) => patchLine(index, { unitPrice: event.target.value })}
-                        inputMode="decimal"
-                        className="text-right font-mono"
-                        placeholder="0.00"
-                        aria-label={`Line ${index + 1} unit price`}
-                      />
-                      <Input
-                        value={line.discountPercent}
-                        onChange={(event) =>
-                          patchLine(index, { discountPercent: event.target.value })
-                        }
-                        inputMode="decimal"
-                        className="text-right font-mono"
-                        placeholder="0"
-                        aria-label={`Line ${index + 1} discount percent`}
-                      />
-                      <Input
-                        value={line.taxRate}
-                        onChange={(event) => patchLine(index, { taxRate: event.target.value })}
-                        inputMode="decimal"
-                        className="text-right font-mono"
-                        placeholder="0"
-                        aria-label={`Line ${index + 1} tax percent`}
-                      />
-                      <span className="px-1 text-right font-mono text-sm tabular-nums">
-                        {net.toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
-                      </span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="h-9 w-9 px-0"
-                        aria-label={`Remove line ${index + 1}`}
-                        disabled={lines.length === 1}
-                        onClick={() => setLines((prev) => prev.filter((_, i) => i !== index))}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  );
-                })}
-
+            return (
+              <div
+                key={index}
+                className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem] sm:items-center"
+              >
+                <Input
+                  value={line.description}
+                  onChange={(event) => patchLine(index, { description: event.target.value })}
+                  placeholder="What are you charging for?"
+                  aria-label={`Line ${index + 1} description`}
+                  maxLength={300}
+                />
+                <Input
+                  value={line.quantity}
+                  onChange={(event) => patchLine(index, { quantity: event.target.value })}
+                  inputMode="decimal"
+                  className="text-right font-mono"
+                  aria-label={`Line ${index + 1} quantity`}
+                />
+                <Input
+                  value={line.unitPrice}
+                  onChange={(event) => patchLine(index, { unitPrice: event.target.value })}
+                  inputMode="decimal"
+                  className="text-right font-mono"
+                  placeholder="0.00"
+                  aria-label={`Line ${index + 1} unit price`}
+                />
+                <Input
+                  value={line.discountPercent}
+                  onChange={(event) =>
+                    patchLine(index, { discountPercent: event.target.value })
+                  }
+                  inputMode="decimal"
+                  className="text-right font-mono"
+                  placeholder="0"
+                  aria-label={`Line ${index + 1} discount percent`}
+                />
+                <Input
+                  value={line.taxRate}
+                  onChange={(event) => patchLine(index, { taxRate: event.target.value })}
+                  inputMode="decimal"
+                  className="text-right font-mono"
+                  placeholder="0"
+                  aria-label={`Line ${index + 1} tax percent`}
+                />
+                <span className="px-1 text-right font-mono text-sm tabular-nums">
+                  {net.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </span>
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
-                  className="gap-1.5"
-                  onClick={() => setLines((prev) => [...prev, emptyLine()])}
+                  className="h-9 w-9 px-0"
+                  aria-label={`Remove line ${index + 1}`}
+                  disabled={lines.length === 1}
+                  onClick={() => setLines((prev) => prev.filter((_, i) => i !== index))}
                 >
-                  <Plus className="h-3.5 w-3.5" />
-                  Add line
+                  <Trash2 className="h-4 w-4" />
                 </Button>
-              </section>
-            )}
-
-            {!fromQuotationId ? (
-              <section className="ml-auto w-full max-w-sm space-y-1.5 rounded-[var(--card-radius)] border border-[var(--border)] p-3 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-[var(--text-muted)]">List total</span>
-                  <span className="font-mono tabular-nums">
-                    {formatMoney(totals.listTotal, currency)}
-                  </span>
-                </div>
-                {totals.lineDiscount > 0 ? (
-                  <div className="flex justify-between">
-                    <span className="text-[var(--text-muted)]">Line discounts</span>
-                    <span className="font-mono tabular-nums">
-                      −{formatMoney(totals.lineDiscount, currency)}
-                    </span>
-                  </div>
-                ) : null}
-                <div className="flex items-center justify-between gap-2">
-                  <Label htmlFor="doc-discount" className="text-[var(--text-muted)]">
-                    Document discount %
-                  </Label>
-                  <Input
-                    id="doc-discount"
-                    value={documentDiscount}
-                    onChange={(event) => setDocumentDiscount(event.target.value)}
-                    inputMode="decimal"
-                    className="h-8 w-20 text-right font-mono"
-                    placeholder="0"
-                  />
-                </div>
-                {totals.docDiscountAmount > 0 ? (
-                  <div className="flex justify-between">
-                    <span className="text-[var(--text-muted)]">Document discount</span>
-                    <span className="font-mono tabular-nums">
-                      −{formatMoney(totals.docDiscountAmount, currency)}
-                    </span>
-                  </div>
-                ) : null}
-                <div className="flex justify-between">
-                  <span className="text-[var(--text-muted)]">Subtotal</span>
-                  <span className="font-mono tabular-nums">
-                    {formatMoney(totals.subTotal, currency)}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-[var(--text-muted)]">Tax</span>
-                  <span className="font-mono tabular-nums">
-                    {formatMoney(totals.taxTotal, currency)}
-                  </span>
-                </div>
-                <div className="flex justify-between border-t border-[var(--border)] pt-1.5 text-base font-semibold">
-                  <span>Total</span>
-                  <span className="font-mono tabular-nums">
-                    {formatMoney(totals.total, currency)}
-                  </span>
-                </div>
-              </section>
-            ) : null}
-
-            <section className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="doc-date">{isQuotation ? "Valid until" : "Due date"}</Label>
-                <Input
-                  id="doc-date"
-                  type="date"
-                  value={isQuotation ? validUntil : dueDate}
-                  onChange={(event) =>
-                    isQuotation ? setValidUntil(event.target.value) : setDueDate(event.target.value)
-                  }
-                />
               </div>
-            </section>
+            );
+          })}
 
-            <div className="space-y-1.5">
-              <Label htmlFor="doc-notes">Notes</Label>
-              <Textarea
-                id="doc-notes"
-                value={notes}
-                onChange={(event) => setNotes(event.target.value)}
-                rows={3}
-                placeholder="Terms, lead times, exclusions — anything the client should read."
-              />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setLines((prev) => [...prev, emptyLine()])}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add line
+          </Button>
+        </section>
+      )}
+
+      {!fromQuotationId ? (
+        <section className="ml-auto w-full max-w-sm space-y-1.5 rounded-[var(--card-radius)] border border-[var(--border)] p-3 text-sm">
+          <div className="flex justify-between">
+            <span className="text-[var(--text-muted)]">List total</span>
+            <span className="font-mono tabular-nums">
+              {formatMoney(totals.listTotal, currency)}
+            </span>
+          </div>
+          {totals.lineDiscount > 0 ? (
+            <div className="flex justify-between">
+              <span className="text-[var(--text-muted)]">Line discounts</span>
+              <span className="font-mono tabular-nums">
+                −{formatMoney(totals.lineDiscount, currency)}
+              </span>
             </div>
+          ) : null}
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="doc-discount" className="text-[var(--text-muted)]">
+              Document discount %
+            </Label>
+            <Input
+              id="doc-discount"
+              value={documentDiscount}
+              onChange={(event) => setDocumentDiscount(event.target.value)}
+              inputMode="decimal"
+              className="h-8 w-20 text-right font-mono"
+              placeholder="0"
+            />
+          </div>
+          {totals.docDiscountAmount > 0 ? (
+            <div className="flex justify-between">
+              <span className="text-[var(--text-muted)]">Document discount</span>
+              <span className="font-mono tabular-nums">
+                −{formatMoney(totals.docDiscountAmount, currency)}
+              </span>
+            </div>
+          ) : null}
+          <div className="flex justify-between">
+            <span className="text-[var(--text-muted)]">Subtotal</span>
+            <span className="font-mono tabular-nums">
+              {formatMoney(totals.subTotal, currency)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-[var(--text-muted)]">Tax</span>
+            <span className="font-mono tabular-nums">
+              {formatMoney(totals.taxTotal, currency)}
+            </span>
+          </div>
+          <div className="flex justify-between border-t border-[var(--border)] pt-1.5 text-base font-semibold">
+            <span>Total</span>
+            <span className="font-mono tabular-nums">
+              {formatMoney(totals.total, currency)}
+            </span>
+          </div>
+        </section>
+      ) : null}
 
-            {isQuotation ? (
-              <label className="flex cursor-pointer items-start gap-2.5">
-                <Checkbox
-                  checked={sendApproval}
-                  onCheckedChange={(checked) => setSendApproval(checked === true)}
-                  className="mt-0.5"
-                />
-                <span className="text-sm">
-                  Create an approval link
-                  <span className="block text-[var(--text-muted)]">
-                    The client can accept or decline from the link without an account.
-                  </span>
-                </span>
-              </label>
-            ) : null}
-          </FormShell>
+      <section className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="doc-date">{isQuotation ? "Valid until" : "Due date"}</Label>
+          <Input
+            id="doc-date"
+            type="date"
+            value={isQuotation ? validUntil : dueDate}
+            onChange={(event) =>
+              isQuotation ? setValidUntil(event.target.value) : setDueDate(event.target.value)
+            }
+          />
         </div>
-      </SheetContent>
-    </Sheet>
+      </section>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="doc-notes">Notes</Label>
+        <Textarea
+          id="doc-notes"
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          rows={3}
+          placeholder="Terms, lead times, exclusions — anything the client should read."
+        />
+      </div>
+
+      {isQuotation ? (
+        <label className="flex cursor-pointer items-start gap-2.5">
+          <Checkbox
+            checked={sendApproval}
+            onCheckedChange={(checked) => setSendApproval(checked === true)}
+            className="mt-0.5"
+          />
+          <span className="text-sm">
+            Create an approval link
+            <span className="block text-[var(--text-muted)]">
+              The client can accept or decline from the link without an account.
+            </span>
+          </span>
+        </label>
+      ) : null}
+    </RecordDialog>
   );
 }

--- a/components/crm/documents/document-list.tsx
+++ b/components/crm/documents/document-list.tsx
@@ -132,7 +132,7 @@ export function DocumentList({
           </EmptyHeader>
         </Empty>
       ) : (
-        <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+        <ul className="divide-y divide-[var(--border-subtle)]">
           {documents.map((doc) => {
             const status = documentStatus(doc);
             const outstanding = doc.invoice ? invoiceOutstanding(doc.invoice) : 0;
@@ -150,17 +150,17 @@ export function DocumentList({
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-mono text-sm">{documentNumber(doc)}</span>
-                    <span className="text-xs text-[var(--text-muted)]">
+                    <span className="text-sm text-[var(--text-muted)]">
                       {DOCUMENT_KIND_LABELS[doc.type]}
                     </span>
                     {doc.version > 1 ? (
-                      <span className="rounded bg-[var(--surface-subtle)] px-1.5 py-0.5 text-[11px] text-[var(--text-muted)]">
+                      <span className="rounded bg-[var(--surface-subtle)] px-1.5 py-0.5 text-sm text-[var(--text-muted)]">
                         v{doc.version}
                       </span>
                     ) : null}
                     <StatusChip status={status.status} label={status.label} />
                   </div>
-                  <div className="text-xs text-[var(--text-muted)]">
+                  <div className="text-sm text-[var(--text-muted)]">
                     <ClientDate value={doc.createdAt} mode="date" />
                     {canPay ? ` · ${formatMoney(outstanding, doc.currency)} outstanding` : ""}
                     {doc.revisionNote ? ` · ${doc.revisionNote}` : ""}

--- a/components/crm/documents/documents-list-content.tsx
+++ b/components/crm/documents/documents-list-content.tsx
@@ -15,6 +15,7 @@ import { ClientDate } from "@/components/ui/client-date";
 import { Download, DotsThree, FileText } from "@/lib/icons";
 import { useDebounced } from "@/hooks/use-debounced";
 import { fetchCrmDocuments, type CrmDocumentKind, type CrmDocumentRecord } from "@/lib/crm/crm-v2";
+import { DOCUMENT_STATUS } from "@/lib/crm/tones";
 
 import {
   GroupedRecordList,
@@ -28,18 +29,6 @@ import { formatMoney } from "./document-types";
 const PAGE_SIZE = 50;
 
 /** The accounting statuses, said the way a salesperson would say them. */
-const STATUS_TONE: Record<string, { label: string; tone: "neutral" | "info" | "success" | "warn" | "danger" }> = {
-  DRAFT: { label: "Draft", tone: "neutral" },
-  SENT: { label: "Sent", tone: "info" },
-  ISSUED: { label: "Issued", tone: "info" },
-  ACCEPTED: { label: "Accepted", tone: "success" },
-  PAID: { label: "Paid", tone: "success" },
-  RECEIVED: { label: "Received", tone: "success" },
-  EXPIRED: { label: "Expired", tone: "warn" },
-  VOIDED: { label: "Voided", tone: "neutral" },
-  MISSING: { label: "No paperwork", tone: "danger" },
-};
-
 /**
  * Where the document came from, and therefore where its PDF lives — the
  * render route hangs off the record the document was raised against.
@@ -100,7 +89,7 @@ export function DocumentsListContent({
       emptyBody: `Nothing ${bucket.label.toLowerCase()}.`,
       rows: bucket.items.map((document) => {
         const from = origin(document);
-        const status = STATUS_TONE[document.status] ?? {
+        const status = DOCUMENT_STATUS[document.status] ?? {
           label: document.status,
           tone: "neutral" as const,
         };

--- a/components/crm/documents/record-payment-sheet.tsx
+++ b/components/crm/documents/record-payment-sheet.tsx
@@ -13,14 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 
@@ -105,103 +98,91 @@ export function RecordPaymentSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="md" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>Record a payment</SheetTitle>
-          <SheetDescription>
-            {document?.invoice
-              ? `Against invoice ${document.invoice.invoiceNumber} — ${formatMoney(
-                  outstanding,
-                  document.currency,
-                )} outstanding.`
-              : "Against this invoice."}
-          </SheetDescription>
-        </SheetHeader>
-
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            requiredHint="Amount and method are required."
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) record.mutate();
-            }}
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={record.isPending}>
-                  {record.isPending ? "Recording…" : "Record payment"}
-                </Button>
-              </>
-            }
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Record a payment"
+      description={document?.invoice
+        ? `Against invoice ${document.invoice.invoiceNumber} — ${formatMoney(
+            outstanding,
+            document.currency,
+          )} outstanding.`
+        : "Against this invoice."}
+      size="md"
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) record.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={record.isPending}>
+          {record.isPending ? "Recording…" : "Record payment"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="payment-amount">Amount *</Label>
+        <Input
+          id="payment-amount"
+          value={amount}
+          onChange={(event) => setAmount(event.target.value)}
+          inputMode="decimal"
+          className="font-mono"
+          placeholder="0.00"
+        />
+        {outstanding > 0 && Number(amount) < outstanding ? (
+          <button
+            type="button"
+            className="text-sm text-[var(--text-muted)] underline"
+            onClick={() => setAmount(outstanding.toFixed(2))}
           >
-            <div className="space-y-1.5">
-              <Label htmlFor="payment-amount">Amount *</Label>
-              <Input
-                id="payment-amount"
-                value={amount}
-                onChange={(event) => setAmount(event.target.value)}
-                inputMode="decimal"
-                className="font-mono"
-                placeholder="0.00"
-              />
-              {outstanding > 0 && Number(amount) < outstanding ? (
-                <button
-                  type="button"
-                  className="text-sm text-[var(--text-muted)] underline"
-                  onClick={() => setAmount(outstanding.toFixed(2))}
-                >
-                  Pay the full {formatMoney(outstanding, document?.currency ?? "USD")}
-                </button>
-              ) : null}
-            </div>
+            Pay the full {formatMoney(outstanding, document?.currency ?? "USD")}
+          </button>
+        ) : null}
+      </div>
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="payment-method">Method *</Label>
-                <Select value={method} onValueChange={setMethod}>
-                  <SelectTrigger id="payment-method">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PAYMENT_METHODS.map((entry) => (
-                      <SelectItem key={entry} value={entry}>
-                        {entry}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="payment-date">Received on</Label>
-                <Input
-                  id="payment-date"
-                  type="date"
-                  value={receivedAt}
-                  onChange={(event) => setReceivedAt(event.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="payment-reference">Reference</Label>
-              <Input
-                id="payment-reference"
-                value={reference}
-                onChange={(event) => setReference(event.target.value)}
-                placeholder="Transfer reference, cheque number…"
-                maxLength={120}
-              />
-            </div>
-          </FormShell>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="payment-method">Method *</Label>
+          <Select value={method} onValueChange={setMethod}>
+            <SelectTrigger id="payment-method">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAYMENT_METHODS.map((entry) => (
+                <SelectItem key={entry} value={entry}>
+                  {entry}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-      </SheetContent>
-    </Sheet>
+        <div className="space-y-1.5">
+          <Label htmlFor="payment-date">Received on</Label>
+          <Input
+            id="payment-date"
+            type="date"
+            value={receivedAt}
+            onChange={(event) => setReceivedAt(event.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="payment-reference">Reference</Label>
+        <Input
+          id="payment-reference"
+          value={reference}
+          onChange={(event) => setReference(event.target.value)}
+          placeholder="Transfer reference, cheque number…"
+          maxLength={120}
+        />
+      </div>
+    </RecordDialog>
   );
 }

--- a/components/crm/documents/record-payment-sheet.tsx
+++ b/components/crm/documents/record-payment-sheet.tsx
@@ -154,7 +154,7 @@ export function RecordPaymentSheet({
               {outstanding > 0 && Number(amount) < outstanding ? (
                 <button
                   type="button"
-                  className="text-xs text-[var(--text-muted)] underline"
+                  className="text-sm text-[var(--text-muted)] underline"
                   onClick={() => setAmount(outstanding.toFixed(2))}
                 >
                   Pay the full {formatMoney(outstanding, document?.currency ?? "USD")}

--- a/components/crm/import/import-wizard.tsx
+++ b/components/crm/import/import-wizard.tsx
@@ -295,7 +295,7 @@ export function ImportWizard() {
           </div>
 
           {preview.rowCount > preview.rows.length ? (
-            <p className="text-xs text-[var(--text-muted)]">
+            <p className="text-sm text-[var(--text-muted)]">
               Showing the first {preview.rows.length} of {preview.rowCount} rows. All of them will
               be imported.
             </p>

--- a/components/crm/lead-detail/activity-composer.tsx
+++ b/components/crm/lead-detail/activity-composer.tsx
@@ -104,7 +104,7 @@ export function ActivityComposer({ target }: { target: ActivityTarget }) {
         rows={3}
       />
       <div className="flex items-center justify-between gap-2">
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-sm text-[var(--text-muted)]">
           First line becomes the heading. ⌘/Ctrl + Enter to save.
         </p>
         <Button

--- a/components/crm/lead-detail/activity-timeline.tsx
+++ b/components/crm/lead-detail/activity-timeline.tsx
@@ -98,7 +98,7 @@ export function ActivityTimeline({ activities }: { activities: LeadActivity[] })
     <div className="space-y-5">
       {groups.map(([key, entries]) => (
         <section key={key} className="space-y-2">
-          <h4 className="text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
+          <h4 className="text-sm font-medium uppercase tracking-wide text-[var(--text-muted)]">
             {dayLabel(entries[0].occurredAt)}
           </h4>
           <ul className="space-y-2">
@@ -126,7 +126,7 @@ export function ActivityTimeline({ activities }: { activities: LeadActivity[] })
                         {activity.body}
                       </p>
                     ) : null}
-                    <p className="text-xs text-[var(--text-muted)]">
+                    <p className="text-sm text-[var(--text-muted)]">
                       {timeLabel(activity.occurredAt)}
                     </p>
                   </div>

--- a/components/crm/lead-detail/attributes-panel.tsx
+++ b/components/crm/lead-detail/attributes-panel.tsx
@@ -35,7 +35,7 @@ function Row({
 }) {
   return (
     <div className="group flex items-start justify-between gap-2 py-1.5">
-      <dt className="w-28 shrink-0 pt-0.5 text-xs text-[var(--text-muted)]">{label}</dt>
+      <dt className="w-28 shrink-0 pt-0.5 text-sm text-[var(--text-muted)]">{label}</dt>
       <dd className="flex min-w-0 flex-1 items-start justify-end gap-1 text-right text-sm">
         <span className="min-w-0 break-words">{children}</span>
         {action}

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -63,7 +63,7 @@ function draftsToLines(drafts: MeasurementDraft[]): CrmDocumentLineInput[] {
 function RailSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+      <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
         {title}
       </h3>
       {children}
@@ -296,8 +296,8 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
               <p
                 className={
                   isOverdue(nextTask.dueAt)
-                    ? "text-xs font-medium text-[var(--status-error-text)]"
-                    : "text-xs text-[var(--text-muted)]"
+                    ? "text-sm font-medium text-[var(--status-error-text)]"
+                    : "text-sm text-[var(--text-muted)]"
                 }
               >
                 {isOverdue(nextTask.dueAt) ? "Overdue · " : "Due "}
@@ -324,7 +324,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           {nextVisit ? (
             <RailSection title="Next visit">
               <p className="text-sm">{nextVisit.title}</p>
-              <p className="text-xs text-[var(--text-muted)]">
+              <p className="text-sm text-[var(--text-muted)]">
                 <ClientDate value={nextVisit.scheduledStart} />
                 {nextVisit.location ? ` · ${nextVisit.location}` : ""}
               </p>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import type { CrmLeadStage } from "@prisma/client";
@@ -14,12 +13,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ClientDate } from "@/components/ui/client-date";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { ArrowRight, Calendar, FileText, Pencil } from "@/lib/icons";
+import { ArrowRight, Calendar, FileText, Funnel, Pencil } from "@/lib/icons";
 import { updateCrmLeadStage } from "@/lib/crm/crm-v2";
 import { visitItemsToQuotationLines } from "@/lib/crm/site-visits";
 import type { CrmDocumentLineInput } from "@/lib/crm/accounting-bridge";
 
+import { PageChrome } from "@/components/layout/page-chrome";
 import { DocumentList } from "@/components/crm/documents/document-list";
+import { EntityLink } from "@/components/crm/records/entity-link";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import { LeadFormSheet } from "@/components/crm/leads/lead-form-sheet";
 import type { LeadFilterOwner } from "@/components/crm/leads/leads-filters";
@@ -151,61 +152,71 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
 
   return (
     <div className="space-y-4">
+      {/* Name, back and actions all live in the top app bar, the same as every
+          other page. What stays here is the part the bar cannot carry: who this
+          lead is with, and where it has got to. */}
+      <PageChrome
+        title={lead.title ?? lead.leadNo}
+        icon={Funnel}
+        backHref="/crm/leads"
+        backLabel="All leads"
+      >
+        <>
+          <Button size="sm" variant="outline" className="gap-1.5" onClick={() => setEditOpen(true)}>
+            <Pencil className="h-3.5 w-3.5" />
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5"
+            onClick={() => setScheduleOpen(true)}
+          >
+            <Calendar className="h-3.5 w-3.5" />
+            Schedule visit
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5"
+            disabled={!lead.clientId}
+            title={lead.clientId ? undefined : "Attach a client before quoting"}
+            onClick={() => setTab("documents")}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Documents
+          </Button>
+          {/* Converting is the one thing a qualified lead exists to do, so it
+              is the primary action until it has been done. */}
+          <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
+            <ArrowRight className="h-3.5 w-3.5" />
+            Convert to deal
+          </Button>
+        </>
+      </PageChrome>
+
       <header className="space-y-3">
-        <Link href="/crm/leads" className="text-sm text-[var(--text-muted)] hover:underline">
-          ← All leads
-        </Link>
-
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-2xl font-semibold">{lead.title ?? lead.leadNo}</h1>
-              <StatusChip
-                status={CRM_STAGE_STATUS[lead.stage]}
-                label={CRM_STAGE_LABELS[lead.stage]}
-              />
-            </div>
-            <p className="text-sm text-[var(--text-muted)]">
-              <span className="font-mono">{lead.leadNo}</span>
-              {" · "}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <span className="font-mono text-sm text-[var(--text-muted)]">{lead.leadNo}</span>
+          <StatusChip
+            status={CRM_STAGE_STATUS[lead.stage]}
+            label={CRM_STAGE_LABELS[lead.stage]}
+          />
+          <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">
+            <EntityLink
+              href={lead.clientId ? `/crm/companies/${lead.clientId}` : null}
+              muted
+            >
               {lead.client?.name ?? "No client"}
-              {" · "}
+            </EntityLink>
+            {" · "}
+            <EntityLink
+              href={lead.assignedTo ? `/crm/reps/${lead.assignedTo.id}` : null}
+              muted
+            >
               {lead.assignedTo?.name ?? "Unassigned"}
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <Button size="sm" variant="outline" className="gap-1.5" onClick={() => setEditOpen(true)}>
-              <Pencil className="h-3.5 w-3.5" />
-              Edit
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              onClick={() => setScheduleOpen(true)}
-            >
-              <Calendar className="h-3.5 w-3.5" />
-              Schedule visit
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              className="gap-1.5"
-              disabled={!lead.clientId}
-              title={lead.clientId ? undefined : "Attach a client before quoting"}
-              onClick={() => setTab("documents")}
-            >
-              <FileText className="h-3.5 w-3.5" />
-              Documents
-            </Button>
-            {/* Converting is the one thing a qualified lead exists to do, so it
-                is the primary action until it has been done. */}
-            <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
-              <ArrowRight className="h-3.5 w-3.5" />
-              Convert to deal
-            </Button>
-          </div>
+            </EntityLink>
+          </span>
         </div>
 
         <StageProgress

--- a/components/crm/lead-detail/stage-progress.tsx
+++ b/components/crm/lead-detail/stage-progress.tsx
@@ -36,7 +36,7 @@ export function StageProgress({
             onClick={() => onChange(entry)}
             aria-current={isCurrent ? "step" : undefined}
             className={cn(
-              "rounded-[var(--button-radius)] px-2.5 py-1 text-xs font-medium transition-colors",
+              "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
               "disabled:cursor-not-allowed disabled:opacity-60",
               isCurrent
                 ? "bg-[var(--action-primary-bg)] text-[var(--action-primary-text)]"
@@ -57,7 +57,7 @@ export function StageProgress({
         disabled={disabled}
         onClick={() => onChange("WON")}
         className={cn(
-          "rounded-[var(--button-radius)] px-2.5 py-1 text-xs font-medium transition-colors",
+          "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
           "disabled:cursor-not-allowed disabled:opacity-60",
           stage === "WON"
             ? "bg-[var(--status-success-bg)] text-[var(--status-success-text)]"
@@ -71,7 +71,7 @@ export function StageProgress({
         disabled={disabled}
         onClick={() => onChange("LOST")}
         className={cn(
-          "rounded-[var(--button-radius)] px-2.5 py-1 text-xs font-medium transition-colors",
+          "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
           "disabled:cursor-not-allowed disabled:opacity-60",
           stage === "LOST"
             ? "bg-[var(--status-error-bg)] text-[var(--status-error-text)]"

--- a/components/crm/lead-detail/tasks-tab.tsx
+++ b/components/crm/lead-detail/tasks-tab.tsx
@@ -115,11 +115,11 @@ export function TasksTab({
             {task.title}
           </p>
           {task.notes ? (
-            <p className="text-xs text-[var(--text-muted)]">{task.notes}</p>
+            <p className="text-sm text-[var(--text-muted)]">{task.notes}</p>
           ) : null}
           <p
             className={cn(
-              "text-xs",
+              "text-sm",
               overdue ? "font-medium text-[var(--status-error-text)]" : "text-[var(--text-muted)]",
             )}
           >

--- a/components/crm/lead-detail/visits-tab.tsx
+++ b/components/crm/lead-detail/visits-tab.tsx
@@ -38,7 +38,7 @@ export function VisitsTab({
           anything substantial.
         </p>
       ) : (
-        <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+        <ul className="divide-y divide-[var(--border-subtle)]">
           {appointments.map((visit) => {
             const status = VISIT_STATUS[visit.status];
             return (
@@ -48,11 +48,11 @@ export function VisitsTab({
                     <span className="font-mono text-sm">{visit.appointmentNo}</span>
                     <StatusChip status={status.status} label={status.label} />
                     {visit.reportCompletedAt ? (
-                      <span className="text-xs text-[var(--text-muted)]">Written up</span>
+                      <span className="text-sm text-[var(--text-muted)]">Written up</span>
                     ) : null}
                   </div>
                   <p className="text-sm">{visit.title}</p>
-                  <p className="text-xs text-[var(--text-muted)]">
+                  <p className="text-sm text-[var(--text-muted)]">
                     <ClientDate value={visit.scheduledStart} />
                     {visit.location ? ` · ${visit.location}` : ""}
                   </p>

--- a/components/crm/leads/board-column.tsx
+++ b/components/crm/leads/board-column.tsx
@@ -41,10 +41,10 @@ export function BoardColumn({
       <header className="flex items-baseline justify-between gap-2 border-b border-[var(--border)] px-3 py-2.5">
         <div className="flex items-baseline gap-2">
           <h3 className="text-sm font-medium">{CRM_STAGE_LABELS[column.stage]}</h3>
-          <span className="font-mono text-xs text-[var(--text-muted)]">{column.count}</span>
+          <span className="font-mono text-sm text-[var(--text-muted)]">{column.count}</span>
         </div>
         {column.totalValue > 0 ? (
-          <span className="font-mono text-xs text-[var(--text-muted)]">
+          <span className="font-mono text-sm text-[var(--text-muted)]">
             {formatLeadValue(column.totalValue, currency)}
           </span>
         ) : null}
@@ -63,7 +63,7 @@ export function BoardColumn({
         {column.leads.length === 0 ? (
           <p
             className={cn(
-              "rounded-[var(--radius-md)] border border-dashed border-[var(--border)] px-1 py-6 text-center text-xs transition-colors",
+              "rounded-[var(--radius-md)] border border-dashed border-[var(--border)] px-1 py-6 text-center text-sm transition-colors",
               isOver
                 ? "border-[var(--action-primary-bg)] text-[var(--action-primary-bg)]"
                 : "text-[var(--text-muted)]",
@@ -77,7 +77,7 @@ export function BoardColumn({
           <button
             type="button"
             onClick={() => onViewAll(column.stage)}
-            className="rounded px-2 py-1.5 text-xs text-[var(--text-muted)] underline hover:text-[var(--text)]"
+            className="rounded px-2 py-1.5 text-sm text-[var(--text-muted)] underline hover:text-[var(--text)]"
           >
             View all {column.count} in table
           </button>

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -90,14 +90,14 @@ function CandidateRow({
       <span className="min-w-0">
         <span className="flex flex-wrap items-center gap-1.5">
           <span className="font-medium">{title}</span>
-          <Badge variant="secondary" className="text-[11px]">
+          <Badge variant="secondary" className="text-sm">
             {CONFIDENCE_LABELS[confidence]}
           </Badge>
         </span>
         {subtitle ? (
           <span className="block truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
         ) : null}
-        <span className="block text-xs text-[var(--text-muted)]">{reasons.join(" · ")}</span>
+        <span className="block text-sm text-[var(--text-muted)]">{reasons.join(" · ")}</span>
       </span>
       {selected ? <Check className="mt-0.5 h-4 w-4 shrink-0" /> : null}
     </button>
@@ -248,7 +248,7 @@ export function ConvertLeadSheet({
               }
             >
               <section className="space-y-2">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   Person
                 </h3>
                 {prep.personDuplicates.length > 0 ? (
@@ -293,7 +293,7 @@ export function ConvertLeadSheet({
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   Company
                 </h3>
                 {prep.companyDuplicates.length > 0 ? (
@@ -330,7 +330,7 @@ export function ConvertLeadSheet({
                       placeholder="Leave blank for an individual customer"
                       maxLength={200}
                     />
-                    <p className="text-xs text-[var(--text-muted)]">
+                    <p className="text-sm text-[var(--text-muted)]">
                       Plenty of jobs are for a person rather than a business — leaving this empty is
                       fine.
                     </p>
@@ -339,7 +339,7 @@ export function ConvertLeadSheet({
               </section>
 
               <section className="space-y-3">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   Deal
                 </h3>
                 <div className="space-y-1.5">
@@ -362,7 +362,7 @@ export function ConvertLeadSheet({
                     placeholder="0.00"
                   />
                 </div>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   Notes, calls, tasks and documents from lead {prep.lead.leadNo} carry across to the
                   deal. The lead stays as the record of where this came from.
                 </p>

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { ArrowRight, Check } from "@/lib/icons";
 import type { DuplicateConfidence } from "@/lib/crm/duplicates";
+import { DUPLICATE_CONFIDENCE_TONE } from "@/lib/crm/tones";
 import { cn } from "@/lib/utils";
 
 type DuplicateMatch = {
@@ -83,7 +84,7 @@ function CandidateRow({
       <span className="min-w-0">
         <span className="flex flex-wrap items-center gap-1.5">
           <span className="font-medium">{title}</span>
-          <Badge variant="secondary" className="text-sm">
+          <Badge tone={DUPLICATE_CONFIDENCE_TONE[confidence] ?? "neutral"} size="sm">
             {CONFIDENCE_LABELS[confidence]}
           </Badge>
         </span>

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -9,14 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { ArrowRight, Check } from "@/lib/icons";
@@ -186,191 +179,193 @@ export function ConvertLeadSheet({
 
   const alreadyConverted = Boolean(prep?.lead.convertedAt);
 
+  // The dialog is one of three things depending on where the lead is, and only
+  // the third is a form — so the submit handler and the buttons come and go
+  // with it rather than sitting under a screen that has nothing to submit.
+  const showForm = !prepQuery.isLoading && !alreadyConverted && Boolean(prep);
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="lg" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>Convert lead</SheetTitle>
-          <SheetDescription>
-            Turn a qualified enquiry into a deal, reusing the people and companies you already have.
-          </SheetDescription>
-        </SheetHeader>
-
-        {prepQuery.isLoading ? (
-          <div className="mt-6 space-y-3">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <Skeleton key={index} className="h-24 w-full" />
-            ))}
-          </div>
-        ) : alreadyConverted ? (
-          <div className="mt-6 space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
-            <p className="text-sm">
-              This lead was already converted. Its deal carries the work from here.
-            </p>
-            {prep?.lead.convertedDealId ? (
-              <Button
-                size="sm"
-                className="gap-1.5"
-                onClick={() => {
-                  onOpenChange(false);
-                  router.push(`/crm/deals/${prep.lead.convertedDealId}`);
-                }}
-              >
-                Open the deal
-                <ArrowRight className="h-3.5 w-3.5" />
-              </Button>
-            ) : null}
-          </div>
-        ) : prep ? (
-          <div className="mt-6">
-            <FormShell
-              variant="bare"
-              errors={errors}
-              requiredHint="The deal needs a title. Everything else can be filled in later."
-              onSubmit={(event) => {
-                event.preventDefault();
-                if (!dealTitle.trim()) {
-                  setErrors(["Give the deal a title."]);
-                  return;
-                }
-                setErrors([]);
-                convert.mutate();
-              }}
-              actions={
-                <>
-                  <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={convert.isPending}>
-                    {convert.isPending ? "Converting…" : "Convert to deal"}
-                  </Button>
-                </>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Convert lead"
+      description="Turn a qualified enquiry into a deal, reusing the people and companies you already have."
+      errors={showForm ? errors : undefined}
+      onSubmit={
+        showForm
+          ? (event) => {
+              event.preventDefault();
+              if (!dealTitle.trim()) {
+                setErrors(["Give the deal a title."]);
+                return;
               }
+              setErrors([]);
+              convert.mutate();
+            }
+          : undefined
+      }
+      footer={
+        showForm ? (
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={convert.isPending}>
+              {convert.isPending ? "Converting…" : "Convert to deal"}
+            </Button>
+          </>
+        ) : null
+      }
+    >
+      {prepQuery.isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : alreadyConverted ? (
+        <div className="space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
+          <p className="text-sm">
+            This lead was already converted. Its deal carries the work from here.
+          </p>
+          {prep?.lead.convertedDealId ? (
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={() => {
+                onOpenChange(false);
+                router.push(`/crm/deals/${prep.lead.convertedDealId}`);
+              }}
             >
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Person
-                </h3>
-                {prep.personDuplicates.length > 0 ? (
-                  <>
-                    <p className="text-sm text-[var(--text-muted)]">
-                      {prep.personDuplicates.length === 1
-                        ? "Someone on file looks like this contact."
-                        : `${prep.personDuplicates.length} people on file look like this contact.`}
-                    </p>
-                    <div className="space-y-1.5">
-                      {prep.personDuplicates.map((match) => (
-                        <CandidateRow
-                          key={match.record.id}
-                          title={String(match.record.fullName ?? "Unnamed")}
-                          subtitle={
-                            [
-                              match.record.jobTitle,
-                              (match.record.client as { name?: string } | null)?.name,
-                              match.record.email,
-                            ]
-                              .filter(Boolean)
-                              .join(" · ") || null
-                          }
-                          reasons={match.reasons}
-                          confidence={match.confidence}
-                          selected={personId === match.record.id}
-                          onSelect={() =>
-                            setPersonId(personId === match.record.id ? null : match.record.id)
-                          }
-                        />
-                      ))}
-                    </div>
-                  </>
-                ) : null}
+              Open the deal
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Button>
+          ) : null}
+        </div>
+      ) : prep ? (
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Person
+            </h3>
+            {prep.personDuplicates.length > 0 ? (
+              <>
                 <p className="text-sm text-[var(--text-muted)]">
-                  {personId
-                    ? "That existing person will be used."
-                    : `A new person will be created: ${prep.suggested.personFirstName}${
-                        prep.suggested.personLastName ? ` ${prep.suggested.personLastName}` : ""
-                      }.`}
+                  {prep.personDuplicates.length === 1
+                    ? "Someone on file looks like this contact."
+                    : `${prep.personDuplicates.length} people on file look like this contact.`}
                 </p>
-              </section>
-
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Company
-                </h3>
-                {prep.companyDuplicates.length > 0 ? (
-                  <div className="space-y-1.5">
-                    {prep.companyDuplicates.map((match) => (
-                      <CandidateRow
-                        key={match.record.id}
-                        title={String(match.record.name ?? "Unnamed")}
-                        subtitle={
-                          [match.record.city, match.record.website].filter(Boolean).join(" · ") ||
-                          null
-                        }
-                        reasons={match.reasons}
-                        confidence={match.confidence}
-                        selected={clientId === match.record.id}
-                        onSelect={() =>
-                          setClientId(clientId === match.record.id ? null : match.record.id)
-                        }
-                      />
-                    ))}
-                  </div>
-                ) : null}
-
-                {!clientId ? (
-                  <div className="space-y-1.5">
-                    <Label htmlFor="convert-company">New company name</Label>
-                    <Input
-                      id="convert-company"
-                      value={companyName}
-                      onChange={(event) => {
-                        setCompanyName(event.target.value);
-                        setCreateCompany(event.target.value.trim().length > 0);
-                      }}
-                      placeholder="Leave blank for an individual customer"
-                      maxLength={200}
+                <div className="space-y-1.5">
+                  {prep.personDuplicates.map((match) => (
+                    <CandidateRow
+                      key={match.record.id}
+                      title={String(match.record.fullName ?? "Unnamed")}
+                      subtitle={
+                        [
+                          match.record.jobTitle,
+                          (match.record.client as { name?: string } | null)?.name,
+                          match.record.email,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ") || null
+                      }
+                      reasons={match.reasons}
+                      confidence={match.confidence}
+                      selected={personId === match.record.id}
+                      onSelect={() =>
+                        setPersonId(personId === match.record.id ? null : match.record.id)
+                      }
                     />
-                    <p className="text-sm text-[var(--text-muted)]">
-                      Plenty of jobs are for a person rather than a business — leaving this empty is
-                      fine.
-                    </p>
-                  </div>
-                ) : null}
-              </section>
+                  ))}
+                </div>
+              </>
+            ) : null}
+            <p className="text-sm text-[var(--text-muted)]">
+              {personId
+                ? "That existing person will be used."
+                : `A new person will be created: ${prep.suggested.personFirstName}${
+                    prep.suggested.personLastName ? ` ${prep.suggested.personLastName}` : ""
+                  }.`}
+            </p>
+          </section>
 
-              <section className="space-y-3">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Deal
-                </h3>
-                <div className="space-y-1.5">
-                  <Label htmlFor="convert-title">Title *</Label>
-                  <Input
-                    id="convert-title"
-                    value={dealTitle}
-                    onChange={(event) => setDealTitle(event.target.value)}
-                    maxLength={200}
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Company
+            </h3>
+            {prep.companyDuplicates.length > 0 ? (
+              <div className="space-y-1.5">
+                {prep.companyDuplicates.map((match) => (
+                  <CandidateRow
+                    key={match.record.id}
+                    title={String(match.record.name ?? "Unnamed")}
+                    subtitle={
+                      [match.record.city, match.record.website].filter(Boolean).join(" · ") ||
+                      null
+                    }
+                    reasons={match.reasons}
+                    confidence={match.confidence}
+                    selected={clientId === match.record.id}
+                    onSelect={() =>
+                      setClientId(clientId === match.record.id ? null : match.record.id)
+                    }
                   />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="convert-value">Value ({prep.lead.currency})</Label>
-                  <Input
-                    id="convert-value"
-                    inputMode="decimal"
-                    className="font-mono"
-                    value={value}
-                    onChange={(event) => setValue(event.target.value)}
-                    placeholder="0.00"
-                  />
-                </div>
+                ))}
+              </div>
+            ) : null}
+
+            {!clientId ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="convert-company">New company name</Label>
+                <Input
+                  id="convert-company"
+                  value={companyName}
+                  onChange={(event) => {
+                    setCompanyName(event.target.value);
+                    setCreateCompany(event.target.value.trim().length > 0);
+                  }}
+                  placeholder="Leave blank for an individual customer"
+                  maxLength={200}
+                />
                 <p className="text-sm text-[var(--text-muted)]">
-                  Notes, calls, tasks and documents from lead {prep.lead.leadNo} carry across to the
-                  deal. The lead stays as the record of where this came from.
+                  Plenty of jobs are for a person rather than a business — leaving this empty is
+                  fine.
                 </p>
-              </section>
-            </FormShell>
-          </div>
-        ) : null}
-      </SheetContent>
-    </Sheet>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Deal
+            </h3>
+            <div className="space-y-1.5">
+              <Label htmlFor="convert-title">Title *</Label>
+              <Input
+                id="convert-title"
+                value={dealTitle}
+                onChange={(event) => setDealTitle(event.target.value)}
+                maxLength={200}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="convert-value">Value ({prep.lead.currency})</Label>
+              <Input
+                id="convert-value"
+                inputMode="decimal"
+                className="font-mono"
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                placeholder="0.00"
+              />
+            </div>
+            <p className="text-sm text-[var(--text-muted)]">
+              Notes, calls, tasks and documents from lead {prep.lead.leadNo} carry across to the
+              deal. The lead stays as the record of where this came from.
+            </p>
+          </section>
+        </div>
+      ) : null}
+    </RecordDialog>
   );
 }

--- a/components/crm/leads/lead-card.tsx
+++ b/components/crm/leads/lead-card.tsx
@@ -24,7 +24,7 @@ export function LeadCardBody({ lead }: { lead: CrmBoardCard }) {
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{lead.title ?? lead.leadNo}</p>
-          <p className="truncate text-xs text-[var(--text-muted)]">
+          <p className="truncate text-sm text-[var(--text-muted)]">
             <span className="font-mono">{lead.deal?.dealNo ?? lead.leadNo}</span>
             {" · "}
             {lead.client?.name ?? lead.contactName ?? "No client"}
@@ -44,7 +44,7 @@ export function LeadCardBody({ lead }: { lead: CrmBoardCard }) {
           {formatLeadValue(lead.estimatedValue, lead.currency)}
         </span>
         <span
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-[10px] font-medium"
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-sm font-medium"
           title={lead.assignedTo?.name ?? "Unassigned"}
         >
           {initialsOf(lead.assignedTo?.name)}
@@ -53,7 +53,7 @@ export function LeadCardBody({ lead }: { lead: CrmBoardCard }) {
 
       <div
         className={cn(
-          "flex items-center gap-1 text-[11px]",
+          "flex items-center gap-1 text-sm",
           sla.breached
             ? "font-medium text-[var(--status-danger-fg)]"
             : sla.atRisk

--- a/components/crm/leads/lead-form-sheet.tsx
+++ b/components/crm/leads/lead-form-sheet.tsx
@@ -73,7 +73,7 @@ type LeadSourceOption = { id: string; name: string; channel: string; isActive: b
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="space-y-3">
-      <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
         {title}
       </h3>
       {children}
@@ -383,7 +383,7 @@ export function LeadFormSheet({
                       onChange={(event) => patch({ probability: event.target.value })}
                       placeholder={String(CRM_STAGE_DEFAULT_PROBABILITY[form.stage])}
                     />
-                    <p className="text-xs text-[var(--text-muted)]">
+                    <p className="text-sm text-[var(--text-muted)]">
                       Leave blank to use the {CRM_STAGE_LABELS[form.stage].toLowerCase()} default of{" "}
                       {CRM_STAGE_DEFAULT_PROBABILITY[form.stage]}%.
                     </p>
@@ -521,7 +521,7 @@ export function LeadFormSheet({
                     ))}
                   </SelectContent>
                 </Select>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   Unassigned leads are claimable by anyone on the team.
                 </p>
               </div>

--- a/components/crm/leads/lead-form-sheet.tsx
+++ b/components/crm/leads/lead-form-sheet.tsx
@@ -15,15 +15,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { SearchableSelect, type SearchableOption } from "@/components/ui/searchable-select";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { X } from "@/lib/icons";
@@ -279,256 +272,244 @@ export function LeadFormSheet({
   const patch = (next: Partial<LeadFormValues>) => setForm((prev) => ({ ...prev, ...next }));
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="xl" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>{isEdit ? "Edit lead" : "New lead"}</SheetTitle>
-          <SheetDescription>
-            {isEdit
-              ? "Update what you know about this opportunity."
-              : "Capture the opportunity now — you can fill in the rest as it develops."}
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEdit ? "Edit lead" : "New lead"}
+      description={isEdit
+        ? "Update what you know about this opportunity."
+        : "Capture the opportunity now — you can fill in the rest as it develops."}
+      size="xl"
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) save.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={save.isPending}>
+          {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create lead"}
+        </Button>
+      </>}
+    >
+      <Section title="Opportunity">
+        <div className="space-y-1.5">
+          <Label htmlFor="lead-title">Title</Label>
+          <Input
+            id="lead-title"
+            value={form.title}
+            onChange={(event) => patch({ title: event.target.value })}
+            placeholder="e.g. Warehouse roof replacement"
+            maxLength={200}
+          />
+        </div>
 
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) save.mutate();
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor="lead-value">Estimated value</Label>
+            <Input
+              id="lead-value"
+              inputMode="decimal"
+              className="font-mono"
+              value={form.estimatedValue}
+              onChange={(event) => patch({ estimatedValue: event.target.value })}
+              placeholder="0.00"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-currency">Currency</Label>
+            <Select value={form.currency} onValueChange={(value) => patch({ currency: value })}>
+              <SelectTrigger id="lead-currency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CURRENCIES.map((currency) => (
+                  <SelectItem key={currency} value={currency}>
+                    {currency}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-stage">Stage</Label>
+            <Select
+              value={form.stage}
+              onValueChange={(value) => patch({ stage: value as CrmLeadStage })}
+            >
+              <SelectTrigger id="lead-stage">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CRM_LEAD_STAGES.map((stage: CrmLeadStage) => (
+                  <SelectItem key={stage} value={stage}>
+                    {CRM_STAGE_LABELS[stage]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {isEdit ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="lead-probability">Probability (%)</Label>
+              <Input
+                id="lead-probability"
+                inputMode="numeric"
+                className="font-mono"
+                value={form.probability}
+                onChange={(event) => patch({ probability: event.target.value })}
+                placeholder={String(CRM_STAGE_DEFAULT_PROBABILITY[form.stage])}
+              />
+              <p className="text-sm text-[var(--text-muted)]">
+                Leave blank to use the {CRM_STAGE_LABELS[form.stage].toLowerCase()} default of{" "}
+                {CRM_STAGE_DEFAULT_PROBABILITY[form.stage]}%.
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Services</Label>
+          <ServicesInput
+            services={form.services}
+            onChange={(services) => patch({ services })}
+          />
+        </div>
+      </Section>
+
+      <Section title="Contact">
+        <div className="space-y-1.5">
+          <SearchableSelect
+            label="Client"
+            value={form.clientId}
+            options={clientOptions}
+            placeholder={clientsQuery.isLoading ? "Loading clients…" : "Search clients"}
+            searchPlaceholder="Search by name"
+            onValueChange={(clientId) => {
+              const client = clients.find((entry) => entry.id === clientId);
+              patch({
+                clientId,
+                // Prefill from the client, but leave anything already
+                // typed alone — the site contact often isn't the client.
+                contactName: form.contactName || client?.contactName || "",
+                contactEmail: form.contactEmail || client?.email || "",
+                contactPhone: form.contactPhone || client?.phone || "",
+              });
             }}
-            requiredHint="A lead needs at least a title, a client, or a contact name."
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={save.isPending}>
-                  {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create lead"}
-                </Button>
-              </>
+            onAddOption={(name) => createClient.mutate(name)}
+            addLabel="Create client"
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-contact-name">Contact name</Label>
+            <Input
+              id="lead-contact-name"
+              value={form.contactName}
+              onChange={(event) => patch({ contactName: event.target.value })}
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-contact-email">Email</Label>
+            <Input
+              id="lead-contact-email"
+              type="email"
+              value={form.contactEmail}
+              onChange={(event) => patch({ contactEmail: event.target.value })}
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-contact-phone">Phone</Label>
+            <Input
+              id="lead-contact-phone"
+              value={form.contactPhone}
+              onChange={(event) => patch({ contactPhone: event.target.value })}
+              maxLength={40}
+            />
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Attribution & ownership">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-source">Source</Label>
+            <Input
+              id="lead-source"
+              list="crm-lead-source-options"
+              value={form.source}
+              onChange={(event) => {
+                const value = event.target.value;
+                const match = sources.find((source) => source.name === value);
+                patch({
+                  source: value,
+                  sourceChannel: match?.channel ?? form.sourceChannel,
+                });
+              }}
+              placeholder="e.g. Referral from Musa"
+              maxLength={120}
+            />
+            <datalist id="crm-lead-source-options">
+              {sources.map((source) => (
+                <option key={source.id} value={source.name} />
+              ))}
+            </datalist>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="lead-channel">Channel</Label>
+            <Select
+              value={form.sourceChannel}
+              onValueChange={(value) => patch({ sourceChannel: value })}
+            >
+              <SelectTrigger id="lead-channel">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CRM_LEAD_CHANNELS.map((channel) => (
+                  <SelectItem key={channel} value={channel}>
+                    {CRM_CHANNEL_LABELS[channel]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="lead-owner">Owner</Label>
+          <Select
+            value={form.assignedToId || "__unassigned"}
+            onValueChange={(value) =>
+              patch({ assignedToId: value === "__unassigned" ? "" : value })
             }
           >
-            <Section title="Opportunity">
-              <div className="space-y-1.5">
-                <Label htmlFor="lead-title">Title</Label>
-                <Input
-                  id="lead-title"
-                  value={form.title}
-                  onChange={(event) => patch({ title: event.target.value })}
-                  placeholder="e.g. Warehouse roof replacement"
-                  maxLength={200}
-                />
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-3">
-                <div className="space-y-1.5 sm:col-span-2">
-                  <Label htmlFor="lead-value">Estimated value</Label>
-                  <Input
-                    id="lead-value"
-                    inputMode="decimal"
-                    className="font-mono"
-                    value={form.estimatedValue}
-                    onChange={(event) => patch({ estimatedValue: event.target.value })}
-                    placeholder="0.00"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-currency">Currency</Label>
-                  <Select value={form.currency} onValueChange={(value) => patch({ currency: value })}>
-                    <SelectTrigger id="lead-currency">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CURRENCIES.map((currency) => (
-                        <SelectItem key={currency} value={currency}>
-                          {currency}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-stage">Stage</Label>
-                  <Select
-                    value={form.stage}
-                    onValueChange={(value) => patch({ stage: value as CrmLeadStage })}
-                  >
-                    <SelectTrigger id="lead-stage">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CRM_LEAD_STAGES.map((stage: CrmLeadStage) => (
-                        <SelectItem key={stage} value={stage}>
-                          {CRM_STAGE_LABELS[stage]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                {isEdit ? (
-                  <div className="space-y-1.5">
-                    <Label htmlFor="lead-probability">Probability (%)</Label>
-                    <Input
-                      id="lead-probability"
-                      inputMode="numeric"
-                      className="font-mono"
-                      value={form.probability}
-                      onChange={(event) => patch({ probability: event.target.value })}
-                      placeholder={String(CRM_STAGE_DEFAULT_PROBABILITY[form.stage])}
-                    />
-                    <p className="text-sm text-[var(--text-muted)]">
-                      Leave blank to use the {CRM_STAGE_LABELS[form.stage].toLowerCase()} default of{" "}
-                      {CRM_STAGE_DEFAULT_PROBABILITY[form.stage]}%.
-                    </p>
-                  </div>
-                ) : null}
-              </div>
-
-              <div className="space-y-1.5">
-                <Label>Services</Label>
-                <ServicesInput
-                  services={form.services}
-                  onChange={(services) => patch({ services })}
-                />
-              </div>
-            </Section>
-
-            <Section title="Contact">
-              <div className="space-y-1.5">
-                <SearchableSelect
-                  label="Client"
-                  value={form.clientId}
-                  options={clientOptions}
-                  placeholder={clientsQuery.isLoading ? "Loading clients…" : "Search clients"}
-                  searchPlaceholder="Search by name"
-                  onValueChange={(clientId) => {
-                    const client = clients.find((entry) => entry.id === clientId);
-                    patch({
-                      clientId,
-                      // Prefill from the client, but leave anything already
-                      // typed alone — the site contact often isn't the client.
-                      contactName: form.contactName || client?.contactName || "",
-                      contactEmail: form.contactEmail || client?.email || "",
-                      contactPhone: form.contactPhone || client?.phone || "",
-                    });
-                  }}
-                  onAddOption={(name) => createClient.mutate(name)}
-                  addLabel="Create client"
-                />
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-contact-name">Contact name</Label>
-                  <Input
-                    id="lead-contact-name"
-                    value={form.contactName}
-                    onChange={(event) => patch({ contactName: event.target.value })}
-                    maxLength={200}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-contact-email">Email</Label>
-                  <Input
-                    id="lead-contact-email"
-                    type="email"
-                    value={form.contactEmail}
-                    onChange={(event) => patch({ contactEmail: event.target.value })}
-                    maxLength={200}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-contact-phone">Phone</Label>
-                  <Input
-                    id="lead-contact-phone"
-                    value={form.contactPhone}
-                    onChange={(event) => patch({ contactPhone: event.target.value })}
-                    maxLength={40}
-                  />
-                </div>
-              </div>
-            </Section>
-
-            <Section title="Attribution & ownership">
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-source">Source</Label>
-                  <Input
-                    id="lead-source"
-                    list="crm-lead-source-options"
-                    value={form.source}
-                    onChange={(event) => {
-                      const value = event.target.value;
-                      const match = sources.find((source) => source.name === value);
-                      patch({
-                        source: value,
-                        sourceChannel: match?.channel ?? form.sourceChannel,
-                      });
-                    }}
-                    placeholder="e.g. Referral from Musa"
-                    maxLength={120}
-                  />
-                  <datalist id="crm-lead-source-options">
-                    {sources.map((source) => (
-                      <option key={source.id} value={source.name} />
-                    ))}
-                  </datalist>
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="lead-channel">Channel</Label>
-                  <Select
-                    value={form.sourceChannel}
-                    onValueChange={(value) => patch({ sourceChannel: value })}
-                  >
-                    <SelectTrigger id="lead-channel">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CRM_LEAD_CHANNELS.map((channel) => (
-                        <SelectItem key={channel} value={channel}>
-                          {CRM_CHANNEL_LABELS[channel]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="lead-owner">Owner</Label>
-                <Select
-                  value={form.assignedToId || "__unassigned"}
-                  onValueChange={(value) =>
-                    patch({ assignedToId: value === "__unassigned" ? "" : value })
-                  }
-                >
-                  <SelectTrigger id="lead-owner">
-                    <SelectValue placeholder="Unassigned" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__unassigned">Unassigned</SelectItem>
-                    {owners.map((owner) => (
-                      <SelectItem key={owner.id} value={owner.id}>
-                        {owner.name ?? "Unnamed"}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-sm text-[var(--text-muted)]">
-                  Unassigned leads are claimable by anyone on the team.
-                </p>
-              </div>
-            </Section>
-          </FormShell>
+            <SelectTrigger id="lead-owner">
+              <SelectValue placeholder="Unassigned" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__unassigned">Unassigned</SelectItem>
+              {owners.map((owner) => (
+                <SelectItem key={owner.id} value={owner.id}>
+                  {owner.name ?? "Unnamed"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-[var(--text-muted)]">
+            Unassigned leads are claimable by anyone on the team.
+          </p>
         </div>
-      </SheetContent>
-    </Sheet>
+      </Section>
+    </RecordDialog>
   );
 }

--- a/components/crm/leads/leads-filters.tsx
+++ b/components/crm/leads/leads-filters.tsx
@@ -47,7 +47,7 @@ function MultiFilter({ label, options, selected, onChange, extra }: MultiFilterP
         <Button variant="outline" size="sm" className="gap-1.5">
           {label}
           {activeCount > 0 ? (
-            <Badge variant="secondary" className="px-1.5 py-0 text-[11px]">
+            <Badge variant="secondary" className="px-1.5 py-0 text-sm">
               {activeCount}
             </Badge>
           ) : null}
@@ -121,14 +121,14 @@ function ValueRangeFilter({
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1.5">
           Value
-          {active ? <Badge variant="secondary" className="px-1.5 py-0 text-[11px]">1</Badge> : null}
+          {active ? <Badge variant="secondary" className="px-1.5 py-0 text-sm">1</Badge> : null}
           <ChevronDown className="h-3.5 w-3.5 opacity-60" />
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-64 space-y-3 p-3">
         <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1.5">
-            <Label htmlFor="value-min" className="text-xs">
+            <Label htmlFor="value-min" className="text-sm">
               Min
             </Label>
             <Input
@@ -140,7 +140,7 @@ function ValueRangeFilter({
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="value-max" className="text-xs">
+            <Label htmlFor="value-max" className="text-sm">
               Max
             </Label>
             <Input
@@ -189,13 +189,13 @@ function DateRangeFilter({
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1.5">
           Created
-          {active ? <Badge variant="secondary" className="px-1.5 py-0 text-[11px]">1</Badge> : null}
+          {active ? <Badge variant="secondary" className="px-1.5 py-0 text-sm">1</Badge> : null}
           <ChevronDown className="h-3.5 w-3.5 opacity-60" />
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-64 space-y-3 p-3">
         <div className="space-y-1.5">
-          <Label htmlFor="created-from" className="text-xs">
+          <Label htmlFor="created-from" className="text-sm">
             From
           </Label>
           <Input
@@ -208,7 +208,7 @@ function DateRangeFilter({
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="created-to" className="text-xs">
+          <Label htmlFor="created-to" className="text-sm">
             To
           </Label>
           <Input

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -42,7 +42,7 @@ function OwnerCell({ owner }: { owner: CrmLeadListRecord["assignedTo"] }) {
   return (
     <div className="flex items-center gap-2">
       <span
-        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-[10px] font-medium"
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-sm font-medium"
         aria-hidden="true"
       >
         {initialsOf(owner.name)}
@@ -60,7 +60,7 @@ function NextTaskCell({ task }: { task: CrmLeadListRecord["nextFollowUp"] }) {
       <div className="truncate text-sm">{task.title}</div>
       <div
         className={cn(
-          "text-xs",
+          "text-sm",
           overdue ? "font-medium text-[var(--status-error-text)]" : "text-[var(--text-muted)]",
         )}
       >
@@ -110,7 +110,7 @@ export function LeadsTable({
             <div className="truncate font-medium">
               {row.original.title ?? row.original.leadNo}
             </div>
-            <div className="truncate font-mono text-xs text-[var(--text-muted)]">
+            <div className="truncate font-mono text-sm text-[var(--text-muted)]">
               {row.original.leadNo}
             </div>
           </Link>
@@ -124,7 +124,7 @@ export function LeadsTable({
           <div className="min-w-0">
             <div className="truncate text-sm">{row.original.client?.name ?? "—"}</div>
             {row.original.contactName ? (
-              <div className="truncate text-xs text-[var(--text-muted)]">
+              <div className="truncate text-sm text-[var(--text-muted)]">
                 {row.original.contactName}
               </div>
             ) : null}
@@ -171,7 +171,7 @@ export function LeadsTable({
         cell: ({ row }) => (
           <div className="min-w-0">
             <div className="truncate text-sm">{row.original.source ?? "—"}</div>
-            <div className="truncate text-xs text-[var(--text-muted)]">
+            <div className="truncate text-sm text-[var(--text-muted)]">
               {CRM_CHANNEL_LABELS[row.original.sourceChannel ?? ""] ??
                 row.original.sourceChannel ??
                 ""}
@@ -287,7 +287,7 @@ export function LeadsTable({
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">
               <div className="truncate font-medium">{row.title ?? row.leadNo}</div>
-              <div className="truncate font-mono text-xs text-[var(--text-muted)]">
+              <div className="truncate font-mono text-sm text-[var(--text-muted)]">
                 {row.leadNo} · {row.client?.name ?? "No client"}
               </div>
             </div>

--- a/components/crm/public/approval-content.tsx
+++ b/components/crm/public/approval-content.tsx
@@ -139,7 +139,7 @@ export function ApprovalContent({ token }: { token: string }) {
                 ) : (
                   <p className="text-lg font-semibold text-neutral-900">{doc.companyName}</p>
                 )}
-                <div className="text-xs leading-relaxed text-neutral-500">
+                <div className="text-sm leading-relaxed text-neutral-500">
                   {doc.branding.physicalAddress ? <p>{doc.branding.physicalAddress}</p> : null}
                   <p>
                     {[doc.branding.email, doc.branding.phone, doc.branding.website]
@@ -162,22 +162,22 @@ export function ApprovalContent({ token }: { token: string }) {
                 </h1>
                 <p className="font-mono text-sm text-neutral-700">{doc.number}</p>
                 {doc.issuedAt ? (
-                  <p className="mt-1 text-xs text-neutral-500">
+                  <p className="mt-1 text-sm text-neutral-500">
                     Issued {formatDate(doc.issuedAt)}
                   </p>
                 ) : null}
                 {doc.validUntil ? (
-                  <p className="text-xs text-neutral-500">Valid until {formatDate(doc.validUntil)}</p>
+                  <p className="text-sm text-neutral-500">Valid until {formatDate(doc.validUntil)}</p>
                 ) : null}
                 {doc.dueDate ? (
-                  <p className="text-xs text-neutral-500">Due {formatDate(doc.dueDate)}</p>
+                  <p className="text-sm text-neutral-500">Due {formatDate(doc.dueDate)}</p>
                 ) : null}
               </div>
             </header>
 
             {doc.billedTo ? (
               <section className="mt-6">
-                <p className="text-xs uppercase tracking-wide text-neutral-400">
+                <p className="text-sm uppercase tracking-wide text-neutral-400">
                   {doc.documentType === "QUOTATION" ? "Prepared for" : "Billed to"}
                 </p>
                 <p className="text-sm font-medium text-neutral-900">{doc.billedTo}</p>
@@ -194,7 +194,7 @@ export function ApprovalContent({ token }: { token: string }) {
                 <div className="mt-6 -mx-2 overflow-x-auto px-2">
                   <table className="w-full min-w-[32rem] text-sm">
                     <thead>
-                      <tr className="border-b border-neutral-200 text-left text-xs uppercase tracking-wide text-neutral-400">
+                      <tr className="border-b border-neutral-200 text-left text-sm uppercase tracking-wide text-neutral-400">
                         <th className="py-2 font-medium">Description</th>
                         <th className="py-2 text-right font-medium">Qty</th>
                         <th className="py-2 text-right font-medium">Unit price</th>
@@ -254,14 +254,14 @@ export function ApprovalContent({ token }: { token: string }) {
 
             {doc.notes ? (
               <section className="mt-6 border-t border-neutral-100 pt-4">
-                <p className="text-xs uppercase tracking-wide text-neutral-400">Notes</p>
+                <p className="text-sm uppercase tracking-wide text-neutral-400">Notes</p>
                 <p className="mt-1 whitespace-pre-wrap text-sm text-neutral-700">{doc.notes}</p>
               </section>
             ) : null}
 
             {doc.branding.bankAccountNumber ? (
               <section className="mt-6 rounded-lg bg-neutral-50 p-4">
-                <p className="text-xs uppercase tracking-wide text-neutral-400">Payment details</p>
+                <p className="text-sm uppercase tracking-wide text-neutral-400">Payment details</p>
                 <dl className="mt-1 space-y-0.5 text-sm text-neutral-700">
                   {doc.branding.bankName ? (
                     <div className="flex gap-2">
@@ -284,10 +284,10 @@ export function ApprovalContent({ token }: { token: string }) {
             ) : null}
 
             {doc.branding.paymentTerms ? (
-              <p className="mt-4 text-xs text-neutral-500">{doc.branding.paymentTerms}</p>
+              <p className="mt-4 text-sm text-neutral-500">{doc.branding.paymentTerms}</p>
             ) : null}
             {doc.branding.footerText ? (
-              <p className="mt-2 text-xs text-neutral-400">{doc.branding.footerText}</p>
+              <p className="mt-2 text-sm text-neutral-400">{doc.branding.footerText}</p>
             ) : null}
           </div>
         </article>
@@ -341,7 +341,7 @@ export function ApprovalContent({ token }: { token: string }) {
           )}
         </section>
 
-        <p className="text-center text-xs text-neutral-400 print:hidden">{doc.companyName}</p>
+        <p className="text-center text-sm text-neutral-400 print:hidden">{doc.companyName}</p>
       </div>
     </div>
   );

--- a/components/crm/public/intake-form-content.tsx
+++ b/components/crm/public/intake-form-content.tsx
@@ -282,7 +282,7 @@ function Field({
         {required ? <span className="text-red-500"> *</span> : null}
       </span>
       {children}
-      {help ? <span className="mt-1 block text-xs text-neutral-500">{help}</span> : null}
+      {help ? <span className="mt-1 block text-sm text-neutral-500">{help}</span> : null}
     </label>
   );
 }

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -85,7 +85,7 @@ type CompanyDetail = {
 function DetailRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex items-start justify-between gap-2 py-1.5">
-      <dt className="w-32 shrink-0 text-xs text-[var(--text-muted)]">{label}</dt>
+      <dt className="w-32 shrink-0 text-sm text-[var(--text-muted)]">{label}</dt>
       <dd className="min-w-0 flex-1 break-words text-right text-sm">{children}</dd>
     </div>
   );
@@ -300,7 +300,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
                     {company.parent.name}
                   </Link>
                   {company.parentRelation ? (
-                    <span className="text-xs text-[var(--text-muted)]">
+                    <span className="text-sm text-[var(--text-muted)]">
                       {" · "}
                       {RELATION_LABELS[company.parentRelation] ?? company.parentRelation}
                     </span>
@@ -315,7 +315,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
                         {child.name}
                       </Link>
                       {child.parentRelation ? (
-                        <span className="text-xs text-[var(--text-muted)]">
+                        <span className="text-sm text-[var(--text-muted)]">
                           {" · "}
                           {RELATION_LABELS[child.parentRelation] ?? child.parentRelation}
                         </span>

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
@@ -20,6 +19,7 @@ import { ActivityTimeline } from "@/components/crm/lead-detail/activity-timeline
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
+import { EntityLink } from "./entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { CompanyFormSheet } from "./company-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
@@ -156,9 +156,18 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
     );
   }
 
-  const subtitle = [company.tradingName, company.city, company.assignedTo?.name ?? "Unassigned"]
-    .filter(Boolean)
-    .join(" · ");
+  const subtitle = (
+    <>
+      {[company.tradingName, company.city].filter(Boolean).join(" · ")}
+      {company.tradingName || company.city ? " · " : null}
+      <EntityLink
+        href={company.assignedTo ? `/crm/reps/${company.assignedTo.id}` : null}
+        muted
+      >
+        {company.assignedTo?.name ?? "Unassigned"}
+      </EntityLink>
+    </>
+  );
 
   const wonValue = company.deals
     .filter((deal) => deal.status === "WON")
@@ -296,9 +305,9 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
             <RailSection title="Hierarchy">
               {company.parent ? (
                 <p className="text-sm">
-                  <Link href={`/crm/companies/${company.parent.id}`} className="hover:underline">
+                  <EntityLink href={`/crm/companies/${company.parent.id}`}>
                     {company.parent.name}
-                  </Link>
+                  </EntityLink>
                   {company.parentRelation ? (
                     <span className="text-sm text-[var(--text-muted)]">
                       {" · "}
@@ -311,9 +320,9 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
                 <ul className={company.parent ? "mt-2 space-y-1.5" : "space-y-1.5"}>
                   {company.children.map((child) => (
                     <li key={child.id} className="text-sm">
-                      <Link href={`/crm/companies/${child.id}`} className="hover:underline">
+                      <EntityLink href={`/crm/companies/${child.id}`}>
                         {child.name}
-                      </Link>
+                      </EntityLink>
                       {child.parentRelation ? (
                         <span className="text-sm text-[var(--text-muted)]">
                           {" · "}

--- a/components/crm/records/company-form-sheet.tsx
+++ b/components/crm/records/company-form-sheet.tsx
@@ -15,15 +15,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { SearchableSelect, type SearchableOption } from "@/components/ui/searchable-select";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -262,285 +255,272 @@ export function CompanyFormSheet({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent size="lg" className="w-full overflow-y-auto p-6">
-          <SheetHeader>
-            <SheetTitle>{isEdit ? "Edit company" : "New company"}</SheetTitle>
-            <SheetDescription>
-              The account everything else hangs off — people, sites, deals and invoices.
-            </SheetDescription>
-          </SheetHeader>
+      <RecordDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        title={isEdit ? "Edit company" : "New company"}
+        description="The account everything else hangs off — people, sites, deals and invoices."
+        errors={errors}
+        onSubmit={(event) => {
+          event.preventDefault();
+          const found = validate();
+          setErrors(found);
+          if (found.length === 0) save.mutate(false);
+        }}
+        footer={<>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={save.isPending}>
+            {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create company"}
+          </Button>
+        </>}
+      >
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-name">Registered name *</Label>
+            <Input
+              id="company-name"
+              value={form.name}
+              onChange={(event) => patch({ name: event.target.value })}
+              maxLength={200}
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-trading">Trading as</Label>
+            <Input
+              id="company-trading"
+              value={form.tradingName}
+              onChange={(event) => patch({ tradingName: event.target.value })}
+              placeholder="Only if it differs from the registered name"
+              maxLength={200}
+            />
+          </div>
+        </div>
 
-          <div className="mt-6">
-            <FormShell
-              variant="bare"
-              errors={errors}
-              requiredHint="A company name is required."
-              onSubmit={(event) => {
-                event.preventDefault();
-                const found = validate();
-                setErrors(found);
-                if (found.length === 0) save.mutate(false);
-              }}
-              actions={
-                <>
-                  <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={save.isPending}>
-                    {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create company"}
-                  </Button>
-                </>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-type">Relationship</Label>
+            <Select
+              value={form.companyType}
+              onValueChange={(companyType) => patch({ companyType })}
+            >
+              <SelectTrigger id="company-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {COMPANY_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-status">Account status</Label>
+            <Select
+              value={form.accountStatus}
+              onValueChange={(accountStatus) => patch({ accountStatus })}
+            >
+              <SelectTrigger id="company-status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCOUNT_STATUSES.map((status) => (
+                  <SelectItem key={status.value} value={status.value}>
+                    {status.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-reg">Company registration number</Label>
+            <Input
+              id="company-reg"
+              value={form.registrationNumber}
+              onChange={(event) => patch({ registrationNumber: event.target.value })}
+              maxLength={80}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-tax">Tax number</Label>
+            <Input
+              id="company-tax"
+              value={form.taxNumber}
+              onChange={(event) => patch({ taxNumber: event.target.value })}
+              maxLength={80}
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-website">Website</Label>
+            <Input
+              id="company-website"
+              value={form.website}
+              onChange={(event) => patch({ website: event.target.value })}
+              placeholder="example.co.zw"
+              maxLength={300}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-industry">Industry</Label>
+            <Input
+              id="company-industry"
+              value={form.industry}
+              onChange={(event) => patch({ industry: event.target.value })}
+              placeholder="e.g. Mining, Retail, Logistics"
+              maxLength={120}
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-email">Main email</Label>
+            <Input
+              id="company-email"
+              type="email"
+              value={form.email}
+              onChange={(event) => patch({ email: event.target.value })}
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-phone">Main phone</Label>
+            <Input
+              id="company-phone"
+              value={form.phone}
+              onChange={(event) => patch({ phone: event.target.value })}
+              maxLength={40}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-address">Street address</Label>
+          <Input
+            id="company-address"
+            value={form.addressLine}
+            onChange={(event) => patch({ addressLine: event.target.value })}
+            maxLength={300}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="company-city">City</Label>
+            <Input
+              id="company-city"
+              value={form.city}
+              onChange={(event) => patch({ city: event.target.value })}
+              maxLength={120}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="company-country">Country</Label>
+            <Input
+              id="company-country"
+              value={form.country}
+              onChange={(event) => patch({ country: event.target.value })}
+              maxLength={120}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-billing">Billing address</Label>
+          <Textarea
+            id="company-billing"
+            value={form.billingAddress}
+            onChange={(event) => patch({ billingAddress: event.target.value })}
+            placeholder="Leave blank if invoices go to the street address above"
+            rows={3}
+            maxLength={500}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <SearchableSelect
+            label="Part of a larger group?"
+            value={form.parentClientId}
+            options={parentOptions}
+            placeholder={
+              companiesQuery.isLoading ? "Loading companies…" : "Search for the parent company"
+            }
+            onValueChange={(parentClientId) => patch({ parentClientId })}
+          />
+        </div>
+
+        {form.parentClientId ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="company-relation">This company is the parent&apos;s…</Label>
+            <Select
+              value={form.parentRelation || "__none"}
+              onValueChange={(value) =>
+                patch({ parentRelation: value === "__none" ? "" : value })
               }
             >
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-name">Registered name *</Label>
-                  <Input
-                    id="company-name"
-                    value={form.name}
-                    onChange={(event) => patch({ name: event.target.value })}
-                    maxLength={200}
-                    autoFocus
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-trading">Trading as</Label>
-                  <Input
-                    id="company-trading"
-                    value={form.tradingName}
-                    onChange={(event) => patch({ tradingName: event.target.value })}
-                    placeholder="Only if it differs from the registered name"
-                    maxLength={200}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-type">Relationship</Label>
-                  <Select
-                    value={form.companyType}
-                    onValueChange={(companyType) => patch({ companyType })}
-                  >
-                    <SelectTrigger id="company-type">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {COMPANY_TYPES.map((type) => (
-                        <SelectItem key={type.value} value={type.value}>
-                          {type.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-status">Account status</Label>
-                  <Select
-                    value={form.accountStatus}
-                    onValueChange={(accountStatus) => patch({ accountStatus })}
-                  >
-                    <SelectTrigger id="company-status">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {ACCOUNT_STATUSES.map((status) => (
-                        <SelectItem key={status.value} value={status.value}>
-                          {status.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-reg">Company registration number</Label>
-                  <Input
-                    id="company-reg"
-                    value={form.registrationNumber}
-                    onChange={(event) => patch({ registrationNumber: event.target.value })}
-                    maxLength={80}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-tax">Tax number</Label>
-                  <Input
-                    id="company-tax"
-                    value={form.taxNumber}
-                    onChange={(event) => patch({ taxNumber: event.target.value })}
-                    maxLength={80}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-website">Website</Label>
-                  <Input
-                    id="company-website"
-                    value={form.website}
-                    onChange={(event) => patch({ website: event.target.value })}
-                    placeholder="example.co.zw"
-                    maxLength={300}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-industry">Industry</Label>
-                  <Input
-                    id="company-industry"
-                    value={form.industry}
-                    onChange={(event) => patch({ industry: event.target.value })}
-                    placeholder="e.g. Mining, Retail, Logistics"
-                    maxLength={120}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-email">Main email</Label>
-                  <Input
-                    id="company-email"
-                    type="email"
-                    value={form.email}
-                    onChange={(event) => patch({ email: event.target.value })}
-                    maxLength={200}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-phone">Main phone</Label>
-                  <Input
-                    id="company-phone"
-                    value={form.phone}
-                    onChange={(event) => patch({ phone: event.target.value })}
-                    maxLength={40}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="company-address">Street address</Label>
-                <Input
-                  id="company-address"
-                  value={form.addressLine}
-                  onChange={(event) => patch({ addressLine: event.target.value })}
-                  maxLength={300}
-                />
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-city">City</Label>
-                  <Input
-                    id="company-city"
-                    value={form.city}
-                    onChange={(event) => patch({ city: event.target.value })}
-                    maxLength={120}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-country">Country</Label>
-                  <Input
-                    id="company-country"
-                    value={form.country}
-                    onChange={(event) => patch({ country: event.target.value })}
-                    maxLength={120}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="company-billing">Billing address</Label>
-                <Textarea
-                  id="company-billing"
-                  value={form.billingAddress}
-                  onChange={(event) => patch({ billingAddress: event.target.value })}
-                  placeholder="Leave blank if invoices go to the street address above"
-                  rows={3}
-                  maxLength={500}
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <SearchableSelect
-                  label="Part of a larger group?"
-                  value={form.parentClientId}
-                  options={parentOptions}
-                  placeholder={
-                    companiesQuery.isLoading ? "Loading companies…" : "Search for the parent company"
-                  }
-                  onValueChange={(parentClientId) => patch({ parentClientId })}
-                />
-              </div>
-
-              {form.parentClientId ? (
-                <div className="space-y-1.5">
-                  <Label htmlFor="company-relation">This company is the parent&apos;s…</Label>
-                  <Select
-                    value={form.parentRelation || "__none"}
-                    onValueChange={(value) =>
-                      patch({ parentRelation: value === "__none" ? "" : value })
-                    }
-                  >
-                    <SelectTrigger id="company-relation">
-                      <SelectValue placeholder="Not specified" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none">Not specified</SelectItem>
-                      {PARENT_RELATIONS.map((relation) => (
-                        <SelectItem key={relation.value} value={relation.value}>
-                          {relation.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ) : null}
-
-              <div className="space-y-1.5">
-                <Label htmlFor="company-owner">Owner</Label>
-                <Select
-                  value={form.assignedToId || "__unassigned"}
-                  onValueChange={(value) =>
-                    patch({ assignedToId: value === "__unassigned" ? "" : value })
-                  }
-                >
-                  <SelectTrigger id="company-owner">
-                    <SelectValue placeholder="Unassigned" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__unassigned">Unassigned</SelectItem>
-                    {owners.map((owner) => (
-                      <SelectItem key={owner.id} value={owner.id}>
-                        {owner.name ?? "Unnamed"}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="company-notes">Notes</Label>
-                <Textarea
-                  id="company-notes"
-                  value={form.notes}
-                  onChange={(event) => patch({ notes: event.target.value })}
-                  rows={3}
-                />
-              </div>
-
-              <CustomFieldInputs
-                definitions={definitions}
-                values={customValues}
-                onChange={setCustomValues}
-              />
-            </FormShell>
+              <SelectTrigger id="company-relation">
+                <SelectValue placeholder="Not specified" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">Not specified</SelectItem>
+                {PARENT_RELATIONS.map((relation) => (
+                  <SelectItem key={relation.value} value={relation.value}>
+                    {relation.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </SheetContent>
-      </Sheet>
+        ) : null}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-owner">Owner</Label>
+          <Select
+            value={form.assignedToId || "__unassigned"}
+            onValueChange={(value) =>
+              patch({ assignedToId: value === "__unassigned" ? "" : value })
+            }
+          >
+            <SelectTrigger id="company-owner">
+              <SelectValue placeholder="Unassigned" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__unassigned">Unassigned</SelectItem>
+              {owners.map((owner) => (
+                <SelectItem key={owner.id} value={owner.id}>
+                  {owner.name ?? "Unnamed"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-notes">Notes</Label>
+          <Textarea
+            id="company-notes"
+            value={form.notes}
+            onChange={(event) => patch({ notes: event.target.value })}
+            rows={3}
+          />
+        </div>
+
+        <CustomFieldInputs
+          definitions={definitions}
+          values={customValues}
+          onChange={setCustomValues}
+        />
+      </RecordDialog>
 
       <DuplicateWarningDialog
         open={Boolean(duplicates)}

--- a/components/crm/records/custom-field-display.tsx
+++ b/components/crm/records/custom-field-display.tsx
@@ -30,7 +30,7 @@ export function CustomFieldDisplay({
     <>
       {Array.from(sections.entries()).map(([section, fields]) => (
         <section key={section} className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
             {section}
           </h3>
           <dl className="divide-y divide-[var(--border)]">
@@ -42,7 +42,7 @@ export function CustomFieldDisplay({
               );
               return (
                 <div key={definition.id} className="flex items-start justify-between gap-2 py-1.5">
-                  <dt className="w-32 shrink-0 text-xs text-[var(--text-muted)]">
+                  <dt className="w-32 shrink-0 text-sm text-[var(--text-muted)]">
                     {definition.label}
                   </dt>
                   <dd className="min-w-0 flex-1 text-right text-sm">

--- a/components/crm/records/custom-field-inputs.tsx
+++ b/components/crm/records/custom-field-inputs.tsx
@@ -49,7 +49,7 @@ export function CustomFieldInputs({
     <>
       {sections.map(([section, fields]) => (
         <section key={section} className="space-y-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
             {section}
           </h3>
           {fields.map((definition) => (
@@ -83,7 +83,7 @@ function CustomFieldInput({
     </Label>
   );
   const hint = definition.description ? (
-    <p className="text-xs text-[var(--text-muted)]">{definition.description}</p>
+    <p className="text-sm text-[var(--text-muted)]">{definition.description}</p>
   ) : null;
 
   switch (definition.type) {

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -34,6 +34,7 @@ import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet
 import { RaiseJobSheet } from "@/components/crm/work-orders/raise-job-sheet";
 
 import { CustomFieldDisplay } from "./custom-field-display";
+import { EntityLink } from "./entity-link";
 import { DealStageBar } from "./deal-stage-bar";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { RecordHistoryTab } from "./record-history-tab";
@@ -219,9 +220,19 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
         }}
         subtitle={
           <>
-            {deal.client?.name ?? "No company"}
+            <EntityLink
+              href={deal.clientId ? `/crm/companies/${deal.clientId}` : null}
+              muted
+            >
+              {deal.client?.name ?? "No company"}
+            </EntityLink>
             {" · "}
-            {deal.assignedTo?.name ?? "Unassigned"}
+            <EntityLink
+              href={deal.assignedTo ? `/crm/reps/${deal.assignedTo.id}` : null}
+              muted
+            >
+              {deal.assignedTo?.name ?? "Unassigned"}
+            </EntityLink>
             {stale ? " · going cold" : ""}
           </>
         }
@@ -381,7 +392,9 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
 
             {deal.site ? (
               <RailSection title="Site">
-                <p className="text-sm">{deal.site.name}</p>
+                <p className="text-sm">
+                  <EntityLink href={`/crm/sites/${deal.site.id}`}>{deal.site.name}</EntityLink>
+                </p>
                 <p className="text-sm text-[var(--text-muted)]">
                   {[deal.site.addressLine, deal.site.city].filter(Boolean).join(", ")}
                 </p>
@@ -402,7 +415,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 <ul className="space-y-1.5">
                   {deal.contacts.map((contact) => (
                     <li key={contact.id} className="flex items-center justify-between gap-2 text-sm">
-                      <span className="min-w-0 truncate">{contact.person.fullName}</span>
+                      <EntityLink
+                        href={`/crm/people/${contact.person.id}`}
+                        className="min-w-0 truncate"
+                      >
+                        {contact.person.fullName}
+                      </EntityLink>
                       <Badge variant="outline" className="shrink-0 text-sm">
                         {ROLE_LABELS[contact.role] ?? contact.role}
                       </Badge>

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -346,8 +346,8 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 <p
                   className={
                     isOverdue(nextTask.dueAt)
-                      ? "text-xs font-medium text-[var(--status-error-text)]"
-                      : "text-xs text-[var(--text-muted)]"
+                      ? "text-sm font-medium text-[var(--status-error-text)]"
+                      : "text-sm text-[var(--text-muted)]"
                   }
                 >
                   {isOverdue(nextTask.dueAt) ? "Overdue · " : "Due "}
@@ -365,7 +365,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             {nextVisit ? (
               <RailSection title="Next visit">
                 <p className="text-sm">{nextVisit.title}</p>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   <ClientDate value={nextVisit.scheduledStart} />
                 </p>
                 <Button
@@ -382,7 +382,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             {deal.site ? (
               <RailSection title="Site">
                 <p className="text-sm">{deal.site.name}</p>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   {[deal.site.addressLine, deal.site.city].filter(Boolean).join(", ")}
                 </p>
               </RailSection>
@@ -403,7 +403,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                   {deal.contacts.map((contact) => (
                     <li key={contact.id} className="flex items-center justify-between gap-2 text-sm">
                       <span className="min-w-0 truncate">{contact.person.fullName}</span>
-                      <Badge variant="outline" className="shrink-0 text-[11px]">
+                      <Badge variant="outline" className="shrink-0 text-sm">
                         {ROLE_LABELS[contact.role] ?? contact.role}
                       </Badge>
                     </li>

--- a/components/crm/records/deal-form-sheet.tsx
+++ b/components/crm/records/deal-form-sheet.tsx
@@ -13,15 +13,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { SearchableSelect, type SearchableOption } from "@/components/ui/searchable-select";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -227,212 +220,199 @@ export function DealFormSheet({
   const patch = (next: Partial<FormState>) => setForm((prev) => ({ ...prev, ...next }));
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="lg" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>New deal</SheetTitle>
-          <SheetDescription>
-            A live opportunity — this is what carries the quote, the visit and the payment.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="New deal"
+      description="A live opportunity — this is what carries the quote, the visit and the payment."
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) save.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={save.isPending}>
+          {save.isPending ? "Saving…" : "Create deal"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="deal-title">Title *</Label>
+        <Input
+          id="deal-title"
+          value={form.title}
+          onChange={(event) => patch({ title: event.target.value })}
+          placeholder="e.g. Warehouse roof replacement"
+          maxLength={200}
+          autoFocus
+        />
+      </div>
 
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            requiredHint="A title and a starting stage are required."
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) save.mutate();
+      <div className="space-y-1.5">
+        <SearchableSelect
+          label="Company"
+          value={form.clientId}
+          options={companyOptions}
+          placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
+          onValueChange={(clientId) =>
+            // Contacts and sites are scoped to the company, so a change
+            // here invalidates whatever was picked under the old one.
+            patch({ clientId, primaryContactId: "", siteId: "" })
+          }
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <SearchableSelect
+          label="Primary contact"
+          value={form.primaryContactId}
+          options={personOptions}
+          placeholder="Search people"
+          onValueChange={(primaryContactId) => patch({ primaryContactId })}
+        />
+        <SearchableSelect
+          label="Site"
+          value={form.siteId}
+          options={siteOptions}
+          placeholder="Search sites"
+          onValueChange={(siteId) => patch({ siteId })}
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="deal-pipeline">Pipeline</Label>
+          <Select
+            value={form.pipelineId}
+            onValueChange={(pipelineId) => {
+              const pipeline = pipelines.find((entry) => entry.id === pipelineId);
+              const firstOpen = pipeline?.stages.filter((stage) => stage.status === "OPEN")[0];
+              patch({ pipelineId, stageId: firstOpen?.id ?? "" });
             }}
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={save.isPending}>
-                  {save.isPending ? "Saving…" : "Create deal"}
-                </Button>
-              </>
-            }
           >
-            <div className="space-y-1.5">
-              <Label htmlFor="deal-title">Title *</Label>
-              <Input
-                id="deal-title"
-                value={form.title}
-                onChange={(event) => patch({ title: event.target.value })}
-                placeholder="e.g. Warehouse roof replacement"
-                maxLength={200}
-                autoFocus
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <SearchableSelect
-                label="Company"
-                value={form.clientId}
-                options={companyOptions}
-                placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
-                onValueChange={(clientId) =>
-                  // Contacts and sites are scoped to the company, so a change
-                  // here invalidates whatever was picked under the old one.
-                  patch({ clientId, primaryContactId: "", siteId: "" })
-                }
-              />
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <SearchableSelect
-                label="Primary contact"
-                value={form.primaryContactId}
-                options={personOptions}
-                placeholder="Search people"
-                onValueChange={(primaryContactId) => patch({ primaryContactId })}
-              />
-              <SearchableSelect
-                label="Site"
-                value={form.siteId}
-                options={siteOptions}
-                placeholder="Search sites"
-                onValueChange={(siteId) => patch({ siteId })}
-              />
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="deal-pipeline">Pipeline</Label>
-                <Select
-                  value={form.pipelineId}
-                  onValueChange={(pipelineId) => {
-                    const pipeline = pipelines.find((entry) => entry.id === pipelineId);
-                    const firstOpen = pipeline?.stages.filter((stage) => stage.status === "OPEN")[0];
-                    patch({ pipelineId, stageId: firstOpen?.id ?? "" });
-                  }}
-                >
-                  <SelectTrigger id="deal-pipeline">
-                    <SelectValue placeholder="Choose a pipeline" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {pipelines.map((pipeline) => (
-                      <SelectItem key={pipeline.id} value={pipeline.id}>
-                        {pipeline.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="deal-stage">Starting stage *</Label>
-                <Select value={form.stageId} onValueChange={(stageId) => patch({ stageId })}>
-                  <SelectTrigger id="deal-stage">
-                    <SelectValue placeholder="Choose a stage" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {openStages.map((stage) => (
-                      <SelectItem key={stage.id} value={stage.id}>
-                        {stage.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="space-y-1.5 sm:col-span-2">
-                <Label htmlFor="deal-value">Value</Label>
-                <Input
-                  id="deal-value"
-                  inputMode="decimal"
-                  className="font-mono"
-                  value={form.value}
-                  onChange={(event) => patch({ value: event.target.value })}
-                  placeholder="0.00"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="deal-currency">Currency</Label>
-                <Select value={form.currency} onValueChange={(currency) => patch({ currency })}>
-                  <SelectTrigger id="deal-currency">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CURRENCIES.map((currency) => (
-                      <SelectItem key={currency} value={currency}>
-                        {currency}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="deal-close">Expected close</Label>
-                <Input
-                  id="deal-close"
-                  type="date"
-                  value={form.expectedCloseDate}
-                  onChange={(event) => patch({ expectedCloseDate: event.target.value })}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="deal-forecast">Forecast</Label>
-                <Select
-                  value={form.forecastCategory}
-                  onValueChange={(forecastCategory) => patch({ forecastCategory })}
-                >
-                  <SelectTrigger id="deal-forecast">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {FORECAST_CATEGORIES.map((category) => (
-                      <SelectItem key={category.value} value={category.value}>
-                        {category.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-sm text-[var(--text-muted)]">
-                  {FORECAST_CATEGORIES.find((entry) => entry.value === form.forecastCategory)?.hint}
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="deal-owner">Owner</Label>
-              <Select
-                value={form.assignedToId || "__unassigned"}
-                onValueChange={(value) =>
-                  patch({ assignedToId: value === "__unassigned" ? "" : value })
-                }
-              >
-                <SelectTrigger id="deal-owner">
-                  <SelectValue placeholder="Unassigned" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__unassigned">Unassigned</SelectItem>
-                  {owners.map((owner) => (
-                    <SelectItem key={owner.id} value={owner.id}>
-                      {owner.name ?? "Unnamed"}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <CustomFieldInputs
-              definitions={definitions}
-              values={customValues}
-              onChange={setCustomValues}
-            />
-          </FormShell>
+            <SelectTrigger id="deal-pipeline">
+              <SelectValue placeholder="Choose a pipeline" />
+            </SelectTrigger>
+            <SelectContent>
+              {pipelines.map((pipeline) => (
+                <SelectItem key={pipeline.id} value={pipeline.id}>
+                  {pipeline.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-      </SheetContent>
-    </Sheet>
+        <div className="space-y-1.5">
+          <Label htmlFor="deal-stage">Starting stage *</Label>
+          <Select value={form.stageId} onValueChange={(stageId) => patch({ stageId })}>
+            <SelectTrigger id="deal-stage">
+              <SelectValue placeholder="Choose a stage" />
+            </SelectTrigger>
+            <SelectContent>
+              {openStages.map((stage) => (
+                <SelectItem key={stage.id} value={stage.id}>
+                  {stage.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="space-y-1.5 sm:col-span-2">
+          <Label htmlFor="deal-value">Value</Label>
+          <Input
+            id="deal-value"
+            inputMode="decimal"
+            className="font-mono"
+            value={form.value}
+            onChange={(event) => patch({ value: event.target.value })}
+            placeholder="0.00"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="deal-currency">Currency</Label>
+          <Select value={form.currency} onValueChange={(currency) => patch({ currency })}>
+            <SelectTrigger id="deal-currency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CURRENCIES.map((currency) => (
+                <SelectItem key={currency} value={currency}>
+                  {currency}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="deal-close">Expected close</Label>
+          <Input
+            id="deal-close"
+            type="date"
+            value={form.expectedCloseDate}
+            onChange={(event) => patch({ expectedCloseDate: event.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="deal-forecast">Forecast</Label>
+          <Select
+            value={form.forecastCategory}
+            onValueChange={(forecastCategory) => patch({ forecastCategory })}
+          >
+            <SelectTrigger id="deal-forecast">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FORECAST_CATEGORIES.map((category) => (
+                <SelectItem key={category.value} value={category.value}>
+                  {category.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-[var(--text-muted)]">
+            {FORECAST_CATEGORIES.find((entry) => entry.value === form.forecastCategory)?.hint}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="deal-owner">Owner</Label>
+        <Select
+          value={form.assignedToId || "__unassigned"}
+          onValueChange={(value) =>
+            patch({ assignedToId: value === "__unassigned" ? "" : value })
+          }
+        >
+          <SelectTrigger id="deal-owner">
+            <SelectValue placeholder="Unassigned" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__unassigned">Unassigned</SelectItem>
+            {owners.map((owner) => (
+              <SelectItem key={owner.id} value={owner.id}>
+                {owner.name ?? "Unnamed"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <CustomFieldInputs
+        definitions={definitions}
+        values={customValues}
+        onChange={setCustomValues}
+      />
+    </RecordDialog>
   );
 }

--- a/components/crm/records/deal-form-sheet.tsx
+++ b/components/crm/records/deal-form-sheet.tsx
@@ -397,7 +397,7 @@ export function DealFormSheet({
                     ))}
                   </SelectContent>
                 </Select>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   {FORECAST_CATEGORIES.find((entry) => entry.value === form.forecastCategory)?.hint}
                 </p>
               </div>

--- a/components/crm/records/deal-stage-bar.tsx
+++ b/components/crm/records/deal-stage-bar.tsx
@@ -102,7 +102,7 @@ export function DealStageBar({
 
   return (
     <div className="space-y-2">
-      <p className="text-xs text-[var(--text-muted)]">{pipelineName}</p>
+      <p className="text-sm text-[var(--text-muted)]">{pipelineName}</p>
 
       <div className="flex flex-wrap gap-1">
         {path.map((stage, index) => {
@@ -116,7 +116,7 @@ export function DealStageBar({
               onClick={() => requestMove(stage)}
               aria-current={isCurrent ? "step" : undefined}
               className={cn(
-                "rounded-[var(--button-radius)] px-2 py-1 text-xs font-medium transition-colors",
+                "rounded-[var(--button-radius)] px-2 py-1 text-sm font-medium transition-colors",
                 "disabled:cursor-not-allowed disabled:opacity-60",
                 isCurrent
                   ? "bg-[var(--action-primary-bg)] text-[var(--action-primary-text)]"
@@ -158,9 +158,9 @@ export function DealStageBar({
 
       {checklist && checklist.length > 0 ? (
         <div className="space-y-1 border-t border-[var(--border)] pt-2">
-          <p className="text-xs text-[var(--text-muted)]">What should happen at this stage</p>
+          <p className="text-sm text-[var(--text-muted)]">What should happen at this stage</p>
           {checklist.map((item) => (
-            <label key={item.key} className="flex cursor-pointer items-start gap-2 text-xs">
+            <label key={item.key} className="flex cursor-pointer items-start gap-2 text-sm">
               <Checkbox
                 checked={checked[item.key] === true}
                 onCheckedChange={(value) =>

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -72,7 +72,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
         cell: ({ row }) => (
           <Link href={`/crm/deals/${row.original.id}`} className="block min-w-0 hover:underline">
             <div className="truncate font-medium">{row.original.title}</div>
-            <div className="truncate font-mono text-xs text-[var(--text-muted)]">
+            <div className="truncate font-mono text-sm text-[var(--text-muted)]">
               {row.original.dealNo}
             </div>
           </Link>
@@ -86,7 +86,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
           <div className="min-w-0">
             <div className="truncate text-sm">{row.original.client?.name ?? "—"}</div>
             {row.original.primaryContact ? (
-              <div className="truncate text-xs text-[var(--text-muted)]">
+              <div className="truncate text-sm text-[var(--text-muted)]">
                 {row.original.primaryContact.fullName}
               </div>
             ) : null}
@@ -109,7 +109,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
                 label={row.original.stage.name}
               />
               {stale ? (
-                <Badge variant="outline" className="text-[11px] text-[var(--status-warning-text)]">
+                <Badge variant="outline" className="text-sm text-[var(--status-warning-text)]">
                   Stale
                 </Badge>
               ) : null}
@@ -155,7 +155,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
           row.original.nextFollowUp ? (
             <div className="min-w-0">
               <div className="truncate text-sm">{row.original.nextFollowUp.title}</div>
-              <div className="truncate text-xs text-[var(--text-muted)]">
+              <div className="truncate text-sm text-[var(--text-muted)]">
                 <ClientDate value={row.original.nextFollowUp.dueAt} />
               </div>
             </div>
@@ -230,7 +230,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="truncate font-medium">{row.title}</div>
-                <div className="truncate font-mono text-xs text-[var(--text-muted)]">
+                <div className="truncate font-mono text-sm text-[var(--text-muted)]">
                   {row.dealNo} · {row.client?.name ?? "No company"}
                 </div>
               </div>

--- a/components/crm/records/duplicate-warning-dialog.tsx
+++ b/components/crm/records/duplicate-warning-dialog.tsx
@@ -74,14 +74,14 @@ export function DuplicateWarningDialog({
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-medium">{rendered.title}</span>
-                    <Badge variant="secondary" className="text-[11px]">
+                    <Badge variant="secondary" className="text-sm">
                       {CONFIDENCE_LABELS[entry.confidence]}
                     </Badge>
                   </div>
                   {rendered.subtitle ? (
                     <p className="text-sm text-[var(--text-muted)]">{rendered.subtitle}</p>
                   ) : null}
-                  <p className="text-xs text-[var(--text-muted)]">
+                  <p className="text-sm text-[var(--text-muted)]">
                     {entry.reasons.join(" · ")}
                   </p>
                 </div>

--- a/components/crm/records/duplicate-warning-dialog.tsx
+++ b/components/crm/records/duplicate-warning-dialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { DuplicateConfidence } from "@/lib/crm/duplicates";
+import { DUPLICATE_CONFIDENCE_TONE } from "@/lib/crm/tones";
 
 export type DuplicateEntry = {
   record: { id: string; [key: string]: unknown };
@@ -74,7 +75,7 @@ export function DuplicateWarningDialog({
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-medium">{rendered.title}</span>
-                    <Badge variant="secondary" className="text-sm">
+                    <Badge tone={DUPLICATE_CONFIDENCE_TONE[entry.confidence] ?? "neutral"} size="sm">
                       {CONFIDENCE_LABELS[entry.confidence]}
                     </Badge>
                   </div>

--- a/components/crm/records/entity-link.tsx
+++ b/components/crm/records/entity-link.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A named reference to another record.
+ *
+ * Detail pages are mostly made of other records — a deal names a company, a
+ * site, the people on it, whoever owns it. Those were plain text, so the page
+ * told you the name and then made you go and find it. Every one of them is now
+ * the way there.
+ *
+ * Underlined, not just coloured. A colour shift alone is easy to miss against
+ * a page of near-black text, and on a screen in daylight on a site it is
+ * invisible; the underline is the part that says "this goes somewhere" without
+ * relying on anyone noticing a hue.
+ */
+export function EntityLink({
+  href,
+  children,
+  className,
+  muted,
+}: {
+  /** Where the record lives. Pass null for a reference with no page yet. */
+  href: string | null | undefined;
+  children: ReactNode;
+  className?: string;
+  /** For references in supporting text, which should not shout. */
+  muted?: boolean;
+}) {
+  if (!href) {
+    return <span className={className}>{children}</span>;
+  }
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]",
+        muted ? "text-[var(--text-muted)] hover:text-[var(--text)]" : "hover:text-[var(--text)]",
+        className,
+      )}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/crm/records/history-feed.tsx
+++ b/components/crm/records/history-feed.tsx
@@ -81,7 +81,7 @@ function HistoryRow({ event }: { event: HistoryEvent }) {
         ) : null}
         <time
           dateTime={event.occurredAt}
-          className="mt-0.5 block font-mono text-xs text-[var(--text-subtle)]"
+          className="mt-0.5 block font-mono text-sm text-[var(--text-subtle)]"
         >
           {Number.isNaN(time.getTime())
             ? event.occurredAt
@@ -111,7 +111,7 @@ function HistoryRow({ event }: { event: HistoryEvent }) {
           type="button"
           aria-expanded={expanded}
           onClick={() => setExpanded((value) => !value)}
-          className="flex h-7 items-center gap-1 self-start rounded px-1.5 text-xs text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
+          className="flex h-7 items-center gap-1 self-start rounded px-1.5 text-sm text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
         >
           {expanded ? (
             <ChevronDown className="size-3.5" />
@@ -202,7 +202,7 @@ export function HistoryFeed({
             type="button"
             size="sm"
             variant="ghost"
-            className="ml-auto h-7 gap-1.5 px-2 text-xs"
+            className="ml-auto h-7 gap-1.5 px-2 text-sm"
             onClick={download}
           >
             <Download className="size-3.5" />
@@ -220,7 +220,7 @@ export function HistoryFeed({
           <section key={bucket.id} aria-labelledby={`history-${bucket.id}`}>
             <h4
               id={`history-${bucket.id}`}
-              className="sticky top-14 z-10 bg-[var(--surface-base)] py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+              className="sticky top-14 z-10 bg-[var(--surface-base)] py-1.5 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
             >
               {bucket.label}
             </h4>
@@ -251,7 +251,7 @@ function FilterChip({
       aria-pressed={pressed}
       onClick={onToggle}
       className={cn(
-        "rounded-full border px-2.5 py-1 text-xs capitalize transition-colors",
+        "rounded-full border px-2.5 py-1 text-sm capitalize transition-colors",
         pressed
           ? "border-[var(--action-primary-bg)] bg-[var(--action-primary-bg)] text-[var(--action-primary-fg)]"
           : "border-[var(--border)] text-[var(--text-muted)] hover:bg-[var(--surface-muted)]",

--- a/components/crm/records/merge-dialog.tsx
+++ b/components/crm/records/merge-dialog.tsx
@@ -182,7 +182,7 @@ export function MergeDialog({
                         }}
                       >
                         <span>{label}</span>
-                        <span className="font-mono text-xs text-[var(--text-muted)]">
+                        <span className="font-mono text-sm text-[var(--text-muted)]">
                           {reference}
                         </span>
                       </button>
@@ -207,7 +207,7 @@ export function MergeDialog({
             ) : null}
 
             <div className="overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)]">
-              <div className="grid grid-cols-[1fr_1fr_1fr] gap-2 bg-[var(--surface-subtle)] px-3 py-2 text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              <div className="grid grid-cols-[1fr_1fr_1fr] gap-2 bg-[var(--surface-subtle)] px-3 py-2 text-sm font-medium uppercase tracking-wide text-[var(--text-muted)]">
                 <span>Field</span>
                 <span>{plan.survivor.label}</span>
                 <span>{plan.loser.label}</span>

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -59,7 +59,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
         id: person.id,
         href: `/crm/people/${person.id}`,
         leading: (
-          <span className="flex size-9 items-center justify-center rounded-full bg-[var(--surface-muted)] text-xs font-medium text-[var(--text-muted)]">
+          <span className="flex size-9 items-center justify-center rounded-full bg-[var(--surface-muted)] text-sm font-medium text-[var(--text-muted)]">
             {initials(person.fullName)}
           </span>
         ),

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
@@ -18,6 +17,7 @@ import { ActivityTimeline } from "@/components/crm/lead-detail/activity-timeline
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
+import { EntityLink } from "./entity-link";
 import { Users } from "@/lib/icons";
 
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
@@ -160,9 +160,25 @@ export function PersonDetailPage({ personId }: { personId: string }) {
     );
   }
 
-  const subtitle = [person.jobTitle, person.client?.name, person.assignedTo?.name ?? "Unassigned"]
-    .filter(Boolean)
-    .join(" · ");
+  const subtitle = (
+    <>
+      {person.jobTitle ? <>{person.jobTitle} · </> : null}
+      {person.client ? (
+        <>
+          <EntityLink href={`/crm/companies/${person.client.id}`} muted>
+            {person.client.name}
+          </EntityLink>
+          {" · "}
+        </>
+      ) : null}
+      <EntityLink
+        href={person.assignedTo ? `/crm/reps/${person.assignedTo.id}` : null}
+        muted
+      >
+        {person.assignedTo?.name ?? "Unassigned"}
+      </EntityLink>
+    </>
+  );
 
   return (
     <>
@@ -252,9 +268,9 @@ export function PersonDetailPage({ personId }: { personId: string }) {
 
           <RailSection title="Company">
             {person.client ? (
-              <Link href={`/crm/companies/${person.client.id}`} className="text-sm hover:underline">
+              <EntityLink href={`/crm/companies/${person.client.id}`} className="text-sm">
                 {person.client.name}
-              </Link>
+              </EntityLink>
             ) : (
               <p className="text-sm text-[var(--text-muted)]">No company</p>
             )}
@@ -265,9 +281,9 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               <ul className="space-y-1.5">
                 {person.companyLinks.map((link) => (
                   <li key={link.id} className="text-sm">
-                    <Link href={`/crm/companies/${link.client.id}`} className="hover:underline">
+                    <EntityLink href={`/crm/companies/${link.client.id}`}>
                       {link.client.name}
-                    </Link>
+                    </EntityLink>
                     {link.jobTitle ? (
                       <span className="text-sm text-[var(--text-muted)]"> · {link.jobTitle}</span>
                     ) : null}

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -95,7 +95,7 @@ type PersonDetail = {
 function DetailRow({ label, value }: { label: string; value: string | null }) {
   return (
     <div className="flex items-start justify-between gap-2 py-1.5">
-      <dt className="w-32 shrink-0 text-xs text-[var(--text-muted)]">{label}</dt>
+      <dt className="w-32 shrink-0 text-sm text-[var(--text-muted)]">{label}</dt>
       <dd className="min-w-0 flex-1 text-right text-sm">
         {value ? value : <span className="text-[var(--text-muted)]">—</span>}
       </dd>
@@ -269,7 +269,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
                       {link.client.name}
                     </Link>
                     {link.jobTitle ? (
-                      <span className="text-xs text-[var(--text-muted)]"> · {link.jobTitle}</span>
+                      <span className="text-sm text-[var(--text-muted)]"> · {link.jobTitle}</span>
                     ) : null}
                   </li>
                 ))}

--- a/components/crm/records/person-form-sheet.tsx
+++ b/components/crm/records/person-form-sheet.tsx
@@ -15,15 +15,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { SearchableSelect, type SearchableOption } from "@/components/ui/searchable-select";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -240,185 +233,172 @@ export function PersonFormSheet({
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent size="lg" className="w-full overflow-y-auto p-6">
-          <SheetHeader>
-            <SheetTitle>{isEdit ? "Edit person" : "New person"}</SheetTitle>
-            <SheetDescription>
-              A contact you can attach to any number of deals and sites without re-typing them.
-            </SheetDescription>
-          </SheetHeader>
+      <RecordDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        title={isEdit ? "Edit person" : "New person"}
+        description="A contact you can attach to any number of deals and sites without re-typing them."
+        errors={errors}
+        onSubmit={(event) => {
+          event.preventDefault();
+          const found = validate();
+          setErrors(found);
+          if (found.length === 0) save.mutate(false);
+        }}
+        footer={<>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={save.isPending}>
+            {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create person"}
+          </Button>
+        </>}
+      >
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="person-first">First name *</Label>
+            <Input
+              id="person-first"
+              value={form.firstName}
+              onChange={(event) => patch({ firstName: event.target.value })}
+              maxLength={120}
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="person-last">Last name</Label>
+            <Input
+              id="person-last"
+              value={form.lastName}
+              onChange={(event) => patch({ lastName: event.target.value })}
+              maxLength={120}
+            />
+          </div>
+        </div>
 
-          <div className="mt-6">
-            <FormShell
-              variant="bare"
-              errors={errors}
-              requiredHint="A first name is required."
-              onSubmit={(event) => {
-                event.preventDefault();
-                const found = validate();
-                setErrors(found);
-                if (found.length === 0) save.mutate(false);
-              }}
-              actions={
-                <>
-                  <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={save.isPending}>
-                    {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create person"}
-                  </Button>
-                </>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="person-email">Email</Label>
+            <Input
+              id="person-email"
+              type="email"
+              value={form.email}
+              onChange={(event) => patch({ email: event.target.value })}
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="person-phone">Phone</Label>
+            <Input
+              id="person-phone"
+              value={form.phone}
+              onChange={(event) => patch({ phone: event.target.value })}
+              maxLength={40}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <SearchableSelect
+            label="Company"
+            value={form.clientId}
+            options={companyOptions}
+            placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
+            onValueChange={(clientId) => patch({ clientId })}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="person-title">Job title</Label>
+            <Input
+              id="person-title"
+              value={form.jobTitle}
+              onChange={(event) => patch({ jobTitle: event.target.value })}
+              maxLength={120}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="person-type">Contact type</Label>
+            <Select
+              value={form.contactType}
+              onValueChange={(value) => patch({ contactType: value })}
+            >
+              <SelectTrigger id="person-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CONTACT_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="person-channel">Preferred channel</Label>
+            <Select
+              value={form.preferredChannel || "__none"}
+              onValueChange={(value) =>
+                patch({ preferredChannel: value === "__none" ? "" : value })
               }
             >
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-first">First name *</Label>
-                  <Input
-                    id="person-first"
-                    value={form.firstName}
-                    onChange={(event) => patch({ firstName: event.target.value })}
-                    maxLength={120}
-                    autoFocus
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-last">Last name</Label>
-                  <Input
-                    id="person-last"
-                    value={form.lastName}
-                    onChange={(event) => patch({ lastName: event.target.value })}
-                    maxLength={120}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-email">Email</Label>
-                  <Input
-                    id="person-email"
-                    type="email"
-                    value={form.email}
-                    onChange={(event) => patch({ email: event.target.value })}
-                    maxLength={200}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-phone">Phone</Label>
-                  <Input
-                    id="person-phone"
-                    value={form.phone}
-                    onChange={(event) => patch({ phone: event.target.value })}
-                    maxLength={40}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <SearchableSelect
-                  label="Company"
-                  value={form.clientId}
-                  options={companyOptions}
-                  placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
-                  onValueChange={(clientId) => patch({ clientId })}
-                />
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-title">Job title</Label>
-                  <Input
-                    id="person-title"
-                    value={form.jobTitle}
-                    onChange={(event) => patch({ jobTitle: event.target.value })}
-                    maxLength={120}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-type">Contact type</Label>
-                  <Select
-                    value={form.contactType}
-                    onValueChange={(value) => patch({ contactType: value })}
-                  >
-                    <SelectTrigger id="person-type">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CONTACT_TYPES.map((type) => (
-                        <SelectItem key={type.value} value={type.value}>
-                          {type.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-channel">Preferred channel</Label>
-                  <Select
-                    value={form.preferredChannel || "__none"}
-                    onValueChange={(value) =>
-                      patch({ preferredChannel: value === "__none" ? "" : value })
-                    }
-                  >
-                    <SelectTrigger id="person-channel">
-                      <SelectValue placeholder="No preference" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none">No preference</SelectItem>
-                      {CHANNELS.map((channel) => (
-                        <SelectItem key={channel.value} value={channel.value}>
-                          {channel.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="person-owner">Owner</Label>
-                  <Select
-                    value={form.assignedToId || "__unassigned"}
-                    onValueChange={(value) =>
-                      patch({ assignedToId: value === "__unassigned" ? "" : value })
-                    }
-                  >
-                    <SelectTrigger id="person-owner">
-                      <SelectValue placeholder="Unassigned" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__unassigned">Unassigned</SelectItem>
-                      {owners.map((owner) => (
-                        <SelectItem key={owner.id} value={owner.id}>
-                          {owner.name ?? "Unnamed"}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="person-notes">Notes</Label>
-                <Textarea
-                  id="person-notes"
-                  value={form.notes}
-                  onChange={(event) => patch({ notes: event.target.value })}
-                  rows={3}
-                />
-              </div>
-
-              <CustomFieldInputs
-                definitions={definitions}
-                values={customValues}
-                onChange={setCustomValues}
-              />
-            </FormShell>
+              <SelectTrigger id="person-channel">
+                <SelectValue placeholder="No preference" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none">No preference</SelectItem>
+                {CHANNELS.map((channel) => (
+                  <SelectItem key={channel.value} value={channel.value}>
+                    {channel.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </SheetContent>
-      </Sheet>
+          <div className="space-y-1.5">
+            <Label htmlFor="person-owner">Owner</Label>
+            <Select
+              value={form.assignedToId || "__unassigned"}
+              onValueChange={(value) =>
+                patch({ assignedToId: value === "__unassigned" ? "" : value })
+              }
+            >
+              <SelectTrigger id="person-owner">
+                <SelectValue placeholder="Unassigned" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__unassigned">Unassigned</SelectItem>
+                {owners.map((owner) => (
+                  <SelectItem key={owner.id} value={owner.id}>
+                    {owner.name ?? "Unnamed"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="person-notes">Notes</Label>
+          <Textarea
+            id="person-notes"
+            value={form.notes}
+            onChange={(event) => patch({ notes: event.target.value })}
+            rows={3}
+          />
+        </div>
+
+        <CustomFieldInputs
+          definitions={definitions}
+          values={customValues}
+          onChange={setCustomValues}
+        />
+      </RecordDialog>
 
       <DuplicateWarningDialog
         open={Boolean(duplicates)}

--- a/components/crm/records/record-dialog.tsx
+++ b/components/crm/records/record-dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { ResponsiveSurfaceSize } from "@/lib/ui/responsive-surface";
+import { cn } from "@/lib/utils";
+
+/**
+ * The modal every CRM form opens in.
+ *
+ * These were drawers sliding in from the right, which is the wrong shape for
+ * them: a drawer says "here is more of the thing you were looking at", and
+ * creating a task is not more of anything — it is a short, self-contained
+ * question that wants your whole attention and then gets out of the way.
+ *
+ * Three regions, so a long form behaves. The header and the footer are fixed
+ * and the body is the only part that scrolls, which is what stops the buttons
+ * being pushed off the bottom of the viewport — the reason these forms looked
+ * cut off. `inset={false}` hands the padding to the regions rather than the
+ * card, because a card that pads itself cannot have a header rule that reaches
+ * its own edges.
+ */
+export function RecordDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  size = "lg",
+  footer,
+  onSubmit,
+  errors,
+  children,
+  bodyClassName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  /** Says what the form is for. Screen-reader only unless you show it. */
+  description?: string;
+  size?: ResponsiveSurfaceSize;
+  /** Buttons, pinned to the bottom. */
+  footer?: ReactNode;
+  /**
+   * Makes the whole card a form, so a submit button in the pinned footer still
+   * belongs to the fields in the scrolling body — and Enter in a text field
+   * submits, which is what people expect of a short form.
+   */
+  onSubmit?: (event: React.FormEvent<HTMLFormElement>) => void;
+  /** What went wrong, shown above the fields rather than beside the button. */
+  errors?: string[];
+  children: ReactNode;
+  bodyClassName?: string;
+}) {
+  const regions = (
+    <>
+      <DialogHeader className="flex-none gap-1 border-b border-[var(--border-subtle)] px-5 py-4 pr-12">
+        <DialogTitle>{title}</DialogTitle>
+        {description ? <DialogDescription>{description}</DialogDescription> : null}
+      </DialogHeader>
+
+      <div className={cn("min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4", bodyClassName)}>
+        {errors && errors.length > 0 ? (
+          <Alert variant="destructive">
+            <AlertTitle>Please fix this before saving</AlertTitle>
+            <AlertDescription>
+              <ul className="list-disc space-y-1 pl-5">
+                {errors.map((error, index) => (
+                  <li key={`${error}-${index}`}>{error}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        {children}
+      </div>
+
+      {footer ? (
+        <div className="flex flex-none flex-wrap items-center justify-end gap-2 border-t border-[var(--border-subtle)] bg-[var(--surface-muted)] px-5 py-3">
+          {footer}
+        </div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size={size}
+        inset={false}
+        // The card is the flex column; only the body inside it scrolls.
+        className="flex max-h-[min(44rem,calc(100dvh-3rem))] flex-col gap-0 overflow-hidden"
+      >
+        {onSubmit ? (
+          <form onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col">
+            {regions}
+          </form>
+        ) : (
+          regions
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/crm/records/record-list-groups.tsx
+++ b/components/crm/records/record-list-groups.tsx
@@ -187,7 +187,7 @@ export function GroupedRecordList({
               id={`${section.id}-heading`}
               // The bar is opaque so rows do not show through the heading as
               // they slide under it.
-              className="sticky top-14 z-10 -mx-1 flex items-baseline gap-2 bg-[var(--surface-base)] px-1 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+              className="sticky top-14 z-10 -mx-1 flex items-baseline gap-2 bg-[var(--surface-base)] px-1 py-1.5 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
             >
               <span>{section.label}</span>
               <span className="font-mono normal-case tracking-normal">
@@ -221,7 +221,7 @@ export function GroupedRecordList({
                 const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
                 heading?.scrollIntoView({ block: "start", behavior: reduced ? "auto" : "smooth" });
               }}
-              className="rounded px-1.5 py-0.5 text-[11px] font-medium text-[var(--text-subtle)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
+              className="rounded px-1.5 py-0.5 text-sm font-medium text-[var(--text-subtle)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
             >
               {section.label}
             </button>

--- a/components/crm/records/record-list.tsx
+++ b/components/crm/records/record-list.tsx
@@ -78,7 +78,7 @@ export function RecordList({
   return (
     <ul
       className={cn(
-        "divide-y divide-[var(--border-subtle)] overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface)]",
+        "divide-y divide-[var(--border-subtle)]",
         className,
       )}
     >
@@ -111,7 +111,7 @@ export function RecordList({
                 {row.facts.map((fact, index) => (
                   <span key={index} className="text-right">
                     {fact.label ? (
-                      <span className="block text-[11px] uppercase tracking-wide text-[var(--text-subtle)]">
+                      <span className="block text-sm uppercase tracking-wide text-[var(--text-subtle)]">
                         {fact.label}
                       </span>
                     ) : null}

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PageChrome } from "@/components/layout/page-chrome";
-import { ArrowLeft, DotsThree, type LucideIcon } from "@/lib/icons";
+import { DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 export type RecordTab = {
@@ -110,19 +110,11 @@ export function RecordPageShell({
 
   return (
     <div className="space-y-4">
-      <PageChrome title={title} icon={icon}>
+      <PageChrome title={title} icon={icon} backHref={backHref} backLabel={backLabel}>
         {barActions}
       </PageChrome>
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        <Link
-          href={backHref}
-          className="flex items-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--text)]"
-        >
-          <ArrowLeft className="size-4" />
-          {backLabel}
-        </Link>
-
         {leading ? <span className="flex-none">{leading}</span> : null}
 
         {reference ? (

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -174,7 +174,7 @@ export function RailSection({
   return (
     <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
           {title}
         </h3>
         {action}
@@ -207,7 +207,7 @@ export function RelatedList<T>({
 
   return (
     <div className="space-y-2">
-      <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+      <ul className="divide-y divide-[var(--border-subtle)]">
         {items.map((item, index) => {
           const rendered = renderItem(item);
           return (
@@ -219,7 +219,7 @@ export function RelatedList<T>({
                 <span className="min-w-0">
                   <span className="block truncate text-sm font-medium">{rendered.title}</span>
                   {rendered.subtitle ? (
-                    <span className="block truncate text-xs text-[var(--text-muted)]">
+                    <span className="block truncate text-sm text-[var(--text-muted)]">
                       {rendered.subtitle}
                     </span>
                   ) : null}

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -129,7 +129,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
                 Nobody has visited this site yet.
               </p>
             ) : (
-              <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+              <ul className="divide-y divide-[var(--border-subtle)]">
                 {site.appointments.map((visit) => {
                   const status = VISIT_STATUS[visit.status];
                   return (
@@ -141,11 +141,11 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
                         ) : null}
                       </div>
                       <p className="text-sm">{visit.title}</p>
-                      <p className="text-xs text-[var(--text-muted)]">
+                      <p className="text-sm text-[var(--text-muted)]">
                         <ClientDate value={visit.scheduledStart} />
                       </p>
                       {visit.visitItems.length > 0 ? (
-                        <p className="text-xs text-[var(--text-muted)]">
+                        <p className="text-sm text-[var(--text-muted)]">
                           {visit.visitItems.length} measurement
                           {visit.visitItems.length === 1 ? "" : "s"} recorded
                         </p>
@@ -231,7 +231,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               <>
                 <p className="text-sm">{site.primaryContact.fullName}</p>
                 {site.primaryContact.phone ? (
-                  <p className="text-xs text-[var(--text-muted)]">{site.primaryContact.phone}</p>
+                  <p className="text-sm text-[var(--text-muted)]">{site.primaryContact.phone}</p>
                 ) : null}
               </>
             ) : (

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -18,6 +18,7 @@ import { CommentThread } from "@/components/crm/collaboration/comment-thread";
 import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 
 import { CustomFieldDisplay } from "./custom-field-display";
+import { EntityLink } from "./entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { SiteFormSheet } from "./site-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
@@ -100,7 +101,17 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
     );
   }
 
-  const subtitle = [site.client?.name, site.city].filter(Boolean).join(" · ");
+  const subtitle = (
+    <>
+      {site.client ? (
+        <EntityLink href={`/crm/companies/${site.client.id}`} muted>
+          {site.client.name}
+        </EntityLink>
+      ) : null}
+      {site.client && site.city ? " · " : null}
+      {site.city}
+    </>
+  );
   const mapsHref =
     site.latitude !== null && site.longitude !== null
       ? `https://www.google.com/maps?q=${site.latitude},${site.longitude}`

--- a/components/crm/records/site-form-sheet.tsx
+++ b/components/crm/records/site-form-sheet.tsx
@@ -7,15 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { SearchableSelect, type SearchableOption } from "@/components/ui/searchable-select";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -202,172 +195,158 @@ export function SiteFormSheet({
   const patch = (next: Partial<FormState>) => setForm((prev) => ({ ...prev, ...next }));
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="lg" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>{isEdit ? "Edit site" : "New site"}</SheetTitle>
-          <SheetDescription>
-            A place your crew actually goes to. Whatever you record here is what they&apos;ll read
-            on the way there.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEdit ? "Edit site" : "New site"}
+      description="A place your crew actually goes to. Whatever you record here is what they&apos;ll read on the way there."
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) save.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={save.isPending}>
+          {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create site"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="site-name">Site name *</Label>
+        <Input
+          id="site-name"
+          value={form.name}
+          onChange={(event) => patch({ name: event.target.value })}
+          placeholder="e.g. Msasa depot — back yard"
+          maxLength={200}
+          autoFocus
+        />
+      </div>
 
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            requiredHint="A site name is required."
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) save.mutate();
-            }}
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={save.isPending}>
-                  {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create site"}
-                </Button>
-              </>
-            }
-          >
-            <div className="space-y-1.5">
-              <Label htmlFor="site-name">Site name *</Label>
-              <Input
-                id="site-name"
-                value={form.name}
-                onChange={(event) => patch({ name: event.target.value })}
-                placeholder="e.g. Msasa depot — back yard"
-                maxLength={200}
-                autoFocus
-              />
-            </div>
+      <div className="space-y-1.5">
+        <SearchableSelect
+          label="Company"
+          value={form.clientId}
+          options={companyOptions}
+          placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
+          onValueChange={(clientId) =>
+            // Contacts are drawn from the chosen company, so switching it
+            // invalidates whoever was picked under the old one.
+            patch({ clientId, primaryContactId: "" })
+          }
+        />
+      </div>
 
-            <div className="space-y-1.5">
-              <SearchableSelect
-                label="Company"
-                value={form.clientId}
-                options={companyOptions}
-                placeholder={companiesQuery.isLoading ? "Loading companies…" : "Search companies"}
-                onValueChange={(clientId) =>
-                  // Contacts are drawn from the chosen company, so switching it
-                  // invalidates whoever was picked under the old one.
-                  patch({ clientId, primaryContactId: "" })
-                }
-              />
-            </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="site-address">Street address</Label>
+        <Input
+          id="site-address"
+          value={form.addressLine}
+          onChange={(event) => patch({ addressLine: event.target.value })}
+          maxLength={300}
+        />
+      </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="site-address">Street address</Label>
-              <Input
-                id="site-address"
-                value={form.addressLine}
-                onChange={(event) => patch({ addressLine: event.target.value })}
-                maxLength={300}
-              />
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="site-city">City</Label>
-                <Input
-                  id="site-city"
-                  value={form.city}
-                  onChange={(event) => patch({ city: event.target.value })}
-                  maxLength={120}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="site-country">Country</Label>
-                <Input
-                  id="site-country"
-                  value={form.country}
-                  onChange={(event) => patch({ country: event.target.value })}
-                  maxLength={120}
-                />
-              </div>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="site-latitude">Latitude</Label>
-                <Input
-                  id="site-latitude"
-                  inputMode="decimal"
-                  className="font-mono"
-                  value={form.latitude}
-                  onChange={(event) => patch({ latitude: event.target.value })}
-                  placeholder="-17.8252"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="site-longitude">Longitude</Label>
-                <Input
-                  id="site-longitude"
-                  inputMode="decimal"
-                  className="font-mono"
-                  value={form.longitude}
-                  onChange={(event) => patch({ longitude: event.target.value })}
-                  placeholder="31.0335"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <SearchableSelect
-                label="Contact on site"
-                value={form.primaryContactId}
-                options={personOptions}
-                placeholder={peopleQuery.isLoading ? "Loading people…" : "Search people"}
-                onValueChange={(primaryContactId) => patch({ primaryContactId })}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="site-access">Getting in</Label>
-              <Textarea
-                id="site-access"
-                value={form.accessInstructions}
-                onChange={(event) => patch({ accessInstructions: event.target.value })}
-                placeholder="Which gate, who to ask for, where the keys live, what hours it's open."
-                rows={3}
-                maxLength={2000}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="site-conditions">What it&apos;s like on the ground</Label>
-              <Textarea
-                id="site-conditions"
-                value={form.siteConditions}
-                onChange={(event) => patch({ siteConditions: event.target.value })}
-                placeholder="Terrain, power, safety gear needed, anything that changes how long the job takes."
-                rows={3}
-                maxLength={4000}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="site-notes">Notes</Label>
-              <Textarea
-                id="site-notes"
-                value={form.notes}
-                onChange={(event) => patch({ notes: event.target.value })}
-                rows={3}
-              />
-            </div>
-
-            <CustomFieldInputs
-              definitions={definitions}
-              values={customValues}
-              onChange={setCustomValues}
-            />
-          </FormShell>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="site-city">City</Label>
+          <Input
+            id="site-city"
+            value={form.city}
+            onChange={(event) => patch({ city: event.target.value })}
+            maxLength={120}
+          />
         </div>
-      </SheetContent>
-    </Sheet>
+        <div className="space-y-1.5">
+          <Label htmlFor="site-country">Country</Label>
+          <Input
+            id="site-country"
+            value={form.country}
+            onChange={(event) => patch({ country: event.target.value })}
+            maxLength={120}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="site-latitude">Latitude</Label>
+          <Input
+            id="site-latitude"
+            inputMode="decimal"
+            className="font-mono"
+            value={form.latitude}
+            onChange={(event) => patch({ latitude: event.target.value })}
+            placeholder="-17.8252"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="site-longitude">Longitude</Label>
+          <Input
+            id="site-longitude"
+            inputMode="decimal"
+            className="font-mono"
+            value={form.longitude}
+            onChange={(event) => patch({ longitude: event.target.value })}
+            placeholder="31.0335"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <SearchableSelect
+          label="Contact on site"
+          value={form.primaryContactId}
+          options={personOptions}
+          placeholder={peopleQuery.isLoading ? "Loading people…" : "Search people"}
+          onValueChange={(primaryContactId) => patch({ primaryContactId })}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="site-access">Getting in</Label>
+        <Textarea
+          id="site-access"
+          value={form.accessInstructions}
+          onChange={(event) => patch({ accessInstructions: event.target.value })}
+          placeholder="Which gate, who to ask for, where the keys live, what hours it's open."
+          rows={3}
+          maxLength={2000}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="site-conditions">What it&apos;s like on the ground</Label>
+        <Textarea
+          id="site-conditions"
+          value={form.siteConditions}
+          onChange={(event) => patch({ siteConditions: event.target.value })}
+          placeholder="Terrain, power, safety gear needed, anything that changes how long the job takes."
+          rows={3}
+          maxLength={4000}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="site-notes">Notes</Label>
+        <Textarea
+          id="site-notes"
+          value={form.notes}
+          onChange={(event) => patch({ notes: event.target.value })}
+          rows={3}
+        />
+      </div>
+
+      <CustomFieldInputs
+        definitions={definitions}
+        values={customValues}
+        onChange={setCustomValues}
+      />
+    </RecordDialog>
   );
 }

--- a/components/crm/reports/reports-content.tsx
+++ b/components/crm/reports/reports-content.tsx
@@ -32,7 +32,7 @@ type ReportResponse = {
     counts: { won: number; lost: number; open: number };
     winRate: number;
     medianCycleDays: number | null;
-    forecast: { weighted: number; unweighted: number; count: number };
+    forecast: { weighted: number; unweighted: number; count: number; estimated: number };
     byOwner: GroupedPerformance[];
     bySource: GroupedPerformance[];
     activity: { period: string; count: number }[];
@@ -91,7 +91,11 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
             <StatCard
               label="Weighted forecast"
               value={formatMoney(report.forecast.weighted, currency)}
-              footer={`${formatMoney(report.forecast.unweighted, currency)} if everything lands`}
+              footer={
+                report.forecast.estimated === 0
+                  ? `${formatMoney(report.forecast.unweighted, currency)} if everything lands`
+                  : `${formatMoney(report.forecast.unweighted, currency)} if everything lands · ${report.forecast.estimated} of ${report.forecast.count} at a default likelihood`
+              }
             />
             <StatCard
               label="Typical cycle"

--- a/components/crm/reports/reports-content.tsx
+++ b/components/crm/reports/reports-content.tsx
@@ -24,8 +24,8 @@ import {
   type ReportRange,
 } from "@/lib/crm/reports";
 
+/** Bare, like every other report route — see the collections note. */
 type ReportResponse = {
-  data: {
     range: ReportRange;
     scope: "TEAM" | "MINE";
     funnel: FunnelStage[];
@@ -37,7 +37,6 @@ type ReportResponse = {
     bySource: GroupedPerformance[];
     activity: { period: string; count: number }[];
     leads: { created: number; converted: number };
-  };
 };
 
 export function ReportsContent({ currency = "USD" }: { currency?: string }) {
@@ -48,7 +47,7 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
     queryFn: () => fetchJson<ReportResponse>(`/api/v2/crm/reports?range=${range}`),
   });
 
-  const report = data?.data;
+  const report = data;
   const leak = report ? biggestLeak(report.funnel) : null;
   const peak = Math.max(1, ...(report?.activity.map((bucket) => bucket.count) ?? [1]));
 
@@ -159,7 +158,7 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
                 />
               ))}
             </div>
-            <p className="mt-2 text-xs text-[var(--text-muted)]">
+            <p className="mt-2 text-sm text-[var(--text-muted)]">
               Calls, emails and notes logged. Peak {peak} in a single period.
             </p>
           </Card>
@@ -184,7 +183,7 @@ function PerformanceTable({
         <EmptyState title="Nothing to show yet" />
       ) : (
         <table className="w-full text-sm">
-          <thead className="text-left text-xs uppercase tracking-wide text-[var(--text-muted)]">
+          <thead className="text-left text-sm uppercase tracking-wide text-[var(--text-muted)]">
             <tr>
               <th className="pb-1 font-medium">Name</th>
               <th className="pb-1 text-right font-medium">Won</th>

--- a/components/crm/reps/rep-detail-page.tsx
+++ b/components/crm/reps/rep-detail-page.tsx
@@ -38,13 +38,13 @@ function Stat({
 }) {
   return (
     <div className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <h3 className="text-xs font-medium uppercase tracking-wide text-[var(--text-subtle)]">
+      <h3 className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]">
         {label}
         <span className="mt-1 block font-mono text-xl font-semibold tracking-normal text-[var(--text-strong)]">
           {value}
         </span>
       </h3>
-      {hint ? <p className="mt-0.5 text-xs text-[var(--text-muted)]">{hint}</p> : null}
+      {hint ? <p className="mt-0.5 text-sm text-[var(--text-muted)]">{hint}</p> : null}
     </div>
   );
 }

--- a/components/crm/reps/rep-detail-page.tsx
+++ b/components/crm/reps/rep-detail-page.tsx
@@ -5,6 +5,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Avatar, Badge } from "@corelithzw/react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { StatusChip } from "@/components/ui/status-chip";
+import {
+  CRM_STAGE_LABELS,
+  CRM_STAGE_STATUS,
+} from "@/components/crm/leads/stage-config";
 import { ClientDate } from "@/components/ui/client-date";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getApiErrorMessage } from "@/lib/api-client";
@@ -83,9 +88,10 @@ function pipelineRows(detail: CrmRepDetail): RecordListRow[] {
       title: lead.title,
       subtitle: [lead.client?.name, lead.leadNo].filter(Boolean).join(" · "),
       status: (
-        <Badge tone="neutral" size="sm">
-          {lead.stage.replace(/_/g, " ").toLowerCase()}
-        </Badge>
+        <StatusChip
+          status={CRM_STAGE_STATUS[lead.stage]}
+          label={CRM_STAGE_LABELS[lead.stage]}
+        />
       ),
       facts: [
         {

--- a/components/crm/settings/automations-panel.tsx
+++ b/components/crm/settings/automations-panel.tsx
@@ -204,7 +204,7 @@ export function AutomationsPanel() {
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--text-muted)]">
+                <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--text-muted)]">
                   <span>
                     Fired {rule.runCount} time{rule.runCount === 1 ? "" : "s"}
                   </span>
@@ -598,7 +598,7 @@ function AutomationFormSheet({
             </div>
 
             {conditions.length === 0 ? (
-              <p className="text-xs text-[var(--text-muted)]">
+              <p className="text-sm text-[var(--text-muted)]">
                 No conditions — the rule fires every time.
               </p>
             ) : (

--- a/components/crm/settings/automations-panel.tsx
+++ b/components/crm/settings/automations-panel.tsx
@@ -15,14 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -460,393 +453,382 @@ function AutomationFormSheet({
     );
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
-        <SheetHeader>
-          <SheetTitle>{isEdit ? "Edit rule" : "New rule"}</SheetTitle>
-          <SheetDescription>
-            When something happens, check a few things, then do something about
-            it.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEdit ? "Edit rule" : "New rule"}
+      description="When something happens, check a few things, then do something about it."
+      size="xl"
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found: string[] = [];
+        if (!name.trim()) found.push("Give the rule a name.");
+        if (actions.length === 0) found.push("Add at least one action.");
+        if (actions.some((action) => action.type === "ADD_TAG" && !action.tag.trim())) {
+          found.push("A tag action needs a tag.");
+        }
+        if (
+          actions.some((action) => action.type === "CREATE_TASK" && !action.title.trim())
+        ) {
+          found.push("A task action needs a title.");
+        }
+        if (actions.some((action) => action.type === "NOTIFY" && !action.message.trim())) {
+          found.push("A notification needs something to say.");
+        }
+        if (actions.some((action) => action.type === "SET_FIELD" && !action.field)) {
+          found.push("Pick the field to set.");
+        }
+        if (conditions.some((condition) => !condition.field)) {
+          found.push("Every condition needs a field.");
+        }
+        setErrors(found);
+        if (found.length === 0) save.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={save.isPending}>
+          {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create rule"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="rule-name">Name *</Label>
+        <Input
+          id="rule-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Chase big new leads the same day"
+        />
+      </div>
 
-        <FormShell
-          variant="bare"
-          errors={errors}
-          requiredHint="A name, a trigger and at least one action are required."
-          onSubmit={(event) => {
-            event.preventDefault();
-            const found: string[] = [];
-            if (!name.trim()) found.push("Give the rule a name.");
-            if (actions.length === 0) found.push("Add at least one action.");
-            if (actions.some((action) => action.type === "ADD_TAG" && !action.tag.trim())) {
-              found.push("A tag action needs a tag.");
-            }
-            if (
-              actions.some((action) => action.type === "CREATE_TASK" && !action.title.trim())
-            ) {
-              found.push("A task action needs a title.");
-            }
-            if (actions.some((action) => action.type === "NOTIFY" && !action.message.trim())) {
-              found.push("A notification needs something to say.");
-            }
-            if (actions.some((action) => action.type === "SET_FIELD" && !action.field)) {
-              found.push("Pick the field to set.");
-            }
-            if (conditions.some((condition) => !condition.field)) {
-              found.push("Every condition needs a field.");
-            }
-            setErrors(found);
-            if (found.length === 0) save.mutate();
+      <div className="space-y-1.5">
+        <Label>When</Label>
+        <OptionSelect
+          value={trigger}
+          onValueChange={(value) => {
+            setTrigger(value as (typeof AUTOMATION_TRIGGERS)[number]);
+            // The fields a condition can name depend on which record the
+            // trigger hands over, so conditions written against the old
+            // one would silently stop matching. Clearing is honest.
+            setConditions([]);
           }}
-          actions={
-            <>
-              <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={save.isPending}>
-                {save.isPending ? "Saving…" : isEdit ? "Save changes" : "Create rule"}
-              </Button>
-            </>
-          }
-        >
+          options={AUTOMATION_TRIGGERS.map((value) => ({
+            value,
+            label: TRIGGER_LABELS[value],
+          }))}
+          ariaLabel="Trigger"
+        />
+      </div>
+
+      {triggerUsesStage(trigger) ? (
+        <div className="space-y-1.5">
+          <Label>Only when it lands on</Label>
+          <OptionSelect
+            value={stage}
+            onValueChange={setStage}
+            options={[{ value: "", label: "Any stage" }, ...LEAD_STAGE_OPTIONS]}
+            placeholder="Any stage"
+            ariaLabel="Landing stage"
+          />
+        </div>
+      ) : null}
+
+      {triggerUsesIdle(trigger) ? (
+        <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="rule-name">Name *</Label>
+            <Label htmlFor="rule-idle-days">Days of silence</Label>
             <Input
-              id="rule-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder="Chase big new leads the same day"
+              id="rule-idle-days"
+              type="number"
+              min={1}
+              value={idleDays}
+              onChange={(event) => setIdleDays(Number(event.target.value) || 1)}
             />
           </div>
-
           <div className="space-y-1.5">
-            <Label>When</Label>
+            <Label>On</Label>
             <OptionSelect
-              value={trigger}
-              onValueChange={(value) => {
-                setTrigger(value as (typeof AUTOMATION_TRIGGERS)[number]);
-                // The fields a condition can name depend on which record the
-                // trigger hands over, so conditions written against the old
-                // one would silently stop matching. Clearing is honest.
-                setConditions([]);
-              }}
-              options={AUTOMATION_TRIGGERS.map((value) => ({
-                value,
-                label: TRIGGER_LABELS[value],
-              }))}
-              ariaLabel="Trigger"
+              value={idleEntity}
+              onValueChange={(value) => setIdleEntity(value as "LEAD" | "DEAL")}
+              options={[
+                { value: "LEAD", label: "Leads" },
+                { value: "DEAL", label: "Deals" },
+              ]}
+              ariaLabel="Record type"
             />
           </div>
+        </div>
+      ) : null}
 
-          {triggerUsesStage(trigger) ? (
-            <div className="space-y-1.5">
-              <Label>Only when it lands on</Label>
-              <OptionSelect
-                value={stage}
-                onValueChange={setStage}
-                options={[{ value: "", label: "Any stage" }, ...LEAD_STAGE_OPTIONS]}
-                placeholder="Any stage"
-                ariaLabel="Landing stage"
-              />
-            </div>
-          ) : null}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>And these are true</Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              setConditions((previous) => [
+                ...previous,
+                { field: fields[0]?.path ?? "", operator: "equals", value: "" },
+              ])
+            }
+          >
+            Add condition
+          </Button>
+        </div>
 
-          {triggerUsesIdle(trigger) ? (
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="rule-idle-days">Days of silence</Label>
-                <Input
-                  id="rule-idle-days"
-                  type="number"
-                  min={1}
-                  value={idleDays}
-                  onChange={(event) => setIdleDays(Number(event.target.value) || 1)}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label>On</Label>
+        {conditions.length === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]">
+            No conditions — the rule fires every time.
+          </p>
+        ) : (
+          conditions.map((condition, index) => {
+            const field = findField(trigger, condition.field);
+            const operators = operatorsForKind(field?.kind ?? "text");
+            return (
+              <div key={index} className="flex flex-wrap gap-2">
                 <OptionSelect
-                  value={idleEntity}
-                  onValueChange={(value) => setIdleEntity(value as "LEAD" | "DEAL")}
-                  options={[
-                    { value: "LEAD", label: "Leads" },
-                    { value: "DEAL", label: "Deals" },
-                  ]}
-                  ariaLabel="Record type"
+                  className="min-w-40 flex-1"
+                  value={condition.field}
+                  onValueChange={(value) => {
+                    const next = findField(trigger, value);
+                    // Widened to string: each kind returns its own narrow
+                    // tuple, so `includes` refuses an operator from a
+                    // different kind — which is exactly the case being
+                    // tested for.
+                    const allowed: readonly string[] = operatorsForKind(
+                      next?.kind ?? "text",
+                    );
+                    patchCondition(index, {
+                      field: value,
+                      // Changing the field can invalidate the operator —
+                      // "contains" on a number is a rule that never fires.
+                      operator: allowed.includes(condition.operator)
+                        ? condition.operator
+                        : (allowed[0] as AutomationCondition["operator"]),
+                      value: "",
+                    });
+                  }}
+                  options={fields.map((option) => ({
+                    value: option.path,
+                    label: option.label,
+                  }))}
+                  placeholder="Field"
+                  ariaLabel="Condition field"
                 />
-              </div>
-            </div>
-          ) : null}
 
-          <div className="space-y-2">
+                <OptionSelect
+                  className="w-36"
+                  value={condition.operator}
+                  onValueChange={(value) =>
+                    patchCondition(index, {
+                      operator: value as AutomationCondition["operator"],
+                    })
+                  }
+                  options={operators.map((value) => ({
+                    value,
+                    label: OPERATOR_LABELS[value],
+                  }))}
+                  ariaLabel="Condition operator"
+                />
+
+                {operatorNeedsValue(condition.operator) ? (
+                  <FieldValueInput
+                    className="min-w-32 flex-1"
+                    field={field}
+                    value={condition.value}
+                    owners={owners}
+                    onChange={(value) => patchCondition(index, { value })}
+                  />
+                ) : null}
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-label="Remove condition"
+                  onClick={() =>
+                    setConditions((previous) =>
+                      previous.filter((_item, position) => position !== index),
+                    )
+                  }
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Then</Label>
+          <OptionSelect
+            className="w-40"
+            value=""
+            onValueChange={(value) =>
+              setActions((previous) => [...previous, defaultAction(value as ActionType)])
+            }
+            options={ACTION_TYPES.map((value) => ({
+              value,
+              label: ACTION_LABELS[value],
+            }))}
+            placeholder="Add action"
+            ariaLabel="Add action"
+          />
+        </div>
+
+        {actions.map((action, index) => (
+          <div
+            key={index}
+            className="space-y-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-2"
+          >
             <div className="flex items-center justify-between">
-              <Label>And these are true</Label>
+              <span className="text-sm font-medium">{ACTION_LABELS[action.type]}</span>
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
+                aria-label="Remove action"
                 onClick={() =>
-                  setConditions((previous) => [
-                    ...previous,
-                    { field: fields[0]?.path ?? "", operator: "equals", value: "" },
-                  ])
+                  setActions((previous) =>
+                    previous.filter((_item, position) => position !== index),
+                  )
                 }
               >
-                Add condition
+                <Trash2 className="size-4" />
               </Button>
             </div>
 
-            {conditions.length === 0 ? (
-              <p className="text-sm text-[var(--text-muted)]">
-                No conditions — the rule fires every time.
-              </p>
-            ) : (
-              conditions.map((condition, index) => {
-                const field = findField(trigger, condition.field);
-                const operators = operatorsForKind(field?.kind ?? "text");
-                return (
-                  <div key={index} className="flex flex-wrap gap-2">
-                    <OptionSelect
-                      className="min-w-40 flex-1"
-                      value={condition.field}
-                      onValueChange={(value) => {
-                        const next = findField(trigger, value);
-                        // Widened to string: each kind returns its own narrow
-                        // tuple, so `includes` refuses an operator from a
-                        // different kind — which is exactly the case being
-                        // tested for.
-                        const allowed: readonly string[] = operatorsForKind(
-                          next?.kind ?? "text",
-                        );
-                        patchCondition(index, {
-                          field: value,
-                          // Changing the field can invalidate the operator —
-                          // "contains" on a number is a rule that never fires.
-                          operator: allowed.includes(condition.operator)
-                            ? condition.operator
-                            : (allowed[0] as AutomationCondition["operator"]),
-                          value: "",
-                        });
-                      }}
-                      options={fields.map((option) => ({
-                        value: option.path,
-                        label: option.label,
-                      }))}
-                      placeholder="Field"
-                      ariaLabel="Condition field"
-                    />
-
-                    <OptionSelect
-                      className="w-36"
-                      value={condition.operator}
-                      onValueChange={(value) =>
-                        patchCondition(index, {
-                          operator: value as AutomationCondition["operator"],
-                        })
-                      }
-                      options={operators.map((value) => ({
-                        value,
-                        label: OPERATOR_LABELS[value],
-                      }))}
-                      ariaLabel="Condition operator"
-                    />
-
-                    {operatorNeedsValue(condition.operator) ? (
-                      <FieldValueInput
-                        className="min-w-32 flex-1"
-                        field={field}
-                        value={condition.value}
-                        owners={owners}
-                        onChange={(value) => patchCondition(index, { value })}
-                      />
-                    ) : null}
-
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      aria-label="Remove condition"
-                      onClick={() =>
-                        setConditions((previous) =>
-                          previous.filter((_item, position) => position !== index),
-                        )
-                      }
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  </div>
-                );
-              })
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label>Then</Label>
-              <OptionSelect
-                className="w-40"
-                value=""
-                onValueChange={(value) =>
-                  setActions((previous) => [...previous, defaultAction(value as ActionType)])
-                }
-                options={ACTION_TYPES.map((value) => ({
-                  value,
-                  label: ACTION_LABELS[value],
-                }))}
-                placeholder="Add action"
-                ariaLabel="Add action"
-              />
-            </div>
-
-            {actions.map((action, index) => (
-              <div
-                key={index}
-                className="space-y-2 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-2"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium">{ACTION_LABELS[action.type]}</span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    aria-label="Remove action"
-                    onClick={() =>
-                      setActions((previous) =>
-                        previous.filter((_item, position) => position !== index),
-                      )
-                    }
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                </div>
-
-                {action.type === "CREATE_TASK" ? (
-                  <div className="space-y-2">
-                    <div className="flex gap-2">
-                      <Input
-                        className="flex-1"
-                        value={action.title}
-                        placeholder="Task title"
-                        aria-label="Task title"
-                        onChange={(event) => patchAction(index, { title: event.target.value })}
-                      />
-                      <Input
-                        className="w-28"
-                        type="number"
-                        min={0}
-                        value={action.dueInDays}
-                        aria-label="Days from now"
-                        onChange={(event) =>
-                          patchAction(index, { dueInDays: Number(event.target.value) || 0 })
-                        }
-                      />
-                    </div>
-                    <div className="flex gap-2">
-                      <OptionSelect
-                        className="flex-1"
-                        value={action.taskType ?? "GENERAL"}
-                        onValueChange={(value) => patchAction(index, { taskType: value })}
-                        options={TASK_TYPE_OPTIONS}
-                        ariaLabel="Task type"
-                      />
-                      <OptionSelect
-                        className="flex-1"
-                        value={action.assignedToId ?? ""}
-                        onValueChange={(value) =>
-                          patchAction(index, { assignedToId: value || null })
-                        }
-                        options={[
-                          { value: "", label: "Whoever owns the record" },
-                          ...owners.map((owner) => ({
-                            value: owner.id,
-                            label: owner.name ?? "Unnamed",
-                          })),
-                        ]}
-                        ariaLabel="Task assignee"
-                      />
-                    </div>
-                  </div>
-                ) : null}
-
-                {action.type === "ADD_TAG" ? (
+            {action.type === "CREATE_TASK" ? (
+              <div className="space-y-2">
+                <div className="flex gap-2">
                   <Input
-                    value={action.tag}
-                    placeholder="Tag"
-                    aria-label="Tag"
-                    onChange={(event) => patchAction(index, { tag: event.target.value })}
+                    className="flex-1"
+                    value={action.title}
+                    placeholder="Task title"
+                    aria-label="Task title"
+                    onChange={(event) => patchAction(index, { title: event.target.value })}
                   />
-                ) : null}
-
-                {action.type === "NOTIFY" ? (
-                  <div className="space-y-2">
-                    <Input
-                      value={action.message}
-                      placeholder="What the notification says"
-                      aria-label="Notification message"
-                      onChange={(event) => patchAction(index, { message: event.target.value })}
-                    />
-                    <OptionSelect
-                      value={action.recipientIds[0] ?? ""}
-                      onValueChange={(value) =>
-                        patchAction(index, { recipientIds: value ? [value] : [] })
-                      }
-                      options={[
-                        { value: "", label: "The record's owner" },
-                        ...owners.map((owner) => ({
-                          value: owner.id,
-                          label: owner.name ?? "Unnamed",
-                        })),
-                      ]}
-                      ariaLabel="Notify"
-                    />
-                  </div>
-                ) : null}
-
-                {action.type === "SET_FIELD" ? (
-                  <div className="flex gap-2">
-                    <OptionSelect
-                      className="flex-1"
-                      value={action.field}
-                      onValueChange={(value) => patchAction(index, { field: value, value: "" })}
-                      options={writableFields.map((option) => ({
-                        value: option.path,
-                        label: option.label,
-                      }))}
-                      placeholder="Field"
-                      ariaLabel="Field to set"
-                    />
-                    <FieldValueInput
-                      className="flex-1"
-                      field={findField(trigger, action.field)}
-                      value={action.value}
-                      owners={owners}
-                      onChange={(value) => patchAction(index, { value })}
-                    />
-                  </div>
-                ) : null}
-
-                {action.type === "ASSIGN_OWNER" ? (
+                  <Input
+                    className="w-28"
+                    type="number"
+                    min={0}
+                    value={action.dueInDays}
+                    aria-label="Days from now"
+                    onChange={(event) =>
+                      patchAction(index, { dueInDays: Number(event.target.value) || 0 })
+                    }
+                  />
+                </div>
+                <div className="flex gap-2">
                   <OptionSelect
+                    className="flex-1"
+                    value={action.taskType ?? "GENERAL"}
+                    onValueChange={(value) => patchAction(index, { taskType: value })}
+                    options={TASK_TYPE_OPTIONS}
+                    ariaLabel="Task type"
+                  />
+                  <OptionSelect
+                    className="flex-1"
                     value={action.assignedToId ?? ""}
                     onValueChange={(value) =>
                       patchAction(index, { assignedToId: value || null })
                     }
                     options={[
-                      { value: "", label: "Whoever the assignment rule picks" },
+                      { value: "", label: "Whoever owns the record" },
                       ...owners.map((owner) => ({
                         value: owner.id,
                         label: owner.name ?? "Unnamed",
                       })),
                     ]}
-                    ariaLabel="Owner"
+                    ariaLabel="Task assignee"
                   />
-                ) : null}
+                </div>
               </div>
-            ))}
+            ) : null}
+
+            {action.type === "ADD_TAG" ? (
+              <Input
+                value={action.tag}
+                placeholder="Tag"
+                aria-label="Tag"
+                onChange={(event) => patchAction(index, { tag: event.target.value })}
+              />
+            ) : null}
+
+            {action.type === "NOTIFY" ? (
+              <div className="space-y-2">
+                <Input
+                  value={action.message}
+                  placeholder="What the notification says"
+                  aria-label="Notification message"
+                  onChange={(event) => patchAction(index, { message: event.target.value })}
+                />
+                <OptionSelect
+                  value={action.recipientIds[0] ?? ""}
+                  onValueChange={(value) =>
+                    patchAction(index, { recipientIds: value ? [value] : [] })
+                  }
+                  options={[
+                    { value: "", label: "The record's owner" },
+                    ...owners.map((owner) => ({
+                      value: owner.id,
+                      label: owner.name ?? "Unnamed",
+                    })),
+                  ]}
+                  ariaLabel="Notify"
+                />
+              </div>
+            ) : null}
+
+            {action.type === "SET_FIELD" ? (
+              <div className="flex gap-2">
+                <OptionSelect
+                  className="flex-1"
+                  value={action.field}
+                  onValueChange={(value) => patchAction(index, { field: value, value: "" })}
+                  options={writableFields.map((option) => ({
+                    value: option.path,
+                    label: option.label,
+                  }))}
+                  placeholder="Field"
+                  ariaLabel="Field to set"
+                />
+                <FieldValueInput
+                  className="flex-1"
+                  field={findField(trigger, action.field)}
+                  value={action.value}
+                  owners={owners}
+                  onChange={(value) => patchAction(index, { value })}
+                />
+              </div>
+            ) : null}
+
+            {action.type === "ASSIGN_OWNER" ? (
+              <OptionSelect
+                value={action.assignedToId ?? ""}
+                onValueChange={(value) =>
+                  patchAction(index, { assignedToId: value || null })
+                }
+                options={[
+                  { value: "", label: "Whoever the assignment rule picks" },
+                  ...owners.map((owner) => ({
+                    value: owner.id,
+                    label: owner.name ?? "Unnamed",
+                  })),
+                ]}
+                ariaLabel="Owner"
+              />
+            ) : null}
           </div>
-        </FormShell>
-      </SheetContent>
-    </Sheet>
+        ))}
+      </div>
+    </RecordDialog>
   );
 }

--- a/components/crm/settings/custom-fields-panel.tsx
+++ b/components/crm/settings/custom-fields-panel.tsx
@@ -187,26 +187,26 @@ export function CustomFieldsPanel() {
         ) : (
           grouped.map(([sectionName, fields]) => (
             <section key={sectionName} className="space-y-1.5">
-              <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                 {sectionName}
               </h4>
-              <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+              <ul className="divide-y divide-[var(--border-subtle)]">
                 {fields.map((definition) => (
                   <li key={definition.id} className="flex items-center gap-3 p-3">
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="text-sm font-medium">{definition.label}</span>
-                        <Badge variant="outline" className="text-[11px]">
+                        <Badge variant="outline" className="text-sm">
                           {CRM_FIELD_TYPE_LABELS[definition.type as CrmFieldType] ??
                             definition.type}
                         </Badge>
                         {definition.isRequired ? (
-                          <Badge variant="secondary" className="text-[11px]">
+                          <Badge variant="secondary" className="text-sm">
                             Required
                           </Badge>
                         ) : null}
                       </div>
-                      <p className="truncate font-mono text-xs text-[var(--text-muted)]">
+                      <p className="truncate font-mono text-sm text-[var(--text-muted)]">
                         {definition.key}
                       </p>
                     </div>
@@ -265,7 +265,7 @@ export function CustomFieldsPanel() {
                 autoFocus
               />
               {label.trim() ? (
-                <p className="font-mono text-xs text-[var(--text-muted)]">
+                <p className="font-mono text-sm text-[var(--text-muted)]">
                   key: {normalizeFieldKey(label)}
                 </p>
               ) : null}

--- a/components/crm/settings/permissions-panel.tsx
+++ b/components/crm/settings/permissions-panel.tsx
@@ -51,7 +51,7 @@ export function PermissionsPanel() {
         </table>
       </div>
 
-      <p className="text-xs text-[var(--text-muted)]">
+      <p className="text-sm text-[var(--text-muted)]">
         A rep may also claim an unassigned record, which is what makes
         &ldquo;edit records assigned to them&rdquo; workable in practice.
       </p>

--- a/components/crm/settings/pipelines-panel.tsx
+++ b/components/crm/settings/pipelines-panel.tsx
@@ -30,6 +30,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { ArrowDownward, ArrowUpward, Plus, Trash2 } from "@/lib/icons";
 import { fetchCrmPipelines, type CrmPipelineRecord } from "@/lib/crm/crm-v2";
+import { STAGE_OUTCOME_TONE } from "@/lib/crm/tones";
 import { validateStages, type StageInput } from "@/lib/crm/pipelines";
 
 type StageDraft = StageInput & { dealCount?: number };
@@ -158,7 +159,7 @@ function StageEditor({
                   maxLength={60}
                 />
                 {isOutcome ? (
-                  <Badge variant="secondary">
+                  <Badge tone={STAGE_OUTCOME_TONE[stage.status] ?? "neutral"} size="sm">
                     {stage.status === "WON" ? "Won outcome" : "Lost outcome"}
                   </Badge>
                 ) : null}

--- a/components/crm/settings/pipelines-panel.tsx
+++ b/components/crm/settings/pipelines-panel.tsx
@@ -163,7 +163,7 @@ function StageEditor({
                   </Badge>
                 ) : null}
                 {stage.dealCount ? (
-                  <span className="text-xs text-[var(--text-muted)]">
+                  <span className="text-sm text-[var(--text-muted)]">
                     {stage.dealCount} deal{stage.dealCount === 1 ? "" : "s"}
                   </span>
                 ) : null}
@@ -208,7 +208,7 @@ function StageEditor({
 
               <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                 <div className="space-y-1">
-                  <Label className="text-xs">Probability %</Label>
+                  <Label className="text-sm">Probability %</Label>
                   <Input
                     value={stage.probability}
                     onChange={(event) =>
@@ -219,7 +219,7 @@ function StageEditor({
                   />
                 </div>
                 <div className="space-y-1">
-                  <Label className="text-xs">Goes stale after</Label>
+                  <Label className="text-sm">Goes stale after</Label>
                   <Input
                     value={stage.inactivityDays ?? ""}
                     onChange={(event) =>
@@ -235,7 +235,7 @@ function StageEditor({
                 </div>
                 {!isOutcome ? (
                   <>
-                    <label className="flex items-end gap-2 pb-1.5 text-xs">
+                    <label className="flex items-end gap-2 pb-1.5 text-sm">
                       <Checkbox
                         checked={Boolean(stage.requiresSiteVisit)}
                         onCheckedChange={(checked) =>
@@ -244,7 +244,7 @@ function StageEditor({
                       />
                       Expects a visit
                     </label>
-                    <label className="flex items-end gap-2 pb-1.5 text-xs">
+                    <label className="flex items-end gap-2 pb-1.5 text-sm">
                       <Checkbox
                         checked={Boolean(stage.requiresQuotation)}
                         onCheckedChange={(checked) =>
@@ -393,7 +393,7 @@ export function PipelinesPanel() {
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-medium">{pipeline.name}</span>
                   {pipeline.isDefault ? <Badge variant="secondary">Default</Badge> : null}
-                  <span className="text-xs text-[var(--text-muted)]">
+                  <span className="text-sm text-[var(--text-muted)]">
                     {pipeline._count?.deals ?? 0} deal
                     {(pipeline._count?.deals ?? 0) === 1 ? "" : "s"}
                   </span>
@@ -434,7 +434,7 @@ export function PipelinesPanel() {
                 <Badge
                   key={stage.id}
                   variant={stage.status === "OPEN" ? "outline" : "secondary"}
-                  className="text-[11px]"
+                  className="text-sm"
                 >
                   {stage.name}
                 </Badge>

--- a/components/crm/tasks/task-form-sheet.tsx
+++ b/components/crm/tasks/task-form-sheet.tsx
@@ -14,14 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { createCrmTask, type CrmTaskRecordRef } from "@/lib/crm/crm-v2";
@@ -145,154 +138,145 @@ export function TaskFormSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full sm:max-w-lg">
-        <SheetHeader>
-          <SheetTitle>New task</SheetTitle>
-          <SheetDescription>
-            Pick a type and the task will ask what happened when you complete it.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="New task"
+      description="Pick a type and the task will ask what happened when you complete it."
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+      footer={
+        <>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={create.isPending}>
+            {create.isPending ? "Creating…" : "Create task"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-2">
+        <Label htmlFor="task-title">Title</Label>
+        <Input
+          id="task-title"
+          value={form.title}
+          onChange={(event) => set("title", event.target.value)}
+          placeholder="Call about the revised quote"
+        />
+      </div>
 
-        <FormShell
-          variant="bare"
-          errors={errors}
-          requiredHint="A title and a due date are required."
-          onSubmit={(event) => {
-            event.preventDefault();
-            submit();
-          }}
-          actions={
-            <>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={create.isPending}>
-                {create.isPending ? "Creating…" : "Create task"}
-              </Button>
-            </>
-          }
-        >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Type</Label>
+          <Select value={form.type} onValueChange={(value) => set("type", value)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CRM_TASK_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {CRM_TASK_TYPE_LABELS[type]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Priority</Label>
+          <Select value={form.priority} onValueChange={(value) => set("priority", value)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(CRM_TASK_PRIORITY_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="task-due">Due</Label>
+          <Input
+            id="task-due"
+            type="datetime-local"
+            value={form.dueAt}
+            onChange={(event) => set("dueAt", event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Assigned to</Label>
+          <Select
+            value={form.assignedToId}
+            onValueChange={(value) => set("assignedToId", value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Unassigned" />
+            </SelectTrigger>
+            <SelectContent>
+              {(team?.data ?? []).map((user) => (
+                <SelectItem key={user.id} value={user.id}>
+                  {user.name ?? user.email}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Repeats</Label>
+          <Select value={form.recurrence} onValueChange={(value) => set("recurrence", value)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="NONE">Doesn&apos;t repeat</SelectItem>
+              <SelectItem value="DAILY">Daily</SelectItem>
+              <SelectItem value="WEEKLY">Weekly</SelectItem>
+              <SelectItem value="MONTHLY">Monthly</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {form.recurrence !== "NONE" ? (
           <div className="space-y-2">
-            <Label htmlFor="task-title">Title</Label>
+            <Label htmlFor="task-interval">Every</Label>
             <Input
-              id="task-title"
-              value={form.title}
-              onChange={(event) => set("title", event.target.value)}
-              placeholder="Call about the revised quote"
+              id="task-interval"
+              type="number"
+              min={1}
+              max={52}
+              value={form.recurrenceInterval}
+              onChange={(event) => set("recurrenceInterval", event.target.value)}
             />
+            <p className="text-sm text-[var(--text-muted)]">
+              The next one is created when you complete this one.
+            </p>
           </div>
+        ) : null}
+      </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Type</Label>
-              <Select value={form.type} onValueChange={(value) => set("type", value)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {CRM_TASK_TYPES.map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {CRM_TASK_TYPE_LABELS[type]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Priority</Label>
-              <Select value={form.priority} onValueChange={(value) => set("priority", value)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(CRM_TASK_PRIORITY_LABELS).map(([value, label]) => (
-                    <SelectItem key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="task-due">Due</Label>
-              <Input
-                id="task-due"
-                type="datetime-local"
-                value={form.dueAt}
-                onChange={(event) => set("dueAt", event.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label>Assigned to</Label>
-              <Select
-                value={form.assignedToId}
-                onValueChange={(value) => set("assignedToId", value)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Unassigned" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(team?.data ?? []).map((user) => (
-                    <SelectItem key={user.id} value={user.id}>
-                      {user.name ?? user.email}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Repeats</Label>
-              <Select value={form.recurrence} onValueChange={(value) => set("recurrence", value)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="NONE">Doesn&apos;t repeat</SelectItem>
-                  <SelectItem value="DAILY">Daily</SelectItem>
-                  <SelectItem value="WEEKLY">Weekly</SelectItem>
-                  <SelectItem value="MONTHLY">Monthly</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {form.recurrence !== "NONE" ? (
-              <div className="space-y-2">
-                <Label htmlFor="task-interval">Every</Label>
-                <Input
-                  id="task-interval"
-                  type="number"
-                  min={1}
-                  max={52}
-                  value={form.recurrenceInterval}
-                  onChange={(event) => set("recurrenceInterval", event.target.value)}
-                />
-                <p className="text-sm text-[var(--text-muted)]">
-                  The next one is created when you complete this one.
-                </p>
-              </div>
-            ) : null}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="task-notes">Notes</Label>
-            <Textarea
-              id="task-notes"
-              rows={3}
-              value={form.description}
-              onChange={(event) => set("description", event.target.value)}
-            />
-          </div>
-        </FormShell>
-      </SheetContent>
-    </Sheet>
+      <div className="space-y-2">
+        <Label htmlFor="task-notes">Notes</Label>
+        <Textarea
+          id="task-notes"
+          rows={3}
+          value={form.description}
+          onChange={(event) => set("description", event.target.value)}
+        />
+      </div>
+    </RecordDialog>
   );
 }

--- a/components/crm/tasks/task-form-sheet.tsx
+++ b/components/crm/tasks/task-form-sheet.tsx
@@ -275,7 +275,7 @@ export function TaskFormSheet({
                   value={form.recurrenceInterval}
                   onChange={(event) => set("recurrenceInterval", event.target.value)}
                 />
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   The next one is created when you complete this one.
                 </p>
               </div>

--- a/components/crm/tasks/task-list.tsx
+++ b/components/crm/tasks/task-list.tsx
@@ -17,18 +17,12 @@ import {
   requiresOutcome,
   taskRecordRef,
 } from "@/lib/crm/tasks";
+import { TASK_PRIORITY_TONE } from "@/lib/crm/tones";
 import { Clock, Repeat, Trash2 } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 import { CompleteTaskDialog } from "./complete-task-dialog";
 import { TaskFormSheet } from "./task-form-sheet";
-
-const PRIORITY_TONE: Record<string, string> = {
-  LOW: "text-[var(--text-muted)]",
-  NORMAL: "text-[var(--text-muted)]",
-  HIGH: "text-[var(--status-warning-fg)]",
-  URGENT: "text-[var(--status-danger-fg)]",
-};
 
 /**
  * The task list, shared by the queue page and every record page's Tasks tab.
@@ -161,8 +155,10 @@ export function TaskList({
                     <Clock className="size-3.5" />
                     <ClientDate value={task.dueAt} mode={task.hasDueTime ? "datetime" : "date"} />
                   </span>
-                  {task.priority !== "NORMAL" ? (
-                    <span className={PRIORITY_TONE[task.priority]}>{task.priority}</span>
+                  {task.priority !== "NORMAL" && task.priority !== "LOW" ? (
+                    <Badge tone={TASK_PRIORITY_TONE[task.priority] ?? "neutral"} size="sm">
+                      {task.priority.toLowerCase()}
+                    </Badge>
                   ) : null}
                   {task.assignedTo ? <span>{task.assignedTo.name}</span> : <span>Unassigned</span>}
                   {record && recordLabel ? (

--- a/components/crm/tasks/task-list.tsx
+++ b/components/crm/tasks/task-list.tsx
@@ -151,7 +151,7 @@ export function TaskList({
                   ) : null}
                 </div>
 
-                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--text-muted)]">
                   <span
                     className={cn(
                       "inline-flex items-center gap-1",
@@ -178,7 +178,7 @@ export function TaskList({
                 </div>
 
                 {task.outcomeNotes ? (
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">{task.outcomeNotes}</p>
+                  <p className="mt-1 text-sm text-[var(--text-muted)]">{task.outcomeNotes}</p>
                 ) : null}
               </div>
 

--- a/components/crm/tasks/tasks-register-content.tsx
+++ b/components/crm/tasks/tasks-register-content.tsx
@@ -120,7 +120,7 @@ export function TasksRegisterContent() {
           <section key={bucket.id} aria-labelledby={`tasks-${bucket.id}`} className="space-y-2">
             <h3
               id={`tasks-${bucket.id}`}
-              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
             >
               <span
                 className={

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -9,14 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { Camera, Plus, Trash2 } from "@/lib/icons";
@@ -212,347 +205,345 @@ export function VisitReportSheet({
   const isLoading = reportQuery.isLoading;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="xl" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>Site visit report{appointmentNo ? ` · ${appointmentNo}` : ""}</SheetTitle>
-          <SheetDescription>
-            Everything captured here feeds the quotation — measure once, quote from it.
-          </SheetDescription>
-        </SheetHeader>
-
-        {isLoading ? (
-          <div className="mt-6 space-y-3">
-            {Array.from({ length: 4 }).map((_, index) => (
-              <Skeleton key={index} className="h-20 w-full" />
-            ))}
-          </div>
-        ) : (
-          <div className="mt-6">
-            <FormShell
-              variant="bare"
-              errors={errors}
-              requiredHint="Save a draft any time — complete the visit when you're off site."
-              onSubmit={(event) => {
-                event.preventDefault();
-                const found = validateForCompletion();
-                setErrors(found);
-                if (found.length === 0) save.mutate(true);
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Site visit report${appointmentNo ? ` · ${appointmentNo}` : ""}`}
+      description="Everything captured here feeds the quotation — measure once, quote from it."
+      size="xl"
+      errors={isLoading ? undefined : errors}
+      onSubmit={
+        isLoading
+          ? undefined
+          : (event) => {
+              event.preventDefault();
+              const found = validateForCompletion();
+              setErrors(found);
+              if (found.length === 0) save.mutate(true);
+            }
+      }
+      footer={
+        isLoading ? null : (
+          <>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={save.isPending}
+              onClick={() => {
+                setErrors([]);
+                save.mutate(false);
               }}
-              actions={
-                <>
-                  <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                    Close
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={save.isPending}
-                    onClick={() => {
-                      setErrors([]);
-                      save.mutate(false);
-                    }}
-                  >
-                    Save draft
-                  </Button>
-                  <Button type="submit" disabled={save.isPending}>
-                    {save.isPending ? "Saving…" : "Complete visit"}
-                  </Button>
-                </>
-              }
             >
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  On-site checklist
-                </h3>
-                <ul className="divide-y divide-[var(--border-subtle)]">
-                  {checklist.map((entry, index) => (
-                    <li key={entry.key} className="space-y-1.5 p-2.5">
-                      <label className="flex cursor-pointer items-center gap-2.5 text-sm">
-                        <Checkbox
-                          checked={entry.checked}
-                          onCheckedChange={(checked) =>
-                            setChecklist((current) =>
-                              current.map((item, i) =>
-                                i === index ? { ...item, checked: checked === true } : item,
-                              ),
-                            )
-                          }
-                        />
-                        <span>{entry.label}</span>
-                      </label>
-                      {entry.checked ? null : (
-                        <Input
-                          value={entry.notes ?? ""}
-                          onChange={(event) =>
-                            setChecklist((current) =>
-                              current.map((item, i) =>
-                                i === index ? { ...item, notes: event.target.value } : item,
-                              ),
-                            )
-                          }
-                          placeholder="Why not? (optional)"
-                          className="h-8 text-sm"
-                          aria-label={`Note for ${entry.label}`}
-                        />
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              </section>
+              Save draft
+            </Button>
+            <Button type="submit" disabled={save.isPending}>
+              {save.isPending ? "Saving…" : "Complete visit"}
+            </Button>
+          </>
+        )
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-20 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              On-site checklist
+            </h3>
+            <ul className="divide-y divide-[var(--border-subtle)]">
+              {checklist.map((entry, index) => (
+                <li key={entry.key} className="space-y-1.5 p-2.5">
+                  <label className="flex cursor-pointer items-center gap-2.5 text-sm">
+                    <Checkbox
+                      checked={entry.checked}
+                      onCheckedChange={(checked) =>
+                        setChecklist((current) =>
+                          current.map((item, i) =>
+                            i === index ? { ...item, checked: checked === true } : item,
+                          ),
+                        )
+                      }
+                    />
+                    <span>{entry.label}</span>
+                  </label>
+                  {entry.checked ? null : (
+                    <Input
+                      value={entry.notes ?? ""}
+                      onChange={(event) =>
+                        setChecklist((current) =>
+                          current.map((item, i) =>
+                            i === index ? { ...item, notes: event.target.value } : item,
+                          ),
+                        )
+                      }
+                      placeholder="Why not? (optional)"
+                      className="h-8 text-sm"
+                      aria-label={`Note for ${entry.label}`}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
 
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Measurements & specifications
-                </h3>
-                <p className="text-sm text-[var(--text-muted)]">
-                  Each row becomes a quotation line. Prices are optional — leave them blank to
-                  price up back at the office.
-                </p>
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Measurements & specifications
+            </h3>
+            <p className="text-sm text-[var(--text-muted)]">
+              Each row becomes a quotation line. Prices are optional — leave them blank to
+              price up back at the office.
+            </p>
 
-                <div className="space-y-3">
-                  {items.map((item, index) => (
-                    <div
-                      key={index}
-                      className="space-y-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
-                    >
-                      <div className="grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_2rem]">
-                        <Input
-                          value={item.category}
-                          onChange={(event) => patchItem(index, { category: event.target.value })}
-                          placeholder="Category"
-                          aria-label={`Item ${index + 1} category`}
-                          maxLength={80}
-                        />
-                        <Input
-                          value={item.description}
-                          onChange={(event) =>
-                            patchItem(index, { description: event.target.value })
-                          }
-                          placeholder="What is it? e.g. Aluminium sliding window"
-                          aria-label={`Item ${index + 1} description`}
-                          maxLength={300}
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-9 w-9 px-0"
-                          aria-label={`Remove item ${index + 1}`}
-                          disabled={items.length === 1}
-                          onClick={() =>
-                            setItems((current) => current.filter((_, i) => i !== index))
-                          }
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-
-                      <div className="grid grid-cols-2 gap-2 sm:grid-cols-6">
-                        <div className="space-y-1">
-                          <Label className="text-sm">Qty</Label>
-                          <Input
-                            value={item.quantity}
-                            onChange={(event) =>
-                              patchItem(index, { quantity: event.target.value })
-                            }
-                            inputMode="decimal"
-                            className="font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-sm">Unit</Label>
-                          <Input
-                            value={item.unit}
-                            onChange={(event) => patchItem(index, { unit: event.target.value })}
-                            list="crm-visit-units"
-                            maxLength={20}
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-sm">Width mm</Label>
-                          <Input
-                            value={item.widthMm}
-                            onChange={(event) => patchItem(index, { widthMm: event.target.value })}
-                            inputMode="decimal"
-                            className="font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-sm">Height mm</Label>
-                          <Input
-                            value={item.heightMm}
-                            onChange={(event) =>
-                              patchItem(index, { heightMm: event.target.value })
-                            }
-                            inputMode="decimal"
-                            className="font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-sm">Depth mm</Label>
-                          <Input
-                            value={item.depthMm}
-                            onChange={(event) => patchItem(index, { depthMm: event.target.value })}
-                            inputMode="decimal"
-                            className="font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-sm">Est. price</Label>
-                          <Input
-                            value={item.unitPrice}
-                            onChange={(event) =>
-                              patchItem(index, { unitPrice: event.target.value })
-                            }
-                            inputMode="decimal"
-                            className="font-mono"
-                            placeholder="—"
-                          />
-                        </div>
-                      </div>
-
-                      <Input
-                        value={item.specNotes}
-                        onChange={(event) => patchItem(index, { specNotes: event.target.value })}
-                        placeholder="Material, finish, glass type, colour…"
-                        aria-label={`Item ${index + 1} specification notes`}
-                        maxLength={500}
-                      />
-                    </div>
-                  ))}
-                </div>
-
-                <datalist id="crm-visit-units">
-                  {UNITS.map((unit) => (
-                    <option key={unit} value={unit} />
-                  ))}
-                </datalist>
-
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5"
-                    onClick={() => setItems((current) => [...current, emptyMeasurement()])}
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    Add item
-                  </Button>
-                  {items.length > 0 ? (
+            <div className="space-y-3">
+              {items.map((item, index) => (
+                <div
+                  key={index}
+                  className="space-y-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
+                >
+                  <div className="grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_2rem]">
+                    <Input
+                      value={item.category}
+                      onChange={(event) => patchItem(index, { category: event.target.value })}
+                      placeholder="Category"
+                      aria-label={`Item ${index + 1} category`}
+                      maxLength={80}
+                    />
+                    <Input
+                      value={item.description}
+                      onChange={(event) =>
+                        patchItem(index, { description: event.target.value })
+                      }
+                      placeholder="What is it? e.g. Aluminium sliding window"
+                      aria-label={`Item ${index + 1} description`}
+                      maxLength={300}
+                    />
                     <Button
                       type="button"
                       variant="ghost"
                       size="sm"
+                      className="h-9 w-9 px-0"
+                      aria-label={`Remove item ${index + 1}`}
+                      disabled={items.length === 1}
                       onClick={() =>
-                        setItems((current) => [...current, { ...current[current.length - 1] }])
+                        setItems((current) => current.filter((_, i) => i !== index))
                       }
                     >
-                      Duplicate last
+                      <Trash2 className="h-4 w-4" />
                     </Button>
-                  ) : null}
-                </div>
-              </section>
+                  </div>
 
-              <section className="space-y-2">
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                  Photos & files
-                </h3>
-                <label className="flex cursor-pointer items-center justify-center gap-2 rounded-[var(--card-radius)] border border-dashed border-[var(--border)] p-4 text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)]">
-                  <Camera className="h-4 w-4" />
-                  {uploading ? "Uploading…" : "Add photos of every work area"}
-                  <input
-                    type="file"
-                    multiple
-                    accept="image/*,application/pdf"
-                    className="sr-only"
-                    disabled={uploading}
-                    onChange={(event) => {
-                      const files = Array.from(event.target.files ?? []);
-                      if (files.length > 0) void uploadFiles(files);
-                      event.target.value = "";
-                    }}
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-6">
+                    <div className="space-y-1">
+                      <Label className="text-sm">Qty</Label>
+                      <Input
+                        value={item.quantity}
+                        onChange={(event) =>
+                          patchItem(index, { quantity: event.target.value })
+                        }
+                        inputMode="decimal"
+                        className="font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-sm">Unit</Label>
+                      <Input
+                        value={item.unit}
+                        onChange={(event) => patchItem(index, { unit: event.target.value })}
+                        list="crm-visit-units"
+                        maxLength={20}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-sm">Width mm</Label>
+                      <Input
+                        value={item.widthMm}
+                        onChange={(event) => patchItem(index, { widthMm: event.target.value })}
+                        inputMode="decimal"
+                        className="font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-sm">Height mm</Label>
+                      <Input
+                        value={item.heightMm}
+                        onChange={(event) =>
+                          patchItem(index, { heightMm: event.target.value })
+                        }
+                        inputMode="decimal"
+                        className="font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-sm">Depth mm</Label>
+                      <Input
+                        value={item.depthMm}
+                        onChange={(event) => patchItem(index, { depthMm: event.target.value })}
+                        inputMode="decimal"
+                        className="font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-sm">Est. price</Label>
+                      <Input
+                        value={item.unitPrice}
+                        onChange={(event) =>
+                          patchItem(index, { unitPrice: event.target.value })
+                        }
+                        inputMode="decimal"
+                        className="font-mono"
+                        placeholder="—"
+                      />
+                    </div>
+                  </div>
+
+                  <Input
+                    value={item.specNotes}
+                    onChange={(event) => patchItem(index, { specNotes: event.target.value })}
+                    placeholder="Material, finish, glass type, colour…"
+                    aria-label={`Item ${index + 1} specification notes`}
+                    maxLength={500}
                   />
-                </label>
+                </div>
+              ))}
+            </div>
 
-                {photos.length > 0 ? (
-                  <ul className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    {photos.map((photo, index) => (
-                      <li
-                        key={photo.url}
-                        className="space-y-1 rounded-[var(--card-radius)] border border-[var(--border)] p-1.5"
-                      >
-                        <a href={photo.url} target="_blank" rel="noreferrer" className="block">
-                          {photo.kind === "PHOTO" ? (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img
-                              src={photo.url}
-                              alt={photo.caption ?? photo.fileName ?? "Site photo"}
-                              className="h-24 w-full rounded object-cover"
-                            />
-                          ) : (
-                            <span className="flex h-24 items-center justify-center rounded bg-[var(--surface-muted)] px-2 text-center text-sm">
-                              {photo.fileName ?? "File"}
-                            </span>
-                          )}
-                        </a>
-                        <Input
-                          value={photo.caption ?? ""}
-                          onChange={(event) =>
-                            setPhotos((current) =>
-                              current.map((entry, i) =>
-                                i === index ? { ...entry, caption: event.target.value } : entry,
-                              ),
-                            )
-                          }
-                          placeholder="Caption"
-                          className="h-7 text-sm"
-                          aria-label="Photo caption"
+            <datalist id="crm-visit-units">
+              {UNITS.map((unit) => (
+                <option key={unit} value={unit} />
+              ))}
+            </datalist>
+
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => setItems((current) => [...current, emptyMeasurement()])}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add item
+              </Button>
+              {items.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setItems((current) => [...current, { ...current[current.length - 1] }])
+                  }
+                >
+                  Duplicate last
+                </Button>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Photos & files
+            </h3>
+            <label className="flex cursor-pointer items-center justify-center gap-2 rounded-[var(--card-radius)] border border-dashed border-[var(--border)] p-4 text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)]">
+              <Camera className="h-4 w-4" />
+              {uploading ? "Uploading…" : "Add photos of every work area"}
+              <input
+                type="file"
+                multiple
+                accept="image/*,application/pdf"
+                className="sr-only"
+                disabled={uploading}
+                onChange={(event) => {
+                  const files = Array.from(event.target.files ?? []);
+                  if (files.length > 0) void uploadFiles(files);
+                  event.target.value = "";
+                }}
+              />
+            </label>
+
+            {photos.length > 0 ? (
+              <ul className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {photos.map((photo, index) => (
+                  <li
+                    key={photo.url}
+                    className="space-y-1 rounded-[var(--card-radius)] border border-[var(--border)] p-1.5"
+                  >
+                    <a href={photo.url} target="_blank" rel="noreferrer" className="block">
+                      {photo.kind === "PHOTO" ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={photo.url}
+                          alt={photo.caption ?? photo.fileName ?? "Site photo"}
+                          className="h-24 w-full rounded object-cover"
                         />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 w-full text-sm"
-                          onClick={() =>
-                            setPhotos((current) => current.filter((_, i) => i !== index))
-                          }
-                        >
-                          Remove
-                        </Button>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </section>
+                      ) : (
+                        <span className="flex h-24 items-center justify-center rounded bg-[var(--surface-muted)] px-2 text-center text-sm">
+                          {photo.fileName ?? "File"}
+                        </span>
+                      )}
+                    </a>
+                    <Input
+                      value={photo.caption ?? ""}
+                      onChange={(event) =>
+                        setPhotos((current) =>
+                          current.map((entry, i) =>
+                            i === index ? { ...entry, caption: event.target.value } : entry,
+                          ),
+                        )
+                      }
+                      placeholder="Caption"
+                      className="h-7 text-sm"
+                      aria-label="Photo caption"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-full text-sm"
+                      onClick={() =>
+                        setPhotos((current) => current.filter((_, i) => i !== index))
+                      }
+                    >
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </section>
 
-              <section className="space-y-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="site-conditions">Site conditions</Label>
-                  <Textarea
-                    id="site-conditions"
-                    value={siteConditions}
-                    onChange={(event) => setSiteConditions(event.target.value)}
-                    rows={3}
-                    placeholder="Access, power and water, terrain, obstructions, anything that affects the price or the schedule."
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="report-notes">Findings</Label>
-                  <Textarea
-                    id="report-notes"
-                    value={reportNotes}
-                    onChange={(event) => setReportNotes(event.target.value)}
-                    rows={3}
-                    placeholder="What you found, what the client asked for, what you promised."
-                  />
-                </div>
-              </section>
-            </FormShell>
-          </div>
-        )}
-      </SheetContent>
-    </Sheet>
+          <section className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="site-conditions">Site conditions</Label>
+              <Textarea
+                id="site-conditions"
+                value={siteConditions}
+                onChange={(event) => setSiteConditions(event.target.value)}
+                rows={3}
+                placeholder="Access, power and water, terrain, obstructions, anything that affects the price or the schedule."
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="report-notes">Findings</Label>
+              <Textarea
+                id="report-notes"
+                value={reportNotes}
+                onChange={(event) => setReportNotes(event.target.value)}
+                rows={3}
+                placeholder="What you found, what the client asked for, what you promised."
+              />
+            </div>
+          </section>
+        </div>
+      )}
+    </RecordDialog>
   );
 }

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -262,10 +262,10 @@ export function VisitReportSheet({
               }
             >
               <section className="space-y-2">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   On-site checklist
                 </h3>
-                <ul className="divide-y divide-[var(--border)] rounded-[var(--card-radius)] border border-[var(--border)]">
+                <ul className="divide-y divide-[var(--border-subtle)]">
                   {checklist.map((entry, index) => (
                     <li key={entry.key} className="space-y-1.5 p-2.5">
                       <label className="flex cursor-pointer items-center gap-2.5 text-sm">
@@ -302,10 +302,10 @@ export function VisitReportSheet({
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   Measurements & specifications
                 </h3>
-                <p className="text-xs text-[var(--text-muted)]">
+                <p className="text-sm text-[var(--text-muted)]">
                   Each row becomes a quotation line. Prices are optional — leave them blank to
                   price up back at the office.
                 </p>
@@ -350,7 +350,7 @@ export function VisitReportSheet({
 
                       <div className="grid grid-cols-2 gap-2 sm:grid-cols-6">
                         <div className="space-y-1">
-                          <Label className="text-xs">Qty</Label>
+                          <Label className="text-sm">Qty</Label>
                           <Input
                             value={item.quantity}
                             onChange={(event) =>
@@ -361,7 +361,7 @@ export function VisitReportSheet({
                           />
                         </div>
                         <div className="space-y-1">
-                          <Label className="text-xs">Unit</Label>
+                          <Label className="text-sm">Unit</Label>
                           <Input
                             value={item.unit}
                             onChange={(event) => patchItem(index, { unit: event.target.value })}
@@ -370,7 +370,7 @@ export function VisitReportSheet({
                           />
                         </div>
                         <div className="space-y-1">
-                          <Label className="text-xs">Width mm</Label>
+                          <Label className="text-sm">Width mm</Label>
                           <Input
                             value={item.widthMm}
                             onChange={(event) => patchItem(index, { widthMm: event.target.value })}
@@ -379,7 +379,7 @@ export function VisitReportSheet({
                           />
                         </div>
                         <div className="space-y-1">
-                          <Label className="text-xs">Height mm</Label>
+                          <Label className="text-sm">Height mm</Label>
                           <Input
                             value={item.heightMm}
                             onChange={(event) =>
@@ -390,7 +390,7 @@ export function VisitReportSheet({
                           />
                         </div>
                         <div className="space-y-1">
-                          <Label className="text-xs">Depth mm</Label>
+                          <Label className="text-sm">Depth mm</Label>
                           <Input
                             value={item.depthMm}
                             onChange={(event) => patchItem(index, { depthMm: event.target.value })}
@@ -399,7 +399,7 @@ export function VisitReportSheet({
                           />
                         </div>
                         <div className="space-y-1">
-                          <Label className="text-xs">Est. price</Label>
+                          <Label className="text-sm">Est. price</Label>
                           <Input
                             value={item.unitPrice}
                             onChange={(event) =>
@@ -456,7 +456,7 @@ export function VisitReportSheet({
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                   Photos & files
                 </h3>
                 <label className="flex cursor-pointer items-center justify-center gap-2 rounded-[var(--card-radius)] border border-dashed border-[var(--border)] p-4 text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)]">
@@ -492,7 +492,7 @@ export function VisitReportSheet({
                               className="h-24 w-full rounded object-cover"
                             />
                           ) : (
-                            <span className="flex h-24 items-center justify-center rounded bg-[var(--surface-muted)] px-2 text-center text-xs">
+                            <span className="flex h-24 items-center justify-center rounded bg-[var(--surface-muted)] px-2 text-center text-sm">
                               {photo.fileName ?? "File"}
                             </span>
                           )}
@@ -507,14 +507,14 @@ export function VisitReportSheet({
                             )
                           }
                           placeholder="Caption"
-                          className="h-7 text-xs"
+                          className="h-7 text-sm"
                           aria-label="Photo caption"
                         />
                         <Button
                           type="button"
                           variant="ghost"
                           size="sm"
-                          className="h-7 w-full text-xs"
+                          className="h-7 w-full text-sm"
                           onClick={() =>
                             setPhotos((current) => current.filter((_, i) => i !== index))
                           }

--- a/components/crm/visits/visit-schedule-sheet.tsx
+++ b/components/crm/visits/visit-schedule-sheet.tsx
@@ -14,14 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 
@@ -140,112 +133,99 @@ export function VisitScheduleSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent size="md" className="w-full overflow-y-auto p-6">
-        <SheetHeader>
-          <SheetTitle>Schedule a site visit</SheetTitle>
-          <SheetDescription>
-            The visit is where the job gets specified — measurements taken here become the
-            quotation.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Schedule a site visit"
+      description="The visit is where the job gets specified — measurements taken here become the quotation."
+      size="md"
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const found = validate();
+        setErrors(found);
+        if (found.length === 0) book.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={book.isPending}>
+          {book.isPending ? "Scheduling…" : "Schedule visit"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="visit-title">Title</Label>
+        <Input
+          id="visit-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          maxLength={200}
+        />
+      </div>
 
-        <div className="mt-6">
-          <FormShell
-            variant="bare"
-            errors={errors}
-            requiredHint="A start time and an assignee are required."
-            onSubmit={(event) => {
-              event.preventDefault();
-              const found = validate();
-              setErrors(found);
-              if (found.length === 0) book.mutate();
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="visit-start">Starts *</Label>
+          <Input
+            id="visit-start"
+            type="datetime-local"
+            value={start}
+            onChange={(event) => {
+              setStart(event.target.value);
+              if (event.target.value) setEnd(addHours(event.target.value, 2));
             }}
-            actions={
-              <>
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={book.isPending}>
-                  {book.isPending ? "Scheduling…" : "Schedule visit"}
-                </Button>
-              </>
-            }
-          >
-            <div className="space-y-1.5">
-              <Label htmlFor="visit-title">Title</Label>
-              <Input
-                id="visit-title"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                maxLength={200}
-              />
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="visit-start">Starts *</Label>
-                <Input
-                  id="visit-start"
-                  type="datetime-local"
-                  value={start}
-                  onChange={(event) => {
-                    setStart(event.target.value);
-                    if (event.target.value) setEnd(addHours(event.target.value, 2));
-                  }}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="visit-end">Ends</Label>
-                <Input
-                  id="visit-end"
-                  type="datetime-local"
-                  value={end}
-                  onChange={(event) => setEnd(event.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="visit-location">Location</Label>
-              <Input
-                id="visit-location"
-                value={location}
-                onChange={(event) => setLocation(event.target.value)}
-                placeholder="Street address, or where to meet on site"
-                maxLength={300}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="visit-assignee">Assigned to *</Label>
-              <Select value={assignedToId} onValueChange={setAssignedToId}>
-                <SelectTrigger id="visit-assignee">
-                  <SelectValue placeholder="Who's going?" />
-                </SelectTrigger>
-                <SelectContent>
-                  {owners.map((owner) => (
-                    <SelectItem key={owner.id} value={owner.id}>
-                      {owner.name ?? "Unnamed"}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="visit-notes">Notes</Label>
-              <Textarea
-                id="visit-notes"
-                value={notes}
-                onChange={(event) => setNotes(event.target.value)}
-                rows={3}
-                placeholder="Access arrangements, who to ask for, what to bring."
-              />
-            </div>
-          </FormShell>
+          />
         </div>
-      </SheetContent>
-    </Sheet>
+        <div className="space-y-1.5">
+          <Label htmlFor="visit-end">Ends</Label>
+          <Input
+            id="visit-end"
+            type="datetime-local"
+            value={end}
+            onChange={(event) => setEnd(event.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="visit-location">Location</Label>
+        <Input
+          id="visit-location"
+          value={location}
+          onChange={(event) => setLocation(event.target.value)}
+          placeholder="Street address, or where to meet on site"
+          maxLength={300}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="visit-assignee">Assigned to *</Label>
+        <Select value={assignedToId} onValueChange={setAssignedToId}>
+          <SelectTrigger id="visit-assignee">
+            <SelectValue placeholder="Who's going?" />
+          </SelectTrigger>
+          <SelectContent>
+            {owners.map((owner) => (
+              <SelectItem key={owner.id} value={owner.id}>
+                {owner.name ?? "Unnamed"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="visit-notes">Notes</Label>
+        <Textarea
+          id="visit-notes"
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          rows={3}
+          placeholder="Access arrangements, who to ask for, what to bring."
+        />
+      </div>
+    </RecordDialog>
   );
 }

--- a/components/crm/work-orders/raise-job-sheet.tsx
+++ b/components/crm/work-orders/raise-job-sheet.tsx
@@ -14,14 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { FormShell } from "@/components/shared/form-shell";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 
@@ -120,120 +113,109 @@ export function RaiseJobSheet({
   });
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full sm:max-w-lg">
-        <SheetHeader>
-          <SheetTitle>Raise a job</SheetTitle>
-          <SheetDescription>
-            The checklist comes straight off the quote, so nothing is retyped.
-          </SheetDescription>
-        </SheetHeader>
+    <RecordDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Raise a job"
+      description="The checklist comes straight off the quote, so nothing is retyped."
+      errors={errors}
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!title.trim()) {
+          setErrors(["Give the job a title the crew will recognise"]);
+          return;
+        }
+        setErrors([]);
+        create.mutate();
+      }}
+      footer={<>
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={create.isPending}>
+          {create.isPending ? "Raising…" : "Raise job"}
+        </Button>
+      </>}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="job-title">Title *</Label>
+        <Input
+          id="job-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="Install 14 panels — Msasa depot"
+        />
+      </div>
 
-        <FormShell
-          variant="bare"
-          errors={errors}
-          requiredHint="A title is required."
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (!title.trim()) {
-              setErrors(["Give the job a title the crew will recognise"]);
-              return;
-            }
-            setErrors([]);
-            create.mutate();
-          }}
-          actions={
-            <>
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={create.isPending}>
-                {create.isPending ? "Raising…" : "Raise job"}
-              </Button>
-            </>
-          }
-        >
-          <div className="space-y-1.5">
-            <Label htmlFor="job-title">Title *</Label>
-            <Input
-              id="job-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="Install 14 panels — Msasa depot"
-            />
-          </div>
+      {quotationDocuments.length ? (
+        <div className="space-y-1.5">
+          <Label>Checklist from</Label>
+          <Select value={documentId} onValueChange={setDocumentId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Nothing — I'll add items later" />
+            </SelectTrigger>
+            <SelectContent>
+              {quotationDocuments.map((document) => (
+                <SelectItem key={document.id} value={document.id}>
+                  {document.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : (
+        <p className="text-sm text-[var(--text-muted)]">
+          No quote on this deal, so the job starts with an empty checklist.
+        </p>
+      )}
 
-          {quotationDocuments.length ? (
-            <div className="space-y-1.5">
-              <Label>Checklist from</Label>
-              <Select value={documentId} onValueChange={setDocumentId}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Nothing — I'll add items later" />
-                </SelectTrigger>
-                <SelectContent>
-                  {quotationDocuments.map((document) => (
-                    <SelectItem key={document.id} value={document.id}>
-                      {document.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ) : (
-            <p className="text-sm text-[var(--text-muted)]">
-              No quote on this deal, so the job starts with an empty checklist.
-            </p>
-          )}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="job-start">Starts</Label>
+          <Input
+            id="job-start"
+            type="datetime-local"
+            value={scheduledStart}
+            onChange={(event) => setScheduledStart(event.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label>Crew lead</Label>
+          <Select value={assignedToId} onValueChange={setAssignedToId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Unassigned" />
+            </SelectTrigger>
+            <SelectContent>
+              {(team?.data ?? []).map((user) => (
+                <SelectItem key={user.id} value={user.id}>
+                  {user.name ?? user.email}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="job-start">Starts</Label>
-              <Input
-                id="job-start"
-                type="datetime-local"
-                value={scheduledStart}
-                onChange={(event) => setScheduledStart(event.target.value)}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label>Crew lead</Label>
-              <Select value={assignedToId} onValueChange={setAssignedToId}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Unassigned" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(team?.data ?? []).map((user) => (
-                    <SelectItem key={user.id} value={user.id}>
-                      {user.name ?? user.email}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="job-address">Address</Label>
+        <Input
+          id="job-address"
+          value={addressLine}
+          onChange={(event) => setAddressLine(event.target.value)}
+          placeholder="Leave blank to use the site's"
+        />
+      </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="job-address">Address</Label>
-            <Input
-              id="job-address"
-              value={addressLine}
-              onChange={(event) => setAddressLine(event.target.value)}
-              placeholder="Leave blank to use the site's"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="job-access">Getting in</Label>
-            <Textarea
-              id="job-access"
-              rows={2}
-              value={accessNotes}
-              onChange={(event) => setAccessNotes(event.target.value)}
-              placeholder="Ask for the security office, gate code 4471…"
-            />
-          </div>
-        </FormShell>
-      </SheetContent>
-    </Sheet>
+      <div className="space-y-1.5">
+        <Label htmlFor="job-access">Getting in</Label>
+        <Textarea
+          id="job-access"
+          rows={2}
+          value={accessNotes}
+          onChange={(event) => setAccessNotes(event.target.value)}
+          placeholder="Ask for the security office, gate code 4471…"
+        />
+      </div>
+    </RecordDialog>
   );
 }

--- a/components/crm/work-orders/work-order-sheet.tsx
+++ b/components/crm/work-orders/work-order-sheet.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -12,13 +11,8 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusChip } from "@/components/ui/status-chip";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { RecordDialog } from "@/components/crm/records/record-dialog";
+import { EntityLink } from "@/components/crm/records/entity-link";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -158,248 +152,247 @@ export function WorkOrderSheet({
       !order.assignedTo);
 
   return (
-    <Sheet open={Boolean(workOrderId)} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
-        {isLoading || !order ? (
-          <div className="space-y-3 pt-6">
-            <Skeleton className="h-8 w-2/3" />
-            <Skeleton className="h-40" />
+    <RecordDialog
+      open={Boolean(workOrderId)}
+      onOpenChange={onOpenChange}
+      title={order?.title ?? "Job"}
+      description="What was agreed, what has been done, and who signed it off."
+    >
+      {isLoading || !order ? (
+        <div className="space-y-3">
+          <Skeleton className="h-8 w-2/3" />
+          <Skeleton className="h-40" />
+        </div>
+      ) : (
+        <>
+          {/* The reference and status sit here rather than in the dialog
+              header, which only carries a name. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-sm text-[var(--text-muted)]">
+              {order.workOrderNo}
+            </span>
+            <StatusChip
+              status={STATUS_TONE[order.status] ?? "inactive"}
+              label={WORK_ORDER_STATUS_LABELS[order.status]}
+            />
+            {order.deal ? (
+              <EntityLink href={`/crm/deals/${order.deal.id}`} muted className="text-sm">
+                {order.deal.title}
+              </EntityLink>
+            ) : null}
           </div>
-        ) : (
-          <>
-            <SheetHeader>
-              <div className="flex flex-wrap items-center gap-2">
-                <SheetTitle>{order.title}</SheetTitle>
-                <StatusChip
-                  status={STATUS_TONE[order.status] ?? "inactive"}
-                  label={WORK_ORDER_STATUS_LABELS[order.status]}
-                />
-              </div>
-              <SheetDescription>
-                <span className="font-mono">{order.workOrderNo}</span>
-                {order.deal ? (
-                  <>
-                    {" · "}
-                    <Link href={`/crm/deals/${order.deal.id}`} className="hover:underline">
-                      {order.deal.title}
-                    </Link>
-                  </>
-                ) : null}
-              </SheetDescription>
-            </SheetHeader>
 
-            <div className="space-y-5 pb-6">
-              {error ? (
-                <Alert variant="destructive">
-                  <AlertDescription>{error}</AlertDescription>
-                </Alert>
-              ) : null}
+          <div className="space-y-5">
+            {error ? (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            ) : null}
 
-              {blockers.length ? (
-                <Alert>
-                  <AlertTitle>Not ready to close</AlertTitle>
-                  <AlertDescription>
-                    <ul className="list-disc space-y-1 pl-5">
-                      {blockers.map((blocker) => (
-                        <li key={blocker}>{blocker}</li>
-                      ))}
-                    </ul>
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-
-              <section className="space-y-1.5 text-sm">
-                {order.scheduledStart ? (
-                  <p className="flex items-center gap-2">
-                    <Clock className="size-4 text-[var(--text-muted)]" />
-                    <ClientDate value={order.scheduledStart} mode="datetime" />
-                  </p>
-                ) : null}
-                {order.site?.addressLine || order.addressLine ? (
-                  <p className="flex items-start gap-2">
-                    <MapPin className="mt-0.5 size-4 shrink-0 text-[var(--text-muted)]" />
-                    <span>
-                      {order.site?.name ? <strong>{order.site.name}</strong> : null}
-                      {order.site?.name ? " — " : ""}
-                      {order.site?.addressLine ?? order.addressLine}
-                    </span>
-                  </p>
-                ) : null}
-                {order.contactPhone ? (
-                  <p className="flex items-center gap-2">
-                    <Phone className="size-4 text-[var(--text-muted)]" />
-                    {/* Tappable, because this is read standing outside a gate. */}
-                    <a href={`tel:${order.contactPhone}`} className="hover:underline">
-                      {order.contactName ? `${order.contactName} — ` : ""}
-                      {order.contactPhone}
-                    </a>
-                  </p>
-                ) : null}
-                {order.accessNotes || order.site?.accessInstructions ? (
-                  <p className="rounded-[var(--radius-md)] bg-[var(--surface-subtle)] p-2 text-sm">
-                    {order.accessNotes ?? order.site?.accessInstructions}
-                  </p>
-                ) : null}
-              </section>
-
-              {order.description ? (
-                <p className="whitespace-pre-wrap text-sm text-[var(--text-muted)]">
-                  {order.description}
-                </p>
-              ) : null}
-
-              {order.items.length > 0 ? (
-                <section className="space-y-2">
-                  <div className="flex items-baseline justify-between">
-                    <h3 className="text-sm font-semibold">What needs doing</h3>
-                    <span className="text-sm text-[var(--text-muted)]">
-                      {completionPercent(order.items)}% done
-                    </span>
-                  </div>
-
-                  <ul className="space-y-2">
-                    {order.items.map((item) => (
-                      <li
-                        key={item.id}
-                        className="flex items-center gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-2"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm">{item.description}</p>
-                          {item.notes ? (
-                            <p className="text-sm text-[var(--text-muted)]">{item.notes}</p>
-                          ) : null}
-                        </div>
-                        <div className="flex items-center gap-1 text-sm">
-                          <Input
-                            className="h-9 w-16 text-right"
-                            type="number"
-                            min={0}
-                            max={item.quantity}
-                            inputMode="decimal"
-                            disabled={order.status === "COMPLETED"}
-                            value={progress[item.id] ?? String(item.completedQuantity)}
-                            onChange={(event) =>
-                              setProgress((previous) => ({
-                                ...previous,
-                                [item.id]: event.target.value,
-                              }))
-                            }
-                          />
-                          <span className="text-[var(--text-muted)]">
-                            / {item.quantity}
-                            {item.unit ? ` ${item.unit}` : ""}
-                          </span>
-                        </div>
-                      </li>
+            {blockers.length ? (
+              <Alert>
+                <AlertTitle>Not ready to close</AlertTitle>
+                <AlertDescription>
+                  <ul className="list-disc space-y-1 pl-5">
+                    {blockers.map((blocker) => (
+                      <li key={blocker}>{blocker}</li>
                     ))}
                   </ul>
-                </section>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <section className="space-y-1.5 text-sm">
+              {order.scheduledStart ? (
+                <p className="flex items-center gap-2">
+                  <Clock className="size-4 text-[var(--text-muted)]" />
+                  <ClientDate value={order.scheduledStart} mode="datetime" />
+                </p>
               ) : null}
+              {order.site?.addressLine || order.addressLine ? (
+                <p className="flex items-start gap-2">
+                  <MapPin className="mt-0.5 size-4 shrink-0 text-[var(--text-muted)]" />
+                  <span>
+                    {order.site?.name ? <strong>{order.site.name}</strong> : null}
+                    {order.site?.name ? " — " : ""}
+                    {order.site?.addressLine ?? order.addressLine}
+                  </span>
+                </p>
+              ) : null}
+              {order.contactPhone ? (
+                <p className="flex items-center gap-2">
+                  <Phone className="size-4 text-[var(--text-muted)]" />
+                  {/* Tappable, because this is read standing outside a gate. */}
+                  <a href={`tel:${order.contactPhone}`} className="hover:underline">
+                    {order.contactName ? `${order.contactName} — ` : ""}
+                    {order.contactPhone}
+                  </a>
+                </p>
+              ) : null}
+              {order.accessNotes || order.site?.accessInstructions ? (
+                <p className="rounded-[var(--radius-md)] bg-[var(--surface-subtle)] p-2 text-sm">
+                  {order.accessNotes ?? order.site?.accessInstructions}
+                </p>
+              ) : null}
+            </section>
 
-              {order.status === "COMPLETED" ? (
-                <section className="space-y-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-3 text-sm">
-                  <p className="font-medium">Signed off by {order.signedByName}</p>
-                  {order.customerRating ? (
-                    <p className="text-[var(--text-muted)]">
-                      Rated {order.customerRating} out of 5
-                    </p>
-                  ) : null}
-                  {order.completionNotes ? (
-                    <p className="text-[var(--text-muted)]">{order.completionNotes}</p>
-                  ) : null}
-                </section>
-              ) : canAct ? (
-                <section className="space-y-3">
-                  {order.status === "IN_PROGRESS" ? (
-                    <>
-                      <div className="space-y-1.5">
-                        <Label htmlFor="signed-by">Signed off by *</Label>
+            {order.description ? (
+              <p className="whitespace-pre-wrap text-sm text-[var(--text-muted)]">
+                {order.description}
+              </p>
+            ) : null}
+
+            {order.items.length > 0 ? (
+              <section className="space-y-2">
+                <div className="flex items-baseline justify-between">
+                  <h3 className="text-sm font-semibold">What needs doing</h3>
+                  <span className="text-sm text-[var(--text-muted)]">
+                    {completionPercent(order.items)}% done
+                  </span>
+                </div>
+
+                <ul className="space-y-2">
+                  {order.items.map((item) => (
+                    <li
+                      key={item.id}
+                      className="flex items-center gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-2"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm">{item.description}</p>
+                        {item.notes ? (
+                          <p className="text-sm text-[var(--text-muted)]">{item.notes}</p>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center gap-1 text-sm">
                         <Input
-                          id="signed-by"
-                          value={signedByName}
-                          onChange={(event) => setSignedByName(event.target.value)}
-                          placeholder="Who at the site accepted the work"
+                          className="h-9 w-16 text-right"
+                          type="number"
+                          min={0}
+                          max={item.quantity}
+                          inputMode="decimal"
+                          disabled={order.status === "COMPLETED"}
+                          value={progress[item.id] ?? String(item.completedQuantity)}
+                          onChange={(event) =>
+                            setProgress((previous) => ({
+                              ...previous,
+                              [item.id]: event.target.value,
+                            }))
+                          }
                         />
+                        <span className="text-[var(--text-muted)]">
+                          / {item.quantity}
+                          {item.unit ? ` ${item.unit}` : ""}
+                        </span>
                       </div>
-                      <div className="space-y-1.5">
-                        <Label htmlFor="completion-notes">Notes</Label>
-                        <Textarea
-                          id="completion-notes"
-                          rows={2}
-                          value={completionNotes}
-                          onChange={(event) => setCompletionNotes(event.target.value)}
-                        />
-                      </div>
-                    </>
-                  ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
 
-                  {order.status === "BLOCKED" || order.allowedTransitions?.includes("BLOCKED") ? (
+            {order.status === "COMPLETED" ? (
+              <section className="space-y-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] p-3 text-sm">
+                <p className="font-medium">Signed off by {order.signedByName}</p>
+                {order.customerRating ? (
+                  <p className="text-[var(--text-muted)]">
+                    Rated {order.customerRating} out of 5
+                  </p>
+                ) : null}
+                {order.completionNotes ? (
+                  <p className="text-[var(--text-muted)]">{order.completionNotes}</p>
+                ) : null}
+              </section>
+            ) : canAct ? (
+              <section className="space-y-3">
+                {order.status === "IN_PROGRESS" ? (
+                  <>
                     <div className="space-y-1.5">
-                      <Label htmlFor="blocked-reason">If it&apos;s blocked, why</Label>
+                      <Label htmlFor="signed-by">Signed off by *</Label>
                       <Input
-                        id="blocked-reason"
-                        value={blockedReason || (order.blockedReason ?? "")}
-                        onChange={(event) => setBlockedReason(event.target.value)}
-                        placeholder="Gate locked, wrong parts delivered…"
+                        id="signed-by"
+                        value={signedByName}
+                        onChange={(event) => setSignedByName(event.target.value)}
+                        placeholder="Who at the site accepted the work"
                       />
                     </div>
-                  ) : null}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="completion-notes">Notes</Label>
+                      <Textarea
+                        id="completion-notes"
+                        rows={2}
+                        value={completionNotes}
+                        onChange={(event) => setCompletionNotes(event.target.value)}
+                      />
+                    </div>
+                  </>
+                ) : null}
 
-                  <div className="flex flex-wrap gap-2">
-                    {(order.allowedTransitions ?? []).map((status) => (
-                      <Button
-                        key={status}
-                        type="button"
-                        variant={status === "COMPLETED" ? "default" : "outline"}
-                        size="sm"
-                        disabled={update.isPending}
-                        onClick={() =>
-                          update.mutate({
-                            status,
-                            itemProgress: itemProgress(),
-                            ...(status === "COMPLETED"
-                              ? {
-                                  signedByName: signedByName.trim() || undefined,
-                                  completionNotes: completionNotes.trim() || undefined,
-                                }
-                              : {}),
-                            ...(status === "BLOCKED"
-                              ? { blockedReason: blockedReason.trim() || undefined }
-                              : {}),
-                          })
-                        }
-                      >
-                        {status === "COMPLETED"
-                          ? "Complete job"
-                          : status === "IN_PROGRESS"
-                            ? "Start job"
-                            : WORK_ORDER_STATUS_LABELS[status]}
-                      </Button>
-                    ))}
+                {order.status === "BLOCKED" || order.allowedTransitions?.includes("BLOCKED") ? (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="blocked-reason">If it&apos;s blocked, why</Label>
+                    <Input
+                      id="blocked-reason"
+                      value={blockedReason || (order.blockedReason ?? "")}
+                      onChange={(event) => setBlockedReason(event.target.value)}
+                      placeholder="Gate locked, wrong parts delivered…"
+                    />
                   </div>
+                ) : null}
 
-                  {Object.keys(progress).length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {(order.allowedTransitions ?? []).map((status) => (
                     <Button
+                      key={status}
                       type="button"
-                      variant="ghost"
+                      variant={status === "COMPLETED" ? "default" : "outline"}
                       size="sm"
                       disabled={update.isPending}
-                      onClick={() => update.mutate({ itemProgress: itemProgress() })}
+                      onClick={() =>
+                        update.mutate({
+                          status,
+                          itemProgress: itemProgress(),
+                          ...(status === "COMPLETED"
+                            ? {
+                                signedByName: signedByName.trim() || undefined,
+                                completionNotes: completionNotes.trim() || undefined,
+                              }
+                            : {}),
+                          ...(status === "BLOCKED"
+                            ? { blockedReason: blockedReason.trim() || undefined }
+                            : {}),
+                        })
+                      }
                     >
-                      Save progress
+                      {status === "COMPLETED"
+                        ? "Complete job"
+                        : status === "IN_PROGRESS"
+                          ? "Start job"
+                          : WORK_ORDER_STATUS_LABELS[status]}
                     </Button>
-                  ) : null}
-                </section>
-              ) : (
-                <p className="text-sm text-[var(--text-muted)]">
-                  You&apos;re not on this job, so it&apos;s read-only for you.
-                </p>
-              )}
-            </div>
-          </>
-        )}
-      </SheetContent>
-    </Sheet>
+                  ))}
+                </div>
+
+                {Object.keys(progress).length > 0 ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={update.isPending}
+                    onClick={() => update.mutate({ itemProgress: itemProgress() })}
+                  >
+                    Save progress
+                  </Button>
+                ) : null}
+              </section>
+            ) : (
+              <p className="text-sm text-[var(--text-muted)]">
+                You&apos;re not on this job, so it&apos;s read-only for you.
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </RecordDialog>
   );
 }
 

--- a/components/crm/work-orders/work-order-sheet.tsx
+++ b/components/crm/work-orders/work-order-sheet.tsx
@@ -14,6 +14,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { RecordDialog } from "@/components/crm/records/record-dialog";
 import { EntityLink } from "@/components/crm/records/entity-link";
 import { useToast } from "@/components/ui/use-toast";
+import { WORK_ORDER_STATUS } from "@/lib/crm/tones";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   WORK_ORDER_STATUS_LABELS,
@@ -21,7 +22,6 @@ import {
   type WorkOrderQueue,
 } from "@/lib/crm/work-orders";
 import { Clock, MapPin, Phone } from "@/lib/icons";
-import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 export type WorkOrderItem = {
   id: string;
@@ -55,15 +55,6 @@ export type WorkOrderRecord = {
   client: { id: string; name: string } | null;
   deal: { id: string; dealNo: string; title: string } | null;
   allowedTransitions?: (keyof typeof WORK_ORDER_STATUS_LABELS)[];
-};
-
-const STATUS_TONE: Record<string, CanonicalUiStatus> = {
-  DRAFT: "inactive",
-  SCHEDULED: "pending",
-  IN_PROGRESS: "in_progress",
-  BLOCKED: "failing",
-  COMPLETED: "passing",
-  CANCELLED: "inactive",
 };
 
 /**
@@ -172,7 +163,7 @@ export function WorkOrderSheet({
               {order.workOrderNo}
             </span>
             <StatusChip
-              status={STATUS_TONE[order.status] ?? "inactive"}
+              status={WORK_ORDER_STATUS[order.status] ?? "inactive"}
               label={WORK_ORDER_STATUS_LABELS[order.status]}
             />
             {order.deal ? (

--- a/components/crm/work-orders/work-order-sheet.tsx
+++ b/components/crm/work-orders/work-order-sheet.tsx
@@ -236,7 +236,7 @@ export function WorkOrderSheet({
                   </p>
                 ) : null}
                 {order.accessNotes || order.site?.accessInstructions ? (
-                  <p className="rounded-[var(--radius-md)] bg-[var(--surface-subtle)] p-2 text-xs">
+                  <p className="rounded-[var(--radius-md)] bg-[var(--surface-subtle)] p-2 text-sm">
                     {order.accessNotes ?? order.site?.accessInstructions}
                   </p>
                 ) : null}
@@ -266,7 +266,7 @@ export function WorkOrderSheet({
                         <div className="min-w-0 flex-1">
                           <p className="text-sm">{item.description}</p>
                           {item.notes ? (
-                            <p className="text-xs text-[var(--text-muted)]">{item.notes}</p>
+                            <p className="text-sm text-[var(--text-muted)]">{item.notes}</p>
                           ) : null}
                         </div>
                         <div className="flex items-center gap-1 text-sm">

--- a/components/crm/work-orders/work-orders-content.tsx
+++ b/components/crm/work-orders/work-orders-content.tsx
@@ -7,6 +7,7 @@ import { useSession } from "next-auth/react";
 import { Alert, EmptyState, Progress, SegmentedControl, Skeleton } from "@corelithzw/react";
 import { ClientDate } from "@/components/ui/client-date";
 import { StatusChip } from "@/components/ui/status-chip";
+import { WORK_ORDER_STATUS } from "@/lib/crm/tones";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   WORK_ORDER_QUEUE_LABELS,
@@ -16,20 +17,10 @@ import {
   type WorkOrderQueue,
 } from "@/lib/crm/work-orders";
 import { Clock, MapPin, Users } from "@/lib/icons";
-import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { WorkOrderSheet, type WorkOrderRecord } from "./work-order-sheet";
 
 const QUEUES: WorkOrderQueue[] = ["TODAY", "SCHEDULED", "IN_PROGRESS", "BLOCKED", "MINE", "DONE"];
-
-const STATUS_TONE: Record<string, CanonicalUiStatus> = {
-  DRAFT: "inactive",
-  SCHEDULED: "pending",
-  IN_PROGRESS: "in_progress",
-  BLOCKED: "failing",
-  COMPLETED: "passing",
-  CANCELLED: "inactive",
-};
 
 const EMPTY_MESSAGES: Partial<Record<WorkOrderQueue, string>> = {
   TODAY: "No jobs booked for today.",
@@ -93,7 +84,7 @@ export function WorkOrdersContent() {
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="font-mono text-sm">{order.workOrderNo}</span>
                     <StatusChip
-                      status={STATUS_TONE[order.status] ?? "inactive"}
+                      status={WORK_ORDER_STATUS[order.status] ?? "inactive"}
                       label={WORK_ORDER_STATUS_LABELS[order.status]}
                     />
                     {late ? (

--- a/components/crm/work-orders/work-orders-content.tsx
+++ b/components/crm/work-orders/work-orders-content.tsx
@@ -97,7 +97,7 @@ export function WorkOrdersContent() {
                       label={WORK_ORDER_STATUS_LABELS[order.status]}
                     />
                     {late ? (
-                      <span className="text-xs font-medium text-[var(--status-error-text)]">
+                      <span className="text-sm font-medium text-[var(--status-error-text)]">
                         Should have started
                       </span>
                     ) : null}
@@ -105,7 +105,7 @@ export function WorkOrdersContent() {
 
                   <p className="font-medium">{order.title}</p>
 
-                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text-muted)]">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-[var(--text-muted)]">
                     {order.scheduledStart ? (
                       <span className="inline-flex items-center gap-1">
                         <Clock className="size-3.5" />
@@ -134,7 +134,7 @@ export function WorkOrdersContent() {
                         tone={percent === 100 ? "success" : "brand"}
                         label={`${percent}% of the job done`}
                       />
-                      <p className="text-xs text-[var(--text-muted)]">
+                      <p className="text-sm text-[var(--text-muted)]">
                         {percent}% done · {order.items.length} item
                         {order.items.length === 1 ? "" : "s"}
                       </p>
@@ -142,7 +142,7 @@ export function WorkOrdersContent() {
                   ) : null}
 
                   {order.status === "BLOCKED" && order.blockedReason ? (
-                    <p className="text-xs text-[var(--status-error-text)]">
+                    <p className="text-sm text-[var(--status-error-text)]">
                       {order.blockedReason}
                     </p>
                   ) : null}

--- a/components/inventory/price-lists-panel.tsx
+++ b/components/inventory/price-lists-panel.tsx
@@ -136,7 +136,7 @@ export function PriceListsPanel() {
           }
         />
       ) : (
-        <ul className="divide-y divide-[var(--border-subtle)] overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface)]">
+        <ul className="divide-y divide-[var(--border-subtle)]">
           {lists.map((list) => (
             <li key={list.id} className="flex items-center gap-3 px-3 py-3">
               <button

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -46,7 +46,11 @@ export function AppShell({
     <PageChromeProvider>
       <SidebarProvider>
         <AppSidebar />
-        <SidebarInset className="flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden bg-surface-base md:m-2 md:h-[calc(100dvh-1rem)] md:min-h-[calc(100dvh-1rem)] md:rounded-xl md:border md:shadow-sm">
+        {/* Flat: no inset margin, rounding, border or shadow. The framed card
+            read as a window floating over a desktop, which cost a gutter on
+            every side and drew a line between the nav and the work that is
+            not a real boundary. */}
+        <SidebarInset className="flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden bg-surface-base">
           <Navbar />
           <main
             className={

--- a/components/layout/app-sidebar.tsx
+++ b/components/layout/app-sidebar.tsx
@@ -233,7 +233,7 @@ function SidebarSectionHeading({
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center gap-1 px-2 pb-1 pt-2 text-[12px] font-medium text-[var(--text-subtle)] transition-colors hover:text-foreground"
+        className="flex w-full items-center gap-1 px-2 pb-1 pt-2 text-sm font-medium text-[var(--text-subtle)] transition-colors hover:text-foreground"
       >
         <span className="truncate">{label}</span>
         {expanded ? (
@@ -245,7 +245,7 @@ function SidebarSectionHeading({
     );
   }
   return (
-    <div className="flex items-center gap-1 px-2 pb-1 pt-2 text-[12px] font-medium text-[var(--text-subtle)]">
+    <div className="flex items-center gap-1 px-2 pb-1 pt-2 text-sm font-medium text-[var(--text-subtle)]">
       <span className="truncate">{label}</span>
       <MedusaChevronDownIcon className="h-3.5 w-3.5 text-[var(--text-subtle)]" />
     </div>

--- a/components/layout/app-sidebar/sidebar-account-menu.tsx
+++ b/components/layout/app-sidebar/sidebar-account-menu.tsx
@@ -81,7 +81,7 @@ export function SidebarAccountMenu({
                   <p className="truncate text-[14px] font-medium">
                     {user?.name ?? user?.email ?? "Signed in"}
                   </p>
-                  <p className="truncate text-[12px] text-[var(--text-muted)]">
+                  <p className="truncate text-sm text-[var(--text-muted)]">
                     {workspaceLabel}
                     {user?.role ? ` · ${String(user.role).toLowerCase().replace(/_/g, " ")}` : ""}
                   </p>

--- a/components/layout/app-sidebar/sidebar-nav-sections.tsx
+++ b/components/layout/app-sidebar/sidebar-nav-sections.tsx
@@ -205,7 +205,7 @@ function SidebarExpandableSection({
                   <React.Fragment key={band.id ?? "__ungrouped"}>
                     {band.label ? (
                       <li
-                        className="px-2 pb-0.5 pt-2 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+                        className="px-2 pb-0.5 pt-2 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
                         aria-hidden="true"
                       >
                         {band.label}
@@ -290,28 +290,66 @@ export function SidebarNavSections({
 }) {
   return (
     <>
-      {sections.map((section) => {
+      {sections.flatMap((section) => {
+        // A flattened section is not one entry with bands inside it — it is
+        // several entries. Split before anything else looks at it, so each
+        // group opens and closes on its own like any other root entry.
+        if (section.flattenGroups && section.groups?.length) {
+          const ungrouped = section.items.filter((item) => !item.group);
+          const bands = section.groups
+            .map((group) => ({
+              group,
+              items: section.items.filter((item) => item.group === group.id),
+            }))
+            .filter((band) => band.items.length > 0);
+
+          return [
+            // Items with no group are destinations in their own right — an
+            // overview page is not a category to expand.
+            ...ungrouped.map((item) => (
+              <SidebarDirectSectionLink
+                key={`${section.id}-${item.href}`}
+                section={{ ...section, items: [item], title: item.label }}
+                activeHref={activeHref}
+              />
+            )),
+            ...bands.map(({ group, items }) => {
+              const id = `${section.id}-${group.id}`;
+              return (
+                <SidebarExpandableSection
+                  key={id}
+                  section={{ ...section, id, title: group.label, groups: undefined, items }}
+                  activeHref={activeHref}
+                  isCollapsed={isCollapsed}
+                  isOpen={openSectionId === id}
+                  onToggle={() => onToggleSection(id)}
+                />
+              );
+            }),
+          ];
+        }
+
         if (isDirectLinkSection(section)) {
-          return (
+          return [
             <SidebarDirectSectionLink
               key={section.id}
               section={section}
               activeHref={activeHref}
-            />
-          );
+            />,
+          ];
         }
 
         if (isFlatLinkSection(section)) {
-          return (
+          return [
             <SidebarFlatSection
               key={section.id}
               section={section}
               activeHref={activeHref}
-            />
-          );
+            />,
+          ];
         }
 
-        return (
+        return [
           <SidebarExpandableSection
             key={section.id}
             section={section}
@@ -319,8 +357,8 @@ export function SidebarNavSections({
             isCollapsed={isCollapsed}
             isOpen={openSectionId === section.id}
             onToggle={() => onToggleSection(section.id)}
-          />
-        );
+          />,
+        ];
       })}
     </>
   );

--- a/components/layout/global-search.tsx
+++ b/components/layout/global-search.tsx
@@ -224,7 +224,7 @@ export function GlobalSearch({ compact = false }: { compact?: boolean }) {
         {compact ? null : (
           <>
             <span className="flex-1 text-left">Search everything</span>
-            <kbd className="rounded border border-[var(--border)] px-1 text-[10px]">⌘K</kbd>
+            <kbd className="rounded border border-[var(--border)] px-1 text-sm">⌘K</kbd>
           </>
         )}
       </Button>
@@ -259,7 +259,7 @@ export function GlobalSearch({ compact = false }: { compact?: boolean }) {
                         <Icon className="h-4 w-4 shrink-0 opacity-60" />
                         <span className="truncate">{entry.title}</span>
                         {entry.subtitle ? (
-                          <span className="truncate text-xs text-[var(--text-muted)]">
+                          <span className="truncate text-sm text-[var(--text-muted)]">
                             {entry.subtitle}
                           </span>
                         ) : null}
@@ -291,13 +291,13 @@ export function GlobalSearch({ compact = false }: { compact?: boolean }) {
                         <span className="min-w-0 flex-1">
                           <span className="block truncate">{result.title}</span>
                           {result.subtitle ? (
-                            <span className="block truncate text-xs text-[var(--text-muted)]">
+                            <span className="block truncate text-sm text-[var(--text-muted)]">
                               {result.subtitle}
                             </span>
                           ) : null}
                         </span>
                         {result.reference ? (
-                          <span className="shrink-0 font-mono text-xs text-[var(--text-muted)]">
+                          <span className="shrink-0 font-mono text-sm text-[var(--text-muted)]">
                             {result.reference}
                           </span>
                         ) : null}
@@ -320,7 +320,7 @@ export function GlobalSearch({ compact = false }: { compact?: boolean }) {
                       >
                         <ArrowRight className="h-4 w-4 shrink-0 opacity-60" />
                         <span className="min-w-0 flex-1 truncate">{destination.label}</span>
-                        <span className="shrink-0 text-xs text-[var(--text-muted)]">
+                        <span className="shrink-0 text-sm text-[var(--text-muted)]">
                           {destination.section}
                         </span>
                       </CommandItem>
@@ -352,7 +352,7 @@ export function GlobalSearch({ compact = false }: { compact?: boolean }) {
           <div
             className={cn(
               "flex items-center justify-between border-t border-[var(--border)] px-3 py-1.5",
-              "text-[11px] text-[var(--text-muted)]",
+              "text-sm text-[var(--text-muted)]",
             )}
           >
             <span>↑↓ to move · ↵ to open · esc to close</span>

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -8,6 +8,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
+import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -24,7 +25,7 @@ import { usePageChrome } from "@/components/layout/page-chrome";
 import { GlobalSearch } from "@/components/layout/global-search";
 import { CrmMembers } from "@/components/crm/crm-members";
 import { NotificationCenter } from "@/components/notifications/notification-center";
-import { MoreHorizontal, type LucideIcon } from "@/lib/icons";
+import { ArrowLeft, MoreHorizontal, type LucideIcon } from "@/lib/icons";
 import { navSections } from "@/lib/navigation";
 import { canAccessCapabilityWithToken } from "@/lib/platform/gating/token-check";
 
@@ -65,6 +66,7 @@ export function Navbar() {
   // does it: a capitalised binding assigned from a call reads to the lint rule
   // as a component defined during render, which would reset its state.
   const pageIcon = identity?.icon ?? routeIcon(pathname);
+  const back = identity?.back;
   // The CRM is the one module that is genuinely a shared book, so it is the
   // one that shows you who else is in it.
   const showMembers = pathname === "/crm" || pathname.startsWith("/crm/");
@@ -76,6 +78,15 @@ export function Navbar() {
           <div className="flex h-14 items-center gap-1.5 md:hidden">
             <SidebarTrigger />
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              {back ? (
+                <Link
+                  href={back.href}
+                  aria-label={`Back to ${back.label}`}
+                  className="-ml-1 flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
+                >
+                  <ArrowLeft className="size-4" />
+                </Link>
+              ) : null}
               {pageIcon
                 ? createElement(pageIcon, {
                     className: "h-4 w-4 shrink-0 text-[var(--text-muted)]",
@@ -92,6 +103,15 @@ export function Navbar() {
           <div className="hidden h-14 items-center gap-3 md:flex justify-between">
             <div className="flex min-w-0 items-center gap-2">
               <SidebarTrigger />
+              {back ? (
+                <Link
+                  href={back.href}
+                  className="ml-1 flex shrink-0 items-center gap-1 rounded-[var(--radius-sm)] px-1.5 py-1 text-sm text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
+                >
+                  <ArrowLeft className="size-4" />
+                  <span className="hidden lg:inline">{back.label}</span>
+                </Link>
+              ) : null}
               <div className="flex min-w-0 items-center gap-2 pl-1">
                 {pageIcon
                   ? createElement(pageIcon, {

--- a/components/layout/offline-runtime-banner.tsx
+++ b/components/layout/offline-runtime-banner.tsx
@@ -62,7 +62,7 @@ export function OfflineRuntimeBanner() {
         <div className="min-w-0 flex-1">
           <div
             style={{ "--status-chip": `var(${bannerTone.colorVar})` } as CSSProperties}
-            className="inline-flex items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--status-chip)_12%,transparent)] bg-[color-mix(in_srgb,var(--surface-muted)_82%,white)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]"
+            className="inline-flex items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--status-chip)_12%,transparent)] bg-[color-mix(in_srgb,var(--surface-muted)_82%,white)] px-3 py-1 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]"
           >
             <BannerIcon className={["size-3", bannerTone.iconClassName].join(" ")} />
             {bannerTone.text}
@@ -83,12 +83,12 @@ export function OfflineRuntimeBanner() {
                   max={progressMax}
                   className="h-2 flex-1 border-0 bg-[color-mix(in_srgb,var(--surface-muted)_78%,white)] shadow-none"
                 />
-                <span className="text-xs font-mono tabular-nums text-[var(--text-muted)]">
+                <span className="text-sm font-mono tabular-nums text-[var(--text-muted)]">
                   {bootstrapProgress?.completedSteps ?? 0}/
                   {bootstrapProgress?.totalSteps ?? 0}
                 </span>
               </div>
-              <div className="mt-2 text-xs text-[var(--text-muted)]">
+              <div className="mt-2 text-sm text-[var(--text-muted)]">
                 {(bootstrapProgress?.completedSteps ?? 0) ===
                 (bootstrapProgress?.totalSteps ?? 0)
                   ? "Core offline setup is ready."
@@ -98,7 +98,7 @@ export function OfflineRuntimeBanner() {
               </div>
             </div>
           ) : (
-            <div className="mt-1 text-xs text-[var(--text-muted)]">
+            <div className="mt-1 text-sm text-[var(--text-muted)]">
               {showUpdatePrompt
                 ? "Refresh when the operator is at a safe stopping point. Offline data stays in place."
                 : "Applying the downloaded update now."}

--- a/components/layout/offline-runtime-panel.tsx
+++ b/components/layout/offline-runtime-panel.tsx
@@ -64,7 +64,7 @@ function SummaryItem({
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
+      <span className="text-sm font-semibold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
         {label}
       </span>
       <span
@@ -191,7 +191,7 @@ export function OfflineRuntimePanel() {
                 </p>
               </div>
               {bootstrapProgress ? (
-                <span className="rounded-full bg-[color-mix(in_srgb,var(--surface-base)_72%,white)] px-3 py-1 text-xs font-mono tabular-nums text-[var(--text-muted)]">
+                <span className="rounded-full bg-[color-mix(in_srgb,var(--surface-base)_72%,white)] px-3 py-1 text-sm font-mono tabular-nums text-[var(--text-muted)]">
                   {bootstrapProgressValue}%
                 </span>
               ) : null}
@@ -203,13 +203,13 @@ export function OfflineRuntimePanel() {
                   max={Math.max(bootstrapProgress.totalSteps, 1)}
                   className="h-2 border-0 bg-[color-mix(in_srgb,var(--surface-base)_78%,white)] shadow-none"
                 />
-                <p className="mt-2 text-xs text-[var(--text-muted)]">
+                <p className="mt-2 text-sm text-[var(--text-muted)]">
                   {bootstrapProgress.currentStepLabel ?? "Preparing offline data."}
                 </p>
               </div>
             ) : null}
             {stillPreparingLabels.length > 0 ? (
-              <p className="mt-3 text-xs text-[var(--text-muted)]">
+              <p className="mt-3 text-sm text-[var(--text-muted)]">
                 Still preparing: {stillPreparingLabels.join(", ")}
                 {unreadyModules.length > stillPreparingLabels.length ? ", and more." : "."}
               </p>
@@ -272,7 +272,7 @@ export function OfflineRuntimePanel() {
       </div>
 
       <DialogFooter className="border-t border-[color-mix(in_srgb,var(--border-default)_72%,transparent)] px-6 py-4 sm:items-center sm:justify-between">
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-sm text-[var(--text-muted)]">
           Queued changes stay on the device until they can sync safely.
         </p>
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">

--- a/components/layout/page-chrome.tsx
+++ b/components/layout/page-chrome.tsx
@@ -16,6 +16,12 @@ import type { LucideIcon } from "@/lib/icons";
 export type PageIdentity = {
   title: string;
   icon?: LucideIcon;
+  /**
+   * Where "up" is, for a page that sits under a list. Rendered in the bar
+   * immediately before the title, because that is where the page's name is —
+   * a back link stranded in the body is a second header in a different place.
+   */
+  back?: { href: string; label: string };
 };
 
 type PageChromeContextValue = {
@@ -69,19 +75,28 @@ function usePageChrome() {
 function PageChrome({
   title,
   icon,
+  backHref,
+  backLabel,
   children,
 }: {
   title: string;
   icon?: LucideIcon;
+  /** Where "up" goes. Both this and `backLabel` are needed for a back link. */
+  backHref?: string;
+  backLabel?: string;
   /** The page's actions, rendered in the top app bar. */
   children?: React.ReactNode;
 }) {
   const { setActions, setIdentity } = usePageChrome();
 
   React.useEffect(() => {
-    setIdentity({ title, icon });
+    setIdentity({
+      title,
+      icon,
+      back: backHref && backLabel ? { href: backHref, label: backLabel } : undefined,
+    });
     return () => setIdentity(null);
-  }, [title, icon, setIdentity]);
+  }, [title, icon, backHref, backLabel, setIdentity]);
 
   React.useEffect(() => {
     // Left undefined, this component is only claiming the title — some other

--- a/components/stores/stock-locations-panel.tsx
+++ b/components/stores/stock-locations-panel.tsx
@@ -108,7 +108,7 @@ export function StockLocationsPanel() {
           <section key={site.id} aria-labelledby={`site-${site.id}`} className="space-y-2">
             <h3
               id={`site-${site.id}`}
-              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
             >
               <span>{site.name}</span>
               <span className="font-mono normal-case tracking-normal">
@@ -116,7 +116,7 @@ export function StockLocationsPanel() {
               </span>
             </h3>
 
-            <ul className="divide-y divide-[var(--border-subtle)] overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface)]">
+            <ul className="divide-y divide-[var(--border-subtle)]">
               {site.rows.map((location) => (
                 <li key={location.id}>
                   <Link
@@ -128,7 +128,7 @@ export function StockLocationsPanel() {
                         <span className="truncate text-sm font-medium text-[var(--text-strong)]">
                           {location.name}
                         </span>
-                        <span className="font-mono text-xs text-[var(--text-subtle)]">
+                        <span className="font-mono text-sm text-[var(--text-subtle)]">
                           {location.code}
                         </span>
                         {!location.isActive ? (
@@ -149,7 +149,7 @@ export function StockLocationsPanel() {
                     </span>
 
                     <span className="hidden text-right sm:block">
-                      <span className="block text-[11px] uppercase tracking-wide text-[var(--text-subtle)]">
+                      <span className="block text-sm uppercase tracking-wide text-[var(--text-subtle)]">
                         Value
                       </span>
                       <span className="block font-mono text-sm tabular-nums">
@@ -170,7 +170,7 @@ export function StockLocationsPanel() {
       )}
 
       {grouped.some((site) => site.rows.some((row) => !row.valueComplete)) ? (
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-sm text-[var(--text-muted)]">
           * Some items in this location have no unit cost recorded, so the value
           shown is lower than what is actually there.
         </p>

--- a/components/stores/stock-overview.tsx
+++ b/components/stores/stock-overview.tsx
@@ -141,7 +141,7 @@ export function StockOverview({ siteId }: { siteId?: string }) {
       <section aria-labelledby="stock-attention" className="space-y-2">
         <h2
           id="stock-attention"
-          className="text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+          className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
         >
           Running low
         </h2>
@@ -190,7 +190,7 @@ export function StockOverview({ siteId }: { siteId?: string }) {
         <div className="flex items-baseline justify-between gap-2">
           <h2
             id="stock-recent"
-            className="text-[11px] font-medium uppercase tracking-wide text-[var(--text-subtle)]"
+            className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]"
           >
             Last movements
           </h2>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,42 @@ const eslintConfig = defineConfig([
     // Local multi-agent worktrees used during parallel implementation.
     ".worktrees/**",
   ]),
+  {
+    // The type scale has a floor. Anything under `text-sm` was unreadable on a
+    // phone in a yard, and the CRM had accumulated four sizes below it —
+    // `text-xs` plus three hand-picked pixel values — none of which said
+    // anything `text-sm` and a muted colour could not.
+    //
+    // Scoped to the surfaces that have been brought up to the scale. Widening
+    // it to the rest of the app is a per-module job: raising type changes
+    // layout, and doing it unseen across seventy pages is how you ship a
+    // regression nobody asked for.
+    files: [
+      "components/crm/**/*.tsx",
+      "components/layout/**/*.tsx",
+      "components/stores/**/*.tsx",
+      "components/inventory/**/*.tsx",
+      "app/crm/**/*.tsx",
+      "app/stores/**/*.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "Literal[value=/(^|\\s)text-(xs|\\[(?:9|10|11|12)px\\])(\\s|$)/]",
+          message:
+            "Below the type scale's floor. Use text-sm, and a muted colour if it needs to recede.",
+        },
+        {
+          selector:
+            "TemplateElement[value.raw=/(^|\\s)text-(xs|\\[(?:9|10|11|12)px\\])(\\s|$)/]",
+          message:
+            "Below the type scale's floor. Use text-sm, and a muted colour if it needs to recede.",
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -935,7 +935,7 @@ export type CrmRepDetail = {
     id: string;
     leadNo: string;
     title: string;
-    stage: string;
+    stage: CrmLeadStage;
     estimatedValue: number | null;
     currency: string;
     updatedAt: string;

--- a/lib/crm/insights.ts
+++ b/lib/crm/insights.ts
@@ -51,18 +51,19 @@ export async function getPipelineValue(companyId: string, opts: { repId?: string
       ...(opts.repId ? { assignedToId: opts.repId } : {}),
       stage: { notIn: ["WON", "LOST"] },
     },
-    select: { stage: true, estimatedValue: true, probability: true },
+    select: { stage: true, estimatedValue: true },
   });
 
-  let weighted = 0;
+  // No weighted figure here. It used to count a lead with no probability set
+  // as worth nothing, which meant the weighted total fell as the pipeline
+  // filled up — the opposite of what it appeared to say. `forecast()` in
+  // reports.ts does the weighting properly, with a stated default and a count
+  // of how many rows are relying on it.
   let gross = 0;
   for (const lead of leads) {
-    const value = lead.estimatedValue ?? 0;
-    gross += value;
-    const p = (lead.probability ?? 0) / 100;
-    weighted += value * p;
+    gross += lead.estimatedValue ?? 0;
   }
-  return { openLeads: leads.length, grossValue: Math.round(gross * 100) / 100, weightedValue: Math.round(weighted * 100) / 100 };
+  return { openLeads: leads.length, grossValue: Math.round(gross * 100) / 100 };
 }
 
 export async function getSourceAttribution(companyId: string, opts: Range) {

--- a/lib/crm/reports.test.ts
+++ b/lib/crm/reports.test.ts
@@ -158,6 +158,20 @@ describe("forecast", () => {
     expect(forecast([{ value: 10_000, probability: null }]).weighted).toBe(5_000);
   });
 
+  it("says how much of the figure is resting on that default", () => {
+    const result = forecast([
+      { value: 10_000, probability: 80 },
+      { value: 10_000, probability: null },
+      { value: 5_000, probability: null },
+    ]);
+    expect(result.estimated).toBe(2);
+    expect(result.count).toBe(3);
+  });
+
+  it("reports nothing estimated when every deal carries a probability", () => {
+    expect(forecast([{ value: 10_000, probability: 0 }]).estimated).toBe(0);
+  });
+
   it("clamps a nonsense probability instead of inflating the number", () => {
     expect(forecast([{ value: 10_000, probability: 400 }]).weighted).toBe(10_000);
     expect(forecast([{ value: 10_000, probability: -50 }]).weighted).toBe(0);

--- a/lib/crm/reports.ts
+++ b/lib/crm/reports.ts
@@ -140,13 +140,15 @@ export function summarizeGroups(groups: GroupedOutcome[]): GroupedPerformance[] 
 export function forecast(
   open: { value: number | null; probability: number | null }[],
   defaultProbability = 50,
-): { weighted: number; unweighted: number; count: number } {
+): { weighted: number; unweighted: number; count: number; estimated: number } {
   let weighted = 0;
   let unweighted = 0;
+  let estimated = 0;
 
   for (const deal of open) {
     const value = deal.value ?? 0;
     const probability = deal.probability ?? defaultProbability;
+    if (deal.probability === null) estimated += 1;
     unweighted += value;
     weighted += (value * Math.min(100, Math.max(0, probability))) / 100;
   }
@@ -155,6 +157,10 @@ export function forecast(
     weighted: Math.round(weighted * 100) / 100,
     unweighted: Math.round(unweighted * 100) / 100,
     count: open.length,
+    // How many of those probabilities nobody actually set. A weighted figure
+    // where this equals `count` is the default probability wearing a suit, and
+    // the reader deserves to know that before betting on it.
+    estimated,
   };
 }
 

--- a/lib/crm/tones.ts
+++ b/lib/crm/tones.ts
@@ -1,0 +1,78 @@
+import type { BadgeTone } from "@corelithzw/react";
+
+import type { CanonicalUiStatus } from "@/lib/ui/status-map";
+
+/**
+ * What colour each piece of CRM vocabulary is.
+ *
+ * Two rules, applied consistently, which is the whole point of gathering them
+ * in one file rather than letting each screen invent its own map:
+ *
+ *   - A **state** is coloured. Won is green, blocked is red, awaiting a
+ *     decision is amber. The colour is doing work — it is how you find the row
+ *     that needs you without reading every row.
+ *   - A **category** is not. "Contractor", "Site contact", "Sales rep" are
+ *     facts about a record, not judgements on it, and colouring them spends
+ *     the reader's attention on something that never needs acting on. Those
+ *     stay neutral on purpose; the page is not monochrome by accident, it is
+ *     monochrome everywhere the colour would mean nothing.
+ *
+ * Anything that is genuinely a state and is still rendering grey is a bug.
+ */
+
+/** How likely two records are the same. A near-certain duplicate is a problem. */
+export const DUPLICATE_CONFIDENCE_TONE: Record<string, BadgeTone> = {
+  HIGH: "danger",
+  MEDIUM: "warn",
+  LOW: "neutral",
+};
+
+/** Task priority. Normal and low are not worth a colour — that is what normal means. */
+export const TASK_PRIORITY_TONE: Record<string, BadgeTone> = {
+  LOW: "neutral",
+  NORMAL: "neutral",
+  HIGH: "warn",
+  URGENT: "danger",
+};
+
+/** A pipeline stage's terminal outcome, as configured in settings. */
+export const STAGE_OUTCOME_TONE: Record<string, BadgeTone> = {
+  OPEN: "neutral",
+  WON: "success",
+  LOST: "danger",
+};
+
+/**
+ * Where a job has got to. Canonical UI statuses rather than badge tones,
+ * because these render through `StatusChip`.
+ */
+export const WORK_ORDER_STATUS: Record<string, CanonicalUiStatus> = {
+  DRAFT: "inactive",
+  SCHEDULED: "pending",
+  IN_PROGRESS: "in_progress",
+  BLOCKED: "failing",
+  COMPLETED: "passing",
+  CANCELLED: "inactive",
+};
+
+/** A quote, invoice or receipt's standing. */
+export const DOCUMENT_STATUS: Record<string, { label: string; tone: BadgeTone }> = {
+  DRAFT: { label: "Draft", tone: "neutral" },
+  SENT: { label: "Sent", tone: "info" },
+  ISSUED: { label: "Issued", tone: "info" },
+  ACCEPTED: { label: "Accepted", tone: "success" },
+  PAID: { label: "Paid", tone: "success" },
+  RECEIVED: { label: "Received", tone: "success" },
+  EXPIRED: { label: "Expired", tone: "warn" },
+  VOIDED: { label: "Voided", tone: "neutral" },
+  MISSING: { label: "No paperwork", tone: "danger" },
+};
+
+/** A site visit's standing. */
+export const VISIT_STATUS: Record<string, CanonicalUiStatus> = {
+  SCHEDULED: "pending",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "passing",
+  CANCELLED: "inactive",
+  NO_SHOW: "failing",
+};

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -80,6 +80,12 @@ export type NavSection = {
   featureKey?: string;
   /** Declares group order and labels. Groups with no visible items are dropped. */
   groups?: NavGroup[];
+  /**
+   * Render each group as its own root-level entry instead of as a band inside
+   * this section. For a section whose title names a category rather than a
+   * destination, the groups are the places people are actually going.
+   */
+  flattenGroups?: boolean;
   items: NavItem[];
 };
 
@@ -281,8 +287,11 @@ export const navSections: NavSection[] = [
     })),
   },
   {
-    id: "crm",
-    title: "CRM",
+    // Retail's customer ledger, not the CRM module. It used to share the id
+    // "crm" with it, and since section lookups are built from this array the
+    // later entry silently won.
+    id: "retail-customers",
+    title: "Customers",
     description: "Customer profiles, loyalty, and ledgers",
     featureKey: "crm.customers",
     items: [
@@ -332,26 +341,36 @@ export const navSections: NavSection[] = [
       roles: tab.roles,
     })),
   },
+  // The CRM is not one thing you open, it is six. A single parent entry meant
+  // every route inside it cost two clicks and hid behind a word — "CRM" — that
+  // names a category rather than a place. Its groups are root entries now,
+  // each expanding to its own children, which is how the reference works and
+  // how anybody actually describes where they are going: "the pipeline",
+  // "records", "the paperwork".
+  //
+  // They share `crm.core`, so a tenant without the module loses the whole set
+  // rather than being left with six empty headings.
   {
     id: "crm",
     title: "CRM",
     description: "Leads, clients, site visits, and sales pipeline",
     featureKey: "crm.core",
-    // Grouped by what kind of thing each link is, not by what stage of the job
-    // it belongs to. A flat column of sixteen links was an inventory of pages;
-    // so was a set of groups named after phases nobody uses as a noun. These
-    // are the four nouns people actually say: the pipeline, the records, the
-    // work, the paperwork.
+    // Rendered flat: each group below becomes its own root entry in the
+    // sidebar rather than a band inside a "CRM" parent. "CRM" names a category,
+    // not a place — nobody says "I'm going to CRM", they say "the pipeline" or
+    // "the paperwork", and burying six of those behind one word cost a click
+    // each and told you nothing on the way past.
+    flattenGroups: true,
     groups: [
       { id: "pipeline", label: "Pipeline" },
       { id: "records", label: "Records" },
       { id: "work", label: "Work" },
       { id: "documents", label: "Sales documents" },
       { id: "learn", label: "Insights" },
-      { id: "setup", label: "Setup" },
+      { id: "setup", label: "CRM setup" },
     ],
     items: [
-      { href: "/crm", icon: Dashboard, label: "Overview" },
+      { href: "/crm", icon: Dashboard, label: "CRM overview" },
 
       { href: "/crm/leads", icon: Funnel, label: "Leads", group: "pipeline" },
       { href: "/crm/deals", icon: Funnel, label: "Deals", group: "pipeline" },

--- a/lib/workspaces.ts
+++ b/lib/workspaces.ts
@@ -245,12 +245,27 @@ const WORKSPACE_MODULES: Record<WorkspaceModuleId, WorkspaceModuleDefinition> = 
       return items;
     },
   },
-  crm: createSectionModule({
+  crm: {
     id: "crm",
     label: "CRM",
-    sectionId: "crm",
     homeHref: "/crm",
-  }),
+    /**
+     * Two sections feed this module: the CRM proper and retail's customer
+     * ledger. They used to share the id "crm" and rely on gating to leave
+     * exactly one standing — the ledger surfaced only when `crm.core` was off
+     * and the CRM section had already been filtered away. That worked and read
+     * as a bug, so the ids are distinct now and the module names both.
+     */
+    getItems(context) {
+      return [
+        ...(context.navSectionById.get("crm")?.items ?? []),
+        ...(context.navSectionById.get("retail-customers")?.items ?? []),
+      ];
+    },
+    getGroups(context) {
+      return context.navSectionById.get("crm")?.groups;
+    },
+  },
   hr: createSectionModule({
     id: "hr",
     label: "Human Resources",
@@ -641,16 +656,19 @@ function collectSectionHrefs(sections: WorkspaceNavSection[]): Set<string> {
  * the section but its items. Module ids and section ids line up for every
  * `createSectionModule` module, so reading the declaration back is enough.
  */
-function declaredGroups(moduleId: WorkspaceModuleId): NavGroup[] | undefined {
-  // Last match, not first: two sections share the id "crm" (the retail customer
-  // directory and the CRM module proper), and `navSectionById` — the map the
-  // module reads its items from — is built from this array, so a later entry
-  // wins there. Taking the first here would read groups off the other section.
-  let found: NavGroup[] | undefined;
+function declaredSection(moduleId: WorkspaceModuleId): NavSection | undefined {
+  // Last match, not first, to stay consistent with `navSectionById` — the map
+  // the module reads its items from is built from this array, so a later entry
+  // with the same id wins there and this has to agree.
+  let found: NavSection | undefined;
   for (const section of navSections) {
-    if (section.id === moduleId) found = section.groups;
+    if (section.id === moduleId) found = section;
   }
   return found;
+}
+
+function declaredGroups(moduleId: WorkspaceModuleId): NavGroup[] | undefined {
+  return declaredSection(moduleId)?.groups;
 }
 
 function buildModuleSection(
@@ -670,6 +688,10 @@ function buildModuleSection(
     id: moduleId,
     title: WORKSPACE_MODULES[moduleId].label,
     ...(groups && groups.length > 0 ? { groups } : {}),
+    // Carried through: the sidebar decides whether to render the groups as
+    // root entries or as bands, and it can only do that if the flag survives
+    // the trip through the module layer.
+    ...(declaredSection(moduleId)?.flattenGroups ? { flattenGroups: true } : {}),
     items,
     workspaceGroup,
   };


### PR DESCRIPTION
Round four of the CRM work. This PR is open and still filling up — what is here now is the shell and the two dead pages; the rest of the list is below.

## Fixed

**Collections crashed, Sales reports rendered nothing.** Same cause, and now the fourth and fifth time this has bitten: `successResponse(x)` sends `x` bare, but both clients typed the response as `{ data: … }` and read one level too deep. Collections got `undefined` where it expected a report; reports got it where it expected rows. Both now read the body they are actually sent.

**The sidebar.** The "CRM" entry was a door into the app rather than a destination — every trip started with a click that did no work. Its groups are now root entries that expand in place. That is what `flattenGroups` on a nav section and the flatMap renderer in `sidebar-nav-sections.tsx` do; nothing else in the sidebar changed shape. The surface is white, and the content frame loses its inset margin, rounding, border and shadow: it was reading as a window floating over a desktop rather than as the page you are on.

**Typography has a floor.** 203 uses of `text-xs` and hard-coded sub-12px sizes across 67 files are now `text-sm`. An eslint rule rejects new ones. It is scoped to the surfaces this work owns — CRM, layout, stores, inventory — rather than repo-wide, because raising type unseen across seventy pages ships regressions I cannot look at.

**List rows are not cards.** Nine list containers drop the border, radius and surface fill for a plain `divide-y`. Two rows in an item does not make it a card.

## One correction worth recording

Renaming retail's clashing nav section id looked safe — I reasoned the later `crm` section already won in `navSectionById`, so `/retail/customers` was unreachable anyway. A test said otherwise: gating runs *before* module resolution, so the shared id was load-bearing. `WORKSPACE_MODULES.crm` now reads items from both sections explicitly.

## Still open on this branch

Semantic badge/pill variants; per-record icons, emoji and avatars; dialog padding and the sheets that are pretending to be modals; entity references on detail pages as real links; the board split per pipeline; metrics that mean something in place of the invented weighted-pipeline figure; custom fields on create/edit forms; catalogue autocomplete when quoting; documents on company, deal, person and rep. The form designer and document templates are deferred at your request.

## Verification

705/705 tests pass across 62 files. `tsc --noEmit` clean. eslint on the changed files is clean apart from one pre-existing `<img>` warning in `app/stores/inventory/page.tsx`; the repo's other 40 errors are all in files this branch does not touch (offline runtime, gold, retail, schools).

---
_Generated by [Claude Code](https://claude.ai/code/session_0165pkzEEY2bL2n1i4fL63kk)_