### PR TITLE
CRM: editable properties, quoting without a company, and the register/toolbar round

### DIFF
--- a/app/api/v2/crm/deals/[id]/contacts/route.ts
+++ b/app/api/v2/crm/deals/[id]/contacts/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { canEditRecord } from "@/lib/crm/permissions";
+
+/**
+ * Who is on a deal.
+ *
+ * The related lists on a record page could show the people attached to a deal
+ * and offered no way to attach one, which made every relationship on the page
+ * something you had to have got right when the record was created. A deal
+ * gains a decision maker in week three; that is the normal case, not an
+ * exception.
+ */
+const addSchema = z.object({
+  personId: z.string().uuid(),
+  role: z
+    .enum([
+      "PRIMARY",
+      "DECISION_MAKER",
+      "FINANCE",
+      "SITE",
+      "TECHNICAL",
+      "INFLUENCER",
+      "REFERRER",
+    ])
+    .optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+async function editableDeal(companyId: string, id: string) {
+  return prisma.crmDeal.findFirst({
+    where: { id, companyId },
+    select: { id: true, assignedToId: true },
+  });
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const companyId = session.user.companyId;
+    const { id } = await params;
+
+    const deal = await editableDeal(companyId, id);
+    if (!deal) return errorResponse("Deal not found", 404);
+    if (!(await canEditRecord(session, deal.assignedToId))) {
+      return errorResponse("You can only change deals assigned to you", 403);
+    }
+
+    const data = addSchema.parse(await request.json());
+
+    // Scoped to the company: a person id from another tenant is a 404, not a
+    // row that quietly links across the boundary.
+    const person = await prisma.crmPerson.findFirst({
+      where: { id: data.personId, companyId },
+      select: { id: true },
+    });
+    if (!person) return errorResponse("Person not found", 404);
+
+    const role = data.role ?? "PRIMARY";
+    const existing = await prisma.crmDealContact.findFirst({
+      where: { dealId: id, personId: data.personId, role },
+      select: { id: true },
+    });
+    if (existing) return errorResponse("That person is already on this deal in that role", 409);
+
+    const contact = await prisma.crmDealContact.create({
+      data: {
+        companyId,
+        dealId: id,
+        personId: data.personId,
+        role,
+        notes: data.notes ?? undefined,
+      },
+      include: {
+        person: { select: { id: true, fullName: true, jobTitle: true, phone: true } },
+      },
+    });
+
+    return successResponse(contact, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
+    console.error("[API] POST /api/v2/crm/deals/[id]/contacts error:", error);
+    return errorResponse("Failed to add the person to this deal", 400);
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const companyId = session.user.companyId;
+    const { id } = await params;
+
+    const deal = await editableDeal(companyId, id);
+    if (!deal) return errorResponse("Deal not found", 404);
+    if (!(await canEditRecord(session, deal.assignedToId))) {
+      return errorResponse("You can only change deals assigned to you", 403);
+    }
+
+    const contactId = new URL(request.url).searchParams.get("contactId");
+    if (!contactId) return errorResponse("contactId is required", 400);
+
+    // deleteMany rather than delete: the company scope is part of the match,
+    // so a contact id from elsewhere removes nothing instead of throwing.
+    const removed = await prisma.crmDealContact.deleteMany({
+      where: { id: contactId, dealId: id, companyId },
+    });
+    if (removed.count === 0) return errorResponse("That person is not on this deal", 404);
+
+    return successResponse({ id: contactId });
+  } catch (error) {
+    console.error("[API] DELETE /api/v2/crm/deals/[id]/contacts error:", error);
+    return errorResponse("Failed to remove the person from this deal", 400);
+  }
+}

--- a/app/crm/deals/page.tsx
+++ b/app/crm/deals/page.tsx
@@ -2,7 +2,7 @@ import { getServerSession } from "next-auth";
 import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
 
-import { DealsContent } from "@/components/crm/records/deals-content";
+import { PipelineWorkspace } from "@/components/crm/records/pipeline-workspace";
 import { authOptions } from "@/lib/auth";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
@@ -11,9 +11,12 @@ export default async function CrmDealsPage({ searchParams }: { searchParams: Sea
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
   const params = await searchParams;
+  // Landing here means "show me a deal pipeline"; the menu can walk back to
+  // leads without a navigation.
+  const pipeline = typeof params.pipeline === "string" ? params.pipeline : "deals";
   return (
     <CrmPage>
-      <DealsContent openCreate={params.new === "1"} />
+      <PipelineWorkspace initial={pipeline} openCreate={params.new === "1"} />
     </CrmPage>
   );
 }

--- a/app/crm/leads/page.tsx
+++ b/app/crm/leads/page.tsx
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { CrmPage } from "@/components/crm/crm-page";
 import { redirect } from "next/navigation";
-import { LeadsWorkspace } from "@/components/crm/leads/leads-workspace";
+import { PipelineWorkspace } from "@/components/crm/records/pipeline-workspace";
 import { parseLeadFiltersFromParams } from "@/lib/crm/views";
 import { authOptions } from "@/lib/auth";
 
@@ -24,7 +24,10 @@ export default async function CrmLeadsPage({ searchParams }: { searchParams: Sea
 
   return (
     <CrmPage>
-      <LeadsWorkspace
+      {/* One workspace: the pipeline menu inside it crosses to the deal
+          pipelines without leaving the page. */}
+      <PipelineWorkspace
+        initial="leads"
         initialFilters={parseLeadFiltersFromParams(params)}
         initialView={view}
         initialViewId={params.get("savedView")}

--- a/components/crm/collaboration/rich-text-composer.tsx
+++ b/components/crm/collaboration/rich-text-composer.tsx
@@ -3,7 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
+import { EmojiPicker } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { fetchJson } from "@/lib/api-client";
 import { offsetOf, placeCaret, renderBody, serialise } from "@/lib/crm/reference-dom";
 import {
@@ -14,7 +16,7 @@ import {
   togglePrefix,
   type Reference,
 } from "@/lib/crm/rich-text";
-import { Eye, ListBullets, type LucideIcon } from "@/lib/icons";
+import { Eye, ListBullets, Smiley, type LucideIcon } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 import { referenceChipElement } from "./reference-chip";
@@ -117,6 +119,7 @@ export function RichTextComposer({
   const [query, setQuery] = useState<string | null>(null);
   const [highlighted, setHighlighted] = useState(0);
   const [preview, setPreview] = useState(false);
+  const [emojiOpen, setEmojiOpen] = useState(false);
 
   // What the editor's DOM currently serialises to, or null when the editor
   // holds nothing yet — freshly mounted, or just returned from Preview, which
@@ -254,6 +257,13 @@ export function RichTextComposer({
     rewrite(result.body, result.end);
   }
 
+  /** Drop a glyph in at the caret — the same path a reference chip takes. */
+  function insertEmoji(glyph: string) {
+    const body = shown.current ?? value;
+    const caret = Math.min(caretOffset(), body.length);
+    rewrite(`${body.slice(0, caret)}${glyph}${body.slice(caret)}`, caret + glyph.length);
+  }
+
   return (
     <div className="space-y-1.5">
       <div className="flex flex-wrap items-center gap-0.5">
@@ -287,6 +297,32 @@ export function RichTextComposer({
             </Button>
           );
         })}
+
+        {/* An emoji is punctuation in a work note — "done 👍" is a whole
+            reply — and asking somebody to find their OS picker inside a
+            contenteditable is how they stop bothering. */}
+        <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-label="Insert an emoji"
+              title="Insert an emoji"
+              disabled={preview}
+            >
+              <Smiley className="size-4" aria-hidden="true" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-auto p-0">
+            <EmojiPicker
+              onSelect={(glyph) => {
+                insertEmoji(glyph);
+                setEmojiOpen(false);
+              }}
+            />
+          </PopoverContent>
+        </Popover>
 
         <span className="flex-1" />
 

--- a/components/crm/collections/collections-content.tsx
+++ b/components/crm/collections/collections-content.tsx
@@ -113,53 +113,50 @@ export function CollectionsContent({ currency = "USD" }: { currency?: string }) 
             />
           ) : (
             <Stack as="ul" gap="xs">
+              {/* One line per debt: what is owed, how late, and the chase.
+                  The chase history belongs in the dialog behind the button —
+                  a two-line row of it made the amounts hard to scan down. */}
               {report.data.map((row) => (
-                <li key={row.documentId} className="flex flex-wrap items-center gap-3 p-3">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-mono text-sm">{row.invoiceNumber}</span>
-                      {row.record ? (
-                        <Link
-                          href={`/crm/${row.record.kind === "deal" ? "deals" : "leads"}/${row.record.id}`}
-                          className="text-sm hover:underline"
-                        >
-                          {row.record.label}
-                        </Link>
-                      ) : null}
-                    </div>
-                    <p className="text-sm text-[var(--text-muted)]">
-                      {row.daysOverdue > 0 ? (
-                        <span className="font-medium text-[var(--status-error-text)]">
-                          {row.daysOverdue} day{row.daysOverdue === 1 ? "" : "s"} late
-                        </span>
-                      ) : (
-                        <>
-                          Due <ClientDate value={row.dueDate} />
-                        </>
-                      )}
-                      {row.lastNote ? (
-                        <>
-                          {" · "}
-                          {COLLECTION_OUTCOME_LABELS[row.lastNote.outcome]}
-                          {row.lastNote.promisedAt ? (
-                            <>
-                              {" by "}
-                              <ClientDate value={row.lastNote.promisedAt} />
-                            </>
-                          ) : null}
-                        </>
-                      ) : (
-                        " · never chased"
-                      )}
-                    </p>
-                  </div>
+                <li
+                  key={row.documentId}
+                  className="flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 hover:bg-[var(--surface-subtle)]"
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="flex-none font-mono text-sm">{row.invoiceNumber}</span>
+                    {row.record ? (
+                      <Link
+                        href={`/crm/${row.record.kind === "deal" ? "deals" : "leads"}/${row.record.id}`}
+                        className="min-w-0 truncate text-sm underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text-muted)]"
+                      >
+                        {row.record.label}
+                      </Link>
+                    ) : null}
+                  </span>
 
-                  <span className="font-mono text-sm">
+                  <span className="flex-none text-sm">
+                    {row.daysOverdue > 0 ? (
+                      <span className="font-medium text-[var(--status-error-text)]">
+                        {row.daysOverdue}d late
+                      </span>
+                    ) : (
+                      <span className="text-[var(--text-muted)]">
+                        Due <ClientDate value={row.dueDate} mode="date" />
+                      </span>
+                    )}
+                  </span>
+
+                  <span className="hidden flex-none text-sm text-[var(--text-muted)] md:inline">
+                    {row.lastNote
+                      ? COLLECTION_OUTCOME_LABELS[row.lastNote.outcome]
+                      : "Never chased"}
+                  </span>
+
+                  <span className="flex-none font-mono text-sm tabular-nums">
                     {formatMoney(row.outstanding, row.currency)}
                   </span>
 
                   <Button type="button" size="sm" variant="secondary" onClick={() => setChasing(row)}>
-                    Log a chase
+                    Chase
                   </Button>
                 </li>
               ))}

--- a/components/crm/collections/collections-content.tsx
+++ b/components/crm/collections/collections-content.tsx
@@ -76,7 +76,7 @@ export function CollectionsContent({ currency = "USD" }: { currency?: string }) 
   const report = data;
 
   return (
-    <div className="space-y-5">
+    <div className="max-w-3xl space-y-4">
       {error ? (
         <Alert tone="danger" title="Couldn't load the chase list">
           {getApiErrorMessage(error)}

--- a/components/crm/crm-appointments-content.tsx
+++ b/components/crm/crm-appointments-content.tsx
@@ -175,6 +175,7 @@ export function CrmAppointmentsContent() {
 
   return (
     <RecordListShell
+      width="narrow"
       title="Site visits"
       search={search}
       onSearchChange={setSearch}

--- a/components/crm/crm-dashboard-content.tsx
+++ b/components/crm/crm-dashboard-content.tsx
@@ -224,7 +224,7 @@ export function CrmDashboardContent() {
       </KpiGrid>
 
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold">What needs you</h2>
+        <h2 className="text-base font-semibold text-[var(--text-strong)]">What needs you</h2>
         <div className="grid gap-2">
           <RowCard
             icon={<Clock className="size-4" />}

--- a/components/crm/crm-follow-ups-content.tsx
+++ b/components/crm/crm-follow-ups-content.tsx
@@ -9,6 +9,7 @@ import { Alert, Badge, Button, EmptyState, StatCard, Stack } from "@corelithzw/r
 import { ClientDate } from "@/components/ui/client-date";
 import { useToast } from "@/components/ui/use-toast";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import { ViewToolbar } from "@/components/crm/records/view-toolbar";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmTasks } from "@/lib/crm/crm-v2";
 import { TASK_QUEUE_LABELS, type TaskQueue } from "@/lib/crm/tasks";
@@ -104,7 +105,7 @@ export function CrmFollowUpsContent() {
     !tasks.isLoading && taskRows.length === 0 && legacyRows.length === 0 && queue === "TODAY";
 
   return (
-    <div className="space-y-5">
+    <div className="max-w-3xl space-y-4">
       <div className="grid gap-3 sm:grid-cols-3">
         {HEADLINE_QUEUES.map((value, index) => {
           const count = headline[index]?.data?.pagination?.total ?? 0;
@@ -119,23 +120,27 @@ export function CrmFollowUpsContent() {
         })}
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <SegmentedControl
-          options={QUEUES.map((value) => ({ value, label: TASK_QUEUE_LABELS[value] }))}
-          value={queue}
-          onValueChange={(value) => setQueue(value as TaskQueue)}
-          size="sm"
-          ariaLabel="Follow-up queue"
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          startIcon={<Plus className="size-4" />}
-          onClick={() => setCreating(true)}
-        >
-          New follow-up
-        </Button>
-      </div>
+      <ViewToolbar
+        start={
+          <SegmentedControl
+            options={QUEUES.map((value) => ({ value, label: TASK_QUEUE_LABELS[value] }))}
+            value={queue}
+            onValueChange={(value) => setQueue(value as TaskQueue)}
+            size="sm"
+            ariaLabel="Follow-up queue"
+          />
+        }
+        end={
+          <Button
+            variant="primary"
+            size="sm"
+            startIcon={<Plus className="size-4" />}
+            onClick={() => setCreating(true)}
+          >
+            New follow-up
+          </Button>
+        }
+      />
 
       {tasks.error ? (
         <Alert tone="danger" title="Couldn't load follow-ups">
@@ -165,7 +170,7 @@ export function CrmFollowUpsContent() {
       {legacyRows.length ? (
         <section className="space-y-2">
           <div>
-            <h2 className="text-sm font-semibold">Lead reminders</h2>
+            <h2 className="text-base font-semibold text-[var(--text-strong)]">Lead reminders</h2>
             <p className="text-sm text-[var(--text-muted)]">
               Raised from a lead before follow-ups became tasks. They behave the
               same way — tick one off when it is done.

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -121,7 +121,7 @@ export function CrmFormsContent() {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-sm font-semibold">Your forms</h2>
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">Your forms</h2>
           <p className="text-sm text-[var(--text-muted)]">
             Share the link anywhere — a submission lands in the CRM as a lead,
             assigned and scored on the way in.
@@ -213,7 +213,7 @@ export function CrmFormsContent() {
       )}
 
       <section className="space-y-2">
-        <h2 className="text-sm font-semibold">Latest submissions</h2>
+        <h2 className="text-base font-semibold text-[var(--text-strong)]">Latest submissions</h2>
         {submissions.isLoading ? (
           <Skeleton height={120} />
         ) : (submissions.data?.data ?? []).length === 0 ? (

--- a/components/crm/documents/document-list.tsx
+++ b/components/crm/documents/document-list.tsx
@@ -132,26 +132,35 @@ export function DocumentList({
     <div className="space-y-3">
       <BillingBand documents={documents} currency={currency} />
 
+      {/* Two ways to start a document is not one primary action and one
+          afterthought — a quote and an invoice are peers, so they are drawn as
+          peers. Colour is reserved for the single action a screen wants you to
+          take, and this screen does not have one. */}
       {canCreate ? (
         <div className="flex flex-wrap gap-2">
-          <Button size="sm" className="gap-1.5" onClick={() => setBuilder({ mode: "quotation" })}>
-            <Plus className="h-3.5 w-3.5" />
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 gap-2"
+            onClick={() => setBuilder({ mode: "quotation" })}
+          >
+            <Plus className="size-4" />
             New quotation
           </Button>
           <Button
             size="sm"
             variant="outline"
-            className="gap-1.5"
+            className="h-9 gap-2"
             onClick={() => setBuilder({ mode: "invoice" })}
           >
-            <Plus className="h-3.5 w-3.5" />
+            <Plus className="size-4" />
             New invoice
           </Button>
         </div>
       ) : (
         <p className="rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface-muted)]/50 p-3 text-sm text-[var(--text-muted)]">
-          Attach a company to this record before quoting or invoicing — documents are billed
-          to a customer.
+          Give this record somebody to bill — a contact name or a company — before quoting or
+          invoicing.
         </p>
       )}
 

--- a/components/crm/documents/documents-list-content.tsx
+++ b/components/crm/documents/documents-list-content.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Badge } from "@corelithzw/react";
-import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import {
   DropdownMenu,
@@ -177,6 +176,7 @@ export function DocumentsListContent({
 
   return (
     <RecordListShell
+      width="narrow"
       title={title}
       search={search}
       onSearchChange={(value) => {

--- a/components/crm/import/import-wizard.tsx
+++ b/components/crm/import/import-wizard.tsx
@@ -120,7 +120,7 @@ export function ImportWizard() {
       ) : null}
 
       <section className="space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
-        <h2 className="text-sm font-semibold">1. What are you importing?</h2>
+        <h2 className="text-base font-semibold text-[var(--text-strong)]">1. What are you importing?</h2>
         <div className="flex flex-wrap items-end gap-3">
           <div className="space-y-1.5">
             <Label>Record type</Label>
@@ -162,7 +162,7 @@ export function ImportWizard() {
 
       {table ? (
         <section className="space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
-          <h2 className="text-sm font-semibold">2. Which column is which?</h2>
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">2. Which column is which?</h2>
           <p className="text-sm text-[var(--text-muted)]">
             Guessed from the headers. Change anything that looks wrong — a wrong
             guess applied silently is worse than no guess at all.
@@ -279,7 +279,7 @@ export function ImportWizard() {
 
       {preview ? (
         <section className="space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
-          <h2 className="text-sm font-semibold">3. What will happen</h2>
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">3. What will happen</h2>
 
           <div className="flex flex-wrap gap-4">
             {(

--- a/components/crm/lead-detail/activity-composer.tsx
+++ b/components/crm/lead-detail/activity-composer.tsx
@@ -8,6 +8,7 @@ import { RichTextComposer } from "@/components/crm/collaboration/rich-text-compo
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { richTextToPlain } from "@/lib/crm/rich-text";
 
 const ACTIVITY_TYPES = [
   { value: "NOTE", label: "Note" },
@@ -54,15 +55,18 @@ export function ActivityComposer({ target }: { target: ActivityTarget }) {
   const log = useMutation({
     mutationFn: () => {
       const trimmed = text.trim();
-      const breakAt = trimmed.indexOf("\n");
-      const subject = breakAt === -1 ? trimmed : trimmed.slice(0, breakAt).trim();
-      const body = breakAt === -1 ? undefined : trimmed.slice(breakAt + 1).trim() || undefined;
+      // What was written goes in the body, always. Splitting on the first
+      // newline meant a one-line note — the common case — was stored entirely
+      // as the subject, and the timeline draws a subject as plain text: every
+      // mention came out as `@[Sarah](uuid)` and every bold as asterisks.
+      // The subject is now a flattened reading of the same words, for the
+      // places that cannot run the renderer.
       return fetchJson("/api/v2/crm/activities", {
         method: "POST",
         body: JSON.stringify({
           type,
-          subject: subject.slice(0, 200),
-          body,
+          subject: richTextToPlain(trimmed, 200),
+          body: trimmed,
           [TARGET_KEYS[target.kind]]: target.id,
         }),
       });

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -274,7 +274,9 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
                 basePath={`/api/v2/crm/leads/${leadId}`}
                 currency={lead.currency}
                 documents={lead.documents}
-                canCreate={Boolean(lead.clientId)}
+                // A lead with a name to bill can be quoted; the company is
+                // created from the contact if there is not one already.
+                canCreate={Boolean(lead.clientId || lead.contactName || lead.title)}
                 prefillLines={quotationPrefill}
                 onPrefillConsumed={() => setQuotationPrefill(undefined)}
               />

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -246,7 +246,7 @@ export function ConvertLeadSheet({
       ) : prep ? (
         <div className="space-y-4">
           <section className="space-y-2">
-            <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
               Person
             </h3>
             {prep.personDuplicates.length > 0 ? (
@@ -291,7 +291,7 @@ export function ConvertLeadSheet({
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
               Company
             </h3>
             {prep.companyDuplicates.length > 0 ? (
@@ -337,7 +337,7 @@ export function ConvertLeadSheet({
           </section>
 
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
               Deal
             </h3>
             <div className="space-y-1.5">

--- a/components/crm/leads/lead-form-sheet.tsx
+++ b/components/crm/leads/lead-form-sheet.tsx
@@ -66,7 +66,7 @@ type LeadSourceOption = { id: string; name: string; channel: string; isActive: b
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="space-y-3">
-      <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+      <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
         {title}
       </h3>
       {children}

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -10,6 +10,8 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { Funnel, Plus } from "@/lib/icons";
 import { PageChrome } from "@/components/layout/page-chrome";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { PipelineSwitcher } from "@/components/crm/records/pipeline-switcher";
 import { ViewToolbar } from "@/components/crm/records/view-toolbar";
 import {
   bulkUpdateCrmLeads,
@@ -234,6 +236,10 @@ export function LeadsWorkspace({
 
             <LeadStageFilter filters={filters} onChange={applyFilters} />
 
+            {/* The same pipeline menu deals has. Leads are the intake
+                pipeline; the menu is how you cross to the deal ones. */}
+            <PipelineSwitcher active="leads" />
+
             {/* A board is already ordered by stage, so sorting it means nothing. */}
             {viewType === "TABLE" ? (
               <LeadsSortButton
@@ -247,11 +253,23 @@ export function LeadsWorkspace({
           </>
         }
         end={
-          <ColumnPicker
-            columns={viewType === "TABLE" ? LEAD_TABLE_COLUMNS : LEAD_CARD_FIELDS}
-            state={viewType === "TABLE" ? tableColumns : boardFields}
-            label={viewType === "TABLE" ? "Columns" : "Fields"}
-          />
+          <>
+            <SegmentedControl
+              value={viewType}
+              onValueChange={(value) => setViewType(value as "TABLE" | "BOARD")}
+              size="sm"
+              ariaLabel="Board or list"
+              options={[
+                { value: "BOARD", label: "Board" },
+                { value: "TABLE", label: "List" },
+              ]}
+            />
+            <ColumnPicker
+              columns={viewType === "TABLE" ? LEAD_TABLE_COLUMNS : LEAD_CARD_FIELDS}
+              state={viewType === "TABLE" ? tableColumns : boardFields}
+              label={viewType === "TABLE" ? "Columns" : "Fields"}
+            />
+          </>
         }
       />
 

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -51,12 +51,15 @@ export function LeadsWorkspace({
   initialFilters = {},
   initialView = "BOARD",
   initialViewId = null,
+  onPickPipeline,
 }: {
   /** Parsed from the page's query string, so links like /crm/leads?stages=QUOTED land pre-filtered. */
   initialFilters?: LeadViewFilters;
   initialView?: "TABLE" | "BOARD";
   /** From `?view=`, so the sidebar's saved-view links land on that view. */
   initialViewId?: string | null;
+  /** Set by the unified workspace so the pipeline menu swaps in place. */
+  onPickPipeline?: (target: "leads" | string) => void;
 }) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -238,7 +241,7 @@ export function LeadsWorkspace({
 
             {/* The same pipeline menu deals has. Leads are the intake
                 pipeline; the menu is how you cross to the deal ones. */}
-            <PipelineSwitcher active="leads" />
+            <PipelineSwitcher active="leads" onPick={onPickPipeline} />
 
             {/* A board is already ordered by stage, so sorting it means nothing. */}
             {viewType === "TABLE" ? (

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -21,6 +21,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
+import { CompanyPeopleTab } from "./company-people-tab";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -270,18 +271,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
           value: "people",
           label: "People",
           count: company.people.length,
-          content: (
-            <RelatedList
-              items={company.people}
-              emptyMessage="Nobody is recorded at this company yet."
-              renderItem={(person) => ({
-                href: `/crm/people/${person.id}`,
-                title: person.fullName,
-                subtitle: person.jobTitle,
-                meta: person.phone ?? undefined,
-              })}
-            />
-          ),
+          content: <CompanyPeopleTab companyId={companyId} people={company.people} />,
         },
         {
           value: "deals",

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -22,6 +22,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { RecordAttributes } from "./record-attributes";
+import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { CompanyFormSheet } from "./company-form-sheet";
@@ -98,6 +99,10 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   const companyQuery = useQuery({
     queryKey: ["crm", "company", companyId],
     queryFn: () => fetchJson<CompanyDetail>(`/api/v2/crm/companies/${companyId}`),
+  });
+  const edit = useAttributeEditor({
+    path: `/api/v2/crm/companies/${companyId}`,
+    invalidate: [["crm", "company", companyId], ["crm", "companies"]],
   });
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "COMPANY"],
@@ -212,39 +217,22 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
               id: "phone",
               label: "Phone",
               icon: Phone,
-              display: company.phone ? (
-                <a href={`tel:${company.phone}`} className="text-sm hover:underline">
-                  {company.phone}
-                </a>
-              ) : undefined,
-              value: company.phone,
+              placeholder: "Not recorded",
+              ...edit.text("phone", company.phone),
             },
             {
               id: "email",
               label: "Email",
               icon: Mail,
-              display: company.email ? (
-                <a href={`mailto:${company.email}`} className="text-sm hover:underline">
-                  {company.email}
-                </a>
-              ) : undefined,
-              value: company.email,
+              placeholder: "Not recorded",
+              ...edit.text("email", company.email),
             },
             {
               id: "website",
               label: "Website",
               icon: Globe,
-              display: company.website ? (
-                <a
-                  href={company.website}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-sm hover:underline"
-                >
-                  {company.website}
-                </a>
-              ) : undefined,
-              value: company.website,
+              placeholder: "Not recorded",
+              ...edit.text("website", company.website),
             },
             {
               id: "location",
@@ -253,14 +241,26 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
               value: [company.city, company.country].filter(Boolean).join(", ") || null,
               placeholder: "Not recorded",
             },
-            { id: "industry", label: "Industry", value: company.industry },
+            {
+              id: "industry",
+              label: "Industry",
+              placeholder: "Not recorded",
+              ...edit.text("industry", company.industry),
+            },
             {
               id: "registration",
               label: "Registration no.",
-              value: company.registrationNumber,
               mono: true,
+              placeholder: "Not recorded",
+              ...edit.text("registrationNumber", company.registrationNumber),
             },
-            { id: "tax", label: "Tax number", value: company.taxNumber, mono: true },
+            {
+              id: "tax",
+              label: "Tax number",
+              mono: true,
+              placeholder: "Not recorded",
+              ...edit.text("taxNumber", company.taxNumber),
+            },
           ]}
         />
       }

--- a/components/crm/records/company-people-tab.tsx
+++ b/components/crm/records/company-people-tab.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { Plus, X } from "@/lib/icons";
+
+import { EntityLink } from "./entity-link";
+import { RecordPicker, type PickedRecord } from "./record-picker";
+
+export type CompanyPerson = {
+  id: string;
+  fullName: string;
+  jobTitle?: string | null;
+  phone?: string | null;
+};
+
+/**
+ * Who works at a company, and how to say so.
+ *
+ * A person belongs to a company through their own record, so attaching one is
+ * a write to the person rather than to a join table — which is why this reads
+ * "move this person here" rather than "create a membership". Detaching leaves
+ * the person alone with no company, because somebody leaving an employer is
+ * not somebody being deleted.
+ */
+export function CompanyPeopleTab({
+  companyId,
+  people,
+}: {
+  companyId: string;
+  people: CompanyPerson[];
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [picked, setPicked] = useState<PickedRecord | null>(null);
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: ["crm", "company", companyId] });
+    queryClient.invalidateQueries({ queryKey: ["crm", "people"] });
+  };
+
+  const attach = useMutation({
+    mutationFn: (personId: string) =>
+      fetchJson(`/api/v2/crm/people/${personId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ clientId: companyId }),
+      }),
+    onSuccess: () => {
+      setPicked(null);
+      refresh();
+      toast({ title: "Added to this company" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not add that person",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const detach = useMutation({
+    mutationFn: (personId: string) =>
+      fetchJson(`/api/v2/crm/people/${personId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ clientId: null }),
+      }),
+    onSuccess: () => {
+      refresh();
+      toast({ title: "Removed from this company" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not remove that person",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-56 flex-1">
+          <RecordPicker
+            value={picked}
+            onChange={setPicked}
+            types={["PERSON"]}
+            placeholder="Search people to add"
+          />
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-9 gap-2"
+          disabled={!picked || attach.isPending}
+          onClick={() => picked && attach.mutate(picked.id)}
+        >
+          <Plus className="size-4" />
+          Add
+        </Button>
+      </div>
+
+      {people.length === 0 ? (
+        <p className="py-6 text-center text-sm text-[var(--text-muted)]">
+          Nobody is recorded at this company yet.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {people.map((person) => (
+            <li
+              key={person.id}
+              className="flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 hover:bg-[var(--surface-subtle)]"
+            >
+              <EntityLink
+                href={`/crm/people/${person.id}`}
+                className="min-w-0 flex-1 truncate text-sm font-medium"
+              >
+                {person.fullName}
+              </EntityLink>
+              {person.jobTitle ? (
+                <span className="hidden flex-none text-sm text-[var(--text-muted)] sm:inline">
+                  {person.jobTitle}
+                </span>
+              ) : null}
+              {person.phone ? (
+                <span className="hidden flex-none font-mono text-sm text-[var(--text-muted)] sm:inline">
+                  {person.phone}
+                </span>
+              ) : null}
+              <IconButton
+                size="sm"
+                aria-label={`Remove ${person.fullName} from this company`}
+                disabled={detach.isPending}
+                onClick={() => detach.mutate(person.id)}
+              >
+                <X />
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/crm/records/custom-field-inputs.tsx
+++ b/components/crm/records/custom-field-inputs.tsx
@@ -49,7 +49,7 @@ export function CustomFieldInputs({
     <>
       {sections.map(([section, fields]) => (
         <section key={section} className="space-y-3">
-          <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+          <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
             {section}
           </h3>
           {fields.map((definition) => (

--- a/components/crm/records/deal-contacts-tab.tsx
+++ b/components/crm/records/deal-contacts-tab.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { Plus, Trash2 } from "@/lib/icons";
+
+import { EntityLink } from "./entity-link";
+import { RecordPicker, type PickedRecord } from "./record-picker";
+
+const ROLES = [
+  { value: "PRIMARY", label: "Primary contact" },
+  { value: "DECISION_MAKER", label: "Decision maker" },
+  { value: "FINANCE", label: "Finance" },
+  { value: "SITE", label: "Site contact" },
+  { value: "TECHNICAL", label: "Technical" },
+  { value: "INFLUENCER", label: "Influencer" },
+  { value: "REFERRER", label: "Referrer" },
+] as const;
+
+const ROLE_LABEL: Record<string, string> = Object.fromEntries(
+  ROLES.map((role) => [role.value, role.label]),
+);
+
+export type DealContact = {
+  id: string;
+  role: string;
+  person: { id: string; fullName: string; jobTitle?: string | null; phone?: string | null };
+};
+
+/**
+ * The people on a deal — and the way to change who they are.
+ *
+ * This list was read-only, which meant the only chance to say who was
+ * involved was the moment the deal was created. Deals gain a decision maker
+ * in week three and lose a site contact when somebody leaves; that is the
+ * normal shape of the work, not an exception worth a trip to an admin screen.
+ */
+export function DealContactsTab({
+  dealId,
+  contacts,
+}: {
+  dealId: string;
+  contacts: DealContact[];
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [picked, setPicked] = useState<PickedRecord | null>(null);
+  const [role, setRole] = useState<string>("PRIMARY");
+
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["crm", "deal", dealId] });
+
+  const add = useMutation({
+    mutationFn: () =>
+      fetchJson(`/api/v2/crm/deals/${dealId}/contacts`, {
+        method: "POST",
+        body: JSON.stringify({ personId: picked?.id, role }),
+      }),
+    onSuccess: () => {
+      setPicked(null);
+      setRole("PRIMARY");
+      refresh();
+      toast({ title: "Added to this deal" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not add that person",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (contactId: string) =>
+      fetchJson(`/api/v2/crm/deals/${dealId}/contacts?contactId=${contactId}`, {
+        method: "DELETE",
+      }),
+    onSuccess: () => {
+      refresh();
+      toast({ title: "Removed from this deal" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not remove that person",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-56 flex-1">
+          <RecordPicker
+            value={picked}
+            onChange={setPicked}
+            types={["PERSON"]}
+            placeholder="Search people to add"
+          />
+        </div>
+
+        <Select value={role} onValueChange={setRole}>
+          <SelectTrigger className="h-9 w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ROLES.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-9 gap-2"
+          disabled={!picked || add.isPending}
+          onClick={() => add.mutate()}
+        >
+          <Plus className="size-4" />
+          Add
+        </Button>
+      </div>
+
+      {contacts.length === 0 ? (
+        <p className="py-6 text-center text-sm text-[var(--text-muted)]">
+          Nobody is attached to this deal yet.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {contacts.map((contact) => (
+            <li
+              key={contact.id}
+              className="flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 hover:bg-[var(--surface-subtle)]"
+            >
+              <EntityLink
+                href={`/crm/people/${contact.person.id}`}
+                className="min-w-0 flex-1 truncate text-sm font-medium"
+              >
+                {contact.person.fullName}
+              </EntityLink>
+              <span className="flex-none text-sm text-[var(--text-muted)]">
+                {ROLE_LABEL[contact.role] ?? contact.role}
+              </span>
+              {contact.person.phone ? (
+                <span className="hidden flex-none font-mono text-sm text-[var(--text-muted)] sm:inline">
+                  {contact.person.phone}
+                </span>
+              ) : null}
+              <IconButton
+                size="sm"
+                aria-label={`Remove ${contact.person.fullName} from this deal`}
+                disabled={remove.isPending}
+                onClick={() => remove.mutate(contact.id)}
+              >
+                <Trash2 />
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -46,10 +46,11 @@ import { RaiseJobSheet } from "@/components/crm/work-orders/raise-job-sheet";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
+import { DealContactsTab } from "./deal-contacts-tab";
 import { RecordAttributes } from "./record-attributes";
 import { EntityLink } from "./entity-link";
 import { DealStageBar } from "./deal-stage-bar";
-import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
+import { RailSection, RecordPageShell } from "./record-page-shell";
 import { RecordHistoryTab } from "./record-history-tab";
 import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 
@@ -419,21 +420,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             value: "people",
             label: "People",
             count: deal.contacts.length,
-            content: (
-              <RelatedList
-                items={deal.contacts}
-                emptyMessage="Nobody is attached to this deal yet."
-                renderItem={(contact) => ({
-                  href: `/crm/people/${contact.person.id}`,
-                  title: contact.person.fullName,
-                  subtitle:
-                    [ROLE_LABELS[contact.role] ?? contact.role, contact.person.jobTitle]
-                      .filter(Boolean)
-                      .join(" · ") || null,
-                  meta: contact.person.phone ?? undefined,
-                })}
-              />
-            ),
+            content: <DealContactsTab dealId={dealId} contacts={deal.contacts} />,
           },
           {
             value: "comments",

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -10,16 +11,7 @@ import { NumericCell } from "@/components/ui/numeric-cell";
 import { StatusChip } from "@/components/ui/status-chip";
 import { ClientDate } from "@/components/ui/client-date";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { SegmentedControl } from "@/components/ui/segmented-control";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ChevronDown } from "@/lib/icons";
 import { useDebounced } from "@/hooks/use-debounced";
 import { fetchCrmDeals, fetchCrmPipelines, type CrmDealRecord } from "@/lib/crm/crm-v2";
 import { isDealStale } from "@/lib/crm/pipelines";
@@ -30,6 +22,7 @@ import { BoardFieldsProvider, DEAL_CARD_FIELDS } from "./board-fields";
 import { ColumnPicker } from "@/components/ui/column-picker";
 import { useVisibleColumns, type ColumnOption } from "@/lib/ui/visible-columns";
 import { DealFormSheet } from "./deal-form-sheet";
+import { PipelineSwitcher } from "./pipeline-switcher";
 import { RecordListShell } from "./record-list-shell";
 
 const PAGE_SIZE = 50;
@@ -66,7 +59,9 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
   // Which pipeline, and whether to work it as a board or read it as a list.
   // Both live in state rather than the URL because they are how you are
   // looking at the page, not what the page is.
-  const [pipelineId, setPipelineId] = useState<string | null>(null);
+  // Arriving from the leads page's pipeline menu lands on ?pipeline=<id>.
+  const requestedPipeline = useSearchParams().get("pipeline");
+  const [pipelineId, setPipelineId] = useState<string | null>(requestedPipeline);
   const [layout, setLayout] = useState<"BOARD" | "LIST">("BOARD");
 
   const pipelinesQuery = useQuery({
@@ -109,7 +104,10 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
         header: "Deal",
         size: 240,
         cell: ({ row }) => (
-          <Link href={`/crm/deals/${row.original.id}`} className="block min-w-0 hover:underline">
+          <Link
+            href={`/crm/deals/${row.original.id}`}
+            className="block min-w-0 underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text-muted)]"
+          >
             <div className="truncate font-medium">{row.original.title}</div>
             <div className="truncate font-mono text-sm text-[var(--text-muted)]">
               {row.original.dealNo}
@@ -250,31 +248,10 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
           {/* A pipeline is a different shape of work, not a filter over one
               shape — supply-only and supply-and-fit do not share stages — so
               picking one swaps the board rather than narrowing it. */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                {activePipeline?.name ?? "Pipeline"}
-                <ChevronDown className="size-3 text-[var(--text-muted)]" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
-              {pipelines.map((pipeline) => (
-                <DropdownMenuItem
-                  key={pipeline.id}
-                  onClick={() => setPipelineId(pipeline.id)}
-                >
-                  {pipeline.name}
-                  {pipeline.isDefault ? (
-                    <span className="ml-2 text-sm text-[var(--text-muted)]">default</span>
-                  ) : null}
-                </DropdownMenuItem>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link href="/crm/settings?tab=pipelines">Manage pipelines</Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <PipelineSwitcher
+            active={activePipeline?.id ?? null}
+            onPickPipeline={setPipelineId}
+          />
 
           <SegmentedControl
             value={layout}

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -49,7 +49,16 @@ const DEAL_TABLE_COLUMNS: ColumnOption[] = [
   { id: "next", label: "Next task" },
 ];
 
-export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
+export function DealsContent({
+  openCreate = false,
+  pipelineId: pipelineIdProp,
+  onPickPipeline,
+}: {
+  openCreate?: boolean;
+  /** Set by the unified workspace, which owns which pipeline is showing. */
+  pipelineId?: string;
+  onPickPipeline?: (target: "leads" | string) => void;
+}) {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<"OPEN" | "WON" | "LOST" | "ALL">("OPEN");
   const [page, setPage] = useState(1);
@@ -61,7 +70,12 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
   // looking at the page, not what the page is.
   // Arriving from the leads page's pipeline menu lands on ?pipeline=<id>.
   const requestedPipeline = useSearchParams().get("pipeline");
-  const [pipelineId, setPipelineId] = useState<string | null>(requestedPipeline);
+  const [ownPipelineId, setOwnPipelineId] = useState<string | null>(requestedPipeline);
+  // The parent wins when there is one: the unified workspace holds the choice
+  // so the menu can cross to leads, which this component knows nothing about.
+  const pipelineId = pipelineIdProp ?? ownPipelineId;
+  const setPipelineId = (next: string) =>
+    onPickPipeline ? onPickPipeline(next) : setOwnPipelineId(next);
   const [layout, setLayout] = useState<"BOARD" | "LIST">("BOARD");
 
   const pipelinesQuery = useQuery({
@@ -250,6 +264,7 @@ export function DealsContent({ openCreate = false }: { openCreate?: boolean }) {
               picking one swaps the board rather than narrowing it. */}
           <PipelineSwitcher
             active={activePipeline?.id ?? null}
+            onPick={onPickPipeline}
             onPickPipeline={setPipelineId}
           />
 

--- a/components/crm/records/field-history-tab.tsx
+++ b/components/crm/records/field-history-tab.tsx
@@ -99,7 +99,7 @@ export function FieldHistoryTab({
         <div className="space-y-4">
           {byField.map(([field, entries]) => (
             <section key={field} className="space-y-1">
-              <h3 className="text-sm font-semibold">{fieldLabel(field)}</h3>
+              <h3 className="text-base font-semibold text-[var(--text-strong)]">{fieldLabel(field)}</h3>
               <Stack as="ul" gap="xs">
                 {entries.map((change) => (
                   <ChangeRow key={change.id} change={change} showField={false} />

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -20,6 +20,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { RecordAttributes } from "./record-attributes";
+import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
 import {
   AddressBook,
@@ -122,6 +123,10 @@ export function PersonDetailPage({ personId }: { personId: string }) {
     queryKey: ["crm", "field-definitions", "PERSON"],
     queryFn: () => fetchCrmFieldDefinitions("PERSON"),
   });
+  const edit = useAttributeEditor({
+    path: `/api/v2/crm/people/${personId}`,
+    invalidate: [["crm", "person", personId], ["crm", "people"]],
+  });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const person = personQuery.data;
@@ -212,23 +217,15 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               id: "email",
               label: "Email",
               icon: Mail,
-              display: person.email ? (
-                <a href={`mailto:${person.email}`} className="text-sm hover:underline">
-                  {person.email}
-                </a>
-              ) : undefined,
-              value: person.email,
+              placeholder: "Not recorded",
+              ...edit.text("email", person.email),
             },
             {
               id: "phone",
               label: "Phone",
               icon: Phone,
-              display: person.phone ? (
-                <a href={`tel:${person.phone}`} className="text-sm hover:underline">
-                  {person.phone}
-                </a>
-              ) : undefined,
-              value: person.phone,
+              placeholder: "Not recorded",
+              ...edit.text("phone", person.phone),
             },
             {
               id: "company",
@@ -267,8 +264,8 @@ export function PersonDetailPage({ personId }: { personId: string }) {
             {
               id: "role",
               label: "Job title",
-              value: person.jobTitle,
               placeholder: "Not recorded",
+              ...edit.text("jobTitle", person.jobTitle),
             },
             {
               id: "prefers",
@@ -281,8 +278,8 @@ export function PersonDetailPage({ personId }: { personId: string }) {
             {
               id: "city",
               label: "City",
-              value: person.city,
               placeholder: "Not recorded",
+              ...edit.text("city", person.city),
             },
           ]}
         />

--- a/components/crm/records/pipeline-switcher.tsx
+++ b/components/crm/records/pipeline-switcher.tsx
@@ -27,6 +27,7 @@ import { fetchCrmPipelines } from "@/lib/crm/crm-v2";
 export function PipelineSwitcher({
   active,
   onPickPipeline,
+  onPick,
 }: {
   /** "leads", or the active deal pipeline's id. */
   active: "leads" | string | null;
@@ -35,6 +36,11 @@ export function PipelineSwitcher({
    * (the deals page). Omitted, the menu navigates instead (the leads page).
    */
   onPickPipeline?: (pipelineId: string) => void;
+  /**
+   * The unified workspace's handler: it can swap between leads and any deal
+   * pipeline without a navigation, so the menu never leaves the page.
+   */
+  onPick?: (target: "leads" | string) => void;
 }) {
   const pipelinesQuery = useQuery({
     queryKey: ["crm", "pipelines"],
@@ -56,18 +62,30 @@ export function PipelineSwitcher({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
-        <DropdownMenuItem asChild>
-          <Link href="/crm/leads" aria-current={active === "leads" ? "true" : undefined}>
+        {onPick ? (
+          <DropdownMenuItem onClick={() => onPick("leads")}>
             Leads
             {active === "leads" ? (
               <span className="ml-2 text-sm text-[var(--text-muted)]">current</span>
             ) : null}
-          </Link>
-        </DropdownMenuItem>
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem asChild>
+            <Link href="/crm/leads" aria-current={active === "leads" ? "true" : undefined}>
+              Leads
+              {active === "leads" ? (
+                <span className="ml-2 text-sm text-[var(--text-muted)]">current</span>
+              ) : null}
+            </Link>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         {pipelines.map((pipeline) =>
-          onPickPipeline ? (
-            <DropdownMenuItem key={pipeline.id} onClick={() => onPickPipeline(pipeline.id)}>
+          onPick || onPickPipeline ? (
+            <DropdownMenuItem
+              key={pipeline.id}
+              onClick={() => (onPick ? onPick(pipeline.id) : onPickPipeline?.(pipeline.id))}
+            >
               {pipeline.name}
               {pipeline.id === active ? (
                 <span className="ml-2 text-sm text-[var(--text-muted)]">current</span>

--- a/components/crm/records/pipeline-switcher.tsx
+++ b/components/crm/records/pipeline-switcher.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "@/lib/icons";
+import { fetchCrmPipelines } from "@/lib/crm/crm-v2";
+
+/**
+ * One control for "which pipeline am I looking at" — the same trigger on
+ * leads and on deals.
+ *
+ * A pipeline is a different shape of work, not a filter over one shape, so
+ * picking one swaps the whole board. Leads are a pipeline too — the fixed
+ * intake one — which is why they appear in this menu rather than being a
+ * place this menu cannot take you. Crossing between them navigates; staying
+ * within deals just swaps the board.
+ */
+export function PipelineSwitcher({
+  active,
+  onPickPipeline,
+}: {
+  /** "leads", or the active deal pipeline's id. */
+  active: "leads" | string | null;
+  /**
+   * Called with a deal pipeline id when the surface can swap in place
+   * (the deals page). Omitted, the menu navigates instead (the leads page).
+   */
+  onPickPipeline?: (pipelineId: string) => void;
+}) {
+  const pipelinesQuery = useQuery({
+    queryKey: ["crm", "pipelines"],
+    queryFn: () => fetchCrmPipelines(),
+  });
+  const pipelines = pipelinesQuery.data?.data ?? [];
+
+  const activePipeline =
+    active !== "leads" ? pipelines.find((pipeline) => pipeline.id === active) : undefined;
+  const triggerLabel =
+    active === "leads" ? "Leads" : (activePipeline?.name ?? "Pipeline");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" variant="outline" className="h-9 gap-2">
+          {triggerLabel}
+          <ChevronDown className="size-3 text-[var(--text-muted)]" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
+        <DropdownMenuItem asChild>
+          <Link href="/crm/leads" aria-current={active === "leads" ? "true" : undefined}>
+            Leads
+            {active === "leads" ? (
+              <span className="ml-2 text-sm text-[var(--text-muted)]">current</span>
+            ) : null}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {pipelines.map((pipeline) =>
+          onPickPipeline ? (
+            <DropdownMenuItem key={pipeline.id} onClick={() => onPickPipeline(pipeline.id)}>
+              {pipeline.name}
+              {pipeline.id === active ? (
+                <span className="ml-2 text-sm text-[var(--text-muted)]">current</span>
+              ) : pipeline.isDefault ? (
+                <span className="ml-2 text-sm text-[var(--text-muted)]">default</span>
+              ) : null}
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem key={pipeline.id} asChild>
+              <Link href={`/crm/deals?pipeline=${pipeline.id}`}>
+                {pipeline.name}
+                {pipeline.isDefault ? (
+                  <span className="ml-2 text-sm text-[var(--text-muted)]">default</span>
+                ) : null}
+              </Link>
+            </DropdownMenuItem>
+          ),
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/crm/settings?tab=pipelines">Manage pipelines</Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/crm/records/pipeline-workspace.tsx
+++ b/components/crm/records/pipeline-workspace.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import { LeadsWorkspace } from "@/components/crm/leads/leads-workspace";
+import type { LeadViewFilters } from "@/lib/crm/views";
+
+import { DealsContent } from "./deals-content";
+
+/**
+ * Leads and deals, on one page.
+ *
+ * They were two routes with two sidebars entries, and the complaint was fair:
+ * a lead and the deal it becomes are the same piece of work at two moments,
+ * and asking somebody to remember which page a thing is on today is asking
+ * them to track our schema. The pipeline menu is the whole switch now — Leads
+ * is the intake pipeline, the deal pipelines are the rest — and picking one
+ * swaps what is under the toolbar without leaving the page.
+ *
+ * The two boards stay separate underneath because their stages are genuinely
+ * different: a lead's are a fixed enum this module can reason about, a deal's
+ * are configured per pipeline. Merging the models is a migration, and it is
+ * not what makes the page confusing — having to navigate is.
+ */
+export function PipelineWorkspace({
+  initial = "leads",
+  initialFilters = {},
+  initialView = "BOARD",
+  initialViewId = null,
+  openCreate = false,
+}: {
+  /** "leads", or a deal pipeline id — usually from the route. */
+  initial?: "leads" | string;
+  initialFilters?: LeadViewFilters;
+  initialView?: "TABLE" | "BOARD";
+  initialViewId?: string | null;
+  openCreate?: boolean;
+}) {
+  const [active, setActive] = useState<"leads" | string>(initial);
+
+  if (active === "leads") {
+    return (
+      <LeadsWorkspace
+        initialFilters={initialFilters}
+        initialView={initialView}
+        initialViewId={initialViewId}
+        onPickPipeline={setActive}
+      />
+    );
+  }
+
+  return (
+    <DealsContent
+      openCreate={openCreate}
+      // `"deals"` means "whichever pipeline is the default" — the deals view
+      // resolves that itself, so it is passed nothing rather than a sentinel
+      // it would fail to find in the list.
+      pipelineId={active === "deals" ? undefined : active}
+      onPickPipeline={setActive}
+    />
+  );
+}

--- a/components/crm/records/record-list-shell.tsx
+++ b/components/crm/records/record-list-shell.tsx
@@ -5,6 +5,7 @@ import { useMemo, type ReactNode } from "react";
 import { Alert, Button, Input } from "@corelithzw/react";
 import { PageChrome } from "@/components/layout/page-chrome";
 import { Plus } from "@/lib/icons";
+import { cn } from "@/lib/utils";
 
 import { ViewToolbar } from "./view-toolbar";
 import { getApiErrorMessage } from "@/lib/api-client";
@@ -30,6 +31,7 @@ export function RecordListShell({
   createLabel,
   onCreate,
   error,
+  width = "full",
   children,
 }: {
   title: string;
@@ -44,6 +46,12 @@ export function RecordListShell({
   createLabel?: string;
   onCreate?: () => void;
   error?: unknown;
+  /**
+   * "narrow" caps the whole surface at max-w-3xl. A register of one-line
+   * items — tasks, receipts, work orders — reads as a column, and stretching
+   * it across a wide screen just puts air between the title and its facts.
+   */
+  width?: "full" | "narrow";
   children: ReactNode;
 }) {
   const actions = useMemo(
@@ -62,7 +70,7 @@ export function RecordListShell({
   );
 
   return (
-    <div className="space-y-4">
+    <div className={cn("space-y-4", width === "narrow" && "max-w-3xl")}>
       <PageChrome title={title}>{actions}</PageChrome>
 
       <ViewToolbar

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -177,7 +177,7 @@ export function RailSection({
   return (
     <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+        <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
           {title}
         </h3>
         {action}

--- a/components/crm/records/relation-attribute.tsx
+++ b/components/crm/records/relation-attribute.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { X } from "@/lib/icons";
+
+import { EntityLink } from "./entity-link";
+import { RecordPicker, type PickableType, type PickedRecord } from "./record-picker";
+
+/**
+ * A property that points at another record, and can be repointed.
+ *
+ * The list-shaped relationships — people on a deal, people at a company —
+ * have their own tabs. This is the other kind: the single link a record
+ * carries as a property, like the company a site belongs to or the person to
+ * ring before turning up. Those were drawn as links and nothing else, so the
+ * only way to correct one was to have got it right at creation.
+ *
+ * Reads as the link it is until you press it, because the common case is
+ * following the reference, not changing it.
+ */
+export function RelationAttribute({
+  value,
+  href,
+  types,
+  placeholder = "Not set",
+  searchPlaceholder,
+  onPick,
+  onClear,
+}: {
+  /** The current record's label, or null when nothing is linked. */
+  value: string | null;
+  href: string | null;
+  types: readonly PickableType[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  onPick: (record: PickedRecord) => void;
+  onClear?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<PickedRecord | null>(null);
+
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {value ? (
+        <EntityLink href={href} className="min-w-0 truncate text-sm">
+          {value}
+        </EntityLink>
+      ) : (
+        <span className="text-sm text-[var(--text-muted)]">{placeholder}</span>
+      )}
+
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setDraft(null);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-sm text-[var(--text-muted)]"
+          >
+            {value ? "Change" : "Set"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-80 space-y-2 p-2">
+          <RecordPicker
+            value={draft}
+            onChange={(next) => {
+              setDraft(next);
+              if (next) {
+                onPick(next);
+                setOpen(false);
+                setDraft(null);
+              }
+            }}
+            types={types}
+            placeholder={searchPlaceholder ?? "Search records"}
+          />
+          {value && onClear ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start gap-1.5 text-[var(--text-muted)]"
+              onClick={() => {
+                onClear();
+                setOpen(false);
+              }}
+            >
+              <X className="size-3.5" />
+              Clear it
+            </Button>
+          ) : null}
+        </PopoverContent>
+      </Popover>
+    </span>
+  );
+}

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -20,6 +20,7 @@ import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { RecordAttributes } from "./record-attributes";
+import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
@@ -155,28 +156,33 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               id: "company",
               label: "Company",
               icon: Building2,
-              display: site.client ? (
-                <EntityLink href={`/crm/companies/${site.client.id}`} className="text-sm">
-                  {site.client.name}
-                </EntityLink>
-              ) : undefined,
-              value: null,
-              placeholder: "No company",
+              display: (
+                <RelationAttribute
+                  value={site.client?.name ?? null}
+                  href={site.client ? `/crm/companies/${site.client.id}` : null}
+                  types={["COMPANY"]}
+                  placeholder="No company"
+                  searchPlaceholder="Search companies"
+                  onPick={(record) => edit.save.mutate({ clientId: record.id })}
+                  onClear={() => edit.save.mutate({ clientId: null })}
+                />
+              ),
             },
             {
               id: "contact",
               label: "Primary contact",
               icon: UserRound,
-              display: site.primaryContact ? (
-                <EntityLink
-                  href={`/crm/people/${site.primaryContact.id}`}
-                  className="text-sm"
-                >
-                  {site.primaryContact.fullName}
-                </EntityLink>
-              ) : undefined,
-              value: null,
-              placeholder: "Nobody named",
+              display: (
+                <RelationAttribute
+                  value={site.primaryContact?.fullName ?? null}
+                  href={site.primaryContact ? `/crm/people/${site.primaryContact.id}` : null}
+                  types={["PERSON"]}
+                  placeholder="Nobody named"
+                  searchPlaceholder="Search people"
+                  onPick={(record) => edit.save.mutate({ primaryContactId: record.id })}
+                  onClear={() => edit.save.mutate({ primaryContactId: null })}
+                />
+              ),
             },
             {
               id: "address",

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -20,6 +20,7 @@ import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { RecordAttributes } from "./record-attributes";
+import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { SiteFormSheet } from "./site-form-sheet";
@@ -75,6 +76,10 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
   const siteQuery = useQuery({
     queryKey: ["crm", "site", siteId],
     queryFn: () => fetchJson<SiteDetail>(`/api/v2/crm/sites/${siteId}`),
+  });
+  const edit = useAttributeEditor({
+    path: `/api/v2/crm/sites/${siteId}`,
+    invalidate: [["crm", "site", siteId], ["crm", "sites"]],
   });
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "SITE"],
@@ -177,8 +182,8 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               id: "address",
               label: "Address",
               icon: MapPin,
-              value: site.addressLine,
               placeholder: "Not recorded",
+              ...edit.text("addressLine", site.addressLine),
             },
             {
               id: "location",

--- a/components/crm/records/use-attribute-editor.ts
+++ b/components/crm/records/use-attribute-editor.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+
+/**
+ * Editing a record's properties in place.
+ *
+ * The attribute list has always been able to write through — `RecordAttribute`
+ * takes an `onCommit` — but no page passed one, so every property on every
+ * record was read-only and the only way to change a phone number was the
+ * create form it was first typed into. This is the missing half: one mutation
+ * per record, and helpers that turn a field name into the `{ value, onCommit }`
+ * pair the list wants.
+ *
+ * Writes go straight through on blur or Enter. There is no save button here
+ * because there is no save button anywhere else on a record page, and a
+ * property somebody changed and forgot to save is worse than one they never
+ * changed at all.
+ */
+export function useAttributeEditor({
+  path,
+  invalidate,
+}: {
+  /** The record's API route, e.g. /api/v2/crm/people/<id>. */
+  path: string;
+  /** Query keys to refresh once the write lands. */
+  invalidate: unknown[][];
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const save = useMutation({
+    mutationFn: (patch: Record<string, unknown>) =>
+      fetchJson(path, { method: "PATCH", body: JSON.stringify(patch) }),
+    onSuccess: () => {
+      for (const key of invalidate) {
+        queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not save that change",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  /** A field that may be emptied — the server takes null for "not known". */
+  const text = (field: string, value: string | null | undefined) => ({
+    value: value ?? null,
+    onCommit: (next: string) => {
+      const trimmed = next.trim();
+      save.mutate({ [field]: trimmed === "" ? null : trimmed });
+    },
+  });
+
+  /** A field the record cannot be without — a name. Blank is refused, not sent. */
+  const required = (field: string, value: string | null | undefined) => ({
+    value: value ?? null,
+    onCommit: (next: string) => {
+      const trimmed = next.trim();
+      if (trimmed === "") {
+        toast({
+          title: "That one cannot be empty",
+          description: "The record needs it to be nameable in a list.",
+          variant: "destructive",
+        });
+        return;
+      }
+      save.mutate({ [field]: trimmed });
+    },
+  });
+
+  /** A number. Anything unparseable is refused rather than silently zeroed. */
+  const numeric = (field: string, value: number | null | undefined) => ({
+    value: value == null ? null : String(value),
+    onCommit: (next: string) => {
+      const trimmed = next.trim();
+      if (trimmed === "") {
+        save.mutate({ [field]: null });
+        return;
+      }
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed)) {
+        toast({
+          title: "That is not a number",
+          description: `"${trimmed}" cannot be stored as ${field}.`,
+          variant: "destructive",
+        });
+        return;
+      }
+      save.mutate({ [field]: parsed });
+    },
+  });
+
+  return { save, text, required, numeric };
+}

--- a/components/crm/reps/rep-detail-page.tsx
+++ b/components/crm/reps/rep-detail-page.tsx
@@ -51,7 +51,7 @@ function Stat({
 }) {
   return (
     <div className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <h3 className="text-sm font-medium text-[var(--text-subtle)]">
+      <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-subtle)]">
         {label}
         <span className="mt-1 block font-mono text-xl font-semibold tracking-normal text-[var(--text-strong)]">
           {value}

--- a/components/crm/reps/rep-settings-tab.tsx
+++ b/components/crm/reps/rep-settings-tab.tsx
@@ -115,7 +115,7 @@ export function RepSettingsTab({ repId, repName }: { repId: string; repName: str
     <div className="space-y-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h3 className="text-sm font-semibold">What {repName} can do</h3>
+          <h3 className="text-base font-semibold text-[var(--text-strong)]">What {repName} can do</h3>
           <p className="text-sm text-[var(--text-muted)]">
             Their role answers most of this. Anything set to allow or deny here
             overrides the role and stays put when the role changes.
@@ -148,7 +148,7 @@ export function RepSettingsTab({ repId, repName }: { repId: string; repName: str
       />
 
       <div className="border-t border-[var(--border-subtle)] pt-4">
-        <h3 className="text-sm font-semibold">The account itself</h3>
+        <h3 className="text-base font-semibold text-[var(--text-strong)]">The account itself</h3>
         <p className="text-sm text-[var(--text-muted)]">
           Suspending, deleting, changing the role or resetting the password are things
           done to an account rather than to a salesperson, so they live with the rest

--- a/components/crm/tasks/tasks-register-content.tsx
+++ b/components/crm/tasks/tasks-register-content.tsx
@@ -7,6 +7,7 @@ import { useSession } from "next-auth/react";
 import { Alert, Button } from "@corelithzw/react";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { PageChrome } from "@/components/layout/page-chrome";
+import { ViewToolbar } from "@/components/crm/records/view-toolbar";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmTasks } from "@/lib/crm/crm-v2";
 import { Checklist, Plus } from "@/lib/icons";
@@ -71,42 +72,50 @@ export function TasksRegisterContent() {
   );
 
   return (
-    <div className="space-y-4">
+    // A register of one-line tasks reads as a column; stretched across a wide
+    // screen it just puts air between a task and when it is due.
+    <div className="max-w-3xl space-y-4">
       <PageChrome title="Tasks" icon={Checklist}>
         {actions}
       </PageChrome>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <SegmentedControl
-          value={scope}
-          onValueChange={(value) => setScope(value as typeof scope)}
-          options={[
-            { value: "ALL", label: "Everyone" },
-            { value: "MINE", label: "Mine" },
-            { value: "UNASSIGNED", label: "Unassigned" },
-          ]}
-        />
+      <ViewToolbar
+        start={
+          <>
+            <SegmentedControl
+              value={scope}
+              onValueChange={(value) => setScope(value as typeof scope)}
+              size="sm"
+              options={[
+                { value: "ALL", label: "Everyone" },
+                { value: "MINE", label: "Mine" },
+                { value: "UNASSIGNED", label: "Unassigned" },
+              ]}
+            />
 
-        {scope === "ALL" ? (
-          <select
-            value={owner}
-            onChange={(event) => setOwner(event.target.value)}
-            aria-label="Filter by owner"
-            className="h-9 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] px-2 text-sm"
-          >
-            <option value="">Any owner</option>
-            {owners.map((person) => (
-              <option key={person.id} value={person.id}>
-                {person.name ?? "Unnamed"}
-              </option>
-            ))}
-          </select>
-        ) : null}
-
-        <p className="ml-auto text-sm text-[var(--text-muted)]">
-          <span className="font-mono">{tasks.length}</span> open
-        </p>
-      </div>
+            {scope === "ALL" ? (
+              <select
+                value={owner}
+                onChange={(event) => setOwner(event.target.value)}
+                aria-label="Filter by owner"
+                className="h-9 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] px-2 text-sm"
+              >
+                <option value="">Any owner</option>
+                {owners.map((person) => (
+                  <option key={person.id} value={person.id}>
+                    {person.name ?? "Unnamed"}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+          </>
+        }
+        end={
+          <p className="text-sm text-[var(--text-muted)]">
+            <span className="font-mono">{tasks.length}</span> open
+          </p>
+        }
+      />
 
       {tasksQuery.error ? (
         <Alert tone="danger" title="Unable to load tasks">
@@ -120,7 +129,7 @@ export function TasksRegisterContent() {
           <section key={bucket.id} aria-labelledby={`tasks-${bucket.id}`} className="space-y-2">
             <h3
               id={`tasks-${bucket.id}`}
-              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-sm font-medium text-[var(--text-subtle)]"
+              className="sticky top-14 z-10 flex items-baseline gap-2 bg-[var(--surface-base)] py-1.5 text-base font-semibold text-[var(--text-strong)]"
             >
               <span
                 className={
@@ -129,7 +138,7 @@ export function TasksRegisterContent() {
               >
                 {bucket.label}
               </span>
-              <span className="font-mono normal-case tracking-normal">
+              <span className="font-mono text-sm font-normal text-[var(--text-muted)]">
                 {bucket.items.length}
               </span>
             </h3>

--- a/components/crm/templates/template-analytics.tsx
+++ b/components/crm/templates/template-analytics.tsx
@@ -31,7 +31,7 @@ function Stat({
 }) {
   return (
     <div className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <h3 className="text-sm font-medium text-[var(--text-subtle)]">
+      <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-subtle)]">
         {label}
         <span className="mt-1 block font-mono text-xl font-semibold tracking-normal text-[var(--text-strong)]">
           {value}

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -256,7 +256,7 @@ export function VisitReportSheet({
       ) : (
         <div className="space-y-4">
           <section className="space-y-2">
-            <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
               On-site checklist
             </h3>
             <Stack as="ul" gap="xs">
@@ -296,7 +296,7 @@ export function VisitReportSheet({
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-sm font-semibold text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
               Measurements & specifications
             </h3>
             <p className="text-sm text-[var(--text-muted)]">

--- a/components/crm/widgets/widget-grid.tsx
+++ b/components/crm/widgets/widget-grid.tsx
@@ -242,7 +242,7 @@ export function WidgetGrid({
       {editing && adding ? (
         <div className="mt-4 rounded-[var(--card-radius)] border border-[var(--border)] p-3">
           <div className="mb-2 flex items-center justify-between gap-2">
-            <h3 className="text-sm font-medium">Add a widget</h3>
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">Add a widget</h3>
             <button
               type="button"
               onClick={() => setAdding(false)}

--- a/components/crm/work-orders/work-order-sheet.tsx
+++ b/components/crm/work-orders/work-order-sheet.tsx
@@ -238,7 +238,7 @@ export function WorkOrderSheet({
             {order.items.length > 0 ? (
               <section className="space-y-2">
                 <div className="flex items-baseline justify-between">
-                  <h3 className="text-sm font-semibold">What needs doing</h3>
+                  <h3 className="text-base font-semibold text-[var(--text-strong)]">What needs doing</h3>
                   <span className="text-sm text-[var(--text-muted)]">
                     {completionPercent(order.items)}% done
                   </span>

--- a/components/crm/work-orders/work-orders-content.tsx
+++ b/components/crm/work-orders/work-orders-content.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
-import { Alert, EmptyState, Progress, SegmentedControl, Skeleton, Stack } from "@corelithzw/react";
+import { Alert, EmptyState, SegmentedControl, Skeleton, Stack } from "@corelithzw/react";
 import { ClientDate } from "@/components/ui/client-date";
 import { StatusChip } from "@/components/ui/status-chip";
 import { WORK_ORDER_STATUS } from "@/lib/crm/tones";
@@ -16,7 +16,7 @@ import {
   isOverdueToStart,
   type WorkOrderQueue,
 } from "@/lib/crm/work-orders";
-import { Clock, MapPin, Users } from "@/lib/icons";
+import { Clock, Users } from "@/lib/icons";
 
 import { WorkOrderSheet, type WorkOrderRecord } from "./work-order-sheet";
 
@@ -68,75 +68,59 @@ export function WorkOrdersContent() {
       ) : orders.length === 0 ? (
         <EmptyState title={EMPTY_MESSAGES[queue] ?? "Nothing here."} />
       ) : (
-        <Stack as="ul" gap="sm">
+        // One line per job. A card with a title, a meta row and a progress
+        // bar is four lines to read before you know whether this is the job
+        // you are looking for; the number and the status answer that, and the
+        // sheet carries the rest.
+        <Stack as="ul" gap="xs">
           {orders.map((order) => {
             const percent = completionPercent(order.items);
             const late = isOverdueToStart(order);
 
             return (
               <li key={order.id}>
-                {/* One big tap target: this list is read on a phone at a gate. */}
                 <button
                   type="button"
                   onClick={() => setOpen(order.id)}
-                  className="w-full space-y-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3 text-left transition-colors hover:bg-[var(--surface-hover)]"
+                  className="flex w-full items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 text-left transition-colors hover:bg-[var(--surface-subtle)]"
                 >
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-mono text-sm">{order.workOrderNo}</span>
-                    <StatusChip
-                      status={WORK_ORDER_STATUS[order.status] ?? "inactive"}
-                      label={WORK_ORDER_STATUS_LABELS[order.status]}
-                    />
-                    {late ? (
-                      <span className="text-sm font-medium text-[var(--status-error-text)]">
-                        Should have started
-                      </span>
-                    ) : null}
-                  </div>
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                    {order.title}
+                    <span className="ml-2 font-mono text-sm font-normal text-[var(--text-muted)]">
+                      {order.workOrderNo}
+                    </span>
+                  </span>
 
-                  <p className="font-medium">{order.title}</p>
-
-                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-[var(--text-muted)]">
-                    {order.scheduledStart ? (
-                      <span className="inline-flex items-center gap-1">
-                        <Clock className="size-3.5" />
-                        <ClientDate value={order.scheduledStart} mode="datetime" />
-                      </span>
-                    ) : null}
-                    {order.site?.name || order.addressLine ? (
-                      <span className="inline-flex items-center gap-1">
-                        <MapPin className="size-3.5" />
-                        {order.site?.name ?? order.addressLine}
-                      </span>
-                    ) : null}
-                    {order.assignedTo ? (
-                      <span className="inline-flex items-center gap-1">
-                        <Users className="size-3.5" />
-                        {order.assignedTo.name}
-                        {order.crewIds.length ? ` +${order.crewIds.length}` : ""}
-                      </span>
-                    ) : null}
-                  </div>
+                  {late ? (
+                    <span className="hidden flex-none text-sm font-medium text-[var(--status-error-text)] sm:inline">
+                      Should have started
+                    </span>
+                  ) : null}
 
                   {order.items.length > 0 ? (
-                    <div className="space-y-1">
-                      <Progress
-                        value={percent}
-                        tone={percent === 100 ? "success" : "brand"}
-                        label={`${percent}% of the job done`}
-                      />
-                      <p className="text-sm text-[var(--text-muted)]">
-                        {percent}% done · {order.items.length} item
-                        {order.items.length === 1 ? "" : "s"}
-                      </p>
-                    </div>
+                    <span className="hidden flex-none font-mono text-sm tabular-nums text-[var(--text-muted)] sm:inline">
+                      {percent}%
+                    </span>
                   ) : null}
 
-                  {order.status === "BLOCKED" && order.blockedReason ? (
-                    <p className="text-sm text-[var(--status-error-text)]">
-                      {order.blockedReason}
-                    </p>
+                  {order.scheduledStart ? (
+                    <span className="hidden flex-none items-center gap-1 text-sm text-[var(--text-muted)] sm:inline-flex">
+                      <Clock className="size-3.5" />
+                      <ClientDate value={order.scheduledStart} mode="date" />
+                    </span>
                   ) : null}
+
+                  {order.assignedTo ? (
+                    <span className="hidden flex-none items-center gap-1 text-sm text-[var(--text-muted)] md:inline-flex">
+                      <Users className="size-3.5" />
+                      {order.assignedTo.name}
+                    </span>
+                  ) : null}
+
+                  <StatusChip
+                    status={WORK_ORDER_STATUS[order.status] ?? "inactive"}
+                    label={WORK_ORDER_STATUS_LABELS[order.status]}
+                  />
                 </button>
               </li>
             );

--- a/components/crm/work-orders/work-orders-content.tsx
+++ b/components/crm/work-orders/work-orders-content.tsx
@@ -45,7 +45,7 @@ export function WorkOrdersContent() {
   const orders = data?.data ?? [];
 
   return (
-    <div className="space-y-4">
+    <div className="max-w-3xl space-y-4">
       <SegmentedControl
         options={QUEUES.map((value) => ({ value, label: WORK_ORDER_QUEUE_LABELS[value] }))}
         value={queue}

--- a/components/crm/workflows/workflows-content.tsx
+++ b/components/crm/workflows/workflows-content.tsx
@@ -6,22 +6,25 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Alert, EmptyState, Switch, Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
-import { ClientDate } from "@/components/ui/client-date";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { IconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TimeAgo } from "@/components/ui/time-ago";
 import { PageChrome } from "@/components/layout/page-chrome";
+import { ViewToolbar } from "@/components/crm/records/view-toolbar";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
-  ACTION_LABELS,
-  TRIGGER_LABELS,
   type AutomationAction,
   type AutomationCondition,
   type AUTOMATION_TRIGGERS,
 } from "@/lib/crm/automation";
-import { Funnel, Plus, Rule, Trash2 } from "@/lib/icons";
-
-import { SequenceStrip } from "./sequence-canvas";
-import { ACTION_ICON, TRIGGER_ICON } from "./workflow-marks";
+import { DotsThree, Plus } from "@/lib/icons";
 
 type WorkflowRow = {
   id: string;
@@ -32,6 +35,7 @@ type WorkflowRow = {
   actions: AutomationAction[];
   isEnabled: boolean;
   runCount: number;
+  createdAt: string;
   lastRunAt: string | null;
   runs: { id: string; status: string; createdAt: string }[];
 };
@@ -96,7 +100,7 @@ export function WorkflowsContent() {
   };
 
   return (
-    <div className="space-y-5">
+    <div className="max-w-3xl space-y-4">
       <PageChrome title="Workflows">
         <Button type="button" asChild>
           <Link href="/crm/workflows/new">
@@ -106,26 +110,31 @@ export function WorkflowsContent() {
         </Button>
       </PageChrome>
 
-      <div className="flex flex-wrap items-center gap-2">
-        {(["all", "live", "paused", "failing"] as const).map((value) => (
-          <Button
-            key={value}
-            type="button"
-            size="sm"
-            variant={filter === value ? "secondary" : "ghost"}
-            onClick={() => setFilter(value)}
-          >
-            {value === "all"
-              ? "All"
-              : value === "live"
-                ? "Live"
-                : value === "paused"
-                  ? "Paused"
-                  : "Needs a look"}
-            <span className="ml-1.5 text-[var(--text-muted)]">{counts[value]}</span>
-          </Button>
-        ))}
-      </div>
+      <ViewToolbar
+        start={
+          <>
+            {(["all", "live", "paused", "failing"] as const).map((value) => (
+              <Button
+                key={value}
+                type="button"
+                size="sm"
+                className="h-9 gap-2"
+                variant={filter === value ? "secondary" : "ghost"}
+                onClick={() => setFilter(value)}
+              >
+                {value === "all"
+                  ? "All"
+                  : value === "live"
+                    ? "Live"
+                    : value === "paused"
+                      ? "Paused"
+                      : "Needs a look"}
+                <span className="text-[var(--text-muted)]">{counts[value]}</span>
+              </Button>
+            ))}
+          </>
+        }
+      />
 
       {error ? (
         <Alert tone="danger" title="Couldn't load workflows">
@@ -145,82 +154,66 @@ export function WorkflowsContent() {
           Nothing in this group.
         </p>
       ) : (
+        // One row per workflow: name, when it was written, how often it has
+        // run, and the switch. What each one *does* is the detail page's job —
+        // a sequence strip per row made the list a wall of diagrams.
         <Stack as="ul" gap="xs">
           {visible.map((workflow) => {
             const failed = failedRuns(workflow);
-            const steps = [
-              {
-                label: TRIGGER_LABELS[workflow.trigger],
-                tone: "trigger" as const,
-                icon: TRIGGER_ICON[workflow.trigger] ?? Rule,
-              },
-              ...(workflow.conditions ?? []).map((condition) => ({
-                label: condition.field,
-                tone: "filter" as const,
-                icon: Funnel,
-              })),
-              ...workflow.actions.map((action) => ({
-                label: ACTION_LABELS[action.type],
-                tone: "action" as const,
-                icon: ACTION_ICON[action.type],
-              })),
-            ];
 
             return (
               <li
                 key={workflow.id}
-                className="flex flex-col gap-3 rounded-[var(--radius-md)] px-3 py-3 transition-colors hover:bg-[var(--surface-subtle)] lg:flex-row lg:items-start lg:justify-between"
+                className="flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 transition-colors hover:bg-[var(--surface-subtle)]"
               >
-                <div className="min-w-0 flex-1 space-y-1.5">
-                  <Link
-                    href={`/crm/workflows/${workflow.id}`}
-                    className="text-sm font-medium underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]"
-                  >
-                    {workflow.name}
-                  </Link>
+                <Link
+                  href={`/crm/workflows/${workflow.id}`}
+                  className="min-w-0 flex-1 truncate text-sm font-medium underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]"
+                >
+                  {workflow.name}
+                </Link>
 
-                  <SequenceStrip steps={steps} />
+                <span className="hidden flex-none text-sm text-[var(--text-muted)] sm:inline">
+                  <TimeAgo value={workflow.createdAt} />
+                </span>
 
-                  <p className="text-sm text-[var(--text-muted)]">
-                    Run {workflow.runCount} time{workflow.runCount === 1 ? "" : "s"}
-                    {workflow.lastRunAt ? (
-                      <>
-                        {" · last "}
-                        <ClientDate value={workflow.lastRunAt} mode="datetime" />
-                      </>
-                    ) : null}
-                    {failed > 0 ? (
-                      <span className="font-medium text-[var(--status-error-text)]">
-                        {" · "}
-                        {failed} of the last {workflow.runs.length} runs had a problem
-                      </span>
-                    ) : null}
-                  </p>
-                </div>
+                <span
+                  className={
+                    failed > 0
+                      ? "flex-none text-sm font-medium text-[var(--status-error-text)]"
+                      : "flex-none text-sm text-[var(--text-muted)]"
+                  }
+                >
+                  <span className="font-mono tabular-nums">{workflow.runCount}</span>
+                  {failed > 0 ? ` · ${failed} failed` : " runs"}
+                </span>
 
-                <div className="flex shrink-0 items-center gap-2">
-                  <label className="flex items-center gap-2 text-sm">
-                    <Switch
-                      checked={workflow.isEnabled}
-                      onChange={() =>
-                        toggle.mutate({ id: workflow.id, isEnabled: !workflow.isEnabled })
-                      }
-                      aria-label={`${workflow.name} is live`}
-                    />
-                    <span className="text-[var(--text-muted)]">
-                      {workflow.isEnabled ? "Live" : "Paused"}
-                    </span>
-                  </label>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    aria-label={`Delete ${workflow.name}`}
-                    onClick={() => remove.mutate(workflow.id)}
-                  >
-                    <Trash2 className="size-4" aria-hidden="true" />
-                  </Button>
-                </div>
+                <Switch
+                  checked={workflow.isEnabled}
+                  onChange={() =>
+                    toggle.mutate({ id: workflow.id, isEnabled: !workflow.isEnabled })
+                  }
+                  aria-label={`${workflow.name} is live`}
+                />
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <IconButton size="sm" aria-label={`Options for ${workflow.name}`}>
+                      <DotsThree />
+                    </IconButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem asChild>
+                      <Link href={`/crm/workflows/${workflow.id}`}>Open</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-[var(--status-error-text)]"
+                      onClick={() => remove.mutate(workflow.id)}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </li>
             );
           })}

--- a/components/templates/template-library.tsx
+++ b/components/templates/template-library.tsx
@@ -291,7 +291,7 @@ export function TemplateLibrary() {
         sections.map((section) => (
           <section key={section.id} className="space-y-1">
             <div>
-              <h2 className="text-sm font-semibold">{section.title}</h2>
+              <h2 className="text-base font-semibold text-[var(--text-strong)]">{section.title}</h2>
               <p className="text-sm text-[var(--text-muted)]">{section.body}</p>
             </div>
 

--- a/components/ui/time-ago.tsx
+++ b/components/ui/time-ago.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * "3d ago", hydration-safe.
+ *
+ * Anything derived from `Date.now()` differs between the server render and
+ * the browser's first paint, which is hydration error #418. So before mount
+ * this emits the raw date slice of the ISO input — same bytes on both sides —
+ * and only swaps to the relative wording after the mount effect, the same
+ * trick ClientDate uses.
+ */
+export function TimeAgo({ value }: { value: string | null | undefined }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!value) return null;
+  if (!mounted) return <>{value.slice(0, 10)}</>;
+
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return <>{value.slice(0, 10)}</>;
+
+  const seconds = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  const label =
+    seconds < 60
+      ? "just now"
+      : seconds < 3600
+        ? `${Math.floor(seconds / 60)}m ago`
+        : seconds < 86400
+          ? `${Math.floor(seconds / 3600)}h ago`
+          : seconds < 86400 * 30
+            ? `${Math.floor(seconds / 86400)}d ago`
+            : seconds < 86400 * 365
+              ? `${Math.floor(seconds / (86400 * 30))}mo ago`
+              : `${Math.floor(seconds / (86400 * 365))}y ago`;
+
+  return <>{label}</>;
+}

--- a/lib/crm/accounting-bridge.ts
+++ b/lib/crm/accounting-bridge.ts
@@ -152,22 +152,85 @@ async function requireDocumentOwner(
 
   const lead = await tx.crmLead.findFirst({
     where: { id: ref.leadId, companyId },
-    select: { id: true, clientId: true, stage: true, assignedToId: true },
+    select: {
+      id: true,
+      clientId: true,
+      stage: true,
+      assignedToId: true,
+      contactName: true,
+      contactEmail: true,
+      contactPhone: true,
+      title: true,
+    },
   });
   if (!lead) throw new Error("Lead not found");
   if (lead.stage === "LOST") {
     throw new Error("This lead is marked LOST — reopen it before creating documents");
   }
-  if (!lead.clientId) {
-    throw new Error("Lead has no client; attach or create a client before quoting/invoicing");
-  }
+
+  // Not every lead is a company. A service call from someone who rang up is a
+  // real lead with a real name and no organisation behind it, and refusing to
+  // quote it until somebody invents a company record is how quoting ends up
+  // looking like it needs the site-visit flow. A document has to be billed to
+  // someone, so the contact on the lead becomes that someone.
+  const clientId = lead.clientId ?? (await clientFromLeadContact(tx, companyId, lead));
+
   return {
     kind: "lead",
     id: lead.id,
-    clientId: lead.clientId,
+    clientId,
     stage: lead.stage,
     assignedToId: lead.assignedToId,
   };
+}
+
+/**
+ * Materialise a customer from a lead that never got a company attached, and
+ * keep it — a second quote for the same person should land on the same
+ * account rather than opening a second one.
+ */
+async function clientFromLeadContact(
+  tx: Tx,
+  companyId: string,
+  lead: {
+    id: string;
+    contactName: string | null;
+    contactEmail: string | null;
+    contactPhone: string | null;
+    title: string | null;
+  },
+): Promise<string> {
+  const name = lead.contactName?.trim() || lead.title?.trim();
+  if (!name) {
+    throw new Error(
+      "This lead has nobody to bill — add a contact name (or attach a company) before quoting",
+    );
+  }
+
+  // Reuse rather than duplicate: matching on the name is what the accounting
+  // side already does when it reconciles a CRM client to a customer.
+  const existing = await tx.crmClient.findFirst({
+    where: { companyId, name },
+    select: { id: true },
+  });
+
+  const clientId =
+    existing?.id ??
+    (
+      await tx.crmClient.create({
+        data: {
+          companyId,
+          clientNo: await reserveIdentifier(tx, { companyId, entity: "CRM_CLIENT" }),
+          name,
+          email: lead.contactEmail ?? undefined,
+          phone: lead.contactPhone ?? undefined,
+        },
+        select: { id: true },
+      })
+    ).id;
+
+  await tx.crmLead.update({ where: { id: lead.id }, data: { clientId } });
+  return clientId;
 }
 
 /** The foreign key to file a document under, given its owner. */

--- a/lib/crm/rich-text-plain.test.ts
+++ b/lib/crm/rich-text-plain.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { richTextToPlain } from "@/lib/crm/rich-text";
+
+describe("richTextToPlain", () => {
+  it("reads a mention as the person's name, not its token", () => {
+    expect(richTextToPlain("Spoke to @[Sarah Moyo](7f1c9f2e-1111-4222-8333-444455556666) today"))
+      .toBe("Spoke to Sarah Moyo today");
+  });
+  it("drops emphasis markers a subject line cannot render", () => {
+    expect(richTextToPlain("**urgent** — call *back*")).toBe("urgent — call back");
+  });
+  it("truncates without cutting mid-token", () => {
+    const long = "a".repeat(300);
+    const out = richTextToPlain(long, 50);
+    expect(out.length).toBe(50);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});

--- a/lib/crm/rich-text.ts
+++ b/lib/crm/rich-text.ts
@@ -287,3 +287,29 @@ export function referenceKindFromSearchType(type: string): ReferenceKind | null 
   if (lowered === "product") return null;
   return isReferenceKind(lowered) ? lowered : null;
 }
+
+/**
+ * A one-line, plain-text reading of a body — for a timeline subject, a
+ * notification, a search snippet, anywhere the words have to survive without
+ * the renderer.
+ *
+ * References collapse to their labels (`@[Sarah](uuid)` → `Sarah`) and the
+ * emphasis markers go, because a subject line showing `**urgent**` is the
+ * failure this exists to prevent.
+ */
+export function richTextToPlain(body: string, maxLength = 200): string {
+  const flattened = segmentRichText(body)
+    .map((segment) => (segment.kind === "reference" ? segment.reference.label : segment.text))
+    .join("");
+
+  const stripped = flattened
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/^>\s?/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (stripped.length <= maxLength) return stripped;
+  return `${stripped.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -61,6 +61,8 @@ function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
   return Icon;
 }
 
+export const Smiley = createPhosphorIcon("Smiley", "Smiley");
+
 export const MedusaAcademicCapIcon = createPhosphorIcon(
   "GraduationCap",
   "MedusaAcademicCapIcon",


### PR DESCRIPTION
Follows #135. The round of defects reported after that merge — several of which turned out to be functional gaps rather than styling.

## Properties were read-only everywhere

`RecordAttribute` has accepted an `onCommit` since the day it was written, and no page ever passed one. Every property on every record was display-only, so the only way to correct a phone number was the create form it was first typed into.

`useAttributeEditor` is the missing half: one mutation per record, and helpers that turn a field name into the `{ value, onCommit }` pair the attribute list wants. Writes go through on blur or Enter — there is no save button because there is no save button anywhere else on a record page. People, companies and sites are wired.

## A lead with no company could not be quoted

Not every lead is an organisation. A service call from somebody who rang up is a real lead with a real name and no company behind it — and `requireDocumentOwner` threw on it, while the UI hid **New quotation** behind `Boolean(lead.clientId)`. That is why quoting appeared to require the site-visit path: the visit flow was the one route that reliably had a company attached by the time it reached the builder.

The contact on the lead now becomes the customer the document is billed to, reusing an existing client of the same name rather than opening a second one, and linking it back to the lead so the second quote lands on the same account. Free-text and catalogue lines both already worked in the builder; nothing about that changed.

## A one-line note came out as its own source code

The activity composer split on the first newline and stored everything before it as the subject. A one-line note — the common case — was therefore stored *entirely* as a subject, and the timeline draws a subject as plain text: every mention rendered as `@[Sarah](uuid)`, every bold as asterisks. Comments looked right because their content goes to the body, which runs through the renderer.

What was written now goes to the body. The subject is a flattened reading of the same words (`richTextToPlain` — references collapse to their labels, emphasis markers go), for notifications and search snippets that cannot run a renderer. Unit-tested.

## Relationships are editable, in all three shapes they take

- **List relations** — people on a deal (attach in a named role, remove) via a new company-scoped `POST`/`DELETE /api/v2/crm/deals/[id]/contacts`; people at a company, which writes to the person's own record because that is how the schema models employment, so detaching leaves them intact with no company.
- **Single relations** — a site's company and its primary contact repoint through a scoped record search. They still read as links, because following the reference is the common case and changing it is one press away.
- **Plain properties** — inline, as above.

## Leads and deals are one page

They were two routes and two sidebar entries, and the complaint was fair: a lead and the deal it becomes are the same piece of work at two moments. The pipeline menu is the whole switch now — Leads is the intake pipeline, sitting in the same list as the configured deal pipelines — and picking one swaps what is under the toolbar without a navigation. Both routes render the one workspace, so existing links keep working.

The two boards stay separate underneath because their stages genuinely differ: a lead's are a fixed enum this module reasons about, a deal's are configured per pipeline. **Merging the models is a migration and is deliberately not in this PR.**

## Lists read as lists

- Every register caps at `max-w-3xl` — tasks, follow-ups, site visits, the document registers, work orders, collections. A register stretched to 1900px puts the title at one edge and its facts at the other.
- **One line per row** on workflows (name · age · run count · live switch), work orders (was a four-line card with a progress bar) and collections (was carrying the whole chase history under the invoice number, which is what made a column of amounts hard to scan).
- **Section headings** were set at body size in muted grey — indistinguishable from the text under them. One step up and a strong colour, across fifteen files.
- **Toolbar** — every CRM list renders through the same `ViewToolbar`, all triggers at one height and gap, carets to the DS spec. Registers that show fewer controls do so because they have nothing to filter by, not because they use a different toolbar.
- An **emoji picker** in the composer, and **quote/invoice drawn as peers** rather than one coloured and one not.

## Verification

`tsc --noEmit` clean · `eslint` clean across the CRM tree · **841 tests passing**, including new cover for the plain-text reduction · both previews green.

## Not done

- Deeper cross-linking beyond `EntityLink`.
- Merging `CrmLead` and `CrmDeal` at the model level — see above; that is a migration touching stages, documents, activities and reporting, and wants planning rather than improvising.
- Older backlog untouched here: deeper detail views, site-visit public brief, client sign-off, the form designer rebuild, custom fields on forms, the reports page, record panels, the workflow canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165pkzEEY2bL2n1i4fL63kk

---
_Generated by [Claude Code](https://claude.ai/code/session_0165pkzEEY2bL2n1i4fL63kk)_