### PR TITLE
One record surface, and the backlog it was blocking

### DIFF
--- a/app/api/public/crm/sign-off/[token]/route.ts
+++ b/app/api/public/crm/sign-off/[token]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { buildSignOffJob, signOffSubmissionSchema } from "@/lib/crm/sign-off";
+
+/**
+ * The job, for the person paying for it.
+ *
+ * No session. The `select` is the boundary: it names what the client needs to
+ * recognise the work and nothing about what it cost or earned — they are
+ * confirming the work happened, not auditing the price.
+ */
+const JOB_SELECT = {
+  workOrderNo: true,
+  title: true,
+  description: true,
+  completedAt: true,
+  addressLine: true,
+  signOffAt: true,
+  signOffName: true,
+  client: { select: { name: true } },
+  site: { select: { name: true, addressLine: true, city: true } },
+  items: { select: { description: true }, orderBy: { position: "asc" } },
+} as const;
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await params;
+    if (!token) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const job = await prisma.crmWorkOrder.findUnique({
+      where: { signOffToken: token },
+      select: JOB_SELECT,
+    });
+    if (!job) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    return NextResponse.json({ data: buildSignOffJob(job) });
+  } catch (error) {
+    console.error("[API] GET /api/public/crm/sign-off/[token] error:", error);
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await params;
+    if (!token) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const existing = await prisma.crmWorkOrder.findUnique({
+      where: { signOffToken: token },
+      select: { id: true, signOffAt: true },
+    });
+    if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    // Once. Letting a link re-answer would mean whoever holds it can rewrite
+    // what the client said.
+    if (existing.signOffAt) {
+      return NextResponse.json({ error: "This job has already been signed off" }, { status: 409 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = signOffSubmissionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Please give the name of whoever is signing", issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const job = await prisma.crmWorkOrder.update({
+      where: { id: existing.id },
+      data: {
+        signOffAt: new Date(),
+        signOffName: parsed.data.name,
+        signOffRating: parsed.data.rating ?? null,
+        signOffNotes: parsed.data.notes ?? null,
+        // Somebody confirming the work is done is the most reliable signal
+        // the job is finished that this system will ever get.
+        status: "COMPLETED",
+        completedAt: new Date(),
+      },
+      select: JOB_SELECT,
+    });
+
+    return NextResponse.json({ data: buildSignOffJob(job) });
+  } catch (error) {
+    console.error("[API] POST /api/public/crm/sign-off/[token] error:", error);
+    return NextResponse.json({ error: "Could not record the sign-off" }, { status: 400 });
+  }
+}

--- a/app/api/public/crm/visits/[token]/route.ts
+++ b/app/api/public/crm/visits/[token]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { buildVisitBrief, isBriefExpired } from "@/lib/crm/visit-brief";
+
+/**
+ * A site visit, readable by whoever holds the link.
+ *
+ * No session: the point is the customer expecting a van and the
+ * subcontractor with a ladder, neither of whom has an account.
+ *
+ * The select is the security boundary. It names exactly the columns the
+ * brief needs, so a field added to the appointment later — a margin, an
+ * internal note — cannot appear on a public page by default. An expired or
+ * unshared visit is a 404 rather than a 403: a link that has been revoked
+ * should not confirm that it ever existed.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await params;
+    if (!token) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const visit = await prisma.crmAppointment.findUnique({
+      where: { briefToken: token },
+      select: {
+        appointmentNo: true,
+        title: true,
+        scheduledStart: true,
+        scheduledEnd: true,
+        location: true,
+        latitude: true,
+        longitude: true,
+        briefExpiresAt: true,
+        status: true,
+        checklist: true,
+        assignedTo: { select: { name: true } },
+        site: { select: { name: true, addressLine: true, city: true } },
+        client: { select: { name: true } },
+      },
+    });
+
+    if (!visit || isBriefExpired(visit.briefExpiresAt)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      data: { ...buildVisitBrief(visit), status: visit.status },
+    });
+  } catch (error) {
+    console.error("[API] GET /api/public/crm/visits/[token] error:", error);
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/app/api/v2/crm/appointments/[id]/brief/route.ts
+++ b/app/api/v2/crm/appointments/[id]/brief/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { canEditRecord } from "@/lib/crm/permissions";
+import { generateBriefToken } from "@/lib/crm/visit-brief";
+
+/**
+ * Share a visit, or stop sharing it.
+ *
+ * POST mints a token (rotating any existing one, which is what revoking a
+ * forwarded link looks like). DELETE clears it, so the page 404s from then on.
+ */
+const shareSchema = z.object({
+  expiresInDays: z.number().int().min(1).max(90).optional(),
+});
+
+async function editableVisit(companyId: string, id: string) {
+  return prisma.crmAppointment.findFirst({
+    where: { id, companyId },
+    select: { id: true, assignedToId: true },
+  });
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const visit = await editableVisit(session.user.companyId, id);
+    if (!visit) return errorResponse("Visit not found", 404);
+    if (!(await canEditRecord(session, visit.assignedToId))) {
+      return errorResponse("You can only share visits assigned to you", 403);
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const data = shareSchema.parse(body ?? {});
+
+    // Rotating rather than reusing: sharing again is also how somebody takes
+    // back a link they sent to the wrong number.
+    const token = generateBriefToken();
+    await prisma.crmAppointment.update({
+      where: { id },
+      data: {
+        briefToken: token,
+        briefSharedAt: new Date(),
+        briefExpiresAt: data.expiresInDays
+          ? new Date(Date.now() + data.expiresInDays * 24 * 60 * 60 * 1000)
+          : null,
+      },
+    });
+
+    return successResponse({ token, path: `/v/${token}` }, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
+    console.error("[API] POST /api/v2/crm/appointments/[id]/brief error:", error);
+    return errorResponse("Failed to share the visit");
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const visit = await editableVisit(session.user.companyId, id);
+    if (!visit) return errorResponse("Visit not found", 404);
+    if (!(await canEditRecord(session, visit.assignedToId))) {
+      return errorResponse("You can only change visits assigned to you", 403);
+    }
+
+    await prisma.crmAppointment.update({
+      where: { id },
+      data: { briefToken: null, briefSharedAt: null, briefExpiresAt: null },
+    });
+
+    return successResponse({ id });
+  } catch (error) {
+    console.error("[API] DELETE /api/v2/crm/appointments/[id]/brief error:", error);
+    return errorResponse("Failed to stop sharing the visit");
+  }
+}

--- a/app/api/v2/crm/automations/enrolment/route.ts
+++ b/app/api/v2/crm/automations/enrolment/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { armedRules, type EnrolmentEntity } from "@/lib/crm/run-insights";
+
+/**
+ * What the workflows have done to this record, and what could still happen.
+ *
+ * "Why is this assigned to somebody I did not pick" and "will anything else
+ * fire at this" are the same question asked at different times, and neither
+ * had an answer anywhere on a record page. The run log answered the first
+ * company-wide, which meant scrolling past everyone else's records to find
+ * one line about yours.
+ *
+ * What is armed is derived rather than queued. The engine runs a rule the
+ * moment its event happens, so nothing is literally pending — listing the
+ * enabled rules whose trigger can reach this kind of record is the honest
+ * version of "what is waiting", and drawing a spinner instead would be a
+ * story about a queue that does not exist.
+ */
+const querySchema = z.object({
+  entity: z.enum(["LEAD", "DEAL", "PERSON", "COMPANY", "SITE", "WORK_ORDER"]),
+  recordId: z.string().uuid(),
+});
+
+const LIMIT = 50;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const { searchParams } = new URL(request.url);
+    const parsed = querySchema.safeParse({
+      entity: searchParams.get("entity"),
+      recordId: searchParams.get("recordId"),
+    });
+    if (!parsed.success) return errorResponse("Which record?", 400);
+    const { entity, recordId } = parsed.data;
+
+    const [runs, rules] = await Promise.all([
+      prisma.crmAutomationRun.findMany({
+        where: { companyId: session.user.companyId, entity, recordId },
+        select: {
+          id: true,
+          status: true,
+          result: true,
+          durationMs: true,
+          actionCount: true,
+          createdAt: true,
+          automation: { select: { id: true, name: true, trigger: true } },
+        },
+        orderBy: { createdAt: "desc" },
+        take: LIMIT,
+      }),
+      prisma.crmAutomation.findMany({
+        where: { companyId: session.user.companyId },
+        select: { id: true, name: true, trigger: true, isEnabled: true },
+        orderBy: { name: "asc" },
+      }),
+    ]);
+
+    return successResponse({
+      entity,
+      recordId,
+      runs,
+      armed: armedRules(rules, entity as EnrolmentEntity),
+    });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/automations/enrolment error:", error);
+    return errorResponse("Failed to load what has run against this record");
+  }
+}

--- a/app/api/v2/crm/automations/insights/route.ts
+++ b/app/api/v2/crm/automations/insights/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { REPORT_RANGES, rangeToDates, type ReportRange } from "@/lib/crm/reports";
+import {
+  failureGroups,
+  rulePerformance,
+  runTotals,
+  type RunRecord,
+} from "@/lib/crm/run-insights";
+
+/**
+ * How the workflows have been behaving.
+ *
+ * The run list already says what happened; this says whether it is going
+ * well. Kept to one query over one window so every figure on the page is a
+ * cut of the same rows — two endpoints would let the headline disagree with
+ * the table under it.
+ *
+ * Capped, because a company with noisy rules can accumulate a great many runs
+ * and this is a summary, not an export. The cap is reported so a reader knows
+ * when they are looking at a sample.
+ */
+const CAP = 5_000;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const { searchParams } = new URL(request.url);
+    const requested = searchParams.get("range");
+    const range: ReportRange = REPORT_RANGES.find((value) => value === requested) ?? "30d";
+    const { from, to } = rangeToDates(range);
+
+    const rows = await prisma.crmAutomationRun.findMany({
+      where: {
+        companyId: session.user.companyId,
+        createdAt: { gte: from, lte: to },
+      },
+      select: {
+        automationId: true,
+        status: true,
+        durationMs: true,
+        actionCount: true,
+        result: true,
+        createdAt: true,
+        automation: { select: { name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: CAP,
+    });
+
+    const runs: RunRecord[] = rows.map((row) => ({
+      automationId: row.automationId,
+      automationName: row.automation?.name ?? "Deleted workflow",
+      status: row.status,
+      durationMs: row.durationMs,
+      actionCount: row.actionCount,
+      createdAt: row.createdAt,
+      result: row.result,
+    }));
+
+    return successResponse({
+      range,
+      from: from.toISOString(),
+      to: to.toISOString(),
+      totals: runTotals(runs),
+      byRule: rulePerformance(runs).slice(0, 12),
+      failures: failureGroups(runs),
+      truncated: rows.length === CAP,
+    });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/automations/insights error:", error);
+    return errorResponse("Failed to summarise the workflow runs");
+  }
+}

--- a/app/api/v2/crm/files/route.ts
+++ b/app/api/v2/crm/files/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { fileOwnerSchema, ownerWhere, recordFileSchema } from "@/lib/crm/record-files";
+
+/**
+ * Files on a record.
+ *
+ * The upload itself goes to /api/v2/crm/uploads, which puts the bytes in blob
+ * storage and hands back a url. This records that the url belongs to a
+ * record — two steps rather than one because an upload that succeeds and a
+ * row that fails should leave a file nobody can see, not a row pointing at
+ * nothing.
+ *
+ * Scoped by companyId on every query. The owner id arrives from the client,
+ * so the company filter is what stops a valid uuid from another tenant
+ * returning that tenant's files.
+ */
+
+const LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const { searchParams } = new URL(request.url);
+    const parsed = fileOwnerSchema.safeParse({
+      owner: searchParams.get("owner"),
+      ownerId: searchParams.get("ownerId"),
+    });
+    if (!parsed.success) return errorResponse("Which record?", 400);
+
+    const files = await prisma.crmRecordFile.findMany({
+      where: {
+        companyId: session.user.companyId,
+        ...ownerWhere({ kind: parsed.data.owner, id: parsed.data.ownerId }),
+      },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        size: true,
+        contentType: true,
+        note: true,
+        createdAt: true,
+        uploadedBy: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: LIMIT,
+    });
+
+    return successResponse({ data: files });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/files error:", error);
+    return errorResponse("Failed to load the files");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const body = recordFileSchema.parse(await request.json());
+
+    const created = await prisma.crmRecordFile.create({
+      data: {
+        companyId: session.user.companyId,
+        name: body.name,
+        url: body.url,
+        size: body.size ?? null,
+        contentType: body.contentType ?? null,
+        note: body.note ?? null,
+        uploadedById: session.user.id,
+        ...ownerWhere({ kind: body.owner, id: body.ownerId }),
+      },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        size: true,
+        contentType: true,
+        note: true,
+        createdAt: true,
+        uploadedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    return successResponse(created, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return errorResponse("Validation failed", 400, error.issues);
+    }
+    // A foreign key that does not resolve means the record is not this
+    // company's — or does not exist. Both are "not found" to the caller.
+    console.error("[API] POST /api/v2/crm/files error:", error);
+    return errorResponse("Couldn't attach that file");
+  }
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const { searchParams } = new URL(request.url);
+    const parsed = deleteSchema.safeParse({ id: searchParams.get("id") });
+    if (!parsed.success) return errorResponse("Which file?", 400);
+
+    // deleteMany rather than delete: scoped by company in the same statement,
+    // so another tenant's id deletes nothing rather than throwing a 500 that
+    // confirms the row exists.
+    const result = await prisma.crmRecordFile.deleteMany({
+      where: { id: parsed.data.id, companyId: session.user.companyId },
+    });
+    if (result.count === 0) return errorResponse("File not found", 404);
+
+    return successResponse({ id: parsed.data.id });
+  } catch (error) {
+    console.error("[API] DELETE /api/v2/crm/files error:", error);
+    return errorResponse("Failed to remove the file");
+  }
+}

--- a/app/api/v2/crm/leads/[id]/route.ts
+++ b/app/api/v2/crm/leads/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
 import { scoreLead } from "@/lib/crm/lead-scoring";
 import { prisma } from "@/lib/prisma";
+import { recordFieldChanges } from "@/lib/crm/history";
 import { canEditRecord } from "@/lib/crm/permissions";
 import { crmLeadChannelSchema } from "@/lib/crm/views";
 import {
@@ -121,7 +122,23 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     const existing = await prisma.crmLead.findFirst({
       where: { id, companyId: session.user.companyId },
-      select: { id: true, assignedToId: true, customFields: true },
+      // The full row, not just the guard fields: recording what changed needs
+      // the values as they were before the write.
+      select: {
+        id: true,
+        assignedToId: true,
+        customFields: true,
+        title: true,
+        clientId: true,
+        contactName: true,
+        contactEmail: true,
+        contactPhone: true,
+        probability: true,
+        estimatedValue: true,
+        currency: true,
+        source: true,
+        sourceChannel: true,
+      },
     });
     if (!existing) return errorResponse("Lead not found", 404);
     if (!await canEditRecord(session, existing.assignedToId)) {
@@ -176,6 +193,32 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         ...(customFields !== undefined ? { customFields } : {}),
       },
     });
+
+    // Leads recorded nothing. Every other record type wrote a field-change
+    // trail, so "who dropped the value from 40k to 12k" was answerable
+    // everywhere except on the record type people actually open.
+    await recordFieldChanges(prisma, {
+      companyId: session.user.companyId,
+      userId: session.user.id,
+      entity: "LEAD",
+      recordId: id,
+      before: existing,
+      after: updated,
+      fields: [
+        "title",
+        "clientId",
+        "contactName",
+        "contactEmail",
+        "contactPhone",
+        "probability",
+        "estimatedValue",
+        "currency",
+        "source",
+        "sourceChannel",
+        "assignedToId",
+      ],
+    });
+
     return successResponse(updated);
   } catch (error) {
     if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);

--- a/app/api/v2/crm/leads/[id]/route.ts
+++ b/app/api/v2/crm/leads/[id]/route.ts
@@ -5,6 +5,11 @@ import { scoreLead } from "@/lib/crm/lead-scoring";
 import { prisma } from "@/lib/prisma";
 import { canEditRecord } from "@/lib/crm/permissions";
 import { crmLeadChannelSchema } from "@/lib/crm/views";
+import {
+  buildCustomFieldValues,
+  mergeCustomFields,
+  type FieldDefinition,
+} from "@/lib/crm/custom-fields";
 import { isCompanyUser } from "../../_helpers";
 
 const updateSchema = z.object({
@@ -20,6 +25,11 @@ const updateSchema = z.object({
   source: z.string().trim().max(120).nullable().optional(),
   sourceChannel: crmLeadChannelSchema.nullable().optional(),
   assignedToId: z.string().uuid().nullable().optional(),
+  // A lead is the one record type that never accepted the administrator's
+  // own fields, so anything captured on an intake form could not be
+  // corrected afterwards.
+  customFields: z.record(z.string(), z.unknown()).optional(),
+  clearCustomFields: z.array(z.string().trim().max(60)).max(50).optional(),
 });
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -111,7 +121,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     const existing = await prisma.crmLead.findFirst({
       where: { id, companyId: session.user.companyId },
-      select: { id: true, assignedToId: true },
+      select: { id: true, assignedToId: true, customFields: true },
     });
     if (!existing) return errorResponse("Lead not found", 404);
     if (!await canEditRecord(session, existing.assignedToId)) {
@@ -128,6 +138,21 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     }
     if (!(await isCompanyUser(session.user.companyId, data.assignedToId))) {
       return errorResponse("Invalid assignee", 400);
+    }
+
+    // Merged, not replaced: the record page writes one property at a time,
+    // and a whole-object write would drop every field it did not send.
+    let customFields: ReturnType<typeof mergeCustomFields> | undefined;
+    if (data.customFields || data.clearCustomFields) {
+      const definitions = (await prisma.crmFieldDefinition.findMany({
+        where: { companyId: session.user.companyId, entity: "LEAD", archivedAt: null },
+        orderBy: { position: "asc" },
+      })) as unknown as FieldDefinition[];
+      const { values, errors } = buildCustomFieldValues(definitions, data.customFields, {
+        partial: true,
+      });
+      if (errors.length > 0) return errorResponse("Validation failed", 400, errors);
+      customFields = mergeCustomFields(existing.customFields, values, data.clearCustomFields ?? []);
     }
 
     // Throughout: `undefined` leaves a field alone, an explicit `null` clears
@@ -148,6 +173,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         source: data.source,
         sourceChannel: data.sourceChannel ?? undefined,
         assignedToId: data.assignedToId,
+        ...(customFields !== undefined ? { customFields } : {}),
       },
     });
     return successResponse(updated);

--- a/app/api/v2/crm/mentions/route.ts
+++ b/app/api/v2/crm/mentions/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Everywhere a record has been written about.
+ *
+ * A record page could show what it points at — its company, its site, its
+ * people — and nothing about what points back. But half of what somebody
+ * writes on a deal is about another deal, the site it is on, or the company
+ * behind both, and those references have been stored in note and comment
+ * bodies since the composer learned to make them: `@[Label](kind:uuid)`.
+ *
+ * So the backlinks are already in the data. This reads them out.
+ *
+ * Matching is a substring search on the record's id rather than a join table.
+ * The id is a uuid — 36 characters with dashes — so a false positive would
+ * need somebody to type one into prose, and the alternative is a migration
+ * plus a write path that can drift out of step with the text it indexes. If
+ * this ever gets slow, the fix is a materialised `CrmReference` table fed by
+ * the same parser, not a different query here.
+ */
+const querySchema = z.object({
+  recordId: z.string().uuid(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+const SOURCE_SELECT = {
+  lead: { select: { id: true, leadNo: true, title: true } },
+  deal: { select: { id: true, dealNo: true, title: true } },
+  client: { select: { id: true, name: true } },
+  person: { select: { id: true, fullName: true } },
+  site: { select: { id: true, name: true } },
+} as const;
+
+type SourceRow = {
+  lead?: { id: string; leadNo: string; title: string | null } | null;
+  deal?: { id: string; dealNo: string; title: string | null } | null;
+  client?: { id: string; name: string } | null;
+  person?: { id: string; fullName: string } | null;
+  site?: { id: string; name: string } | null;
+};
+
+/** Which record the note was written on, named the way a link needs. */
+function sourceOf(row: SourceRow) {
+  if (row.lead) {
+    return {
+      kind: "lead" as const,
+      id: row.lead.id,
+      label: row.lead.title ?? row.lead.leadNo,
+      href: `/crm/leads/${row.lead.id}`,
+    };
+  }
+  if (row.deal) {
+    return {
+      kind: "deal" as const,
+      id: row.deal.id,
+      label: row.deal.title ?? row.deal.dealNo,
+      href: `/crm/deals/${row.deal.id}`,
+    };
+  }
+  if (row.client) {
+    return {
+      kind: "company" as const,
+      id: row.client.id,
+      label: row.client.name,
+      href: `/crm/companies/${row.client.id}`,
+    };
+  }
+  if (row.person) {
+    return {
+      kind: "person" as const,
+      id: row.person.id,
+      label: row.person.fullName,
+      href: `/crm/people/${row.person.id}`,
+    };
+  }
+  if (row.site) {
+    return {
+      kind: "site" as const,
+      id: row.site.id,
+      label: row.site.name,
+      href: `/crm/sites/${row.site.id}`,
+    };
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const companyId = session.user.companyId;
+
+    const { searchParams } = new URL(request.url);
+    const { recordId, limit } = querySchema.parse({
+      recordId: searchParams.get("recordId"),
+      limit: searchParams.get("limit") ?? undefined,
+    });
+
+    const [comments, activities] = await Promise.all([
+      prisma.crmComment.findMany({
+        where: { companyId, body: { contains: recordId } },
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        select: {
+          id: true,
+          body: true,
+          createdAt: true,
+          createdBy: { select: { id: true, name: true } },
+          lead: SOURCE_SELECT.lead,
+          deal: SOURCE_SELECT.deal,
+          client: SOURCE_SELECT.client,
+          person: SOURCE_SELECT.person,
+          site: SOURCE_SELECT.site,
+        },
+      }),
+      prisma.crmActivity.findMany({
+        where: {
+          companyId,
+          OR: [{ body: { contains: recordId } }, { subject: { contains: recordId } }],
+        },
+        orderBy: { occurredAt: "desc" },
+        take: limit,
+        select: {
+          id: true,
+          subject: true,
+          body: true,
+          occurredAt: true,
+          createdBy: { select: { id: true, name: true } },
+          lead: SOURCE_SELECT.lead,
+          deal: SOURCE_SELECT.deal,
+          client: SOURCE_SELECT.client,
+          person: SOURCE_SELECT.person,
+        },
+      }),
+    ]);
+
+    const data = [
+      ...comments.map((row) => ({
+        id: row.id,
+        kind: "comment" as const,
+        // The stored text, tokens and all — the client renders it the same
+        // way it renders a note, so a mention inside a mention still links.
+        body: row.body,
+        occurredAt: row.createdAt.toISOString(),
+        authorName: row.createdBy?.name ?? null,
+        source: sourceOf(row),
+      })),
+      ...activities.map((row) => ({
+        id: row.id,
+        kind: "activity" as const,
+        body: row.body?.trim() ? row.body : row.subject,
+        occurredAt: row.occurredAt.toISOString(),
+        authorName: row.createdBy?.name ?? null,
+        source: sourceOf(row),
+      })),
+    ]
+      // A mention on the record you are already looking at is not a backlink,
+      // it is the note itself — the timeline already shows it.
+      .filter((entry) => entry.source && entry.source.id !== recordId)
+      .sort((a, b) => b.occurredAt.localeCompare(a.occurredAt))
+      .slice(0, limit);
+
+    return successResponse({ data });
+  } catch (error) {
+    if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
+    console.error("[API] GET /api/v2/crm/mentions error:", error);
+    return errorResponse("Failed to load mentions");
+  }
+}

--- a/app/api/v2/crm/reports/route.ts
+++ b/app/api/v2/crm/reports/route.ts
@@ -6,13 +6,17 @@ import { hasCrmFullAccess } from "@/lib/crm/scope";
 import {
   REPORT_RANGES,
   bucketByPeriod,
+  bucketSeries,
   buildFunnel,
   forecast,
   medianCycleDays,
+  medianDaysInStage,
   rangeToDates,
+  shareSlices,
   summarizeGroups,
   winRate,
   type ReportRange,
+  type StageChange,
 } from "@/lib/crm/reports";
 
 /**
@@ -49,6 +53,7 @@ export async function GET(request: NextRequest) {
           wonAt: true,
           lostAt: true,
           source: true,
+          stageId: true,
           assignedToId: true,
           assignedTo: { select: { id: true, name: true } },
           stage: { select: { id: true, name: true, status: true, position: true } },
@@ -74,6 +79,47 @@ export async function GET(request: NextRequest) {
       }),
     ]);
 
+    // How long deals sit in each stage, reconstructed from the stage-change
+    // trail. A separate query rather than part of the fan-out above because it
+    // is keyed on the deals that came back: asking for every stage change in
+    // the company would drag in years of history to answer a question about
+    // this quarter.
+    const stageChanges =
+      deals.length === 0
+        ? []
+        : await prisma.crmActivity.findMany({
+            where: {
+              companyId,
+              type: "STAGE_CHANGE",
+              dealId: { in: deals.map((deal) => deal.id) },
+            },
+            select: { dealId: true, metadata: true, occurredAt: true },
+            orderBy: { occurredAt: "asc" },
+          });
+
+    const transitions: StageChange[] = stageChanges.map((change) => {
+      const metadata = (change.metadata ?? {}) as {
+        fromStageId?: unknown;
+        toStageId?: unknown;
+      };
+      return {
+        dealId: change.dealId!,
+        fromStageId: typeof metadata.fromStageId === "string" ? metadata.fromStageId : null,
+        toStageId: typeof metadata.toStageId === "string" ? metadata.toStageId : null,
+        at: change.occurredAt,
+      };
+    });
+
+    const dwell = medianDaysInStage(
+      deals.map((deal) => ({
+        id: deal.id,
+        createdAt: deal.createdAt,
+        closedAt: deal.wonAt ?? deal.lostAt,
+        currentStageId: deal.stageId,
+      })),
+      transitions,
+    );
+
     // A deal that reached stage 4 also reached stages 1–3, so the funnel counts
     // everything at or past each position. Counting only what sits in a stage
     // right now would show a funnel that widens further down.
@@ -92,7 +138,12 @@ export async function GET(request: NextRequest) {
           value: reached.reduce((sum, deal) => sum + (deal.value ?? 0), 0),
         };
       }),
-    );
+    ).map((stage) => ({
+      // Null rather than zero where nothing has been through: "0 days" reads
+      // as instant, which is the opposite of "we have no idea yet".
+      ...stage,
+      medianDaysInStage: dwell[stage.key] ?? null,
+    }));
 
     const counts = {
       won: deals.filter((deal) => deal.wonAt).length,
@@ -136,6 +187,20 @@ export async function GET(request: NextRequest) {
       return summarizeGroups(Array.from(map.values()));
     };
 
+    const byOwner = groupBy((deal) => ({
+      key: deal.assignedToId ?? "unassigned",
+      label: deal.assignedTo?.name ?? "Unassigned",
+    }));
+    const bySource = groupBy((deal) => ({
+      key: deal.source ?? "unknown",
+      label: deal.source ?? "Not recorded",
+    }));
+
+    // A year of daily points is 365 pixels of noise; a week of weekly points is
+    // one. The bucket follows the range rather than being a setting nobody
+    // would find.
+    const granularity = range === "12m" ? "week" : "day";
+
     return successResponse({
       range,
       from: from.toISOString(),
@@ -153,18 +218,35 @@ export async function GET(request: NextRequest) {
       forecast: forecast(
         openDeals.map((deal) => ({ value: deal.value, probability: deal.probability })),
       ),
-      byOwner: groupBy((deal) => ({
-        key: deal.assignedToId ?? "unassigned",
-        label: deal.assignedTo?.name ?? "Unassigned",
-      })),
-      bySource: groupBy((deal) => ({
-        key: deal.source ?? "unknown",
-        label: deal.source ?? "Not recorded",
-      })),
+      byOwner,
+      bySource,
+      // Where the won money came from, as slices of one total. Value rather
+      // than count: two sources bringing in ten deals each are not equal when
+      // one of them brings in ten times the money.
+      sourceShare: shareSlices(
+        bySource.map((row) => ({ key: row.key, label: row.label, value: row.wonValue })),
+      ),
+      // Won business over time, counted and totalled in the same walk so the
+      // two lines cannot disagree with each other.
+      trend: {
+        granularity,
+        won: bucketSeries(
+          deals
+            .filter((deal) => deal.wonAt)
+            .map((deal) => ({ at: deal.wonAt!, value: deal.value ?? 0 })),
+          { from, to },
+          granularity,
+        ),
+        created: bucketSeries(
+          deals.map((deal) => ({ at: deal.createdAt, value: deal.value ?? 0 })),
+          { from, to },
+          granularity,
+        ),
+      },
       activity: bucketByPeriod(
         activities.map((activity) => activity.occurredAt),
         { from, to },
-        range === "12m" ? "week" : "day",
+        granularity,
       ),
       leads: {
         created: leads.length,

--- a/app/api/v2/crm/visit-items/route.ts
+++ b/app/api/v2/crm/visit-items/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * What was measured on this record's site visits, as quotable lines.
+ *
+ * The visit already fed a quotation once — at the moment somebody completed a
+ * report and pressed "generate quotation", which prefilled every line in one
+ * go. That is the right flow for the common case and no use at all for the
+ * one that follows it: a quote that needs three of the measured items, one
+ * catalogue product and a one-off, or a second quote raised a week later.
+ *
+ * So the measurements are also readable per line, and the quote builder
+ * offers them alongside the catalogue.
+ */
+const querySchema = z
+  .object({
+    leadId: z.string().uuid().optional(),
+    dealId: z.string().uuid().optional(),
+  })
+  // One or the other. Neither would return every measurement in the company.
+  .refine((value) => Boolean(value.leadId) !== Boolean(value.dealId), {
+    message: "Ask for one record",
+  });
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+
+    const { searchParams } = new URL(request.url);
+    const parsed = querySchema.safeParse({
+      leadId: searchParams.get("leadId") ?? undefined,
+      dealId: searchParams.get("dealId") ?? undefined,
+    });
+    if (!parsed.success) return errorResponse("Which record?", 400);
+
+    const visits = await prisma.crmAppointment.findMany({
+      where: {
+        companyId: session.user.companyId,
+        ...(parsed.data.leadId ? { leadId: parsed.data.leadId } : {}),
+        ...(parsed.data.dealId ? { dealId: parsed.data.dealId } : {}),
+        // A cancelled visit's measurements are of a job nobody did.
+        status: { not: "CANCELLED" },
+      },
+      select: {
+        appointmentNo: true,
+        title: true,
+        scheduledStart: true,
+        visitItems: {
+          orderBy: { position: "asc" },
+          select: {
+            id: true,
+            description: true,
+            quantity: true,
+            unit: true,
+            unitPrice: true,
+            category: true,
+          },
+        },
+      },
+      orderBy: { scheduledStart: "desc" },
+      take: 20,
+    });
+
+    const items = visits.flatMap((visit) =>
+      visit.visitItems
+        .filter((item) => item.description.trim())
+        .map((item) => ({
+          id: item.id,
+          description: item.description,
+          quantity: item.quantity,
+          unit: item.unit,
+          unitPrice: item.unitPrice,
+          category: item.category,
+          // Named so two surveys of the same building stay distinguishable.
+          visitLabel: visit.title || visit.appointmentNo,
+        })),
+    );
+
+    return successResponse({ data: items });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/visit-items error:", error);
+    return errorResponse("Failed to load the measured items");
+  }
+}

--- a/app/api/v2/crm/work-orders/[id]/sign-off/route.ts
+++ b/app/api/v2/crm/work-orders/[id]/sign-off/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { canEditRecord } from "@/lib/crm/permissions";
+import { canAskForSignOff, generateSignOffToken } from "@/lib/crm/sign-off";
+
+/** Ask the client to sign the job off, or withdraw the request. */
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const job = await prisma.crmWorkOrder.findFirst({
+      where: { id, companyId: session.user.companyId },
+      select: { id: true, assignedToId: true, status: true, signOffAt: true },
+    });
+    if (!job) return errorResponse("Job not found", 404);
+    if (!(await canEditRecord(session, job.assignedToId))) {
+      return errorResponse("You can only share jobs assigned to you", 403);
+    }
+    if (!canAskForSignOff(job.status)) {
+      return errorResponse(
+        "Ask for sign-off once the job is under way — there is nothing to confirm yet",
+        400,
+      );
+    }
+    // Rotating after an answer would invite overwriting the record.
+    if (job.signOffAt) {
+      return errorResponse("This job has already been signed off", 409);
+    }
+
+    const token = generateSignOffToken();
+    await prisma.crmWorkOrder.update({
+      where: { id },
+      data: { signOffToken: token, signOffAskedAt: new Date() },
+    });
+
+    return successResponse({ token, path: `/s/${token}` }, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
+    console.error("[API] POST /api/v2/crm/work-orders/[id]/sign-off error:", error);
+    return errorResponse("Failed to request sign-off");
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const job = await prisma.crmWorkOrder.findFirst({
+      where: { id, companyId: session.user.companyId },
+      select: { id: true, assignedToId: true, signOffAt: true },
+    });
+    if (!job) return errorResponse("Job not found", 404);
+    if (!(await canEditRecord(session, job.assignedToId))) {
+      return errorResponse("You can only change jobs assigned to you", 403);
+    }
+    // The answer stays; only the way in closes.
+    await prisma.crmWorkOrder.update({
+      where: { id },
+      data: { signOffToken: null, signOffAskedAt: null },
+    });
+
+    return successResponse({ id });
+  } catch (error) {
+    console.error("[API] DELETE /api/v2/crm/work-orders/[id]/sign-off error:", error);
+    return errorResponse("Failed to withdraw the sign-off request");
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -232,6 +232,51 @@
     }
   }
 
+  /* --- Control geometry -------------------------------------------------
+     Everything that reads as a button is built like one: same height, same
+     gap, same radius. Three places where that had drifted.
+
+     1. `.btn` carries `gap: 8px`, but the design system's Button wraps every
+        child in a `.btn-label` span it never styles. An icon passed as a
+        child therefore lands *inside* that span, where the button's gap
+        cannot reach it — measured at exactly 0px against the words on
+        "New lead", "Filter" and "Fields". The DS's own answer is the
+        `startIcon`/`endIcon` props, which render as siblings of the label;
+        this makes the label behave the same way for the hundreds of call
+        sites that pass an icon as a child instead. `gap: inherit` rather
+        than a number, so a button that sets its own gap keeps it. */
+  .btn-label {
+    display: inline-flex;
+    align-items: center;
+    gap: inherit;
+    min-width: 0;
+  }
+
+  /* 2. A segmented control is a row of buttons, so it stands as tall as one.
+        The DS sizes it off its own scale rather than the control-height
+        scale: `md` came out 34px and `sm` 28px beside 36px and 30px buttons,
+        which is what put a 24px Board/List toggle next to a 36px Filter
+        button in the same toolbar. Item height is the button height less the
+        track's own padding, so the *outer* edges line up — that is the part
+        anybody sees. Font sizes come up to the button's at the same size;
+        the DS's 12px `sm` is below this repo's floor anyway. */
+  .segmented {
+    padding: 3px;
+  }
+  .segmented .segmented-item {
+    height: calc(var(--h-control-md) - 6px);
+    font-size: 14px;
+    gap: 8px;
+  }
+  .segmented.segmented-sm {
+    padding: 2px;
+  }
+  .segmented.segmented-sm .segmented-item {
+    height: calc(var(--h-control-sm) - 4px);
+    font-size: 13px;
+    gap: 6px;
+  }
+
   /* Date input color scheme */
   input[type="date"],
   input[type="datetime-local"] {

--- a/app/globals.css
+++ b/app/globals.css
@@ -187,11 +187,25 @@
    Type, colour and canvas all come from the package's `body` rule; this layer
    only adds what the app needs on top of it. */
 
-@layer app {
+/* A default border colour and focus ring, so an element that draws a border
+   without naming a colour gets the theme's rather than the browser's.
+
+   This has to live in `base`, not `app`. A universal selector in a layer that
+   comes *after* `corelith` outranks every design-system rule setting a border
+   colour — specificity never enters into it, later layer simply wins. That is
+   why the selected tab's underline rendered the same grey as the unselected
+   ones: `.utab.current { border-bottom-color: var(--brand) }` was losing to
+   `*`. Every other DS state drawn as a border colour was losing the same way.
+
+   In `base` the order is the one everybody expects: this loses to the design
+   system, and the design system loses to a call site's own `border-*` utility. */
+@layer base {
   * {
     @apply border-border outline-ring/50;
   }
+}
 
+@layer app {
   body {
     position: relative;
     background-image: var(--app-canvas-wash);

--- a/app/globals.css
+++ b/app/globals.css
@@ -209,10 +209,27 @@
     isolation: isolate;
   }
 
-  /* Prevent iOS zoom on input focus */
+  /* Prevent iOS zoom on input focus.
+
+     `[contenteditable]` is a safety net only: a call site that sets its own
+     `text-sm` still wins, because utilities are a later layer than `app`. Any
+     composer that needs 16px on a phone has to say so itself. */
   @media (max-width: 640px) {
     html { font-size: 16px; }
-    input, select, textarea { font-size: 16px; }
+    input, select, textarea, [contenteditable="true"] { font-size: 16px; }
+  }
+
+  /* A record page is one column on anything smaller than a laptop.
+     `.detail-grid` ships from the design system as a hard `1fr 320px` with no
+     media query of its own — at phone width that crushes the content column to
+     a few pixels beside a full-width rail, and at tablet width it leaves ~380px
+     for a timeline or a table. iPad portrait (768/810/834) all land in that
+     band, so this collapses at `lg` rather than `md`. Precedent: the settings
+     shell, whose rail is 100px narrower, already collapses at 900px. */
+  @media (max-width: 1023.98px) {
+    .detail-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
 
   /* Date input color scheme */

--- a/app/globals.css
+++ b/app/globals.css
@@ -252,6 +252,39 @@
     min-width: 0;
   }
 
+  /*    A button stretched to full width is a row, not a centred label: a
+        sheet of stacked controls, a form field filling its column. The words
+        start at the left edge and a trailing caret goes to the *right* edge,
+        which is where the eye looks for it and where a thumb reaches. Only a
+        trailing `svg` is pushed over — a button whose last child is text
+        keeps its label beside the rest of the label. */
+  .btn:where(.w-full) {
+    justify-content: flex-start;
+  }
+  .btn:where(.w-full) > .btn-label {
+    flex: 1 1 auto;
+  }
+  .btn:where(.w-full) > .btn-label > svg:last-child {
+    margin-inline-start: auto;
+  }
+
+  /*    The app bar is one row of controls, so they are one height. Measured
+        at 390px it was four: a 30px sidebar toggle, a 30px search box drawing
+        its own padding, a 36px notification bell and a 30px page action. The
+        sidebar toggle ships from the design system and cannot be sized from
+        its call site, so the row states the height it wants and everything in
+        it obeys — including the toggle. */
+  header .btn,
+  header [data-sidebar="trigger"],
+  header [data-slot="sidebar-trigger"] {
+    height: var(--h-control-md);
+    min-height: var(--h-control-md);
+  }
+  header [data-sidebar="trigger"],
+  header [data-slot="sidebar-trigger"] {
+    width: var(--h-control-md);
+  }
+
   /* 2. A segmented control is a row of buttons, so it stands as tall as one.
         The DS sizes it off its own scale rather than the control-height
         scale: `md` came out 34px and `sm` 28px beside 36px and 30px buttons,

--- a/app/s/[token]/page.tsx
+++ b/app/s/[token]/page.tsx
@@ -1,0 +1,16 @@
+import { SignOffContent } from "@/components/crm/public/sign-off-content";
+
+export const dynamic = "force-dynamic";
+
+export default async function PublicSignOffPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  return (
+    <main className="min-h-screen bg-neutral-50">
+      <SignOffContent token={token} />
+    </main>
+  );
+}

--- a/app/v/[token]/page.tsx
+++ b/app/v/[token]/page.tsx
@@ -1,0 +1,16 @@
+import { VisitBriefContent } from "@/components/crm/public/visit-brief-content";
+
+export const dynamic = "force-dynamic";
+
+export default async function PublicVisitBriefPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  return (
+    <main className="min-h-screen bg-neutral-50">
+      <VisitBriefContent token={token} />
+    </main>
+  );
+}

--- a/components/crm/collaboration/rich-text-composer.test.tsx
+++ b/components/crm/collaboration/rich-text-composer.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { RichTextComposer } from "./rich-text-composer";
+
+/**
+ * iOS zooms the whole page in when a field under 16px takes focus, and never
+ * zooms back out — so a composer at `text-sm` leaves somebody stranded at 1.3×
+ * for the rest of the page.
+ *
+ * `app/globals.css` has a 16px rule for `input`, `select`, `textarea` and
+ * `[contenteditable]`, but it cannot reach this element: it lives in
+ * `@layer app`, and Tailwind's utilities are a later layer, so any `text-sm`
+ * written at the call site wins. The fix has to be at the call site, and this
+ * asserts on the emitted element rather than the source because the cascade
+ * question is exactly the kind that reads correct and renders wrong.
+ */
+function editableTag() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const html = renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <RichTextComposer value="" onChange={() => {}} onSubmit={() => {}} />
+    </QueryClientProvider>,
+  );
+  const index = html.indexOf('role="textbox"');
+  return html.slice(html.lastIndexOf("<", index), html.indexOf(">", index) + 1);
+}
+
+describe("RichTextComposer", () => {
+  it("renders the editable at 16px, dropping to 14px only from sm up", () => {
+    const tag = editableTag();
+
+    expect(tag).toContain('contentEditable="true"');
+    expect(tag).toContain("text-base");
+    expect(tag).toContain("sm:text-sm");
+  });
+
+  it("carries no unqualified text-sm that would win the cascade back", () => {
+    // With the responsive pair removed, nothing resembling `text-sm` should be
+    // left — a bare one would apply at every width and undo the fix.
+    const remaining = editableTag().replace("text-base", "").replace("sm:text-sm", "");
+    expect(remaining).not.toMatch(/\btext-sm\b/);
+  });
+});

--- a/components/crm/collaboration/rich-text-composer.tsx
+++ b/components/crm/collaboration/rich-text-composer.tsx
@@ -358,7 +358,12 @@ export function RichTextComposer({
               placeholder ?? "Write a note. Type @ to mention someone or link a record."
             }
             className={cn(
-              "w-full rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm",
+              // 16px on a phone, because iOS zooms the whole page in when a
+              // field smaller than that takes focus and never zooms back
+              // out. The global rule in globals.css cannot reach this: it
+              // lives in `@layer app`, and utilities are a later layer, so
+              // a `text-sm` written here would win. It has to be said here.
+              "w-full rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-base sm:text-sm",
               "whitespace-pre-wrap break-words",
               "focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]",
               // A contenteditable has no placeholder of its own, and `:empty`
@@ -410,7 +415,9 @@ export function RichTextComposer({
 
           {query !== null && visible.length ? (
             <ul
-              className="absolute z-20 mt-1 w-80 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-raised)] shadow-lg"
+              // Full composer width on a phone; 320px pinned to the left
+              // edge from `sm` up, which is where it started.
+              className="absolute inset-x-0 z-20 mt-1 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-raised)] shadow-lg sm:right-auto sm:w-80"
               role="listbox"
             >
               {visible.map((candidate, index) => {

--- a/components/crm/crm-dashboard-content.tsx
+++ b/components/crm/crm-dashboard-content.tsx
@@ -326,7 +326,10 @@ export function CrmDashboardContent() {
                       href={`/crm/deals?stageId=${stage.id}`}
                       className="flex items-center gap-3 text-sm hover:underline"
                     >
-                      <span className="w-32 shrink-0 truncate">{stage.name}</span>
+                      {/* The name, the bar and the money share one row. 32rem of
+                          name leaves the money nowhere to go at phone width,
+                          so the label gives up a quarter of itself there. */}
+                      <span className="w-24 shrink-0 truncate sm:w-32">{stage.name}</span>
                       <span
                         className="h-2 rounded-full bg-[var(--brand)]"
                         style={{ width: `${Math.max(share, stage.count > 0 ? 3 : 0)}%` }}

--- a/components/crm/crm-follow-ups-content.tsx
+++ b/components/crm/crm-follow-ups-content.tsx
@@ -126,7 +126,6 @@ export function CrmFollowUpsContent() {
             options={QUEUES.map((value) => ({ value, label: TASK_QUEUE_LABELS[value] }))}
             value={queue}
             onValueChange={(value) => setQueue(value as TaskQueue)}
-            size="sm"
             ariaLabel="Follow-up queue"
           />
         }

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -171,7 +171,7 @@ export function CrmFormsContent() {
                 </Badge>
               </div>
 
-              <dl className="mt-3 grid grid-cols-3 gap-2 text-sm">
+              <dl className="mt-3 grid grid-cols-2 gap-2 text-sm sm:grid-cols-3">
                 <div>
                   <dt className="text-sm text-[var(--text-muted)]">Submissions</dt>
                   <dd className="font-mono">{form.submissionCount}</dd>

--- a/components/crm/crm-insights-content.tsx
+++ b/components/crm/crm-insights-content.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { CRM_CHANNEL_LABELS } from "@/lib/crm/sources";
 import { REPORT_RANGES, formatRate, type ReportRange } from "@/lib/crm/reports";
+import { MobileRow, MobileRows } from "@/components/crm/records/mobile-rows";
 
 type FunnelStage = {
   key: string;
@@ -290,7 +291,25 @@ export function CrmInsightsContent() {
 
             <TabsContent value="rep">
               {reps.data?.data.length ? (
-                <div className="scroll-rail overflow-x-auto">
+                <>
+                {/* Seven columns is 680px of table. On a phone it is a list:
+                    who, what they collected, and the rest underneath. */}
+                <MobileRows className="md:hidden">
+                  {reps.data.data.map((row) => (
+                    <MobileRow
+                      key={row.repId}
+                      title={row.name}
+                      subtitle={`${row.leads} leads · ${row.quotes} quotes · ${row.winRate}% won${
+                        row.avgResponseHours != null
+                          ? ` · ${row.avgResponseHours}h to respond`
+                          : ""
+                      }`}
+                      value={money(row.collectedAmount)}
+                    />
+                  ))}
+                </MobileRows>
+
+                <div className="scroll-rail hidden overflow-x-auto md:block">
                   <table className="w-full min-w-[680px] text-sm">
                     <thead>
                       <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
@@ -320,6 +339,7 @@ export function CrmInsightsContent() {
                     </tbody>
                   </table>
                 </div>
+                </>
               ) : (
                 <EmptyState title="No rep activity yet" />
               )}
@@ -361,7 +381,24 @@ function GroupTable({ rows, firstHeader }: { rows: GroupRow[]; firstHeader: stri
   if (!rows.length) return <EmptyState title={`Nothing to break down by ${firstHeader.toLowerCase()} yet`} />;
 
   return (
-    <div className="scroll-rail overflow-x-auto">
+    <>
+    {/* A 560px table on a 358px screen scrolls sideways, which is the old
+        answer to this and a poor one: you cannot compare a column you have to
+        drag into view, and the row labels leave as soon as you do. A phone
+        gets one row per group — won value on the right, the counts and the
+        rate underneath. */}
+    <MobileRows className="md:hidden">
+      {rows.map((row) => (
+        <MobileRow
+          key={row.key}
+          title={row.label}
+          subtitle={`${row.open} open · ${row.won} won · ${row.lost} lost · ${formatRate(row.winRate)}`}
+          value={money(row.wonValue)}
+        />
+      ))}
+    </MobileRows>
+
+    <div className="scroll-rail hidden overflow-x-auto md:block">
       <table className="w-full min-w-[560px] text-sm">
         <thead>
           <tr className="border-b border-[var(--border)] text-left text-[var(--text-muted)]">
@@ -389,5 +426,6 @@ function GroupTable({ rows, firstHeader }: { rows: GroupRow[]; firstHeader: stri
         </tbody>
       </table>
     </div>
+    </>
   );
 }

--- a/components/crm/crm-settings-content.tsx
+++ b/components/crm/crm-settings-content.tsx
@@ -18,6 +18,7 @@ import {
   Lock,
   Megaphone,
   Package,
+  X,
   type LucideIcon,
 } from "@/lib/icons";
 import { CRM_CHANNEL_LABELS, CRM_LEAD_CHANNELS } from "@/lib/crm/sources";
@@ -314,9 +315,11 @@ function CommissionsPanel() {
         <div className="space-y-2">
           <Label>Tiers (marginal rate from a cumulative revenue threshold)</Label>
           {tiers.map((tier, index) => (
-            <div key={index} className="grid grid-cols-12 gap-2">
+            // Two fields and a delete, sized by content rather than by
+            // twelfths: one twelfth of a 390px phone is a 22px delete button,
+            // which is half a touch target.
+            <div key={index} className="grid grid-cols-[1fr_1fr_auto] gap-2">
               <Input
-                className="col-span-6"
                 type="number"
                 placeholder="From revenue"
                 value={tier.thresholdFrom}
@@ -327,7 +330,6 @@ function CommissionsPanel() {
                 }}
               />
               <Input
-                className="col-span-5"
                 type="number"
                 placeholder="Rate %"
                 value={tier.ratePercent}
@@ -338,12 +340,13 @@ function CommissionsPanel() {
                 }}
               />
               <Button
-                className="col-span-1"
+                className="size-9 px-0"
                 variant="ghost"
                 size="sm"
+                aria-label={`Remove tier ${index + 1}`}
                 onClick={() => setTiers(tiers.filter((_, i) => i !== index))}
               >
-                ✕
+                <X className="size-4" />
               </Button>
             </div>
           ))}

--- a/components/crm/documents/catalogue-picker.test.tsx
+++ b/components/crm/documents/catalogue-picker.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { CataloguePicker } from "./catalogue-picker";
+
+/**
+ * The bug this pins down:
+ *
+ * `PopoverTrigger asChild` merges `type="button"` onto its child. `type` was
+ * not among the props written on the `<Input>` here, so it survived the Slot
+ * merge and the description field rendered as `<input type="button">` — a
+ * button, which cannot be typed into at all. The value showed as its label,
+ * the placeholder was ignored, and the only descriptions that could reach a
+ * quote were ones set programmatically: a site-visit prefill or a catalogue
+ * pick. Customers reported it as "I can't add my own items".
+ *
+ * It rendered fine, typechecked fine, and passed every test, because nothing
+ * had ever asserted on the emitted element. So this does.
+ */
+function render(props?: Partial<Parameters<typeof CataloguePicker>[0]>) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <CataloguePicker
+        value="Aluminium sliding window"
+        onChange={() => {}}
+        onPick={() => {}}
+        placeholder="What are you charging for?"
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CataloguePicker", () => {
+  it("renders a text field somebody can type into", () => {
+    const html = render();
+    expect(html).toContain('type="text"');
+    expect(html).not.toContain('type="button"');
+  });
+
+  it("keeps the placeholder, which a button input silently drops", () => {
+    expect(render()).toContain('placeholder="What are you charging for?"');
+  });
+
+  it("shows what was typed as the field's value, not as a label", () => {
+    expect(render()).toContain('value="Aluminium sliding window"');
+  });
+
+  it("announces itself as a combobox rather than as a dialog trigger", () => {
+    // The old markup carried aria-haspopup="dialog" on a text field, which
+    // tells a screen reader the wrong thing about what Enter will do.
+    const html = render();
+    expect(html).toContain('role="combobox"');
+    expect(html).not.toContain('aria-haspopup="dialog"');
+  });
+
+  it("labels the field for anyone not looking at the column header", () => {
+    expect(render({ "aria-label": "Line 2 description" })).toContain(
+      'aria-label="Line 2 description"',
+    );
+  });
+});

--- a/components/crm/documents/catalogue-picker.tsx
+++ b/components/crm/documents/catalogue-picker.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { fetchJson } from "@/lib/api-client";
-import { Package, Search } from "@/lib/icons";
+import { ClipboardList, Package, Search } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 type PricedProduct = {
@@ -27,40 +27,69 @@ type PricedProduct = {
   };
 };
 
-export type CataloguePick = {
-  productId: string;
+/** A measurement somebody took on site, offered as a line. */
+export type VisitItemOption = {
+  id: string;
   description: string;
-  unitPrice: number;
-  taxRate: number;
+  quantity: number;
+  unit: string | null;
+  unitPrice: number | null;
+  /** Which visit it was measured on, so two surveys stay distinguishable. */
+  visitLabel: string;
+};
+
+export type CataloguePick = {
+  productId?: string;
+  description: string;
+  unitPrice: number | null;
+  taxRate?: number;
+  quantity?: number;
+};
+
+type Suggestion = {
+  key: string;
+  source: "catalogue" | "visit";
+  title: string;
+  detail: string;
+  trailing: string | null;
+  pick: CataloguePick;
 };
 
 /**
- * Picking what you sell, instead of retyping it.
+ * Picking what you sell, instead of retyping it — without taking away typing.
  *
- * Quote lines were free text, which is how the same panel ends up on three
- * quotes at three prices under two spellings — and how a discount nobody
- * authorised gets typed in without anything noticing. The catalogue already
- * holds the price, the tax rate and the price-list resolution; this is the
- * shortest path from "the thing we sell" to a line that carries all of it.
+ * Three ways to fill a line, because a real quote has all three on it: what
+ * was measured on site, what we sell off the shelf, and the one-off thing
+ * this customer asked for that nobody has ever sold before.
  *
- * Free text still works. A quote for something not in the catalogue is a real
- * thing that happens, and a builder that refuses it sends people to Word.
+ * The last one is the default. This field is a text box first and a search
+ * second: anything typed stands, and the suggestions are an offer rather than
+ * a gate. It was briefly the other way round — see the note on the anchor
+ * below — and a builder that refuses free text sends people to Word.
  */
 export function CataloguePicker({
   value,
   onChange,
   onPick,
+  visitItems = [],
   placeholder = "Description, or search the catalogue",
   className,
+  "aria-label": ariaLabel = "Description",
 }: {
   value: string;
   onChange: (value: string) => void;
   onPick: (pick: CataloguePick) => void;
+  /** Measured items from this record's site visits, when there are any. */
+  visitItems?: VisitItemOption[];
   placeholder?: string;
   className?: string;
+  "aria-label"?: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
   const [debounced, setDebounced] = useState("");
+  const listId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebounced(value.trim()), 200);
@@ -77,74 +106,176 @@ export function CataloguePicker({
     staleTime: 60_000,
   });
 
-  const products = (data?.data ?? []).filter((product) => product.isActive).slice(0, 8);
+  const needle = value.trim().toLowerCase();
+
+  // Measured items are matched locally — there are a handful per record, and
+  // they should appear from the first keystroke rather than after two.
+  const visitSuggestions: Suggestion[] = visitItems
+    .filter((item) => !needle || item.description.toLowerCase().includes(needle))
+    .slice(0, 6)
+    .map((item) => ({
+      key: `visit-${item.id}`,
+      source: "visit",
+      title: item.description,
+      detail: [
+        item.quantity ? `${item.quantity}${item.unit ? ` ${item.unit}` : ""}` : null,
+        item.visitLabel,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      trailing:
+        item.unitPrice != null
+          ? item.unitPrice.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })
+          : null,
+      pick: {
+        description: item.description,
+        unitPrice: item.unitPrice,
+        quantity: item.quantity,
+      },
+    }));
+
+  const catalogueSuggestions: Suggestion[] = (data?.data ?? [])
+    .filter((product) => product.isActive)
+    .slice(0, 8)
+    .map((product) => ({
+      key: `product-${product.id}`,
+      source: "catalogue",
+      title: product.name,
+      detail:
+        product.line.priceSource !== "standard"
+          ? `${product.code} · ${product.line.priceSource} price`
+          : product.code,
+      trailing: product.line.unitPrice.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+      pick: {
+        productId: product.id,
+        description: product.line.description || product.name,
+        unitPrice: product.line.unitPrice,
+        taxRate: product.line.taxRate,
+      },
+    }));
+
+  // Measured first: on a job that had a survey, the thing being quoted is
+  // almost always the thing somebody stood in front of and measured.
+  const suggestions = [...visitSuggestions, ...catalogueSuggestions];
+  const showing = open && suggestions.length > 0;
+
+  const choose = (suggestion: Suggestion) => {
+    onPick(suggestion.pick);
+    setOpen(false);
+    setActive(0);
+  };
 
   return (
-    <Popover open={open && products.length > 0} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    <Popover open={showing} onOpenChange={setOpen}>
+      {/* An anchor, not a trigger. `PopoverTrigger asChild` merges
+          `type="button"` onto its child, and because `type` is not among the
+          props written here it survived onto the input — so this field
+          rendered as `<input type="button">`, which cannot be typed into at
+          all. Every description had to arrive programmatically. An anchor
+          positions the popover and imposes no button semantics. */}
+      <PopoverAnchor asChild>
         <Input
+          ref={inputRef}
+          type="text"
           value={value}
           className={className}
           placeholder={placeholder}
-          aria-label="Description"
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={showing}
+          aria-controls={showing ? listId : undefined}
+          aria-autocomplete="list"
+          aria-label={ariaLabel}
           onChange={(event) => {
             onChange(event.target.value);
+            setActive(0);
             setOpen(true);
           }}
           onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          onKeyDown={(event) => {
+            if (!showing) {
+              if (event.key === "ArrowDown") setOpen(true);
+              return;
+            }
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setActive((index) => (index + 1) % suggestions.length);
+            } else if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setActive((index) => (index - 1 + suggestions.length) % suggestions.length);
+            } else if (event.key === "Enter") {
+              // Only when a suggestion is highlighted. Otherwise Enter belongs
+              // to the form, and hijacking it means somebody who typed their
+              // own description gets somebody else's product.
+              event.preventDefault();
+              choose(suggestions[active]);
+            } else if (event.key === "Escape") {
+              setOpen(false);
+            }
+          }}
         />
-      </PopoverTrigger>
+      </PopoverAnchor>
 
       <PopoverContent
         align="start"
         className="w-96 p-1"
+        id={listId}
+        role="listbox"
         // Keep the caret in the input: the list is a suggestion, not a step.
         onOpenAutoFocus={(event) => event.preventDefault()}
       >
         <p className="flex items-center gap-1.5 px-2 pb-1 pt-1.5 text-sm text-[var(--text-subtle)]">
           <Search className="size-3.5" aria-hidden="true" />
-          From the catalogue
+          Suggestions — or keep typing your own
         </p>
 
         <ul className="max-h-64 overflow-y-auto">
-          {products.map((product) => (
-            <li key={product.id}>
+          {suggestions.map((suggestion, index) => (
+            <li key={suggestion.key}>
               <button
                 type="button"
+                role="option"
+                aria-selected={index === active}
+                onMouseEnter={() => setActive(index)}
                 onMouseDown={(event) => {
                   // Beat the input's blur so the click is not swallowed.
                   event.preventDefault();
-                  onPick({
-                    productId: product.id,
-                    description: product.line.description || product.name,
-                    unitPrice: product.line.unitPrice,
-                    taxRate: product.line.taxRate,
-                  });
-                  setOpen(false);
+                  choose(suggestion);
                 }}
-                className="flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1.5 text-left hover:bg-[var(--surface-subtle)]"
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1.5 text-left",
+                  index === active && "bg-[var(--surface-subtle)]",
+                )}
               >
-                <Package
-                  className="size-4 shrink-0 text-[var(--text-subtle)]"
-                  aria-hidden="true"
-                />
+                {suggestion.source === "visit" ? (
+                  <ClipboardList
+                    className="size-4 shrink-0 text-[var(--text-subtle)]"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Package
+                    className="size-4 shrink-0 text-[var(--text-subtle)]"
+                    aria-hidden="true"
+                  />
+                )}
+
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm">{product.name}</span>
+                  <span className="block truncate text-sm">{suggestion.title}</span>
                   <span className="block truncate font-mono text-sm text-[var(--text-muted)]">
-                    {product.code}
-                    {product.line.priceSource !== "standard" ? (
-                      <span className={cn("ml-1.5 font-sans not-italic")}>
-                        · {product.line.priceSource} price
-                      </span>
-                    ) : null}
+                    {suggestion.detail}
                   </span>
                 </span>
-                <span className="shrink-0 font-mono text-sm">
-                  {product.line.unitPrice.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                </span>
+
+                {suggestion.trailing ? (
+                  <span className="shrink-0 font-mono text-sm">{suggestion.trailing}</span>
+                ) : null}
               </button>
             </li>
           ))}

--- a/components/crm/documents/catalogue-picker.tsx
+++ b/components/crm/documents/catalogue-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Input } from "@/components/ui/input";
@@ -89,7 +89,6 @@ export function CataloguePicker({
   const [active, setActive] = useState(0);
   const [debounced, setDebounced] = useState("");
   const listId = useId();
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebounced(value.trim()), 200);
@@ -181,7 +180,6 @@ export function CataloguePicker({
           positions the popover and imposes no button semantics. */}
       <PopoverAnchor asChild>
         <Input
-          ref={inputRef}
           type="text"
           value={value}
           className={className}

--- a/components/crm/documents/catalogue-picker.tsx
+++ b/components/crm/documents/catalogue-picker.tsx
@@ -7,53 +7,18 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { fetchJson } from "@/lib/api-client";
 import { ClipboardList, Package, Search } from "@/lib/icons";
+import {
+  buildSuggestions,
+  type CatalogueProduct,
+  type LinePick,
+  type Suggestion,
+  type VisitItemOption,
+} from "@/lib/crm/quote-suggestions";
 import { cn } from "@/lib/utils";
 
-type PricedProduct = {
-  id: string;
-  code: string;
-  name: string;
-  description?: string | null;
-  unit: string;
-  isActive: boolean;
-  line: {
-    productId: string;
-    code: string;
-    description: string;
-    unitPrice: number;
-    taxRate: number;
-    unit: string;
-    priceSource: string;
-  };
-};
-
-/** A measurement somebody took on site, offered as a line. */
-export type VisitItemOption = {
-  id: string;
-  description: string;
-  quantity: number;
-  unit: string | null;
-  unitPrice: number | null;
-  /** Which visit it was measured on, so two surveys stay distinguishable. */
-  visitLabel: string;
-};
-
-export type CataloguePick = {
-  productId?: string;
-  description: string;
-  unitPrice: number | null;
-  taxRate?: number;
-  quantity?: number;
-};
-
-type Suggestion = {
-  key: string;
-  source: "catalogue" | "visit";
-  title: string;
-  detail: string;
-  trailing: string | null;
-  pick: CataloguePick;
-};
+export type { VisitItemOption };
+/** Kept as the old name: four call sites import it. */
+export type CataloguePick = LinePick;
 
 /**
  * Picking what you sell, instead of retyping it — without taking away typing.
@@ -98,70 +63,18 @@ export function CataloguePicker({
   const { data } = useQuery({
     queryKey: ["catalogue-search", debounced],
     queryFn: () =>
-      fetchJson<{ data: PricedProduct[] }>(
+      fetchJson<{ data: CatalogueProduct[] }>(
         `/api/v2/inventory/products?q=${encodeURIComponent(debounced)}`,
       ),
     enabled: open && debounced.length >= 2,
     staleTime: 60_000,
   });
 
-  const needle = value.trim().toLowerCase();
-
-  // Measured items are matched locally — there are a handful per record, and
-  // they should appear from the first keystroke rather than after two.
-  const visitSuggestions: Suggestion[] = visitItems
-    .filter((item) => !needle || item.description.toLowerCase().includes(needle))
-    .slice(0, 6)
-    .map((item) => ({
-      key: `visit-${item.id}`,
-      source: "visit",
-      title: item.description,
-      detail: [
-        item.quantity ? `${item.quantity}${item.unit ? ` ${item.unit}` : ""}` : null,
-        item.visitLabel,
-      ]
-        .filter(Boolean)
-        .join(" · "),
-      trailing:
-        item.unitPrice != null
-          ? item.unitPrice.toLocaleString(undefined, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })
-          : null,
-      pick: {
-        description: item.description,
-        unitPrice: item.unitPrice,
-        quantity: item.quantity,
-      },
-    }));
-
-  const catalogueSuggestions: Suggestion[] = (data?.data ?? [])
-    .filter((product) => product.isActive)
-    .slice(0, 8)
-    .map((product) => ({
-      key: `product-${product.id}`,
-      source: "catalogue",
-      title: product.name,
-      detail:
-        product.line.priceSource !== "standard"
-          ? `${product.code} · ${product.line.priceSource} price`
-          : product.code,
-      trailing: product.line.unitPrice.toLocaleString(undefined, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
-      pick: {
-        productId: product.id,
-        description: product.line.description || product.name,
-        unitPrice: product.line.unitPrice,
-        taxRate: product.line.taxRate,
-      },
-    }));
-
-  // Measured first: on a job that had a survey, the thing being quoted is
-  // almost always the thing somebody stood in front of and measured.
-  const suggestions = [...visitSuggestions, ...catalogueSuggestions];
+  const suggestions = buildSuggestions({
+    visitItems,
+    products: data?.data ?? [],
+    query: value,
+  });
   const showing = open && suggestions.length > 0;
 
   const choose = (suggestion: Suggestion) => {

--- a/components/crm/documents/document-builder-sheet.tsx
+++ b/components/crm/documents/document-builder-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
@@ -42,6 +42,23 @@ type LayoutOption = {
   isActive: boolean;
   isDefault: boolean;
 };
+
+/**
+ * One numeric box on a quote line, labelled on a phone and bare on a desk.
+ *
+ * `sm:contents` is what makes the row work at both widths without writing it
+ * twice: at `sm` and up the wrapper stops generating a box, and the input
+ * below it becomes a direct child of the line's seven-column grid again. The
+ * label is `sm:hidden` because the grid has its own heading row up there.
+ */
+function LineField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block sm:contents">
+      <span className="mb-1 block text-sm text-[var(--text-muted)] sm:hidden">{label}</span>
+      {children}
+    </label>
+  );
+}
 
 export function DocumentBuilderSheet({
   open,
@@ -269,9 +286,16 @@ export function DocumentBuilderSheet({
             const net = round2(quantity * round2(listPrice * (1 - discount / 100)));
 
             return (
+              // On a phone the seven-column row becomes a card. The column
+              // headings above are `sm:grid`, so stacked the four numeric
+              // boxes were four identical unlabelled fields between the
+              // description and the total — the aria-labels are the only
+              // thing that ever said which was which, and nobody sees those.
+              // At `sm` and up the wrappers below go `display: contents` and
+              // the original grid is back, unchanged.
               <div
                 key={index}
-                className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem] sm:items-center"
+                className="grid gap-2 rounded-[var(--radius-md)] border border-[var(--border)] p-3 sm:grid-cols-[minmax(0,1fr)_5rem_7rem_5rem_5rem_7rem_2rem] sm:items-center sm:rounded-none sm:border-0 sm:p-0"
               >
                 {/* Free text still works — a quote for something not in the
                     catalogue is a real thing, and a builder that refuses it
@@ -297,56 +321,73 @@ export function DocumentBuilderSheet({
                   }
                   placeholder="What are you charging for?"
                 />
-                <Input
-                  value={line.quantity}
-                  onChange={(event) => patchLine(index, { quantity: event.target.value })}
-                  inputMode="decimal"
-                  className="text-right font-mono"
-                  aria-label={`Line ${index + 1} quantity`}
-                />
-                <Input
-                  value={line.unitPrice}
-                  onChange={(event) => patchLine(index, { unitPrice: event.target.value })}
-                  inputMode="decimal"
-                  className="text-right font-mono"
-                  placeholder="0.00"
-                  aria-label={`Line ${index + 1} unit price`}
-                />
-                <Input
-                  value={line.discountPercent}
-                  onChange={(event) =>
-                    patchLine(index, { discountPercent: event.target.value })
-                  }
-                  inputMode="decimal"
-                  className="text-right font-mono"
-                  placeholder="0"
-                  aria-label={`Line ${index + 1} discount percent`}
-                />
-                <Input
-                  value={line.taxRate}
-                  onChange={(event) => patchLine(index, { taxRate: event.target.value })}
-                  inputMode="decimal"
-                  className="text-right font-mono"
-                  placeholder="0"
-                  aria-label={`Line ${index + 1} tax percent`}
-                />
-                <span className="px-1 text-right font-mono text-sm tabular-nums">
-                  {net.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                </span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-9 w-9 px-0"
-                  aria-label={`Remove line ${index + 1}`}
-                  disabled={lines.length === 1}
-                  onClick={() => setLines((prev) => prev.filter((_, i) => i !== index))}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+                {/* Two by two on a phone, and back in the row at `sm`. */}
+                <div className="grid grid-cols-2 gap-2 sm:contents">
+                  <LineField label="Qty">
+                    <Input
+                      value={line.quantity}
+                      onChange={(event) => patchLine(index, { quantity: event.target.value })}
+                      inputMode="decimal"
+                      className="text-right font-mono"
+                      aria-label={`Line ${index + 1} quantity`}
+                    />
+                  </LineField>
+                  <LineField label="Unit price">
+                    <Input
+                      value={line.unitPrice}
+                      onChange={(event) => patchLine(index, { unitPrice: event.target.value })}
+                      inputMode="decimal"
+                      className="text-right font-mono"
+                      placeholder="0.00"
+                      aria-label={`Line ${index + 1} unit price`}
+                    />
+                  </LineField>
+                  <LineField label="Disc %">
+                    <Input
+                      value={line.discountPercent}
+                      onChange={(event) =>
+                        patchLine(index, { discountPercent: event.target.value })
+                      }
+                      inputMode="decimal"
+                      className="text-right font-mono"
+                      placeholder="0"
+                      aria-label={`Line ${index + 1} discount percent`}
+                    />
+                  </LineField>
+                  <LineField label="Tax %">
+                    <Input
+                      value={line.taxRate}
+                      onChange={(event) => patchLine(index, { taxRate: event.target.value })}
+                      inputMode="decimal"
+                      className="text-right font-mono"
+                      placeholder="0"
+                      aria-label={`Line ${index + 1} tax percent`}
+                    />
+                  </LineField>
+                </div>
+
+                <div className="flex items-center justify-between gap-2 sm:contents">
+                  <span className="px-1 text-right font-mono text-sm tabular-nums">
+                    <span className="mr-2 font-sans text-[var(--text-muted)] sm:hidden">
+                      Line total
+                    </span>
+                    {net.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-9 w-9 px-0"
+                    aria-label={`Remove line ${index + 1}`}
+                    disabled={lines.length === 1}
+                    onClick={() => setLines((prev) => prev.filter((_, i) => i !== index))}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
             );
           })}

--- a/components/crm/documents/document-builder-sheet.tsx
+++ b/components/crm/documents/document-builder-sheet.tsx
@@ -30,7 +30,7 @@ import {
   type DocumentLineDraft,
 } from "./document-math";
 import { formatMoney } from "./document-types";
-import { CataloguePicker } from "./catalogue-picker";
+import { CataloguePicker, type VisitItemOption } from "./catalogue-picker";
 import { DocumentTemplatePicker } from "./document-template-picker";
 import { refreshAfterDocumentChange } from "@/lib/crm/refresh";
 
@@ -86,6 +86,22 @@ export function DocumentBuilderSheet({
     queryFn: () =>
       fetchJson<LayoutOption[]>(`/api/document-templates?documentType=${docType}`),
   });
+  // What was measured on this record's visits, offered on every line rather
+  // than only as a one-shot prefill when a report is completed. basePath is
+  // `/api/v2/crm/leads/{id}` or `.../deals/{id}`; the record is read off it
+  // rather than threaded through four callers.
+  const recordMatch = /\/(leads|deals)\/([0-9a-f-]{36})/i.exec(basePath);
+  const visitItemsQuery = useQuery({
+    queryKey: ["crm", "visit-items", basePath],
+    enabled: open && Boolean(recordMatch),
+    queryFn: () =>
+      fetchJson<{ data: VisitItemOption[] }>(
+        `/api/v2/crm/visit-items?${recordMatch![1] === "leads" ? "leadId" : "dealId"}=${recordMatch![2]}`,
+      ),
+    staleTime: 60_000,
+  });
+  const visitItems = visitItemsQuery.data?.data ?? [];
+
   const layoutOptions = useMemo(
     () =>
       (layouts.data ?? [])
@@ -263,12 +279,20 @@ export function DocumentBuilderSheet({
                     sell, with its price and tax already right. */}
                 <CataloguePicker
                   value={line.description}
+                  visitItems={visitItems}
+                  aria-label={`Line ${index + 1} description`}
                   onChange={(value) => patchLine(index, { description: value })}
                   onPick={(pick) =>
                     patchLine(index, {
                       description: pick.description,
-                      unitPrice: pick.unitPrice.toFixed(2),
-                      taxRate: String(pick.taxRate),
+                      // A measured item may carry no price — somebody wrote
+                      // down a size and left the pricing for later. Filling
+                      // the box with "0.00" there would look like a decision.
+                      ...(pick.unitPrice != null
+                        ? { unitPrice: pick.unitPrice.toFixed(2) }
+                        : {}),
+                      ...(pick.taxRate != null ? { taxRate: String(pick.taxRate) } : {}),
+                      ...(pick.quantity != null ? { quantity: String(pick.quantity) } : {}),
                     })
                   }
                   placeholder="What are you charging for?"

--- a/components/crm/lead-detail/activity-composer.tsx
+++ b/components/crm/lead-detail/activity-composer.tsx
@@ -29,9 +29,9 @@ const PLACEHOLDERS: Record<ActivityType, string> = {
 };
 
 /**
- * Logs what actually happened with the client. The first line becomes the
- * timeline subject and the rest the body, so a one-line note stays a one-liner
- * and a long call write-up still reads well.
+ * Logs what actually happened with the client. Everything written goes to the
+ * body, where the renderer runs; the subject is a flattened reading of it for
+ * notifications and search snippets, which cannot render.
  */
 export type ActivityTarget =
   | { kind: "lead"; id: string }
@@ -106,7 +106,7 @@ export function ActivityComposer({ target }: { target: ActivityTarget }) {
       />
       <div className="flex items-center justify-between gap-2">
         <p className="text-sm text-[var(--text-muted)]">
-          First line becomes the heading. Type @ to link a person or record. ⌘/Ctrl + Enter to save.
+          Type @ to link a person or record. ⌘/Ctrl + Enter to save.
         </p>
         <Button
           size="sm"

--- a/components/crm/lead-detail/activity-composer.tsx
+++ b/components/crm/lead-detail/activity-composer.tsx
@@ -104,9 +104,13 @@ export function ActivityComposer({ target }: { target: ActivityTarget }) {
         placeholder={PLACEHOLDERS[type]}
         rows={3}
       />
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {/* The keyboard shortcut is the second half of this line and means
+            nothing on a touch keyboard, so a phone reads the first half only
+            and the button stays on the same row. */}
         <p className="text-sm text-[var(--text-muted)]">
-          Type @ to link a person or record. ⌘/Ctrl + Enter to save.
+          Type @ to link a person or record.
+          <span className="hidden sm:inline"> ⌘/Ctrl + Enter to save.</span>
         </p>
         <Button
           size="sm"

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -56,7 +56,10 @@ import {
 import { RecordStory } from "@/components/crm/records/record-story";
 import { customFieldAttributes } from "@/components/crm/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
-import { RecordPageShell } from "@/components/crm/records/record-page-shell";
+// RailSection comes from the shell rather than being redefined here: this
+// file had its own copy, which is why the rail on a lead kept its frames
+// when every other record lost theirs.
+import { RailSection, RecordPageShell } from "@/components/crm/records/record-page-shell";
 import { RelationAttribute } from "@/components/crm/records/relation-attribute";
 import { useAttributeEditor } from "@/components/crm/records/use-attribute-editor";
 import { buildStory } from "@/lib/crm/story";
@@ -79,17 +82,6 @@ function draftsToLines(drafts: MeasurementDraft[]): CrmDocumentLineInput[] {
       specNotes: draft.specNotes || null,
       unitPrice: draft.unitPrice ? Number(draft.unitPrice) : null,
     })),
-  );
-}
-
-function RailSection({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <h3 className="mb-2 text-sm font-semibold text-[var(--text-muted)]">
-        {title}
-      </h3>
-      {children}
-    </section>
   );
 }
 

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -44,7 +44,7 @@ import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 
 import { ActivityComposer } from "./activity-composer";
-import { commentsTab, tasksTab } from "@/components/crm/records/record-tabs";
+import { commentsTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { customFieldAttributes } from "@/components/crm/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
@@ -344,6 +344,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         },
         tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
+        mentionsTab({ ref: { kind: "lead", id: leadId } }),
       ]}
       rail={
         <>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -8,17 +8,21 @@ import type { CrmLeadStage } from "@prisma/client";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { StatusChip } from "@/components/ui/status-chip";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ClientDate } from "@/components/ui/client-date";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { ArrowRight, Calendar, FileText, Funnel, Pencil } from "@/lib/icons";
+import {
+  ArrowRight,
+  Building2,
+  Funnel,
+  Payments,
+  TrendingUp,
+  UserRound,
+} from "@/lib/icons";
 import { updateCrmLeadStage } from "@/lib/crm/crm-v2";
 import { visitItemsToQuotationLines } from "@/lib/crm/site-visits";
 import type { CrmDocumentLineInput } from "@/lib/crm/accounting-bridge";
 
-import { PageChrome } from "@/components/layout/page-chrome";
 import { DocumentList } from "@/components/crm/documents/document-list";
 import { EntityLink } from "@/components/crm/records/entity-link";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
@@ -37,6 +41,10 @@ import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet
 
 import { ActivityComposer } from "./activity-composer";
 import { RecordStory } from "@/components/crm/records/record-story";
+import { RecordAttributes } from "@/components/crm/records/record-attributes";
+import { RecordPageShell } from "@/components/crm/records/record-page-shell";
+import { RelationAttribute } from "@/components/crm/records/relation-attribute";
+import { useAttributeEditor } from "@/components/crm/records/use-attribute-editor";
 import { buildStory } from "@/lib/crm/story";
 import { AttributesPanel } from "./attributes-panel";
 import { StageProgress } from "./stage-progress";
@@ -90,6 +98,11 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   const leadQuery = useQuery({
     queryKey: ["crm-lead", leadId],
     queryFn: () => fetchJson<LeadDetail>(`/api/v2/crm/leads/${leadId}`),
+  });
+
+  const edit = useAttributeEditor({
+    path: `/api/v2/crm/leads/${leadId}`,
+    invalidate: [["crm-lead", leadId], ["crm", "leads"]],
   });
 
   const teamQuery = useQuery({
@@ -152,74 +165,101 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   const latestQuote = lead.documents.find((doc) => doc.type === "QUOTATION");
 
   return (
-    <div className="space-y-4">
-      {/* Name, back and actions all live in the top app bar, the same as every
-          other page. What stays here is the part the bar cannot carry: who this
-          lead is with, and where it has got to. */}
-      <PageChrome
-        title={lead.title ?? lead.leadNo}
-        icon={Funnel}
-        backHref="/crm/leads"
-        backLabel="All leads"
-      >
+    <RecordPageShell
+      icon={Funnel}
+      backHref="/crm/leads"
+      backLabel="All leads"
+      title={lead.title ?? lead.leadNo}
+      reference={lead.leadNo}
+      status={{ status: CRM_STAGE_STATUS[lead.stage], label: CRM_STAGE_LABELS[lead.stage] }}
+      subtitle={
         <>
-          <Button size="sm" variant="outline" className="gap-1.5" onClick={() => setEditOpen(true)}>
-            <Pencil className="h-3.5 w-3.5" />
-            Edit
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="gap-1.5"
-            onClick={() => setScheduleOpen(true)}
-          >
-            <Calendar className="h-3.5 w-3.5" />
-            Schedule visit
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="gap-1.5"
-            disabled={!lead.clientId}
-            title={lead.clientId ? undefined : "Attach a client before quoting"}
-            onClick={() => setTab("documents")}
-          >
-            <FileText className="h-3.5 w-3.5" />
-            Documents
-          </Button>
-          {/* Converting is the one thing a qualified lead exists to do, so it
-              is the primary action until it has been done. */}
-          <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
-            <ArrowRight className="h-3.5 w-3.5" />
-            Convert to deal
-          </Button>
+          <EntityLink href={lead.clientId ? `/crm/companies/${lead.clientId}` : null} muted>
+            {lead.client?.name ?? "No client"}
+          </EntityLink>
+          {" · "}
+          <EntityLink href={lead.assignedTo ? `/crm/reps/${lead.assignedTo.id}` : null} muted>
+            {lead.assignedTo?.name ?? "Unassigned"}
+          </EntityLink>
         </>
-      </PageChrome>
-
-      <header className="space-y-3">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          <span className="font-mono text-sm text-[var(--text-muted)]">{lead.leadNo}</span>
-          <StatusChip
-            status={CRM_STAGE_STATUS[lead.stage]}
-            label={CRM_STAGE_LABELS[lead.stage]}
-          />
-          <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">
-            <EntityLink
-              href={lead.clientId ? `/crm/companies/${lead.clientId}` : null}
-              muted
-            >
-              {lead.client?.name ?? "No client"}
-            </EntityLink>
-            {" · "}
-            <EntityLink
-              href={lead.assignedTo ? `/crm/reps/${lead.assignedTo.id}` : null}
-              muted
-            >
-              {lead.assignedTo?.name ?? "Unassigned"}
-            </EntityLink>
-          </span>
-        </div>
-
+      }
+      primaryAction={
+        // Converting is the one thing a qualified lead exists to do.
+        <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
+          <ArrowRight className="h-3.5 w-3.5" />
+          Convert to deal
+        </Button>
+      }
+      actions={[
+        { label: "Edit", onSelect: () => setEditOpen(true) },
+        { label: "Schedule a visit", onSelect: () => setScheduleOpen(true) },
+      ]}
+      attributes={
+        // A lead had no property list at all, which is why nothing on it
+        // could be corrected without opening the edit form.
+        <RecordAttributes
+          attributes={[
+            {
+              id: "value",
+              label: "Value",
+              icon: Payments,
+              mono: true,
+              placeholder: "Not sized",
+              ...edit.numeric("estimatedValue", lead.estimatedValue),
+            },
+            {
+              id: "probability",
+              label: "Likelihood",
+              icon: TrendingUp,
+              mono: true,
+              placeholder: "0",
+              ...edit.numeric("probability", lead.probability),
+            },
+            {
+              id: "company",
+              label: "Company",
+              icon: Building2,
+              display: (
+                <RelationAttribute
+                  value={lead.client?.name ?? null}
+                  href={lead.clientId ? `/crm/companies/${lead.clientId}` : null}
+                  types={["COMPANY"]}
+                  placeholder="No company"
+                  searchPlaceholder="Search companies"
+                  onPick={(record) => edit.save.mutate({ clientId: record.id })}
+                  onClear={() => edit.save.mutate({ clientId: null })}
+                />
+              ),
+            },
+            {
+              id: "contact",
+              label: "Contact",
+              icon: UserRound,
+              placeholder: "Nobody named",
+              ...edit.text("contactName", lead.contactName),
+            },
+            {
+              id: "phone",
+              label: "Phone",
+              placeholder: "Not recorded",
+              ...edit.text("contactPhone", lead.contactPhone),
+            },
+            {
+              id: "email",
+              label: "Email",
+              placeholder: "Not recorded",
+              ...edit.text("contactEmail", lead.contactEmail),
+            },
+            {
+              id: "source",
+              label: "Source",
+              placeholder: "Not recorded",
+              ...edit.text("source", lead.source),
+            },
+          ]}
+        />
+      }
+      beforeTabs={
         <StageProgress
           stage={lead.stage}
           disabled={changeStage.isPending}
@@ -232,28 +272,16 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             changeStage.mutate({ stage });
           }}
         />
-      </header>
-
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="space-y-4 lg:col-span-2">
-          <ActivityComposer target={{ kind: "lead", id: leadId }} />
-
-          <Tabs value={tab} onValueChange={setTab}>
-            <div className="scroll-rail max-w-full">
-              <TabsList>
-                <TabsTrigger value="timeline">Timeline</TabsTrigger>
-                <TabsTrigger value="documents">
-                  Documents{lead.documents.length > 0 ? ` (${lead.documents.length})` : ""}
-                </TabsTrigger>
-                <TabsTrigger value="visits">
-                  Visits{lead.appointments.length > 0 ? ` (${lead.appointments.length})` : ""}
-                </TabsTrigger>
-                <TabsTrigger value="tasks">Tasks</TabsTrigger>
-                <TabsTrigger value="comments">Comments</TabsTrigger>
-              </TabsList>
-            </div>
-
-            <TabsContent value="timeline" className="pt-4">
+      }
+      activeTab={tab}
+      onTabChange={setTab}
+      tabs={[
+        {
+          value: "timeline",
+          label: "Timeline",
+          content: (
+            <div className="space-y-4">
+              <ActivityComposer target={{ kind: "lead", id: leadId }} />
               {/* The whole story, not just the activity table: visits, tasks,
                   documents and the day it arrived, in one order. */}
               <RecordStory
@@ -267,40 +295,53 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
                 })}
                 emptyMessage="Nothing has happened on this lead yet. Log a call or a note above to start the trail."
               />
-            </TabsContent>
-
-            <TabsContent value="documents" className="pt-4">
-              <DocumentList
-                basePath={`/api/v2/crm/leads/${leadId}`}
-                currency={lead.currency}
-                documents={lead.documents}
-                // A lead with a name to bill can be quoted; the company is
-                // created from the contact if there is not one already.
-                canCreate={Boolean(lead.clientId || lead.contactName || lead.title)}
-                prefillLines={quotationPrefill}
-                onPrefillConsumed={() => setQuotationPrefill(undefined)}
-              />
-            </TabsContent>
-
-            <TabsContent value="visits" className="pt-4">
-              <VisitsTab
-                appointments={lead.appointments}
-                onSchedule={() => setScheduleOpen(true)}
-                onOpenReport={setReportFor}
-              />
-            </TabsContent>
-
-            <TabsContent value="tasks" className="pt-4">
-              <RecordTasksTab record={{ leadId }} currentUserId={currentUserId} />
-            </TabsContent>
-
-            <TabsContent value="comments" className="pt-4">
-              <CommentThread entity="LEAD" recordId={leadId} currentUserId={currentUserId} />
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        <aside className="space-y-3">
+            </div>
+          ),
+        },
+        {
+          value: "documents",
+          label: "Documents",
+          count: lead.documents.length,
+          content: (
+            <DocumentList
+              basePath={`/api/v2/crm/leads/${leadId}`}
+              currency={lead.currency}
+              documents={lead.documents}
+              // A lead with a name to bill can be quoted; the company is
+              // created from the contact if there is not one already.
+              canCreate={Boolean(lead.clientId || lead.contactName || lead.title)}
+              prefillLines={quotationPrefill}
+              onPrefillConsumed={() => setQuotationPrefill(undefined)}
+            />
+          ),
+        },
+        {
+          value: "visits",
+          label: "Visits",
+          count: lead.appointments.length,
+          content: (
+            <VisitsTab
+              appointments={lead.appointments}
+              onSchedule={() => setScheduleOpen(true)}
+              onOpenReport={setReportFor}
+            />
+          ),
+        },
+        {
+          value: "tasks",
+          label: "Tasks",
+          content: <RecordTasksTab record={{ leadId }} currentUserId={currentUserId} />,
+        },
+        {
+          value: "comments",
+          label: "Comments",
+          content: (
+            <CommentThread entity="LEAD" recordId={leadId} currentUserId={currentUserId} />
+          ),
+        },
+      ]}
+      rail={
+        <>
           <RailSection title="Deal">
             <p className="font-mono text-2xl">
               {formatLeadValue(lead.estimatedValue, lead.currency)}
@@ -395,8 +436,10 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           <RailSection title="Details">
             <AttributesPanel lead={lead} owners={owners} />
           </RailSection>
-        </aside>
-      </div>
+        </>
+      }
+    >
+
 
       <LeadFormSheet
         open={editOpen}
@@ -464,6 +507,6 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           )
         }
       />
-    </div>
+    </RecordPageShell>
   );
 }

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -44,7 +44,7 @@ import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 
 import { ActivityComposer } from "./activity-composer";
-import { commentsTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
+import { automationTab, commentsTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { customFieldAttributes } from "@/components/crm/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
@@ -345,6 +345,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         mentionsTab({ ref: { kind: "lead", id: leadId } }),
+        automationTab({ ref: { kind: "lead", id: leadId } }),
       ]}
       rail={
         <>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -8,7 +8,6 @@ import type { CrmLeadStage } from "@prisma/client";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ClientDate } from "@/components/ui/client-date";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -37,7 +36,6 @@ import {
   CRM_STAGE_LABELS,
   CRM_STAGE_STATUS,
   formatLeadValue,
-  isOverdue,
 } from "@/components/crm/leads/stage-config";
 import { ConvertLeadSheet } from "@/components/crm/leads/convert-lead-sheet";
 import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits/visit-report-sheet";
@@ -45,6 +43,14 @@ import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet
 
 import { ActivityComposer } from "./activity-composer";
 import { automationTab, commentsTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
+import {
+  ActivityStrip,
+  CallList,
+  EmailPreview,
+  MeetingCard,
+  NextInteractionCard,
+  type NextInteraction,
+} from "@/components/crm/records/record-panels";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { customFieldAttributes } from "@/components/crm/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
@@ -164,6 +170,43 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
 
   const nextTask = lead.followUps.find((task) => task.status === "PENDING");
   const nextVisit = lead.appointments.find((visit) => visit.status === "SCHEDULED");
+
+  // One "up next" rather than a task card and a visit card each showing their
+  // own soonest: the reader's question is what happens next, not what happens
+  // next of each kind.
+  const nextInteraction: NextInteraction | null = (() => {
+    const candidates: NextInteraction[] = [];
+    if (nextTask) candidates.push({ kind: "task", title: nextTask.title, at: nextTask.dueAt });
+    if (nextVisit) {
+      candidates.push({ kind: "visit", title: nextVisit.title, at: nextVisit.scheduledStart });
+    }
+    return (
+      candidates.sort((a, b) => new Date(a.at).getTime() - new Date(b.at).getTime())[0] ?? null
+    );
+  })();
+
+  const activityCounts = [
+    { label: "calls", count: lead.activities.filter((a) => a.type === "CALL").length },
+    { label: "emails", count: lead.activities.filter((a) => a.type === "EMAIL").length },
+    { label: "notes", count: lead.activities.filter((a) => a.type === "NOTE").length },
+    { label: "meetings", count: lead.activities.filter((a) => a.type === "MEETING").length },
+  ];
+
+  const recentCalls = lead.activities
+    .filter((activity) => activity.type === "CALL")
+    .slice(0, 3)
+    .map((activity) => ({
+      id: activity.id,
+      at: activity.occurredAt,
+      summary: activity.body ?? activity.subject,
+    }));
+
+  const lastEmail = (() => {
+    const found = lead.activities.find((activity) => activity.type === "EMAIL");
+    return found
+      ? { id: found.id, subject: found.subject, body: found.body, at: found.occurredAt }
+      : null;
+  })();
   const openInvoices = lead.documents.filter(
     (doc) => doc.type === "INVOICE" && doc.invoice && invoiceOutstanding(doc.invoice) > 0,
   );
@@ -364,54 +407,56 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             </RailSection>
           ) : null}
 
-          {nextTask ? (
-            <RailSection title="Next task">
-              <p className="text-sm">{nextTask.title}</p>
-              <p
-                className={
-                  isOverdue(nextTask.dueAt)
-                    ? "text-sm font-medium text-[var(--status-error-text)]"
-                    : "text-sm text-[var(--text-muted)]"
-                }
-              >
-                {isOverdue(nextTask.dueAt) ? "Overdue · " : "Due "}
-                <ClientDate value={nextTask.dueAt} />
-              </p>
-            </RailSection>
-          ) : (
-            <RailSection title="Next task">
-              <p className="text-sm text-[var(--text-muted)]">
-                Nothing scheduled — this lead will go quiet.
-              </p>
-              <Button
-                size="sm"
-                variant="outline"
-                className="mt-2 gap-1.5"
-                onClick={() => setTab("tasks")}
-              >
-                Add a task
-                <ArrowRight className="h-3.5 w-3.5" />
-              </Button>
-            </RailSection>
-          )}
+          <RailSection title="Up next">
+            <NextInteractionCard
+              interaction={nextInteraction}
+              emptyMessage="Nothing scheduled — this lead will go quiet."
+              action={
+                nextInteraction ? null : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5"
+                    onClick={() => setTab("tasks")}
+                  >
+                    Add a task
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </Button>
+                )
+              }
+            />
+          </RailSection>
 
           {nextVisit ? (
             <RailSection title="Next visit">
-              <p className="text-sm">{nextVisit.title}</p>
-              <p className="text-sm text-[var(--text-muted)]">
-                <ClientDate value={nextVisit.scheduledStart} />
-                {nextVisit.location ? ` · ${nextVisit.location}` : ""}
-              </p>
-              <Button
-                size="sm"
-                variant="outline"
-                className="mt-2"
-                onClick={() => setReportFor(nextVisit)}
-              >
-                Write it up
-              </Button>
+              <MeetingCard
+                meeting={{
+                  id: nextVisit.id,
+                  title: nextVisit.title,
+                  scheduledStart: nextVisit.scheduledStart,
+                  location: nextVisit.location,
+                }}
+                action={
+                  <Button size="sm" variant="outline" onClick={() => setReportFor(nextVisit)}>
+                    Write it up
+                  </Button>
+                }
+              />
             </RailSection>
           ) : null}
+
+          <RailSection title="Contact so far">
+            <ActivityStrip counts={activityCounts} />
+            {recentCalls.length > 0 ? (
+              <div className="mt-3">
+                <CallList calls={recentCalls} />
+              </div>
+            ) : null}
+          </RailSection>
+
+          <RailSection title="Last email">
+            <EmailPreview message={lastEmail} />
+          </RailSection>
 
           {lead.documents.length > 0 ? (
             <RailSection title="Billing">

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -40,6 +40,7 @@ import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 
 import { ActivityComposer } from "./activity-composer";
+import { commentsTab, tasksTab } from "@/components/crm/records/record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
 import { RecordPageShell } from "@/components/crm/records/record-page-shell";
@@ -50,8 +51,6 @@ import { AttributesPanel } from "./attributes-panel";
 import { StageProgress } from "./stage-progress";
 import { VisitsTab } from "./visits-tab";
 import { LeadScoreCard } from "./lead-score-card";
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
-import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import type { LeadAppointment, LeadDetail } from "./lead-types";
 
 /** Measurements captured on site, shaped into quotation lines for the builder. */
@@ -327,18 +326,8 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             />
           ),
         },
-        {
-          value: "tasks",
-          label: "Tasks",
-          content: <RecordTasksTab record={{ leadId }} currentUserId={currentUserId} />,
-        },
-        {
-          value: "comments",
-          label: "Comments",
-          content: (
-            <CommentThread entity="LEAD" recordId={leadId} currentUserId={currentUserId} />
-          ),
-        },
+        tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
+        commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
       ]}
       rail={
         <>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -43,6 +43,8 @@ import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet
 
 import { ActivityComposer } from "./activity-composer";
 import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
+import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
+import { RecordHistoryTab } from "@/components/crm/records/record-history-tab";
 import {
   ActivityStrip,
   CallList,
@@ -390,6 +392,19 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         mentionsTab({ ref: { kind: "lead", id: leadId } }),
         filesTab({ ref: { kind: "lead", id: leadId } }),
         automationTab({ ref: { kind: "lead", id: leadId } }),
+        {
+          // Leads had neither history tab, while deals, companies, people and
+          // sites had both. The record type people open most was the one with
+          // no answer to "who changed this".
+          value: "history",
+          label: "History",
+          content: <RecordHistoryTab activities={lead.activities} />,
+        },
+        {
+          value: "changes",
+          label: "Field history",
+          content: <FieldHistoryTab entity="LEAD" recordId={leadId} />,
+        },
       ]}
       rail={
         <>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -19,7 +19,11 @@ import {
   TrendingUp,
   UserRound,
 } from "@/lib/icons";
-import { updateCrmLeadStage } from "@/lib/crm/crm-v2";
+import {
+  fetchCrmFieldDefinitions,
+  updateCrmLeadStage,
+  type CrmFieldDefinitionRecord,
+} from "@/lib/crm/crm-v2";
 import { visitItemsToQuotationLines } from "@/lib/crm/site-visits";
 import type { CrmDocumentLineInput } from "@/lib/crm/accounting-bridge";
 
@@ -42,6 +46,7 @@ import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet
 import { ActivityComposer } from "./activity-composer";
 import { commentsTab, tasksTab } from "@/components/crm/records/record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
+import { customFieldAttributes } from "@/components/crm/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
 import { RecordPageShell } from "@/components/crm/records/record-page-shell";
 import { RelationAttribute } from "@/components/crm/records/relation-attribute";
@@ -99,6 +104,10 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
     queryFn: () => fetchJson<LeadDetail>(`/api/v2/crm/leads/${leadId}`),
   });
 
+  const fieldsQuery = useQuery({
+    queryKey: ["crm", "field-definitions", "LEAD"],
+    queryFn: () => fetchCrmFieldDefinitions("LEAD"),
+  });
   const edit = useAttributeEditor({
     path: `/api/v2/crm/leads/${leadId}`,
     invalidate: [["crm-lead", leadId], ["crm", "leads"]],
@@ -110,6 +119,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   });
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
+  const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const lead = leadQuery.data;
 
   const changeStage = useMutation({
@@ -255,6 +265,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
               placeholder: "Not recorded",
               ...edit.text("source", lead.source),
             },
+            ...customFieldAttributes({
+              definitions,
+              values: lead.customFields ?? null,
+              onCommit: (key, value) =>
+                edit.save.mutate({ customFields: { [key]: value } }),
+            }),
           ]}
         />
       }

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -42,7 +42,7 @@ import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 
 import { ActivityComposer } from "./activity-composer";
-import { automationTab, commentsTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
+import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
 import {
   ActivityStrip,
   CallList,
@@ -388,6 +388,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         mentionsTab({ ref: { kind: "lead", id: leadId } }),
+        filesTab({ ref: { kind: "lead", id: leadId } }),
         automationTab({ ref: { kind: "lead", id: leadId } }),
       ]}
       rail={

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -400,20 +400,28 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
       ]}
       rail={
         <>
-          <RailSection title="Deal">
-            <p className="font-mono text-2xl">
+          {/* The headline, and the only raised surface on the page. Removing
+              every frame made the summary calm and also uniform — nine
+              sections of identical weight, so nothing led. One tinted panel
+              carrying the two figures somebody opens a lead to see gives the
+              column a top, and everything below it can stay quiet. */}
+          <section className="rounded-[var(--card-radius)] bg-[var(--surface-muted)] px-4 py-3.5">
+            <p className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]">
+              Worth
+            </p>
+            <p className="mt-1 font-mono text-3xl leading-none tracking-tight text-[var(--text-strong)]">
               {formatLeadValue(lead.estimatedValue, lead.currency)}
             </p>
-            <p className="text-sm text-[var(--text-muted)]">
+            <p className="mt-2 text-sm text-[var(--text-muted)]">
               {lead.probability ?? 0}% likely · {CRM_STAGE_LABELS[lead.stage]}
             </p>
-          </RailSection>
 
-          {lead.scoreBreakdown ? (
-            <RailSection title="Score">
-              <LeadScoreCard score={lead.scoreBreakdown} />
-            </RailSection>
-          ) : null}
+            {lead.scoreBreakdown ? (
+              <div className="mt-3.5 border-t border-[var(--border)] pt-3">
+                <LeadScoreCard score={lead.scoreBreakdown} />
+              </div>
+            ) : null}
+          </section>
 
           <RailSection title="Up next">
             <NextInteractionCard

--- a/components/crm/lead-detail/lead-score-card.tsx
+++ b/components/crm/lead-detail/lead-score-card.tsx
@@ -21,7 +21,7 @@ export function LeadScoreCard({ score }: { score: LeadScore }) {
   return (
     <div className="space-y-2">
       <div className="flex items-baseline gap-2">
-        <span className="font-mono text-2xl">{score.total}</span>
+        <span className="font-mono text-xl leading-none text-[var(--text-strong)]">{score.total}</span>
         <span className={cn("text-sm font-medium", BAND_TONE[score.band])}>
           {SCORE_BAND_LABELS[score.band]}
         </span>

--- a/components/crm/lead-detail/lead-types.ts
+++ b/components/crm/lead-detail/lead-types.ts
@@ -46,6 +46,9 @@ export type LeadIntakeSubmission = {
 export type LeadDetail = {
   id: string;
   leadNo: string;
+  /** The administrator's own fields. `CrmLead.customFields` has always been
+   *  there; the lead page just never read it. */
+  customFields?: Record<string, unknown> | null;
   title: string | null;
   stage: CrmLeadStage;
   probability: number | null;

--- a/components/crm/lead-detail/stage-progress.tsx
+++ b/components/crm/lead-detail/stage-progress.tsx
@@ -1,16 +1,39 @@
 "use client";
 
+import { useState } from "react";
 import type { CrmLeadStage } from "@prisma/client";
 
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ArrowRight, Check } from "@/lib/icons";
 import { CRM_LEAD_STAGES, CRM_STAGE_LABELS } from "@/lib/crm/pipeline";
 import { cn } from "@/lib/utils";
 
-// Won and Lost are outcomes, not steps along the way — the stepper shows the
-// path, and the two terminal stages sit apart from it.
+// Won and Lost are outcomes, not steps along the way — the track shows the
+// path, and the two terminal stages are reached from the menu rather than
+// sitting at the end of it pretending to be steps six and seven.
 const PATH_STAGES: CrmLeadStage[] = CRM_LEAD_STAGES.filter(
   (stage) => stage !== "WON" && stage !== "LOST",
 );
 
+/**
+ * Where this lead has got to, and the one move that comes next.
+ *
+ * This used to be eight equally-loud buttons that wrapped onto two lines with
+ * a divider stranded mid-flow. Eight controls of identical weight is eight
+ * decisions offered at once, and none of them answered the question a stage
+ * actually gets asked: how far along is this, and what happens next.
+ *
+ * So it is a track and a verb. The track is read, not pressed — filled to
+ * where the lead has got to. The next move is one button, because from any
+ * stage there is one obvious next stage. Everything else — jumping back,
+ * marking it won or lost — is behind the stage name, which you press, the way
+ * every other property on this page now works.
+ *
+ * Colour carries meaning rather than position: the track is brand-coloured
+ * while the lead is live, green once it is won, and drains to muted when it is
+ * lost. Nothing is coloured merely to show which button the cursor is on.
+ */
 export function StageProgress({
   stage,
   onChange,
@@ -20,66 +43,114 @@ export function StageProgress({
   onChange: (stage: CrmLeadStage) => void;
   disabled?: boolean;
 }) {
-  const isClosed = stage === "WON" || stage === "LOST";
+  const [open, setOpen] = useState(false);
+
+  const isWon = stage === "WON";
+  const isLost = stage === "LOST";
+  const isClosed = isWon || isLost;
   const currentIndex = PATH_STAGES.indexOf(stage);
+  const next = currentIndex >= 0 ? PATH_STAGES[currentIndex + 1] : undefined;
+
+  const fillClass = isWon
+    ? "bg-[var(--status-success-border)]"
+    : isLost
+      ? "bg-[var(--border-strong)]"
+      : "bg-[var(--action-primary-bg)]";
 
   return (
-    <div className="flex flex-wrap items-center gap-1">
-      {PATH_STAGES.map((entry, index) => {
-        const isCurrent = entry === stage;
-        const isPast = !isClosed && currentIndex > index;
-        return (
-          <button
-            key={entry}
-            type="button"
-            disabled={disabled}
-            onClick={() => onChange(entry)}
-            aria-current={isCurrent ? "step" : undefined}
-            className={cn(
-              "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
-              "disabled:cursor-not-allowed disabled:opacity-60",
-              isCurrent
-                ? "bg-[var(--action-primary-bg)] text-[var(--action-primary-text)]"
-                : isPast
-                  ? "bg-[var(--surface-subtle)] text-[var(--text)]"
-                  : "text-[var(--text-muted)] hover:bg-[var(--surface-hover)]",
-            )}
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              className={cn(
+                "-mx-1.5 rounded-[var(--radius-sm)] px-1.5 py-0.5 text-base font-semibold hover:bg-[var(--surface-subtle)] disabled:cursor-not-allowed disabled:opacity-60",
+                isWon && "text-[var(--status-success-text)]",
+                isLost && "text-[var(--text-muted)]",
+                !isClosed && "text-[var(--text-strong)]",
+              )}
+            >
+              {CRM_STAGE_LABELS[stage]}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            collisionPadding={12}
+            className="w-[min(15rem,calc(100vw-2rem))] p-1"
           >
-            {CRM_STAGE_LABELS[entry]}
-          </button>
-        );
-      })}
+            {CRM_LEAD_STAGES.map((entry) => (
+              <button
+                key={entry}
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  if (entry !== stage) onChange(entry);
+                }}
+                className={cn(
+                  "flex min-h-9 w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 text-left text-sm hover:bg-[var(--surface-hover)]",
+                  entry === stage && "font-medium",
+                )}
+              >
+                <span className="min-w-0 flex-1 truncate">{CRM_STAGE_LABELS[entry]}</span>
+                {entry === stage ? (
+                  <Check className="size-4 shrink-0 text-[var(--text-muted)]" aria-hidden="true" />
+                ) : null}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
 
-      <span className="mx-1 h-4 w-px bg-[var(--border)]" />
+        {/* One verb. From any stage on the path there is exactly one obvious
+            next stage, and offering it as a button is what turns a display
+            into something somebody can act on without thinking. */}
+        {next && !isClosed ? (
+          <Button
+            variant="secondary"
+            disabled={disabled}
+            onClick={() => onChange(next)}
+            endIcon={<ArrowRight className="size-4" aria-hidden="true" />}
+          >
+            Move to {CRM_STAGE_LABELS[next]}
+          </Button>
+        ) : null}
+      </div>
 
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => onChange("WON")}
-        className={cn(
-          "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
-          "disabled:cursor-not-allowed disabled:opacity-60",
-          stage === "WON"
-            ? "bg-[var(--status-success-bg)] text-[var(--status-success-text)]"
-            : "text-[var(--text-muted)] hover:bg-[var(--surface-hover)]",
-        )}
+      {/* Read, not pressed: a 4px track that says how far along this is at a
+          glance. Segments rather than one bar so the number of steps is
+          legible without counting labels. */}
+      <div
+        className="flex gap-1"
+        role="img"
+        aria-label={
+          isClosed
+            ? `Stage: ${CRM_STAGE_LABELS[stage]}`
+            : `Stage ${currentIndex + 1} of ${PATH_STAGES.length}: ${CRM_STAGE_LABELS[stage]}`
+        }
       >
-        Won
-      </button>
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => onChange("LOST")}
-        className={cn(
-          "rounded-[var(--button-radius)] px-2.5 py-1 text-sm font-medium transition-colors",
-          "disabled:cursor-not-allowed disabled:opacity-60",
-          stage === "LOST"
-            ? "bg-[var(--status-error-bg)] text-[var(--status-error-text)]"
-            : "text-[var(--text-muted)] hover:bg-[var(--surface-hover)]",
-        )}
-      >
-        Lost
-      </button>
+        {PATH_STAGES.map((entry, index) => (
+          <span
+            key={entry}
+            className={cn(
+              "h-1 flex-1 rounded-full",
+              isWon || (!isLost && index <= currentIndex)
+                ? fillClass
+                : isLost && index <= currentIndex
+                  ? fillClass
+                  : "bg-[var(--surface-sunken)]",
+            )}
+          />
+        ))}
+      </div>
+
+      <p className="text-sm text-[var(--text-muted)]">
+        {isWon
+          ? "Won"
+          : isLost
+            ? "Lost — reopen it from the stage menu"
+            : `Step ${currentIndex + 1} of ${PATH_STAGES.length}`}
+      </p>
     </div>
   );
 }

--- a/components/crm/lead-detail/visits-tab.tsx
+++ b/components/crm/lead-detail/visits-tab.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
+
 import { Button } from "@/components/ui/button";
 import { StatusChip } from "@/components/ui/status-chip";
 import { ClientDate } from "@/components/ui/client-date";
-import { Plus } from "@/lib/icons";
+import { Plus, Share } from "@/lib/icons";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import type { LeadAppointment } from "./lead-types";
@@ -27,6 +31,35 @@ export function VisitsTab({
   onSchedule: () => void;
   onOpenReport: (appointment: LeadAppointment) => void;
 }) {
+  const { toast } = useToast();
+
+  // Sharing mints a fresh token every time, which is also how somebody takes
+  // back a link they sent to the wrong number.
+  const share = useMutation({
+    mutationFn: (id: string) =>
+      fetchJson<{ path: string }>(`/api/v2/crm/appointments/${id}/brief`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    onSuccess: async (result) => {
+      const url = `${window.location.origin}${result.path}`;
+      try {
+        await navigator.clipboard.writeText(url);
+        toast({ title: "Link copied", description: "Send it to whoever is going." });
+      } catch {
+        // Clipboard is denied often enough on mobile that failing silently
+        // would look like the button did nothing.
+        toast({ title: "Link ready", description: url });
+      }
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not share the visit",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
   return (
     <div className="space-y-3">
       <Button size="sm" className="gap-1.5" onClick={onSchedule}>
@@ -59,6 +92,17 @@ export function VisitsTab({
                     {visit.location ? ` · ${visit.location}` : ""}
                   </p>
                 </div>
+
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="gap-1.5"
+                  disabled={share.isPending}
+                  onClick={() => share.mutate(visit.id)}
+                >
+                  <Share className="h-3.5 w-3.5" />
+                  Share
+                </Button>
 
                 <Button size="sm" variant="outline" onClick={() => onOpenReport(visit)}>
                   {visit.reportCompletedAt ? "View report" : "Write up"}

--- a/components/crm/leads/convert-lead-sheet.tsx
+++ b/components/crm/leads/convert-lead-sheet.tsx
@@ -246,7 +246,7 @@ export function ConvertLeadSheet({
       ) : prep ? (
         <div className="space-y-4">
           <section className="space-y-2">
-            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">
               Person
             </h3>
             {prep.personDuplicates.length > 0 ? (
@@ -291,7 +291,7 @@ export function ConvertLeadSheet({
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">
               Company
             </h3>
             {prep.companyDuplicates.length > 0 ? (
@@ -337,7 +337,7 @@ export function ConvertLeadSheet({
           </section>
 
           <section className="space-y-3">
-            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">
               Deal
             </h3>
             <div className="space-y-1.5">

--- a/components/crm/leads/lead-card.tsx
+++ b/components/crm/leads/lead-card.tsx
@@ -123,7 +123,10 @@ export function LeadCard({ lead }: { lead: CrmBoardCard }) {
       }}
       className={cn(
         "rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] p-3",
-        "cursor-grab shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
+        // `touch-manipulation` keeps the board scrollable under a finger until
+        // the long-press fires; `select-none` stops the hold raising a text
+        // selection callout over the card it is about to move.
+        "cursor-grab touch-manipulation select-none shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
         "hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-sm)]",
         // The card left behind is a hole the size of the card, not a ghost of
         // it — the real thing is under the cursor in the drag overlay.

--- a/components/crm/leads/lead-form-sheet.tsx
+++ b/components/crm/leads/lead-form-sheet.tsx
@@ -66,7 +66,7 @@ type LeadSourceOption = { id: string; name: string; channel: string; isActive: b
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="space-y-3">
-      <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+      <h3 className="text-base font-semibold text-[var(--text-strong)]">
         {title}
       </h3>
       {children}

--- a/components/crm/leads/leads-board.tsx
+++ b/components/crm/leads/leads-board.tsx
@@ -32,10 +32,13 @@ import {
 } from "@/lib/crm/crm-v2";
 import type { LeadViewFilters } from "@/lib/crm/views";
 
+import { LEAD_STAGE_COLOR, stageColor } from "@/lib/crm/tones";
+import { MobileBoard } from "@/components/crm/records/board-mobile";
+
 import { BoardColumn } from "./board-column";
 import { LeadCardBody } from "./lead-card";
 import { LostReasonDialog } from "./lost-reason-dialog";
-import { CRM_STAGE_LABELS } from "./stage-config";
+import { CRM_STAGE_LABELS, formatLeadValue } from "./stage-config";
 
 /**
  * The card animates back into its column rather than vanishing, and the hole
@@ -200,7 +203,7 @@ export function LeadsBoard({
 
   if (boardQuery.isLoading) {
     return (
-      <div className={cn("flex gap-3 overflow-x-auto pb-2", className)}>
+      <div className={cn("scroll-rail flex gap-3 overflow-x-auto pb-2", className)}>
         {Array.from({ length: 5 }).map((_, index) => (
           <Skeleton key={index} className="h-96 w-72 shrink-0 rounded-[var(--card-radius)]" />
         ))}
@@ -224,6 +227,39 @@ export function LeadsBoard({
 
   return (
     <div className={cn("flex min-h-0 flex-col", className)}>
+      {/* A phone gets the stage picker and one list; the strip of columns is
+          desktop-only. Tapping a lead opens it, where the stage stepper is —
+          so restaging stays reachable without dragging anything. */}
+      <MobileBoard
+        className="lg:hidden"
+        emptyTitle="No leads in this stage"
+        stages={columns.map((column) => ({
+          id: column.stage,
+          label: CRM_STAGE_LABELS[column.stage],
+          dot: (LEAD_STAGE_COLOR[column.stage] ?? stageColor(null)).dot,
+          count: column.count,
+          meta:
+            column.totalValue > 0
+              ? formatLeadValue(column.totalValue, currency)
+              : undefined,
+          rows: column.leads.map((lead) => ({
+            id: lead.id,
+            href: `/crm/leads/${lead.id}`,
+            title: lead.title ?? lead.leadNo,
+            subtitle: [
+              lead.deal?.dealNo ?? lead.leadNo,
+              lead.client?.name ?? lead.contactName ?? "No client",
+            ]
+              .filter(Boolean)
+              .join(" · "),
+            facts: [
+              { value: formatLeadValue(lead.estimatedValue, lead.currency ?? currency), mono: true },
+            ],
+          })),
+        }))}
+      />
+
+      <div className="hidden min-h-0 flex-1 flex-col lg:flex">
       <DndContext
         sensors={sensors}
         collisionDetection={closestCorners}
@@ -234,7 +270,7 @@ export function LeadsBoard({
         {/* The strip of columns takes the height the page has left, so a short
             pipeline still reaches the bottom instead of floating in white
             space, and a long one scrolls inside its column. */}
-        <div className="flex min-h-0 flex-1 items-stretch gap-3 overflow-x-auto pb-2">
+        <div className="scroll-rail flex min-h-0 flex-1 items-stretch gap-3 overflow-x-auto pb-2">
           {columns.map((column) => (
             <BoardColumn
               key={column.stage}
@@ -258,6 +294,7 @@ export function LeadsBoard({
           ) : null}
         </DragOverlay>
       </DndContext>
+      </div>
 
       <LostReasonDialog
         open={Boolean(pendingLost)}

--- a/components/crm/leads/leads-board.tsx
+++ b/components/crm/leads/leads-board.tsx
@@ -203,9 +203,9 @@ export function LeadsBoard({
 
   if (boardQuery.isLoading) {
     return (
-      <div className={cn("scroll-rail flex gap-3 overflow-x-auto pb-2", className)}>
+      <div className={cn("space-y-2 lg:flex lg:space-y-0 lg:gap-3 lg:overflow-x-auto lg:pb-2", className)}>
         {Array.from({ length: 5 }).map((_, index) => (
-          <Skeleton key={index} className="h-96 w-72 shrink-0 rounded-[var(--card-radius)]" />
+          <Skeleton key={index} className="h-16 w-full rounded-[var(--card-radius)] lg:h-96 lg:w-72 lg:shrink-0" />
         ))}
       </div>
     );

--- a/components/crm/leads/leads-board.tsx
+++ b/components/crm/leads/leads-board.tsx
@@ -6,7 +6,8 @@ import {
   DragOverlay,
   defaultDropAnimationSideEffects,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCorners,
   useSensor,
   useSensors,
@@ -114,7 +115,13 @@ export function LeadsBoard({
   const sensors = useSensors(
     // A small activation distance keeps a click on the card title a click,
     // not an accidental one-pixel drag.
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    // MouseSensor and TouchSensor rather than PointerSensor. PointerSensor
+    // answers touch too, and its 6px threshold is crossed long before any
+    // long-press delay elapses — so with both registered, every attempt to
+    // swipe the board sideways started a drag instead. Splitting them lets a
+    // finger scroll immediately and drag only after a deliberate hold.
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 

--- a/components/crm/leads/leads-filters.tsx
+++ b/components/crm/leads/leads-filters.tsx
@@ -349,7 +349,7 @@ export function LeadsFilters({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className={cn("h-9 gap-2", className)}>
+        <Button variant="outline" className={cn(className)}>
           <Funnel className="size-4 opacity-70" />
           Filter
           {activeCount > 0 ? (
@@ -481,7 +481,7 @@ export function LeadsSortButton({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className={cn("h-9 gap-2", className)}>
+        <Button variant="outline" className={cn(className)}>
           <SortAscending className="size-4 opacity-70" />
           Sort
           <span className="text-[var(--text-muted)]">{current?.label}</span>

--- a/components/crm/leads/leads-filters.tsx
+++ b/components/crm/leads/leads-filters.tsx
@@ -360,7 +360,12 @@ export function LeadsFilters({
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent align="start" className="w-[22rem] space-y-3 p-3">
+      {/* 22rem is 352px — wider than a 390px phone once the viewport's own
+          gutters are taken off, so the panel used to hang off the edge. */}
+      <PopoverContent
+        align="start"
+        className="w-[min(22rem,calc(100vw-2rem))] space-y-3 p-3"
+      >
         <Input
           value={searchDraft}
           onChange={(event) => setSearchDraft(event.target.value)}

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { CrmLeadStage } from "@prisma/client";
 
@@ -26,6 +25,7 @@ import type { ColumnOption } from "@/lib/ui/visible-columns";
 import { cn } from "@/lib/utils";
 
 import { RecordMark } from "@/components/crm/records/record-mark";
+import { RecordList } from "@/components/crm/records/record-list";
 
 import type { LeadFilterOwner } from "./leads-filters";
 import {
@@ -114,7 +114,6 @@ export function LeadsTable({
   /** Column ids the reader has switched off. */
   hiddenColumns?: string[];
 }) {
-  const router = useRouter();
 
   const columns = useMemo<ColumnDef<CrmLeadListRecord>[]>(
     () => [
@@ -299,31 +298,30 @@ export function LeadsTable({
           );
         },
       }}
-      mobileCardRenderer={({ row }) => (
-        <button
-          type="button"
-          onClick={() => router.push(`/crm/leads/${row.id}`)}
-          className="flex w-full flex-col gap-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3 text-left"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              <div className="truncate font-medium">{row.title ?? row.leadNo}</div>
-              <div className="truncate font-mono text-sm text-[var(--text-muted)]">
-                {row.leadNo} · {row.client?.name ?? "No client"}
-              </div>
-            </div>
-            <StatusChip
-              status={CRM_STAGE_STATUS[row.stage]}
-              label={CRM_STAGE_LABELS[row.stage]}
-            />
-          </div>
-          <div className="flex items-center justify-between gap-2 text-sm">
-            <span className="font-mono">{formatLeadValue(row.estimatedValue, row.currency)}</span>
-            <span className="text-[var(--text-muted)]">
-              {row.assignedTo?.name ?? "Unassigned"}
-            </span>
-          </div>
-        </button>
+      // On a phone the table becomes the same list every other CRM surface
+      // uses: one row per lead, two lines inside it, rows separated by
+      // whitespace. The owner joins the reference line rather than earning a
+      // third row of its own, and the value sits on the right.
+      mobileListRenderer={({ rows: mobileRows }) => (
+        <RecordList
+          rows={mobileRows.map(({ row }) => ({
+            id: row.id,
+            href: `/crm/leads/${row.id}`,
+            title: row.title ?? row.leadNo,
+            subtitle: `${row.leadNo} · ${row.client?.name ?? "No client"} · ${
+              row.assignedTo?.name ?? "Unassigned"
+            }`,
+            status: (
+              <StatusChip
+                status={CRM_STAGE_STATUS[row.stage]}
+                label={CRM_STAGE_LABELS[row.stage]}
+              />
+            ),
+            facts: [
+              { value: formatLeadValue(row.estimatedValue, row.currency), mono: true },
+            ],
+          }))}
+        />
       )}
       emptyState={
         isLoading ? "Loading leads…" : "No leads match these filters."

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -260,7 +260,6 @@ export function LeadsWorkspace({
             <SegmentedControl
               value={viewType}
               onValueChange={(value) => setViewType(value as "TABLE" | "BOARD")}
-              size="sm"
               ariaLabel="Board or list"
               options={[
                 { value: "BOARD", label: "Board" },

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -189,7 +189,7 @@ export function LeadsWorkspace({
 
   const newLeadAction = useMemo(
     () => (
-      <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
+      <Button onClick={() => setCreateOpen(true)}>
         <Plus className="h-4 w-4" />
         New lead
       </Button>

--- a/components/crm/leads/view-picker.tsx
+++ b/components/crm/leads/view-picker.tsx
@@ -206,7 +206,7 @@ export function ViewPicker({
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="h-9 gap-2 pr-2">
+          <Button variant="outline" className="pr-2">
             <LayoutMark layout={active.layout} />
             <span className="max-w-40 truncate font-medium">{active.name}</span>
             <ChevronDown className="size-3 text-[var(--text-muted)]" />

--- a/components/crm/public/sign-off-content.tsx
+++ b/components/crm/public/sign-off-content.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ClientDate } from "@/components/ui/client-date";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+
+type Job = {
+  reference: string;
+  title: string;
+  description: string | null;
+  completedAt: string | null;
+  where: string | null;
+  customerName: string | null;
+  items: string[];
+  signedOffAt: string | null;
+  signedOffName: string | null;
+};
+
+/**
+ * "Is this job finished?", asked of the only person whose answer settles it.
+ *
+ * Read on a phone by somebody who is not a user of this system and never will
+ * be, so: what was done, where, and one box. The rating is optional and says
+ * so — asking for stars before accepting the work makes the accepting feel
+ * like a review, and people who are unhappy just close the page.
+ */
+export function SignOffContent({ token }: { token: string }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [rating, setRating] = useState<number | null>(null);
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const query = useQuery({
+    queryKey: ["public-sign-off", token],
+    queryFn: () => fetchJson<{ data: Job }>(`/api/public/crm/sign-off/${token}`),
+    retry: false,
+  });
+
+  const submit = useMutation({
+    mutationFn: () =>
+      fetchJson<{ data: Job }>(`/api/public/crm/sign-off/${token}`, {
+        method: "POST",
+        body: JSON.stringify({ name, rating, notes: notes.trim() || null }),
+      }),
+    onSuccess: () => {
+      setError(null);
+      queryClient.invalidateQueries({ queryKey: ["public-sign-off", token] });
+    },
+    onError: (err) => setError(getApiErrorMessage(err)),
+  });
+
+  if (query.isLoading) {
+    return <p className="p-6 text-sm text-neutral-500">Loading the job…</p>;
+  }
+
+  if (query.error || !query.data?.data) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <h1 className="text-lg font-semibold">This link isn&apos;t live</h1>
+        <p className="mt-1 text-sm text-neutral-600">
+          It may have been withdrawn or already answered. Ask whoever sent it for a new one.
+        </p>
+      </div>
+    );
+  }
+
+  const job = query.data.data;
+
+  return (
+    <div className="mx-auto max-w-md space-y-5 p-6">
+      <header className="space-y-1">
+        <p className="font-mono text-sm text-neutral-500">{job.reference}</p>
+        <h1 className="text-xl font-semibold">{job.title}</h1>
+        {job.where ? <p className="text-sm text-neutral-600">{job.where}</p> : null}
+      </header>
+
+      {job.items.length > 0 ? (
+        <section>
+          <h2 className="text-sm font-semibold text-neutral-500">What was done</h2>
+          <ul className="mt-1 space-y-1">
+            {job.items.map((item) => (
+              <li key={item} className="text-base">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {job.signedOffAt ? (
+        <section className="rounded-lg border border-green-200 bg-green-50 p-4">
+          <p className="font-medium text-green-900">Signed off. Thank you.</p>
+          <p className="mt-1 text-sm text-green-800">
+            {job.signedOffName} · <ClientDate value={job.signedOffAt} mode="datetime" />
+          </p>
+        </section>
+      ) : (
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (name.trim().length < 2) {
+              setError("Please put your name in so we know who signed.");
+              return;
+            }
+            submit.mutate();
+          }}
+        >
+          <div className="space-y-1">
+            <label htmlFor="signoff-name" className="text-sm font-medium">
+              Your name
+            </label>
+            <input
+              id="signoff-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-base"
+              autoComplete="name"
+            />
+          </div>
+
+          <fieldset className="space-y-1">
+            <legend className="text-sm font-medium">
+              How did it go? <span className="text-neutral-500">(optional)</span>
+            </legend>
+            <div className="flex gap-2">
+              {[1, 2, 3, 4, 5].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={rating === value}
+                  onClick={() => setRating(rating === value ? null : value)}
+                  className={
+                    rating === value
+                      ? "size-11 rounded-lg border-2 border-neutral-900 text-base font-semibold"
+                      : "size-11 rounded-lg border border-neutral-300 text-base"
+                  }
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="space-y-1">
+            <label htmlFor="signoff-notes" className="text-sm font-medium">
+              Anything to add? <span className="text-neutral-500">(optional)</span>
+            </label>
+            <textarea
+              id="signoff-notes"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={3}
+              className="w-full rounded-lg border border-neutral-300 px-3 py-2 text-base"
+            />
+          </div>
+
+          {error ? <p className="text-sm font-medium text-red-700">{error}</p> : null}
+
+          <button
+            type="submit"
+            disabled={submit.isPending}
+            className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-base font-medium text-white disabled:opacity-60"
+          >
+            {submit.isPending ? "Sending…" : "Confirm the work is done"}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/components/crm/public/visit-brief-content.tsx
+++ b/components/crm/public/visit-brief-content.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { ClientDate } from "@/components/ui/client-date";
+import { fetchJson } from "@/lib/api-client";
+import { Calendar, Checklist, MapPin, UserRound } from "@/lib/icons";
+
+type Brief = {
+  reference: string;
+  title: string;
+  scheduledStart: string;
+  scheduledEnd: string | null;
+  where: string | null;
+  mapUrl: string | null;
+  attendingName: string | null;
+  customerName: string | null;
+  checklist: string[];
+  status: string;
+};
+
+/**
+ * The visit, for whoever was sent the link.
+ *
+ * Read on a phone, probably outdoors, probably by somebody deciding whether
+ * to leave the house yet. So: when, where, who — in that order, large, with
+ * the address tappable into a maps app rather than something to squint at
+ * and retype.
+ */
+export function VisitBriefContent({ token }: { token: string }) {
+  const query = useQuery({
+    queryKey: ["public-visit", token],
+    queryFn: () => fetchJson<{ data: Brief }>(`/api/public/crm/visits/${token}`),
+    retry: false,
+  });
+
+  if (query.isLoading) {
+    return <p className="p-6 text-sm text-neutral-500">Loading the visit…</p>;
+  }
+
+  if (query.error || !query.data?.data) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <h1 className="text-lg font-semibold">This link isn&apos;t live</h1>
+        <p className="mt-1 text-sm text-neutral-600">
+          It may have been withdrawn or replaced. Ask whoever sent it for a new one.
+        </p>
+      </div>
+    );
+  }
+
+  const brief = query.data.data;
+  const cancelled = brief.status === "CANCELLED";
+
+  return (
+    <div className="mx-auto max-w-md space-y-5 p-6">
+      <header className="space-y-1">
+        <p className="font-mono text-sm text-neutral-500">{brief.reference}</p>
+        <h1 className="text-xl font-semibold">{brief.title}</h1>
+        {brief.customerName ? (
+          <p className="text-sm text-neutral-600">for {brief.customerName}</p>
+        ) : null}
+      </header>
+
+      {cancelled ? (
+        <p className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-800">
+          This visit has been cancelled. Nobody is coming — please check with whoever
+          arranged it.
+        </p>
+      ) : null}
+
+      <dl className="space-y-4">
+        <div className="flex gap-3">
+          <Calendar className="mt-0.5 size-5 shrink-0 text-neutral-400" aria-hidden="true" />
+          <div>
+            <dt className="text-sm text-neutral-500">When</dt>
+            <dd className="text-base font-medium">
+              <ClientDate value={brief.scheduledStart} mode="datetime" />
+              {brief.scheduledEnd ? (
+                <>
+                  {" – "}
+                  <ClientDate value={brief.scheduledEnd} mode="datetime" />
+                </>
+              ) : null}
+            </dd>
+          </div>
+        </div>
+
+        {brief.where ? (
+          <div className="flex gap-3">
+            <MapPin className="mt-0.5 size-5 shrink-0 text-neutral-400" aria-hidden="true" />
+            <div className="min-w-0">
+              <dt className="text-sm text-neutral-500">Where</dt>
+              <dd className="text-base font-medium">{brief.where}</dd>
+              {brief.mapUrl ? (
+                <a
+                  href={brief.mapUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-1 inline-block text-sm font-medium text-blue-700 underline"
+                >
+                  Open in maps
+                </a>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        {brief.attendingName ? (
+          <div className="flex gap-3">
+            <UserRound className="mt-0.5 size-5 shrink-0 text-neutral-400" aria-hidden="true" />
+            <div>
+              <dt className="text-sm text-neutral-500">Who is coming</dt>
+              <dd className="text-base font-medium">{brief.attendingName}</dd>
+            </div>
+          </div>
+        ) : null}
+
+        {brief.checklist.length > 0 ? (
+          <div className="flex gap-3">
+            <Checklist className="mt-0.5 size-5 shrink-0 text-neutral-400" aria-hidden="true" />
+            <div>
+              <dt className="text-sm text-neutral-500">What the visit covers</dt>
+              <dd>
+                <ul className="mt-1 space-y-1">
+                  {brief.checklist.map((label) => (
+                    <li key={label} className="text-base">
+                      {label}
+                    </li>
+                  ))}
+                </ul>
+              </dd>
+            </div>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  );
+}

--- a/components/crm/records/automation-tab.tsx
+++ b/components/crm/records/automation-tab.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+
+import { Alert, Badge, EmptyState, Stack } from "@corelithzw/react";
+import { ClientDate } from "@/components/ui/client-date";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { TRIGGER_LABELS } from "@/lib/crm/automation";
+import { formatDuration } from "@/lib/crm/run-insights";
+import { Rule } from "@/lib/icons";
+
+type EnrolmentRun = {
+  id: string;
+  status: "SUCCEEDED" | "PARTIAL" | "FAILED";
+  result: unknown;
+  durationMs: number | null;
+  actionCount: number;
+  createdAt: string;
+  automation: { id: string; name: string; trigger: string } | null;
+};
+
+type Enrolment = {
+  runs: EnrolmentRun[];
+  armed: Array<{ id: string; name: string; trigger: string }>;
+};
+
+const STATUS_TONE: Record<EnrolmentRun["status"], "success" | "warn" | "danger"> = {
+  SUCCEEDED: "success",
+  PARTIAL: "warn",
+  FAILED: "danger",
+};
+
+const STATUS_LABEL: Record<EnrolmentRun["status"], string> = {
+  SUCCEEDED: "Done",
+  PARTIAL: "Half done",
+  FAILED: "Failed",
+};
+
+/** `ADD_TAG` is a database value; "Add tag" is what somebody reads. */
+function actionLabel(type: string): string {
+  return type
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
+/** What each action did, or why it did not. */
+function outcomeLines(result: unknown): Array<{ label: string; ok: boolean; detail?: string }> {
+  if (!Array.isArray(result)) return [];
+  return result
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
+    .map((entry) => ({
+      label: typeof entry.type === "string" ? actionLabel(entry.type) : "Action",
+      ok: entry.ok !== false,
+      detail: typeof entry.detail === "string" ? entry.detail : undefined,
+    }));
+}
+
+/**
+ * What the workflows have done to this record.
+ *
+ * "Why is this assigned to somebody I did not pick" had no answer on the page
+ * where the question gets asked — the run log was company-wide, so finding one
+ * line about this lead meant scrolling past everybody else's.
+ *
+ * The second list is what could still fire. It is derived, not queued: this
+ * engine runs a rule the moment its event happens, so nothing is literally
+ * sitting in a pending state, and drawing a spinner next to something that is
+ * not running would be a story about a queue that does not exist.
+ */
+export function AutomationTab({
+  entity,
+  recordId,
+}: {
+  entity: "LEAD" | "DEAL" | "PERSON" | "COMPANY" | "SITE" | "WORK_ORDER";
+  recordId: string;
+}) {
+  const query = useQuery({
+    queryKey: ["crm-automation-enrolment", entity, recordId],
+    queryFn: () =>
+      fetchJson<Enrolment>(
+        `/api/v2/crm/automations/enrolment?entity=${entity}&recordId=${recordId}`,
+      ),
+  });
+
+  if (query.isLoading) return <Skeleton className="h-40 w-full" />;
+
+  if (query.error) {
+    return (
+      <Alert tone="danger" title="Couldn't load what has run">
+        {getApiErrorMessage(query.error)}
+      </Alert>
+    );
+  }
+
+  const runs = query.data?.runs ?? [];
+  const armed = query.data?.armed ?? [];
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h3 className="text-base font-semibold text-[var(--text-strong)]">What has run</h3>
+
+        {runs.length === 0 ? (
+          <EmptyState
+            className="mt-2"
+            title="No workflow has touched this yet"
+            body="Everything on this record was done by a person."
+          />
+        ) : (
+          <Stack as="ol" gap="sm" className="mt-2">
+            {runs.map((run) => {
+              const outcomes = outcomeLines(run.result);
+              return (
+                <li key={run.id} className="border-b border-[var(--border-subtle)] pb-3 last:border-0">
+                  <div className="flex flex-wrap items-baseline gap-2">
+                    {run.automation ? (
+                      <Link
+                        href={`/crm/workflows/${run.automation.id}`}
+                        className="text-sm font-medium text-[var(--text-strong)] underline decoration-[var(--border)] underline-offset-2"
+                      >
+                        {run.automation.name}
+                      </Link>
+                    ) : (
+                      <span className="text-sm font-medium text-[var(--text-muted)]">
+                        Deleted workflow
+                      </span>
+                    )}
+                    <Badge tone={STATUS_TONE[run.status]}>{STATUS_LABEL[run.status]}</Badge>
+                    <span className="text-sm text-[var(--text-muted)]">
+                      <ClientDate value={run.createdAt} mode="datetime" />
+                      {run.durationMs !== null ? ` · ${formatDuration(run.durationMs)}` : ""}
+                    </span>
+                  </div>
+
+                  {run.automation ? (
+                    <p className="mt-0.5 text-sm text-[var(--text-muted)]">
+                      Fired by: {TRIGGER_LABELS[run.automation.trigger as keyof typeof TRIGGER_LABELS] ?? run.automation.trigger}
+                    </p>
+                  ) : null}
+
+                  {outcomes.length > 0 ? (
+                    <ul className="mt-1.5 space-y-0.5">
+                      {outcomes.map((outcome, index) => (
+                        <li
+                          key={index}
+                          className={
+                            outcome.ok
+                              ? "text-sm text-[var(--text)]"
+                              : "text-sm text-[var(--status-error-text)]"
+                          }
+                        >
+                          {outcome.label}
+                          {outcome.detail ? ` — ${outcome.detail}` : ""}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              );
+            })}
+          </Stack>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-base font-semibold text-[var(--text-strong)]">
+          What could still fire
+        </h3>
+        <p className="mt-0.5 text-sm text-[var(--text-muted)]">
+          Enabled workflows pointed at this kind of record. Nothing is queued — each one runs
+          the moment the thing it watches for happens.
+        </p>
+
+        {armed.length === 0 ? (
+          <EmptyState
+            className="mt-2"
+            icon={<Rule className="size-4" aria-hidden="true" />}
+            title="Nothing is watching this record"
+          />
+        ) : (
+          <Stack as="ul" gap="xs" className="mt-2">
+            {armed.map((rule) => (
+              <li key={rule.id} className="flex flex-wrap items-baseline gap-2">
+                <Link
+                  href={`/crm/workflows/${rule.id}`}
+                  className="text-sm font-medium text-[var(--text-strong)] underline decoration-[var(--border)] underline-offset-2"
+                >
+                  {rule.name}
+                </Link>
+                <span className="text-sm text-[var(--text-muted)]">
+                  {TRIGGER_LABELS[rule.trigger as keyof typeof TRIGGER_LABELS] ?? rule.trigger}
+                </span>
+              </li>
+            ))}
+          </Stack>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/crm/records/board-column-header.tsx
+++ b/components/crm/records/board-column-header.tsx
@@ -76,7 +76,7 @@ export function BoardColumnHeader({
               aria-label={addLabel ?? `Add to ${name}`}
               // Visible on hover and on keyboard focus. A row of plus signs
               // across eight columns is eight things competing with the cards.
-              className="flex size-6 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-subtle)] opacity-0 transition-opacity hover:bg-[var(--surface-muted)] hover:text-[var(--text)] focus-visible:opacity-100 group-hover/head:opacity-100"
+              className="flex size-6 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-subtle)] opacity-0 transition-opacity hover:bg-[var(--surface-muted)] hover:text-[var(--text)] focus-visible:opacity-100 group-hover/head:opacity-100 pointer-coarse:opacity-100"
             >
               <Plus className="size-3.5" />
             </button>
@@ -88,7 +88,7 @@ export function BoardColumnHeader({
                 <IconButton
                   size="sm"
                   aria-label={`Options for ${name}`}
-                  className="opacity-0 focus-visible:opacity-100 group-hover/head:opacity-100 data-[state=open]:opacity-100"
+                  className="opacity-0 focus-visible:opacity-100 group-hover/head:opacity-100 data-[state=open]:opacity-100 pointer-coarse:opacity-100"
                 >
                   <DotsThree />
                 </IconButton>

--- a/components/crm/records/board-mobile.test.tsx
+++ b/components/crm/records/board-mobile.test.tsx
@@ -61,7 +61,12 @@ describe("MobileBoard", () => {
     expect(html).toContain("No leads in this stage");
   });
 
-  it("renders nothing when there are no stages at all", () => {
-    expect(renderToStaticMarkup(<MobileBoard stages={[]} />)).toBe("");
+  it("says so when there are no stages at all", () => {
+    // Not an empty document: a phone showing nothing under the toolbar reads
+    // as a page that failed, not a board with nothing in it.
+    const html = renderToStaticMarkup(
+      <MobileBoard stages={[]} emptyTitle="No leads yet" />,
+    );
+    expect(html).toContain("No leads yet");
   });
 });

--- a/components/crm/records/board-mobile.test.tsx
+++ b/components/crm/records/board-mobile.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MobileBoard } from "./board-mobile";
+
+/**
+ * The board's phone view: a stage picker and one list.
+ *
+ * The stage it lands on is resolved on every render rather than stored, so a
+ * stage that disappears when the filters change cannot leave the list stuck on
+ * an id that no longer exists. These assert on what comes out, not on what the
+ * component intends.
+ */
+const STAGES = [
+  { id: "NEW", label: "New", count: 0, rows: [] },
+  {
+    id: "QUOTED",
+    label: "Quoted",
+    count: 2,
+    meta: "USD 18,000",
+    rows: [
+      { id: "a", href: "/crm/deals/a", title: "Shopfront", subtitle: "DL-1 · Meikles" },
+      { id: "b", href: "/crm/deals/b", title: "Balustrade", subtitle: "DL-2 · Rainbow" },
+    ],
+  },
+  { id: "WON", label: "Won", count: 1, rows: [{ id: "c", href: "/c", title: "Curtain wall" }] },
+];
+
+describe("MobileBoard", () => {
+  it("opens on the first stage that has anything in it", () => {
+    const html = renderToStaticMarkup(<MobileBoard stages={STAGES} />);
+
+    expect(html).toContain("Shopfront");
+    expect(html).toContain("Balustrade");
+    // Only the picked stage's rows are in the document — this is one list, not
+    // a stack of every column.
+    expect(html).not.toContain("Curtain wall");
+  });
+
+  it("shows every stage as a chip with its count", () => {
+    const html = renderToStaticMarkup(<MobileBoard stages={STAGES} />);
+    for (const label of ["New", "Quoted", "Won"]) expect(html).toContain(label);
+    // The empty stage is still offered — it is where you look to confirm it is
+    // empty, and a picker that hides stages is a picker you cannot trust.
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('aria-pressed="true"');
+  });
+
+  it("shows the picked stage's total", () => {
+    const html = renderToStaticMarkup(<MobileBoard stages={STAGES} />);
+    expect(html).toContain("USD 18,000");
+  });
+
+  it("falls back to the first stage when every one is empty", () => {
+    const html = renderToStaticMarkup(
+      <MobileBoard
+        stages={[{ id: "NEW", label: "New", count: 0, rows: [] }]}
+        emptyTitle="No leads in this stage"
+      />,
+    );
+    expect(html).toContain("No leads in this stage");
+  });
+
+  it("renders nothing when there are no stages at all", () => {
+    expect(renderToStaticMarkup(<MobileBoard stages={[]} />)).toBe("");
+  });
+});

--- a/components/crm/records/board-mobile.tsx
+++ b/components/crm/records/board-mobile.tsx
@@ -2,6 +2,8 @@
 
 import { useState, type ReactNode } from "react";
 
+import { EmptyState } from "@corelithzw/react";
+
 import { RecordList, type RecordListRow } from "./record-list";
 import { cn } from "@/lib/utils";
 
@@ -50,7 +52,18 @@ export function MobileBoard({
     stages.find((stage) => stage.count > 0) ??
     stages[0];
 
-  if (!active) return null;
+  // A board with no stages at all — an unconfigured pipeline, or a filter that
+  // excluded every one. The desktop strip shows an empty rail and its own
+  // toolbar around it; a phone showed nothing whatsoever under the toolbar,
+  // which reads as a page that failed to load rather than one with nothing in
+  // it. Caught by screenshotting a tenant that had no leads.
+  if (!active) {
+    return (
+      <div className={className}>
+        <EmptyState title={emptyTitle} body={emptyBody} />
+      </div>
+    );
+  }
 
   return (
     <div className={cn("space-y-3", className)}>

--- a/components/crm/records/board-mobile.tsx
+++ b/components/crm/records/board-mobile.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+import { RecordList, type RecordListRow } from "./record-list";
+import { cn } from "@/lib/utils";
+
+/**
+ * A kanban board, on a phone.
+ *
+ * A board is a horizontal instrument. It works because you can see four
+ * columns at once and compare them; at 390px you can see one, and swiping
+ * between them means losing your place in a strip with no landmarks. So a
+ * phone gets the thing the board is actually for — which records are in which
+ * stage — as a stage picker and a single list.
+ *
+ * Dragging stays on the desktop board. Nothing becomes unreachable: tapping a
+ * row opens the record, where the stage control already lives.
+ */
+
+export type MobileBoardStage = {
+  id: string;
+  label: string;
+  count: number;
+  /** The column's colour on the board, so the chips read as the same stages. */
+  dot?: string;
+  /** A one-line summary under the picker — a stage total, usually. */
+  meta?: ReactNode;
+  rows: RecordListRow[];
+};
+
+export function MobileBoard({
+  stages,
+  emptyTitle = "Nothing in this stage",
+  emptyBody,
+  className,
+}: {
+  stages: MobileBoardStage[];
+  emptyTitle?: string;
+  emptyBody?: string;
+  className?: string;
+}) {
+  const [picked, setPicked] = useState<string | null>(null);
+
+  // Resolved rather than stored: a stage the reader picked can disappear when
+  // the filters change, and the first stage holding anything is a better
+  // landing place than an empty one. No effect needed, and no stale id.
+  const active =
+    stages.find((stage) => stage.id === picked) ??
+    stages.find((stage) => stage.count > 0) ??
+    stages[0];
+
+  if (!active) return null;
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="scroll-rail -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+        {stages.map((stage) => {
+          const selected = stage.id === active.id;
+          return (
+            <button
+              key={stage.id}
+              type="button"
+              onClick={() => setPicked(stage.id)}
+              aria-pressed={selected}
+              className={cn(
+                "flex min-h-9 shrink-0 items-center gap-2 rounded-full border px-3 text-sm transition-colors",
+                selected
+                  ? "border-[var(--border-strong)] bg-[var(--surface-muted)] font-medium text-[var(--text-strong)]"
+                  : "border-[var(--border)] text-[var(--text-muted)]",
+              )}
+            >
+              {stage.dot ? (
+                <span
+                  aria-hidden="true"
+                  className={cn("size-2 shrink-0 rounded-full", stage.dot)}
+                />
+              ) : null}
+              {stage.label}
+              <span className="font-mono tabular-nums text-[var(--text-subtle)]">
+                {stage.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {active.meta ? (
+        <p className="text-sm text-[var(--text-muted)]">{active.meta}</p>
+      ) : null}
+
+      <RecordList rows={active.rows} emptyTitle={emptyTitle} emptyBody={emptyBody} />
+    </div>
+  );
+}

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -99,6 +99,30 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
         id: company.id,
         columnId: company.accountStatus,
         href: `/crm/companies/${company.id}`,
+        // What the phone board shows instead of the card face: the same two
+        // lines the list view uses, so switching between them is a change of
+        // arrangement rather than of vocabulary.
+        row: {
+          leading: (
+            <RecordMark
+              kind="company"
+              name={company.name}
+              emoji={company.emoji}
+              avatarUrl={company.avatarUrl}
+              size="md"
+            />
+          ),
+          title: company.name,
+          subtitle: [
+            company.clientNo,
+            [company.city, company.country].filter(Boolean).join(", "),
+          ]
+            .filter(Boolean)
+            .join(" · "),
+          facts: fields.isVisible("people")
+            ? [{ value: `${company._count?.people ?? 0} people` }]
+            : undefined,
+        },
         content: (
           <div className="flex items-start gap-2">
             <RecordMark

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -234,7 +234,7 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
         <ColumnPicker
           columns={COMPANY_FIELDS}
           state={fields}
-          label={layout === "BOARD" ? "Card fields" : "Columns"}
+          label={layout === "BOARD" ? "Fields" : "Columns"}
         />
       }
       filters={

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -266,7 +266,6 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
           <SegmentedControl
             value={layout}
             onValueChange={(value) => setLayout(value as typeof layout)}
-            size="sm"
             ariaLabel="List or board"
             options={[
               { value: "LIST", label: "List" },

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -21,7 +21,7 @@ import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { CompanyPeopleTab } from "./company-people-tab";
-import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -327,6 +327,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
         tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "company", id: companyId } }),
+        automationTab({ ref: { kind: "company", id: companyId } }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -21,7 +21,7 @@ import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { CompanyPeopleTab } from "./company-people-tab";
-import { commentsTab, tasksTab } from "./record-tabs";
+import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -326,6 +326,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
         },
         tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
+        mentionsTab({ ref: { kind: "company", id: companyId } }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -105,6 +105,16 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
     path: `/api/v2/crm/companies/${companyId}`,
     invalidate: [["crm", "company", companyId], ["crm", "companies"]],
   });
+  const teamQuery = useQuery({
+    queryKey: ["crm", "team"],
+    queryFn: () => fetchJson<{ data: Array<{ id: string; name: string | null }> }>(
+      "/api/v2/crm/team",
+    ),
+  });
+  const ownerOptions = (teamQuery.data?.data ?? []).map((member) => ({
+    value: member.id,
+    label: member.name ?? "Unnamed",
+  }));
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "COMPANY"],
     queryFn: () => fetchCrmFieldDefinitions("COMPANY"),
@@ -205,13 +215,14 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
               id: "owner",
               label: "Owner",
               icon: UserRound,
-              display: (
-                <EntityLink
-                  href={company.assignedTo ? `/crm/reps/${company.assignedTo.id}` : null}
-                  className="text-sm"
-                >
-                  {company.assignedTo?.name ?? "Unassigned"}
-                </EntityLink>
+              placeholder: "Unassigned",
+              // A choice, not a label: who owns a record is the property that
+              // changes most and was the one you could not change from here.
+              ...edit.choice(
+                "assignedToId",
+                company.assignedTo?.id ?? null,
+                ownerOptions,
+                "Leave unassigned",
               ),
             },
             {

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -21,7 +21,7 @@ import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { CompanyPeopleTab } from "./company-people-tab";
-import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -327,6 +327,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
         tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "company", id: companyId } }),
+        filesTab({ ref: { kind: "company", id: companyId } }),
         automationTab({ ref: { kind: "company", id: companyId } }),
         {
           value: "history",

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -17,6 +17,7 @@ import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
+import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { CompanyPeopleTab } from "./company-people-tab";
@@ -261,6 +262,12 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
               placeholder: "Not recorded",
               ...edit.text("taxNumber", company.taxNumber),
             },
+            ...customFieldAttributes({
+              definitions,
+              values: company.customFields,
+              onCommit: (key, value) =>
+                edit.save.mutate({ customFields: { [key]: value } }),
+            }),
           ]}
         />
       }

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -13,8 +13,6 @@ import { Building2, Globe, Mail, MapPin, Phone, UserRound } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
-import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
@@ -22,6 +20,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { CompanyPeopleTab } from "./company-people-tab";
+import { commentsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -318,24 +317,8 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
             />
           ),
         },
-        {
-          value: "tasks",
-          label: "Tasks",
-          content: (
-            <RecordTasksTab record={{ clientId: companyId }} currentUserId={session?.user?.id} />
-          ),
-        },
-        {
-          value: "comments",
-          label: "Comments",
-          content: (
-            <CommentThread
-              entity="COMPANY"
-              recordId={companyId}
-              currentUserId={session?.user?.id}
-            />
-          ),
-        },
+        tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
+        commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/custom-field-attributes.tsx
+++ b/components/crm/records/custom-field-attributes.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { formatFieldValue, type FieldDefinition } from "@/lib/crm/custom-fields";
+import type { CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
+
+import type { RecordAttribute } from "./record-attributes";
+
+/**
+ * An administrator's custom fields, as editable properties.
+ *
+ * They were drawn in a boxed panel below the tabs, read-only, on four of the
+ * five record types — leads had none at all. So a field somebody added to
+ * capture "roof type" could be filled in on the create form and never
+ * corrected afterwards, and on a lead not captured at all.
+ *
+ * They are properties like any other now: they join the record's attribute
+ * list, in the order and sections the administrator arranged, and write
+ * through the same PATCH. Anything with a fixed set of answers or a shape a
+ * text box would mangle keeps its formatted read-only rendering until it has
+ * a real editor — a date picker in a property row is its own piece of work,
+ * and a text box that accepts "next tuesday" into a date column is worse than
+ * no editor.
+ */
+
+/** Types a text box can safely round-trip. */
+const TEXT_EDITABLE = new Set(["TEXT", "TEXTAREA", "URL", "EMAIL", "PHONE"]);
+const NUMBER_EDITABLE = new Set(["NUMBER", "CURRENCY", "PERCENT"]);
+
+export function customFieldAttributes({
+  definitions,
+  values,
+  onCommit,
+}: {
+  definitions: CrmFieldDefinitionRecord[];
+  values: Record<string, unknown> | null;
+  /** Writes one custom field. The caller owns the PATCH and its cache. */
+  onCommit: (key: string, value: unknown) => void;
+}): RecordAttribute[] {
+  return [...definitions]
+    .filter((definition) => !definition.archivedAt)
+    .sort((a, b) => a.position - b.position)
+    .map((definition) => {
+      const raw = values?.[definition.key] ?? null;
+      const label = definition.section
+        ? `${definition.section} · ${definition.label}`
+        : definition.label;
+
+      if (TEXT_EDITABLE.has(definition.type)) {
+        return {
+          id: `cf-${definition.key}`,
+          label,
+          placeholder: "Empty",
+          value: raw == null ? null : String(raw),
+          onCommit: (next: string) => onCommit(definition.key, next.trim() || null),
+        };
+      }
+
+      if (NUMBER_EDITABLE.has(definition.type)) {
+        return {
+          id: `cf-${definition.key}`,
+          label,
+          mono: true,
+          placeholder: "Empty",
+          value: raw == null ? null : String(raw),
+          onCommit: (next: string) => {
+            const trimmed = next.trim();
+            if (trimmed === "") return onCommit(definition.key, null);
+            const parsed = Number(trimmed);
+            if (Number.isFinite(parsed)) onCommit(definition.key, parsed);
+          },
+        };
+      }
+
+      // Selects, dates, booleans: shown as the administrator defined them,
+      // formatted, until each has an editor that cannot corrupt the value.
+      return {
+        id: `cf-${definition.key}`,
+        label,
+        value: formatFieldValue(definition as unknown as FieldDefinition, raw),
+        placeholder: "Empty",
+      };
+    });
+}

--- a/components/crm/records/custom-field-inputs.tsx
+++ b/components/crm/records/custom-field-inputs.tsx
@@ -49,7 +49,7 @@ export function CustomFieldInputs({
     <>
       {sections.map(([section, fields]) => (
         <section key={section} className="space-y-3">
-          <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+          <h3 className="text-base font-semibold text-[var(--text-strong)]">
             {section}
           </h3>
           {fields.map((definition) => (

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -31,9 +31,8 @@ import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { DocumentList } from "@/components/crm/documents/document-list";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import type { LeadDocument } from "@/components/crm/documents/document-types";
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
-import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
+import { commentsTab, tasksTab } from "./record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import { VisitsTab } from "@/components/crm/lead-detail/visits-tab";
@@ -421,24 +420,14 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               />
             ),
           },
-          {
-            value: "tasks",
-            label: "Tasks",
-            content: <RecordTasksTab record={{ dealId }} currentUserId={currentUserId} />,
-          },
+          tasksTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
           {
             value: "people",
             label: "People",
             count: deal.contacts.length,
             content: <DealContactsTab dealId={dealId} contacts={deal.contacts} />,
           },
-          {
-            value: "comments",
-            label: "Comments",
-            content: (
-              <CommentThread entity="DEAL" recordId={dealId} currentUserId={currentUserId} />
-            ),
-          },
+          commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
           {
             value: "history",
             label: "History",

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -33,12 +33,19 @@ import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/docu
 import type { LeadDocument } from "@/components/crm/documents/document-types";
 import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
 import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import {
+  ActivityStrip,
+  CallList,
+  EmailPreview,
+  MeetingCard,
+  NextInteractionCard,
+  type NextInteraction,
+} from "./record-panels";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import { VisitsTab } from "@/components/crm/lead-detail/visits-tab";
 import type { LeadActivity, LeadAppointment, LeadFollowUp } from "@/components/crm/lead-detail/lead-types";
 import type { LeadFilterOwner } from "@/components/crm/leads/leads-filters";
-import { isOverdue } from "@/components/crm/leads/stage-config";
 import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits/visit-report-sheet";
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 import { RaiseJobSheet } from "@/components/crm/work-orders/raise-job-sheet";
@@ -190,6 +197,45 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
   const openTasks = deal.followUps.filter((task) => task.status === "PENDING");
   const nextTask = openTasks[0];
   const nextVisit = deal.appointments.find((visit) => visit.status === "SCHEDULED");
+
+  // One "up next" rather than a task card and a visit card each showing their
+  // own soonest: the reader's question is what happens next, not what happens
+  // next of each kind.
+  const nextInteraction: NextInteraction | null = (() => {
+    const candidates: NextInteraction[] = [];
+    if (nextTask) candidates.push({ kind: "task", title: nextTask.title, at: nextTask.dueAt });
+    if (nextVisit) {
+      candidates.push({ kind: "visit", title: nextVisit.title, at: nextVisit.scheduledStart });
+    }
+    return (
+      candidates.sort(
+        (a, b) => new Date(a.at).getTime() - new Date(b.at).getTime(),
+      )[0] ?? null
+    );
+  })();
+
+  const activityCounts = [
+    { label: "calls", count: deal.activities.filter((a) => a.type === "CALL").length },
+    { label: "emails", count: deal.activities.filter((a) => a.type === "EMAIL").length },
+    { label: "notes", count: deal.activities.filter((a) => a.type === "NOTE").length },
+    { label: "meetings", count: deal.activities.filter((a) => a.type === "MEETING").length },
+  ];
+
+  const recentCalls = deal.activities
+    .filter((activity) => activity.type === "CALL")
+    .slice(0, 3)
+    .map((activity) => ({
+      id: activity.id,
+      at: activity.occurredAt,
+      summary: activity.body ?? activity.subject,
+    }));
+
+  const lastEmail = (() => {
+    const found = deal.activities.find((activity) => activity.type === "EMAIL");
+    return found
+      ? { id: found.id, subject: found.subject, body: found.body, at: found.occurredAt }
+      : null;
+  })();
   const openInvoices = deal.documents.filter(
     (doc) => doc.type === "INVOICE" && doc.invoice && invoiceOutstanding(doc.invoice) > 0,
   );
@@ -466,44 +512,43 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               />
             </RailSection>
 
-            {nextTask ? (
-              <RailSection title="Next task">
-                <p className="text-sm">{nextTask.title}</p>
-                <p
-                  className={
-                    isOverdue(nextTask.dueAt)
-                      ? "text-sm font-medium text-[var(--status-error-text)]"
-                      : "text-sm text-[var(--text-muted)]"
-                  }
-                >
-                  {isOverdue(nextTask.dueAt) ? "Overdue · " : "Due "}
-                  <ClientDate value={nextTask.dueAt} />
-                </p>
-              </RailSection>
-            ) : (
-              <RailSection title="Next task">
-                <p className="text-sm text-[var(--text-muted)]">
-                  Nothing scheduled — this deal will go quiet.
-                </p>
-              </RailSection>
-            )}
+            <RailSection title="Up next">
+              <NextInteractionCard
+                interaction={nextInteraction}
+                emptyMessage="Nothing scheduled — this deal will go quiet."
+              />
+            </RailSection>
 
             {nextVisit ? (
               <RailSection title="Next visit">
-                <p className="text-sm">{nextVisit.title}</p>
-                <p className="text-sm text-[var(--text-muted)]">
-                  <ClientDate value={nextVisit.scheduledStart} />
-                </p>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="mt-2"
-                  onClick={() => setReportFor(nextVisit)}
-                >
-                  Write it up
-                </Button>
+                <MeetingCard
+                  meeting={{
+                    id: nextVisit.id,
+                    title: nextVisit.title,
+                    scheduledStart: nextVisit.scheduledStart,
+                    location: nextVisit.location,
+                  }}
+                  action={
+                    <Button size="sm" variant="outline" onClick={() => setReportFor(nextVisit)}>
+                      Write it up
+                    </Button>
+                  }
+                />
               </RailSection>
             ) : null}
+
+            <RailSection title="Contact so far">
+              <ActivityStrip counts={activityCounts} />
+              {recentCalls.length > 0 ? (
+                <div className="mt-3">
+                  <CallList calls={recentCalls} />
+                </div>
+              ) : null}
+            </RailSection>
+
+            <RailSection title="Last email">
+              <EmailPreview message={lastEmail} />
+            </RailSection>
 
             {deal.site ? (
               <RailSection title="Site">

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -32,7 +32,7 @@ import { DocumentList } from "@/components/crm/documents/document-list";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import type { LeadDocument } from "@/components/crm/documents/document-types";
 import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
-import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import { VisitsTab } from "@/components/crm/lead-detail/visits-tab";
@@ -436,6 +436,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
           },
           commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
         mentionsTab({ ref: { kind: "deal", id: dealId } }),
+        automationTab({ ref: { kind: "deal", id: dealId } }),
           {
             value: "history",
             label: "History",

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -48,6 +48,8 @@ import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { DealContactsTab } from "./deal-contacts-tab";
 import { RecordAttributes } from "./record-attributes";
+import { RelationAttribute } from "./relation-attribute";
+import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
 import { DealStageBar } from "./deal-stage-bar";
 import { RailSection, RecordPageShell } from "./record-page-shell";
@@ -144,6 +146,10 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
   const dealQuery = useQuery({
     queryKey: ["crm", "deal", dealId],
     queryFn: () => fetchJson<DealDetail>(`/api/v2/crm/deals/${dealId}`),
+  });
+  const edit = useAttributeEditor({
+    path: `/api/v2/crm/deals/${dealId}`,
+    invalidate: [["crm", "deal", dealId], ["crm", "deals"]],
   });
   const teamQuery = useQuery({
     queryKey: ["crm", "team"],
@@ -278,10 +284,9 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 id: "value",
                 label: "Value",
                 icon: Payments,
-                value:
-                  deal.value !== null ? formatMoney(deal.value, deal.currency) : null,
                 placeholder: "Not sized",
                 mono: true,
+                ...edit.numeric("value", deal.value),
               },
               {
                 id: "stage",
@@ -314,13 +319,17 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 id: "company",
                 label: "Company",
                 icon: Building2,
-                display: deal.client ? (
-                  <EntityLink href={`/crm/companies/${deal.client.id}`} className="text-sm">
-                    {deal.client.name}
-                  </EntityLink>
-                ) : undefined,
-                value: null,
-                placeholder: "No company",
+                display: (
+                  <RelationAttribute
+                    value={deal.client?.name ?? null}
+                    href={deal.client ? `/crm/companies/${deal.client.id}` : null}
+                    types={["COMPANY"]}
+                    placeholder="No company"
+                    searchPlaceholder="Search companies"
+                    onPick={(record) => edit.save.mutate({ clientId: record.id })}
+                    onClear={() => edit.save.mutate({ clientId: null })}
+                  />
+                ),
               },
               {
                 id: "close",
@@ -338,8 +347,9 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 id: "probability",
                 label: "Likelihood",
                 icon: TrendingUp,
-                value: `${deal.probability ?? 0}%`,
                 mono: true,
+                placeholder: "0",
+                ...edit.numeric("probability", deal.probability),
               },
               {
                 id: "forecast",

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -43,6 +43,7 @@ import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 import { RaiseJobSheet } from "@/components/crm/work-orders/raise-job-sheet";
 
+import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { DealContactsTab } from "./deal-contacts-tab";
@@ -369,6 +370,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                     },
                   ]
                 : []),
+              ...customFieldAttributes({
+                definitions,
+                values: deal.customFields,
+                onCommit: (key, value) =>
+                  edit.save.mutate({ customFields: { [key]: value } }),
+              }),
             ]}
           />
         }

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -352,13 +352,17 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 id: "owner",
                 label: "Owner",
                 icon: UserRound,
-                display: (
-                  <EntityLink
-                    href={deal.assignedTo ? `/crm/reps/${deal.assignedTo.id}` : null}
-                    className="text-sm"
-                  >
-                    {deal.assignedTo?.name ?? "Unassigned"}
-                  </EntityLink>
+                placeholder: "Unassigned",
+                // A choice, not a label: who owns a deal is the property that
+                // changes most and was the one you could not change from here.
+                ...edit.choice(
+                  "assignedToId",
+                  deal.assignedTo?.id ?? null,
+                  (teamQuery.data?.data ?? []).map((member) => ({
+                    value: member.id,
+                    label: member.name ?? "Unnamed",
+                  })),
+                  "Leave unassigned",
                 ),
               },
               {

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -32,7 +32,7 @@ import { DocumentList } from "@/components/crm/documents/document-list";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import type { LeadDocument } from "@/components/crm/documents/document-types";
 import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
-import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
 import {
   ActivityStrip,
   CallList,
@@ -482,6 +482,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
           },
           commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
         mentionsTab({ ref: { kind: "deal", id: dealId } }),
+        filesTab({ ref: { kind: "deal", id: dealId } }),
         automationTab({ ref: { kind: "deal", id: dealId } }),
           {
             value: "history",

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -32,7 +32,7 @@ import { DocumentList } from "@/components/crm/documents/document-list";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import type { LeadDocument } from "@/components/crm/documents/document-types";
 import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
-import { commentsTab, tasksTab } from "./record-tabs";
+import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import { VisitsTab } from "@/components/crm/lead-detail/visits-tab";
@@ -435,6 +435,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             content: <DealContactsTab dealId={dealId} contacts={deal.contacts} />,
           },
           commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
+        mentionsTab({ ref: { kind: "deal", id: dealId } }),
           {
             value: "history",
             label: "History",

--- a/components/crm/records/deals-board.tsx
+++ b/components/crm/records/deals-board.tsx
@@ -369,9 +369,11 @@ export function DealsBoard({
 
   if (boardQuery.isLoading && !board) {
     return (
-      <div className="flex gap-3" aria-busy="true">
+      // A phone is about to get a list, so it waits for a list — not a strip
+      // of column skeletons, of which it can see one and a quarter.
+      <div className="space-y-2 lg:flex lg:space-y-0 lg:gap-3" aria-busy="true">
         {Array.from({ length: 4 }).map((_, index) => (
-          <Skeleton key={index} className="h-96 w-72 shrink-0" />
+          <Skeleton key={index} className="h-16 w-full lg:h-96 lg:w-72 lg:shrink-0" />
         ))}
       </div>
     );

--- a/components/crm/records/deals-board.tsx
+++ b/components/crm/records/deals-board.tsx
@@ -7,7 +7,8 @@ import {
   DragOverlay,
   defaultDropAnimationSideEffects,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCorners,
   useSensor,
   useSensors,
@@ -155,7 +156,10 @@ function DealCard({ deal }: { deal: CrmDealBoardCard }) {
       }}
       className={cn(
         "rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] p-3",
-        "cursor-grab shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
+        // `touch-manipulation` keeps the board scrollable under a finger until
+        // the long-press fires; `select-none` stops the hold raising a text
+        // selection callout over the card it is about to move.
+        "cursor-grab touch-manipulation select-none shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
         "hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-sm)]",
         isDragging &&
           "border-dashed bg-[var(--surface-muted)] opacity-50 shadow-none [&_*]:invisible",
@@ -322,7 +326,13 @@ export function DealsBoard({
   });
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    // MouseSensor and TouchSensor rather than PointerSensor. PointerSensor
+    // answers touch too, and its 6px threshold is crossed long before any
+    // long-press delay elapses — so with both registered, every attempt to
+    // swipe the board sideways started a drag instead. Splitting them lets a
+    // finger scroll immediately and drag only after a deliberate hold.
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 

--- a/components/crm/records/deals-board.tsx
+++ b/components/crm/records/deals-board.tsx
@@ -45,6 +45,7 @@ import { cn } from "@/lib/utils";
 import { isOverdue } from "@/components/crm/leads/stage-config";
 
 import { BoardColumnHeader } from "./board-column-header";
+import { MobileBoard } from "./board-mobile";
 import { RecordMark } from "./record-mark";
 import { useBoardField } from "./board-fields";
 
@@ -416,6 +417,29 @@ export function DealsBoard({
   };
 
   return (
+    <>
+    {/* A phone gets the stage picker and one list. Restaging lives on the deal
+        page's stage bar, so nothing is lost by not dragging here. */}
+    <MobileBoard
+      className="lg:hidden"
+      emptyTitle="No deals in this stage"
+      stages={board.columns.map((column) => ({
+        id: column.stage.id,
+        label: column.stage.name,
+        dot: stageColor(column.stage.colorToken).dot,
+        count: column.count,
+        meta: column.totalValue > 0 ? money(column.totalValue, currency) : undefined,
+        rows: column.deals.map((deal) => ({
+          id: deal.id,
+          href: `/crm/deals/${deal.id}`,
+          title: deal.title,
+          subtitle: `${deal.dealNo} · ${deal.client?.name ?? "No company"}`,
+          facts: [{ value: money(deal.value, deal.currency), mono: true }],
+        })),
+      }))}
+    />
+
+    <div className="hidden lg:block">
     <DndContext
       sensors={sensors}
       collisionDetection={closestCorners}
@@ -443,5 +467,7 @@ export function DealsBoard({
         ) : null}
       </DragOverlay>
     </DndContext>
+    </div>
+    </>
   );
 }

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -24,6 +24,7 @@ import { useVisibleColumns, type ColumnOption } from "@/lib/ui/visible-columns";
 import { DealFormSheet } from "./deal-form-sheet";
 import { PipelineSwitcher } from "./pipeline-switcher";
 import { RecordListShell } from "./record-list-shell";
+import { RecordList } from "./record-list";
 
 const PAGE_SIZE = 50;
 
@@ -309,25 +310,26 @@ export function DealsContent({
           total,
           totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
         }}
-        mobileCardRenderer={({ row }) => (
-          <Link
-            href={`/crm/deals/${row.id}`}
-            className="flex flex-col gap-1.5 rounded-[var(--card-radius)] border border-[var(--border)] p-3"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="truncate font-medium">{row.title}</div>
-                <div className="truncate font-mono text-sm text-[var(--text-muted)]">
-                  {row.dealNo} · {row.client?.name ?? "No company"}
-                </div>
-              </div>
-              <StatusChip
-                status={STATUS_PRESENTATION[row.stage.status] ?? "pending"}
-                label={row.stage.name}
-              />
-            </div>
-            <span className="font-mono text-sm">{formatMoney(row.value, row.currency)}</span>
-          </Link>
+        // On a phone the table becomes the same list every other CRM surface
+        // uses: one row per deal, two lines inside it, rows separated by
+        // whitespace. The value moves to the right of the row rather than
+        // taking a third line of its own.
+        mobileListRenderer={({ rows: mobileRows }) => (
+          <RecordList
+            rows={mobileRows.map(({ row }) => ({
+              id: row.id,
+              href: `/crm/deals/${row.id}`,
+              title: row.title,
+              subtitle: `${row.dealNo} · ${row.client?.name ?? "No company"}`,
+              status: (
+                <StatusChip
+                  status={STATUS_PRESENTATION[row.stage.status] ?? "pending"}
+                  label={row.stage.name}
+                />
+              ),
+              facts: [{ value: formatMoney(row.value, row.currency), mono: true }],
+            }))}
+          />
         )}
         emptyState={
           dealsQuery.isLoading

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -251,7 +251,6 @@ export function DealsContent({
               setStatusFilter(value as typeof statusFilter);
               setPage(1);
             }}
-            size="sm"
             ariaLabel="Filter by status"
             options={[
               { value: "OPEN", label: "Open" },
@@ -272,7 +271,6 @@ export function DealsContent({
           <SegmentedControl
             value={layout}
             onValueChange={(value) => setLayout(value as typeof layout)}
-            size="sm"
             ariaLabel="Board or list"
             options={[
               { value: "BOARD", label: "Board" },

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -239,7 +239,7 @@ export function DealsContent({
         <ColumnPicker
           columns={layout === "BOARD" ? DEAL_CARD_FIELDS : DEAL_TABLE_COLUMNS}
           state={layout === "BOARD" ? boardFields : tableColumns}
-          label={layout === "BOARD" ? "Card fields" : "Columns"}
+          label={layout === "BOARD" ? "Fields" : "Columns"}
         />
       }
       filters={

--- a/components/crm/records/files-tab.tsx
+++ b/components/crm/records/files-tab.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { Alert, EmptyState } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { fileMark, formatFileSize } from "@/lib/crm/panels";
+import type { FileOwnerKind } from "@/lib/crm/record-files";
+import { ClientDate } from "@/components/ui/client-date";
+import { Download, Plus, Trash2 } from "@/lib/icons";
+
+type RecordFile = {
+  id: string;
+  name: string;
+  url: string;
+  size: number | null;
+  contentType: string | null;
+  note: string | null;
+  createdAt: string;
+  uploadedBy: { id: string; name: string | null } | null;
+};
+
+/**
+ * The files that belong to this record.
+ *
+ * Quotes and invoices the system raised live in Documents; this is everything
+ * that arrived from outside — the signed contract, the tax clearance, the
+ * scan of a purchase order. Those used to live in whichever inbox received
+ * them, which is a filing system with one member of staff.
+ *
+ * Uploading is two requests: the bytes go to blob storage first and the row
+ * is written only once there is a url to write. The other order leaves a row
+ * pointing at nothing, which reads as a file and opens as an error.
+ */
+export function FilesTab({
+  owner,
+  ownerId,
+}: {
+  owner: FileOwnerKind;
+  ownerId: string;
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const key = ["crm-record-files", owner, ownerId];
+
+  const query = useQuery({
+    queryKey: key,
+    queryFn: () =>
+      fetchJson<{ data: RecordFile[] }>(
+        `/api/v2/crm/files?owner=${owner}&ownerId=${ownerId}`,
+      ),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) =>
+      fetchJson(`/api/v2/crm/files?id=${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: key });
+      toast({ title: "File removed" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Couldn't remove it",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const upload = async (file: File) => {
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const stored = await fetchJson<{ url: string; size?: number; contentType?: string }>(
+        "/api/v2/crm/uploads",
+        { method: "POST", body: form },
+      );
+
+      await fetchJson("/api/v2/crm/files", {
+        method: "POST",
+        body: JSON.stringify({
+          owner,
+          ownerId,
+          name: file.name,
+          url: stored.url,
+          // The browser knows both; trust it over the server's guess at the
+          // extension.
+          size: file.size,
+          contentType: file.type || null,
+        }),
+      });
+
+      queryClient.invalidateQueries({ queryKey: key });
+      toast({ title: "Attached", description: file.name });
+    } catch (error) {
+      toast({
+        title: "Upload failed",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      });
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  const files = query.data?.data ?? [];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-[var(--text-muted)]">
+          Contracts, certificates, scans — anything that arrived from outside.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={uploading}
+          onClick={() => inputRef.current?.click()}
+        >
+          <Plus className="size-4" />
+          {uploading ? "Uploading…" : "Attach a file"}
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) void upload(file);
+          }}
+        />
+      </div>
+
+      {query.error ? (
+        <Alert tone="danger" title="Couldn't load the files">
+          {getApiErrorMessage(query.error)}
+        </Alert>
+      ) : null}
+
+      {query.isLoading ? (
+        <Skeleton className="h-24 w-full" />
+      ) : files.length === 0 ? (
+        <EmptyState
+          title="Nothing attached yet"
+          body="Anything filed here stays with the record rather than in somebody's inbox."
+        />
+      ) : (
+        <ul className="space-y-1">
+          {files.map((file) => {
+            const mark = fileMark(file.name);
+            const size = formatFileSize(file.size);
+            return (
+              <li
+                key={file.id}
+                className="group flex items-center gap-3 rounded-[var(--radius-sm)] py-1.5 hover:bg-[var(--surface-hover)]"
+              >
+                <span
+                  data-accent={mark.accent}
+                  aria-hidden="true"
+                  className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--accent-bg)] font-mono text-sm font-medium text-[var(--accent-fg)]"
+                >
+                  {mark.label}
+                </span>
+
+                <span className="min-w-0 flex-1">
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block truncate text-sm font-medium text-[var(--text-strong)] underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]"
+                  >
+                    {file.name}
+                  </a>
+                  <span className="block truncate text-sm text-[var(--text-muted)]">
+                    {size ? `${size} · ` : ""}
+                    <ClientDate value={file.createdAt} />
+                    {file.uploadedBy?.name ? ` · ${file.uploadedBy.name}` : ""}
+                    {file.note ? ` · ${file.note}` : ""}
+                  </span>
+                </span>
+
+                <a
+                  href={file.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Download ${file.name}`}
+                  className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-subtle)] hover:bg-[var(--surface-subtle)]"
+                >
+                  <Download className="size-4" />
+                </a>
+
+                <IconButton
+                  size="sm"
+                  aria-label={`Remove ${file.name}`}
+                  disabled={remove.isPending}
+                  onClick={() => remove.mutate(file.id)}
+                >
+                  <Trash2 className="size-4 text-[var(--status-error-text)]" />
+                </IconButton>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/crm/records/mentions-tab.tsx
+++ b/components/crm/records/mentions-tab.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { EmptyState, Skeleton, Stack } from "@corelithzw/react";
+import { ClientDate } from "@/components/ui/client-date";
+import { RichTextRenderer } from "@/components/crm/collaboration/rich-text-renderer";
+import { fetchJson } from "@/lib/api-client";
+
+import { EntityLink } from "./entity-link";
+
+type Mention = {
+  id: string;
+  kind: "comment" | "activity";
+  body: string;
+  occurredAt: string;
+  authorName: string | null;
+  source: { kind: string; id: string; label: string; href: string } | null;
+};
+
+/**
+ * The other half of a link.
+ *
+ * A record page showed what it points at and nothing about what points back,
+ * so the site that three deals keep referring to looked unconnected to any of
+ * them. The references have been in the note bodies all along; this reads
+ * them the other way round.
+ *
+ * The text renders through the same renderer the timeline uses, so a mention
+ * inside a mention is still a link you can follow — which is the point: this
+ * is for getting from one record to the next.
+ */
+export function MentionsTab({ recordId }: { recordId: string }) {
+  const query = useQuery({
+    queryKey: ["crm", "mentions", recordId],
+    queryFn: () => fetchJson<{ data: Mention[] }>(`/api/v2/crm/mentions?recordId=${recordId}`),
+  });
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton height={56} />
+        <Skeleton height={56} />
+      </div>
+    );
+  }
+
+  const mentions = query.data?.data ?? [];
+
+  if (mentions.length === 0) {
+    return (
+      <EmptyState
+        title="Not mentioned anywhere yet"
+        body="When somebody links this record in a note or a comment on another record, it shows up here."
+      />
+    );
+  }
+
+  return (
+    <Stack as="ul" gap="xs" className="max-w-3xl">
+      {mentions.map((mention) => (
+        <li
+          key={`${mention.kind}-${mention.id}`}
+          className="rounded-[var(--radius-md)] px-3 py-2 hover:bg-[var(--surface-subtle)]"
+        >
+          <div className="flex flex-wrap items-baseline gap-x-2 text-sm">
+            {mention.source ? (
+              <EntityLink href={mention.source.href} className="font-medium">
+                {mention.source.label}
+              </EntityLink>
+            ) : (
+              <span className="font-medium">Somewhere</span>
+            )}
+            <span className="text-[var(--text-muted)]">
+              {mention.authorName ? `${mention.authorName} · ` : ""}
+              <ClientDate value={mention.occurredAt} mode="datetime" />
+            </span>
+          </div>
+          <RichTextRenderer body={mention.body} className="mt-1" />
+        </li>
+      ))}
+    </Stack>
+  );
+}

--- a/components/crm/records/mobile-rows.test.tsx
+++ b/components/crm/records/mobile-rows.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MobileRow, MobileRows } from "./mobile-rows";
+
+/**
+ * The non-navigating row, used wherever a report table becomes a list.
+ *
+ * Same grammar as `RecordList`: one row per item, at most two lines in it, the
+ * one figure that matters on the right, rows separated by whitespace rather
+ * than ruled off.
+ */
+describe("MobileRows", () => {
+  it("renders a list, not a stack of cards", () => {
+    const html = renderToStaticMarkup(
+      <MobileRows>
+        <MobileRow title="Tendai" subtitle="8 won · 3 lost" value="USD 42,000" />
+      </MobileRows>,
+    );
+
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li");
+    expect(html).toContain("Tendai");
+    expect(html).toContain("8 won · 3 lost");
+    expect(html).toContain("USD 42,000");
+    // No frame around a row — that is what makes it a list rather than cards.
+    expect(html).not.toContain("border");
+  });
+
+  it("drops the value and subtitle when there are none", () => {
+    const html = renderToStaticMarkup(
+      <MobileRows>
+        <MobileRow title="Unassigned" />
+      </MobileRows>,
+    );
+    expect(html).toContain("Unassigned");
+    // One line, so no second span and no right-hand figure.
+    expect(html).not.toContain("tabular-nums");
+  });
+
+  it("puts the value in a monospaced column so figures line up", () => {
+    const html = renderToStaticMarkup(
+      <MobileRows>
+        <MobileRow title="A" value="1,000" />
+        <MobileRow title="B" value="12" />
+      </MobileRows>,
+    );
+    expect(html.match(/font-mono/g)).toHaveLength(2);
+  });
+});

--- a/components/crm/records/mobile-rows.tsx
+++ b/components/crm/records/mobile-rows.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+
+import { Stack } from "@corelithzw/react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A list of things, for a phone.
+ *
+ * The same grammar `RecordList` uses — one row per item, at most two lines
+ * inside it, rows separated by whitespace rather than ruled off — but for rows
+ * that are not links. `RecordListRow` requires an `href` because a record row
+ * is something you open; a rep's win rate or a workflow's failure count is
+ * something you read, and it has nowhere to go.
+ *
+ * This exists so a table can become a list on a phone without every caller
+ * retyping the row. A table is the right shape when somebody is comparing a
+ * column of numbers on a desk. On a 390px screen it is four columns of
+ * `font-mono` fighting over 318px, and the honest answer is a list where the
+ * one number that matters sits on the right and the rest goes underneath.
+ */
+
+export type MobileRowProps = {
+  /** The thing being described — a name, a workflow, a source. */
+  title: ReactNode;
+  /** The supporting line. Keep it to one; a third line is a card, not a row. */
+  subtitle?: ReactNode;
+  /** The figure that earns the right-hand side. Rendered `font-mono`. */
+  value?: ReactNode;
+  /** A chip or badge beside the title. */
+  status?: ReactNode;
+  className?: string;
+};
+
+export function MobileRow({ title, subtitle, value, status, className }: MobileRowProps) {
+  return (
+    <li className={cn("flex items-baseline gap-3 py-1.5", className)}>
+      <span className="min-w-0 flex-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <span className="truncate text-sm font-medium text-[var(--text-strong)]">
+            {title}
+          </span>
+          {status}
+        </span>
+        {subtitle ? (
+          <span className="mt-0.5 block truncate text-sm text-[var(--text-muted)]">
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+
+      {value ? (
+        <span className="shrink-0 font-mono text-sm tabular-nums text-[var(--text-strong)]">
+          {value}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * The container. `Stack` rather than a bare `ul` so the spacing comes from the
+ * design system's scale instead of a number picked per call site.
+ */
+export function MobileRows({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Stack as="ul" gap="xs" className={cn("min-w-0", className)}>
+      {children}
+    </Stack>
+  );
+}

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -173,12 +173,27 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
     [],
   );
 
+  const rowsById = useMemo(() => new Map(rows.map((row) => [row.id, row])), [rows]);
+
   const boardCards = useMemo(
     () =>
       people.map((person) => ({
         id: person.id,
         columnId: person.contactType,
         href: `/crm/people/${person.id}`,
+        // The phone board reuses the list view's row for the same person, so
+        // the two arrangements of these records say the same things.
+        row: (() => {
+          const row = rowsById.get(person.id);
+          if (!row) return undefined;
+          return {
+            leading: row.leading,
+            title: row.title,
+            subtitle: row.subtitle,
+            status: row.status,
+            facts: row.facts,
+          };
+        })(),
         content: (
           <div className="flex items-start gap-2">
             <RecordMark
@@ -210,7 +225,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
           </div>
         ),
       })),
-    [fields, people],
+    [fields, people, rowsById],
   );
 
   const moveContactType = useMutation({

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -254,7 +254,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
         <ColumnPicker
           columns={PERSON_FIELDS}
           state={fields}
-          label={layout === "BOARD" ? "Card fields" : "Columns"}
+          label={layout === "BOARD" ? "Fields" : "Columns"}
         />
       }
       filters={

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -277,7 +277,6 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
           <SegmentedControl
             value={layout}
             onValueChange={(value) => setLayout(value as typeof layout)}
-            size="sm"
             ariaLabel="List or board"
             options={[
               { value: "LIST", label: "List" },

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -11,14 +11,13 @@ import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
-import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
+import { commentsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -320,24 +319,8 @@ export function PersonDetailPage({ personId }: { personId: string }) {
             />
           ),
         },
-        {
-          value: "tasks",
-          label: "Tasks",
-          content: (
-            <RecordTasksTab record={{ personId }} currentUserId={session?.user?.id} />
-          ),
-        },
-        {
-          value: "comments",
-          label: "Comments",
-          content: (
-            <CommentThread
-              entity="PERSON"
-              recordId={personId}
-              currentUserId={session?.user?.id}
-            />
-          ),
-        },
+        tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
+        commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -18,7 +18,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { commentsTab, tasksTab } from "./record-tabs";
+import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -328,6 +328,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
         },
         tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
+        mentionsTab({ ref: { kind: "person", id: personId } }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -18,7 +18,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -329,6 +329,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
         tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "person", id: personId } }),
+        filesTab({ ref: { kind: "person", id: personId } }),
         automationTab({ ref: { kind: "person", id: personId } }),
         {
           value: "history",

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -119,6 +119,16 @@ export function PersonDetailPage({ personId }: { personId: string }) {
     queryKey: ["crm", "person", personId],
     queryFn: () => fetchJson<PersonDetail>(`/api/v2/crm/people/${personId}`),
   });
+  const teamQuery = useQuery({
+    queryKey: ["crm", "team"],
+    queryFn: () => fetchJson<{ data: Array<{ id: string; name: string | null }> }>(
+      "/api/v2/crm/team",
+    ),
+  });
+  const ownerOptions = (teamQuery.data?.data ?? []).map((member) => ({
+    value: member.id,
+    label: member.name ?? "Unnamed",
+  }));
   const fieldsQuery = useQuery({
     queryKey: ["crm", "field-definitions", "PERSON"],
     queryFn: () => fetchCrmFieldDefinitions("PERSON"),
@@ -246,13 +256,14 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               id: "owner",
               label: "Owner",
               icon: UserRound,
-              display: (
-                <EntityLink
-                  href={person.assignedTo ? `/crm/reps/${person.assignedTo.id}` : null}
-                  className="text-sm"
-                >
-                  {person.assignedTo?.name ?? "Unassigned"}
-                </EntityLink>
+              placeholder: "Unassigned",
+              // A choice, not a label: who owns a record is the property that
+              // changes most and was the one you could not change from here.
+              ...edit.choice(
+                "assignedToId",
+                person.assignedTo?.id ?? null,
+                ownerOptions,
+                "Leave unassigned",
               ),
             },
             {

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -18,7 +18,7 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
@@ -329,6 +329,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
         tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "person", id: personId } }),
+        automationTab({ ref: { kind: "person", id: personId } }),
         {
           value: "history",
           label: "History",

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -15,6 +15,7 @@ import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 
+import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { commentsTab, tasksTab } from "./record-tabs";
@@ -280,6 +281,12 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               placeholder: "Not recorded",
               ...edit.text("city", person.city),
             },
+            ...customFieldAttributes({
+              definitions,
+              values: person.customFields,
+              onCommit: (key, value) =>
+                edit.save.mutate({ customFields: { [key]: value } }),
+            }),
           ]}
         />
       }

--- a/components/crm/records/pipeline-switcher.tsx
+++ b/components/crm/records/pipeline-switcher.tsx
@@ -56,7 +56,7 @@ export function PipelineSwitcher({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline" className="h-9 gap-2">
+        <Button variant="outline">
           {triggerLabel}
           <ChevronDown className="size-3 text-[var(--text-muted)]" />
         </Button>

--- a/components/crm/records/record-attributes.tsx
+++ b/components/crm/records/record-attributes.tsx
@@ -4,7 +4,8 @@ import { useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ChevronDown, ChevronRight, type LucideIcon } from "@/lib/icons";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Check, ChevronDown, ChevronRight, type LucideIcon } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 /**
@@ -22,18 +23,113 @@ import { cn } from "@/lib/utils";
  * else either.
  */
 
+export type RecordAttributeOption = {
+  value: string;
+  label: string;
+  /** A dot or avatar shown beside the label in the list. */
+  leading?: ReactNode;
+};
+
 export type RecordAttribute = {
   id: string;
   label: string;
   icon?: LucideIcon;
-  /** For a value the page renders itself — a link, a chip, an avatar. */
+  /**
+   * For a value the page renders itself — a link, a chip, an avatar. A row
+   * that *only* has this is read-only; pair it with `options` or `onCommit`
+   * and it becomes the closed state of an editor instead.
+   */
   display?: ReactNode;
   /** For a plain value somebody can retype in place. */
   value?: string | null;
   onCommit?: (value: string) => void;
+  /**
+   * The row is a choice rather than free text: an owner, a status, a stage,
+   * anything whose value has to be one of a known set. `onCommit` receives the
+   * chosen option's `value`, or an empty string when it is cleared.
+   */
+  options?: RecordAttributeOption[];
+  /** What clearing means, when the row is allowed to be empty. */
+  clearLabel?: string;
   placeholder?: string;
   mono?: boolean;
 };
+
+/**
+ * A property whose value is one of a known set — an owner, a status, a stage.
+ *
+ * The whole value is the trigger, which is the Notion behaviour: you press
+ * what you are looking at, not a "Change" button parked beside it. A row that
+ * needs a separate verb to edit it is a row people stop editing.
+ */
+function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
+  const [open, setOpen] = useState(false);
+  const options = attribute.options ?? [];
+  const current = options.find((option) => option.value === (attribute.value ?? ""));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "-mx-1.5 flex w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)]",
+            !current && "text-[var(--text-muted)]",
+          )}
+        >
+          {attribute.display ?? (
+            <span className="min-w-0 truncate">
+              {current?.label ?? attribute.placeholder ?? "Empty"}
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      {/* The trigger sits in the right-hand column of the property list, so a
+          fixed 240px panel aligned to its start runs off a 390px screen.
+          Bounded by the viewport, and told to keep clear of the edges. */}
+      <PopoverContent
+        align="start"
+        collisionPadding={12}
+        className="w-[min(15rem,calc(100vw-2rem))] p-1"
+      >
+        <div className="max-h-72 overflow-y-auto">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                attribute.onCommit?.(option.value);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex min-h-9 w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 text-left text-sm hover:bg-[var(--surface-hover)]",
+                option.value === attribute.value && "font-medium",
+              )}
+            >
+              {option.leading}
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              {option.value === attribute.value ? (
+                <Check className="size-4 shrink-0 text-[var(--text-muted)]" aria-hidden="true" />
+              ) : null}
+            </button>
+          ))}
+          {attribute.clearLabel && attribute.value ? (
+            <button
+              type="button"
+              onClick={() => {
+                attribute.onCommit?.("");
+                setOpen(false);
+              }}
+              className="flex min-h-9 w-full items-center rounded-[var(--radius-sm)] px-2 text-left text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)]"
+            >
+              {attribute.clearLabel}
+            </button>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 function EditableValue({ attribute }: { attribute: RecordAttribute }) {
   const [draft, setDraft] = useState<string | null>(null);
@@ -119,7 +215,15 @@ export function RecordAttributes({
                 <span className="truncate">{attribute.label}</span>
               </dt>
               <dd className="min-w-0 flex-1">
-                {attribute.display ?? <EditableValue attribute={attribute} />}
+                {/* Which editor a row gets is decided here, from the shape of
+                    the attribute: a known set of values is a choice, a commit
+                    handler is free text, and anything else is a value the page
+                    drew itself and nobody can edit in place. */}
+                {attribute.options && attribute.onCommit ? (
+                  <ChoiceValue attribute={attribute} />
+                ) : (
+                  (attribute.display ?? <EditableValue attribute={attribute} />)
+                )}
               </dd>
             </div>
           );

--- a/components/crm/records/record-board.tsx
+++ b/components/crm/records/record-board.tsx
@@ -29,6 +29,8 @@ import { EmptyState, Skeleton } from "@corelithzw/react";
 import { cn } from "@/lib/utils";
 
 import { BoardColumnHeader } from "./board-column-header";
+import { MobileBoard } from "./board-mobile";
+import type { RecordListRow } from "./record-list";
 
 const DROP_ANIMATION: DropAnimation = {
   duration: 220,
@@ -48,6 +50,14 @@ export type RecordBoardCard = {
   href: string;
   /** The card's face. Composed by the caller so each entity keeps its own. */
   content: ReactNode;
+  /**
+   * The same record as a list row, for the phone board. A card face is two or
+   * three stacked lines because a column is 288px of vertical space; a list
+   * row is a title, one supporting line and a fact on the right. Callers that
+   * already build rows for their list view pass those, so the two views of the
+   * same records agree. Omitted, the card face is reused as-is.
+   */
+  row?: Omit<RecordListRow, "id" | "href">;
 };
 
 function BoardCard({ card }: { card: RecordBoardCard }) {
@@ -226,6 +236,27 @@ export function RecordBoard({
   };
 
   return (
+    <>
+    <MobileBoard
+      className="lg:hidden"
+      emptyTitle={emptyLabel}
+      stages={columns.map((column) => ({
+        id: column.id,
+        label: column.name,
+        dot: column.color.dot,
+        count: (byColumn.get(column.id) ?? []).length,
+        rows: (byColumn.get(column.id) ?? []).map((card) => ({
+          id: card.id,
+          href: card.href,
+          ...(card.row ?? { title: card.content }),
+        })),
+      }))}
+    />
+
+    {/* The board itself is desktop-only. Rendered rather than unmounted so the
+        two views cannot drift apart in behaviour; the drag sensors below never
+        see a touch because nothing here is on screen at phone width. */}
+    <div className="hidden lg:block">
     <DndContext
       sensors={sensors}
       collisionDetection={closestCorners}
@@ -254,5 +285,7 @@ export function RecordBoard({
         ) : null}
       </DragOverlay>
     </DndContext>
+    </div>
+    </>
   );
 }

--- a/components/crm/records/record-board.tsx
+++ b/components/crm/records/record-board.tsx
@@ -7,7 +7,8 @@ import {
   DragOverlay,
   defaultDropAnimationSideEffects,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCorners,
   useDroppable,
   useSensor,
@@ -66,7 +67,10 @@ function BoardCard({ card }: { card: RecordBoardCard }) {
       }}
       className={cn(
         "rounded-[var(--card-radius)] border border-[var(--border)] bg-[var(--surface)] p-3",
-        "cursor-grab shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
+        // `touch-manipulation` keeps the board scrollable under a finger until
+        // the long-press fires; `select-none` stops the hold raising a text
+        // selection callout over the card it is about to move.
+        "cursor-grab touch-manipulation select-none shadow-[var(--shadow-xs)] transition-shadow active:cursor-grabbing",
         "hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-sm)]",
         isDragging &&
           "border-dashed bg-[var(--surface-muted)] opacity-50 shadow-none [&_*]:invisible",
@@ -167,7 +171,13 @@ export function RecordBoard({
   const [dragging, setDragging] = useState<RecordBoardCard | null>(null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    // MouseSensor and TouchSensor rather than PointerSensor. PointerSensor
+    // answers touch too, and its 6px threshold is crossed long before any
+    // long-press delay elapses — so with both registered, every attempt to
+    // swipe the board sideways started a drag instead. Splitting them lets a
+    // finger scroll immediately and drag only after a deliberate hold.
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 

--- a/components/crm/records/record-board.tsx
+++ b/components/crm/records/record-board.tsx
@@ -205,9 +205,11 @@ export function RecordBoard({
 
   if (isLoading) {
     return (
-      <div className="flex gap-3" aria-busy="true">
+      // A phone is about to get a list, so it waits for a list — not a strip
+      // of column skeletons, of which it can see one and a quarter.
+      <div className="space-y-2 lg:flex lg:space-y-0 lg:gap-3" aria-busy="true">
         {Array.from({ length: 4 }).map((_, index) => (
-          <Skeleton key={index} className="h-96 w-72 shrink-0" />
+          <Skeleton key={index} className="h-16 w-full lg:h-96 lg:w-72 lg:shrink-0" />
         ))}
       </div>
     );

--- a/components/crm/records/record-list-shell.tsx
+++ b/components/crm/records/record-list-shell.tsx
@@ -59,7 +59,6 @@ export function RecordListShell({
       createLabel && onCreate ? (
         <Button
           variant="primary"
-          size="sm"
           startIcon={<Plus className="h-4 w-4" />}
           onClick={onCreate}
         >

--- a/components/crm/records/record-list-shell.tsx
+++ b/components/crm/records/record-list-shell.tsx
@@ -80,7 +80,7 @@ export function RecordListShell({
             value={search}
             onChange={(event) => onSearchChange(event.target.value)}
             placeholder={searchPlaceholder}
-            className="h-9 w-full sm:w-64"
+            className="w-full sm:w-64"
             aria-label={searchPlaceholder}
           />
         }

--- a/components/crm/records/record-list.test.tsx
+++ b/components/crm/records/record-list.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RecordList } from "./record-list";
+
+/**
+ * What these pin down:
+ *
+ * A phone gets one row per record, two lines inside it, and the one number the
+ * row is about on the right. That number used to be dropped entirely below
+ * `sm` — every fact was `hidden sm:flex` — so converting the deals and leads
+ * tables to this list would have shown a deal with no value at all, which is
+ * less than the bordered card it replaced.
+ *
+ * These assert on the emitted markup rather than on the source, because the
+ * previous round's untypeable `<input type="button">` typechecked, rendered,
+ * and passed every test that only ever looked at the source.
+ */
+const ROWS = [
+  {
+    id: "deal-1",
+    href: "/crm/deals/deal-1",
+    title: "Aluminium shopfront",
+    subtitle: "DL-0012 · Meikles Hotel",
+    facts: [
+      { label: "Value", value: "USD 12,400", mono: true },
+      { label: "Owner", value: "Tendai" },
+      { label: "Stage", value: "Quoted" },
+    ],
+  },
+];
+
+describe("RecordList facts", () => {
+  it("shows the leading fact on a phone and hides the rest", () => {
+    const html = renderToStaticMarkup(<RecordList rows={ROWS} />);
+
+    // The mobile span: visible by default, hidden from `sm` up.
+    expect(html).toContain("sm:hidden");
+    // It carries the first fact's value…
+    expect(html.match(/USD 12,400/g)).toHaveLength(2); // mobile span + desktop cluster
+    // …and only the first: the other two live solely in the `sm:flex` cluster.
+    expect(html.match(/Tendai/g)).toHaveLength(1);
+    expect(html.match(/Quoted/g)).toHaveLength(1);
+  });
+
+  it("does not repeat the leading fact's label on a phone", () => {
+    const html = renderToStaticMarkup(<RecordList rows={ROWS} />);
+    // "Value" is a desktop column heading; the phone row has no room to
+    // explain a number that is already the only one there.
+    expect(html.match(/>Value</g)).toHaveLength(1);
+  });
+
+  it("keeps a row to two lines — title and subtitle, nothing else", () => {
+    const html = renderToStaticMarkup(<RecordList rows={ROWS} />);
+    expect(html).toContain("Aluminium shopfront");
+    expect(html).toContain("DL-0012 · Meikles Hotel");
+    // No card frame: rows are separated by whitespace, not borders.
+    expect(html).not.toContain("card-radius");
+  });
+
+  it("renders nothing extra when a row has no facts", () => {
+    const html = renderToStaticMarkup(
+      <RecordList rows={[{ id: "a", href: "/a", title: "Plain" }]} />,
+    );
+    expect(html).not.toContain("sm:hidden");
+  });
+});

--- a/components/crm/records/record-list.tsx
+++ b/components/crm/records/record-list.tsx
@@ -125,7 +125,10 @@ export function RecordList({
           <Link
             href={row.href}
             className={cn(
-              "group/row flex min-w-0 flex-1 items-center gap-3 rounded-[var(--radius-md)] py-2.5 pr-3 hover:bg-[var(--surface-muted)]",
+              // `min-h-11` is the 44px touch target. `py-2.5` alone gives a
+              // one-line row about 40px tall, which is under every platform's
+              // minimum and reads as a near-miss rather than a miss.
+              "group/row flex min-h-11 min-w-0 flex-1 items-center gap-3 rounded-[var(--radius-md)] py-2.5 pr-3 hover:bg-[var(--surface-muted)]",
               selection ? "pl-2" : "pl-3",
             )}
           >

--- a/components/crm/records/record-list.tsx
+++ b/components/crm/records/record-list.tsx
@@ -148,7 +148,23 @@ export function RecordList({
             </span>
 
             {/* Facts are supporting detail, so they are the first thing to go
-                when the row runs out of room. */}
+                when the row runs out of room — but not all of them. On a phone
+                the leading fact survives and its label does not: callers put
+                the number the row is about first (a balance, a pipeline, a
+                count), and a row that drops it entirely says less than the
+                card it replaced. Two and three go; three labelled columns
+                will not fit beside a title at 390px. */}
+            {row.facts?.length ? (
+              <span
+                className={cn(
+                  "flex-none text-right text-sm text-[var(--text-body)] sm:hidden",
+                  row.facts[0].mono ? "font-mono tabular-nums" : "",
+                )}
+              >
+                {row.facts[0].value}
+              </span>
+            ) : null}
+
             {row.facts?.length ? (
               <span className="hidden flex-none items-center gap-6 sm:flex">
                 {row.facts.map((fact, index) => (

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -157,7 +157,7 @@ export function RecordPageShell({
           asides are mutually exclusive at every width, so no control is
           duplicated; `.detail-grid` collapses to one column at the same
           breakpoint (see app/globals.css). */}
-      {rail ? <aside className="space-y-3 lg:hidden">{rail}</aside> : null}
+      {rail ? <aside className="space-y-5 lg:hidden">{rail}</aside> : null}
 
       <div className={rail ? "detail-grid" : "min-w-0"}>
         <div className="min-w-0 space-y-4">
@@ -180,7 +180,7 @@ export function RecordPageShell({
           </Tabs>
         </div>
 
-        {rail ? <aside className="hidden space-y-3 lg:block">{rail}</aside> : null}
+        {rail ? <aside className="hidden space-y-5 lg:block">{rail}</aside> : null}
       </div>
 
       {children}
@@ -188,7 +188,18 @@ export function RecordPageShell({
   );
 }
 
-/** A titled block in the record page's right rail. */
+/**
+ * A titled block in the record page's rail.
+ *
+ * No frame. A record has seven or eight of these — the value, the score, what
+ * is next, the last email, what is owed — and a border around each turned the
+ * rail into a column of boxes that all shout equally, which on a phone is the
+ * first thing anybody sees. The heading already says where one section stops
+ * and the next starts; a box around it says the same thing twice, louder.
+ *
+ * Headings are small and quiet on purpose. They are signposts for the figures
+ * beneath them, and the figures are the content.
+ */
 export function RailSection({
   title,
   action,
@@ -199,9 +210,9 @@ export function RailSection({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-base font-semibold text-[var(--text-strong)]">
+    <section>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]">
           {title}
         </h3>
         {action}

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -150,6 +150,15 @@ export function RecordPageShell({
 
       {beforeTabs}
 
+      {/* Stacked, the rail goes above the tabs rather than below them.
+          It carries what somebody opened the record to find — what is next,
+          which stage, what is owed, who to ring — and underneath a timeline
+          that runs to fifty entries, nobody would ever reach it. The two
+          asides are mutually exclusive at every width, so no control is
+          duplicated; `.detail-grid` collapses to one column at the same
+          breakpoint (see app/globals.css). */}
+      {rail ? <aside className="space-y-3 lg:hidden">{rail}</aside> : null}
+
       <div className={rail ? "detail-grid" : "min-w-0"}>
         <div className="min-w-0 space-y-4">
           <Tabs value={activeTab} onValueChange={onTabChange}>
@@ -171,7 +180,7 @@ export function RecordPageShell({
           </Tabs>
         </div>
 
-        {rail ? <aside className="space-y-3">{rail}</aside> : null}
+        {rail ? <aside className="hidden space-y-3 lg:block">{rail}</aside> : null}
       </div>
 
       {children}

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { useIsBelow } from "@/hooks/use-mobile";
 import Link from "next/link";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger, Stack } from "@corelithzw/react";
@@ -15,6 +17,9 @@ import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
 import { DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
+
+/** The synthetic tab the rail becomes when there is no room beside the content. */
+const OVERVIEW_TAB = "overview";
 
 export type RecordTab = {
   value: string;
@@ -94,7 +99,44 @@ export function RecordPageShell({
    */
   attributes?: ReactNode;
 }) {
-  const visibleTabs = tabs.filter((tab) => tab.content !== null && tab.content !== undefined);
+  // Below `lg` there is no room for a rail beside the content, and stacking it
+  // above the tabs pushed the record itself under the fold — you scrolled past
+  // a summary to reach the thing you opened. So the summary becomes a tab, and
+  // it is the one you land on: the same content, in a place with a name.
+  const compact = useIsBelow(1024);
+
+  const visibleTabs = useMemo(() => {
+    const real = tabs.filter((tab) => tab.content !== null && tab.content !== undefined);
+    if (!rail || !compact) return real;
+    return [{ value: OVERVIEW_TAB, label: "Overview", content: rail }, ...real];
+  }, [tabs, rail, compact]);
+
+  // Compact, the landing tab is Overview: it is what the rail used to show
+  // before anything else, and a record that opens on its timeline makes you
+  // hunt for the summary you came for. The parent still owns which *real* tab
+  // is showing, so "add a task" jumping to Tasks works from here too.
+  const [compactTab, setCompactTab] = useState<string | null>(null);
+  // Adjusting state during render rather than in an effect: this is the
+  // sanctioned way to follow a prop, and it lands before paint instead of
+  // showing the old tab for a frame.
+  const [lastActive, setLastActive] = useState(activeTab);
+  if (activeTab !== lastActive) {
+    setLastActive(activeTab);
+    setCompactTab(activeTab);
+  }
+
+  const preferred = compact && rail ? (compactTab ?? OVERVIEW_TAB) : activeTab;
+
+  // Widening the window takes the Overview tab away with the rail. Falling back
+  // to the first real tab beats rendering a pane that no trigger points at.
+  const currentTab = visibleTabs.some((tab) => tab.value === preferred)
+    ? preferred
+    : (visibleTabs[0]?.value ?? activeTab);
+
+  const handleTabChange = (value: string) => {
+    setCompactTab(value);
+    if (value !== OVERVIEW_TAB) onTabChange(value);
+  };
 
   const barActions = useMemo(
     () => (
@@ -150,18 +192,9 @@ export function RecordPageShell({
 
       {beforeTabs}
 
-      {/* Stacked, the rail goes above the tabs rather than below them.
-          It carries what somebody opened the record to find — what is next,
-          which stage, what is owed, who to ring — and underneath a timeline
-          that runs to fifty entries, nobody would ever reach it. The two
-          asides are mutually exclusive at every width, so no control is
-          duplicated; `.detail-grid` collapses to one column at the same
-          breakpoint (see app/globals.css). */}
-      {rail ? <aside className="space-y-5 lg:hidden">{rail}</aside> : null}
-
       <div className={rail ? "detail-grid" : "min-w-0"}>
         <div className="min-w-0 space-y-4">
-          <Tabs value={activeTab} onValueChange={onTabChange}>
+          <Tabs value={currentTab} onValueChange={handleTabChange}>
             <div className="scroll-rail max-w-full">
               <TabsList>
                 {visibleTabs.map((tab) => (
@@ -173,14 +206,18 @@ export function RecordPageShell({
               </TabsList>
             </div>
             {visibleTabs.map((tab) => (
-              <TabsContent key={tab.value} value={tab.value} className="pt-4">
+              <TabsContent
+                key={tab.value}
+                value={tab.value}
+                className={tab.value === OVERVIEW_TAB ? "space-y-7 pt-5" : "pt-4"}
+              >
                 {tab.content}
               </TabsContent>
             ))}
           </Tabs>
         </div>
 
-        {rail ? <aside className="hidden space-y-5 lg:block">{rail}</aside> : null}
+        {rail ? <aside className="hidden space-y-7 lg:block">{rail}</aside> : null}
       </div>
 
       {children}
@@ -211,8 +248,11 @@ export function RailSection({
 }) {
   return (
     <section>
-      <div className="mb-1.5 flex items-center justify-between gap-2">
-        <h3 className="text-sm font-medium uppercase tracking-wide text-[var(--text-subtle)]">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        {/* Uppercase and letter-spaced rather than merely small: at this size
+            a lowercase grey heading reads as another line of body text, which
+            is what left the rail looking like one undifferentiated column. */}
+        <h3 className="text-sm font-semibold uppercase tracking-[0.06em] text-[var(--text-subtle)]">
           {title}
         </h3>
         {action}

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -59,6 +59,8 @@ export function RecordPageShell({
   onTabChange,
   rail,
   attributes,
+  beforeTabs,
+  children,
 }: {
   backHref: string;
   backLabel: string;
@@ -76,6 +78,15 @@ export function RecordPageShell({
   activeTab: string;
   onTabChange: (value: string) => void;
   rail?: ReactNode;
+  /**
+   * A record-specific band between the properties and the tabs. A lead's
+   * stage stepper lives here: its stages are a fixed enum you click along,
+   * which is neither a property nor a tab.
+   */
+  beforeTabs?: ReactNode;
+  /** Sheets and dialogs the page owns — mounted outside the tab content so
+   *  they survive a tab change. */
+  children?: ReactNode;
   /**
    * The record's properties, shown above the tabs. Notion-style, because a
    * property in a right rail is one a phone never shows and a reader looks at
@@ -137,6 +148,8 @@ export function RecordPageShell({
         <div className="border-y border-[var(--border-subtle)] py-3">{attributes}</div>
       ) : null}
 
+      {beforeTabs}
+
       <div className={rail ? "detail-grid" : "min-w-0"}>
         <div className="min-w-0 space-y-4">
           <Tabs value={activeTab} onValueChange={onTabChange}>
@@ -160,6 +173,8 @@ export function RecordPageShell({
 
         {rail ? <aside className="space-y-3">{rail}</aside> : null}
       </div>
+
+      {children}
     </div>
   );
 }

--- a/components/crm/records/record-page-shell.tsx
+++ b/components/crm/records/record-page-shell.tsx
@@ -192,7 +192,7 @@ export function RailSection({
   return (
     <section className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+        <h3 className="text-base font-semibold text-[var(--text-strong)]">
           {title}
         </h3>
         {action}

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -200,7 +200,7 @@ export function AttachmentsPanel({
               </span>
 
               <Download
-                className="size-4 shrink-0 text-[var(--text-subtle)] opacity-0 group-hover:opacity-100"
+                className="size-4 shrink-0 text-[var(--text-subtle)] opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100"
                 aria-hidden="true"
               />
             </a>

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { Badge, Chip, Stack } from "@corelithzw/react";
+import { Badge, Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
 import { ClientDate } from "@/components/ui/client-date";
 import { EntityLink } from "@/components/crm/records/entity-link";
@@ -124,20 +124,26 @@ export function ActivityStrip({ counts }: { counts: ActivityCount[] }) {
     return <p className="text-sm text-[var(--text-muted)]">Nothing logged yet.</p>;
   }
 
+  // Figures, not chips. A chip draws a bordered box around each number, so
+  // four kinds of contact became four boxes inside a fifth — five frames to
+  // say "three calls". The numbers are the content; they only need to be
+  // bigger than their labels to read as figures.
   return (
-    <ul className="flex flex-wrap gap-1.5">
+    <dl className="flex flex-wrap gap-x-5 gap-y-1">
       {counts
         .filter((entry) => entry.count > 0)
         .map((entry) => (
-          <li key={entry.label}>
-            <Chip asChild accent="gray" leading={entry.icon}>
-              <span>
-                <span className="font-mono">{entry.count}</span> {entry.label}
-              </span>
-            </Chip>
-          </li>
+          <div key={entry.label} className="flex items-baseline gap-1.5">
+            <dt className="sr-only">{entry.label}</dt>
+            <dd className="font-mono text-base tabular-nums text-[var(--text-strong)]">
+              {entry.count}
+            </dd>
+            <span aria-hidden="true" className="text-sm text-[var(--text-muted)]">
+              {entry.label}
+            </span>
+          </div>
         ))}
-    </ul>
+    </dl>
   );
 }
 
@@ -243,7 +249,7 @@ export function NextInteractionCard({
 }) {
   if (!interaction) {
     return (
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>
         {action}
       </div>
@@ -252,17 +258,12 @@ export function NextInteractionCard({
 
   const countdown = timeToStart(interaction.at);
 
+  // Two lines and one coloured word. The badge that used to sit up here made
+  // "in 3 days" as loud as "overdue", so lateness — the only thing on this
+  // panel worth a colour — had to compete with the ordinary case for it. Now
+  // the timing is plain text until it is late, and then it is red.
   return (
-    <div className="space-y-2">
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="text-sm text-[var(--text-muted)]">
-          {INTERACTION_LABEL[interaction.kind]}
-        </span>
-        <Badge tone={countdown.past ? "danger" : countdown.imminent ? "warn" : "neutral"}>
-          {countdown.past ? `Overdue ${countdown.label}` : countdown.label}
-        </Badge>
-      </div>
-
+    <div className="space-y-1">
       {interaction.href ? (
         <EntityLink href={interaction.href}>{interaction.title}</EntityLink>
       ) : (
@@ -270,7 +271,16 @@ export function NextInteractionCard({
       )}
 
       <p className="text-sm text-[var(--text-muted)]">
-        <ClientDate value={interaction.at} mode="datetime" />
+        <span
+          className={cn(
+            countdown.past && "font-medium text-[var(--status-error-text)]",
+            countdown.imminent && !countdown.past && "font-medium text-[var(--text-strong)]",
+          )}
+        >
+          {countdown.past ? `Overdue ${countdown.label}` : countdown.label}
+        </span>
+        {" · "}
+        {INTERACTION_LABEL[interaction.kind]}
         {interaction.assigneeName ? ` · ${interaction.assigneeName}` : ""}
       </p>
 

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Badge, Chip, Stack } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
+import { ClientDate } from "@/components/ui/client-date";
+import { EntityLink } from "@/components/crm/records/entity-link";
+import { richTextToPlain } from "@/lib/crm/rich-text";
+import { fileMark, formatFileSize, meetingPlace, timeToStart } from "@/lib/crm/panels";
+import {
+  CalendarCheck,
+  Download,
+  Mail,
+  MapPin,
+  Phone,
+  Video,
+} from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * The compact panels that sit beside a record.
+ *
+ * The rail was a stack of headings with a sentence under each: a date as a
+ * date, an address as a string, a file as a filename. All correct, all inert.
+ * Somebody looking at "14 March 2026, 09:00" still has to work out whether
+ * that is today, and somebody looking at eleven filenames still has to read
+ * eleven filenames to find the PDF.
+ *
+ * So each panel does the small piece of work the reader was doing: how long
+ * until it, where exactly, which one is the photo. The primitives are the
+ * house ones — this is composition, not a second design system.
+ */
+
+export type PanelMeeting = {
+  id: string;
+  title: string;
+  scheduledStart: string;
+  location?: string | null;
+  attendeeName?: string | null;
+};
+
+/**
+ * The next meeting, and what to press when it starts.
+ *
+ * The countdown is the point. A start time answers "when is it" and leaves
+ * "should I be doing something about it right now" to the reader and their
+ * own watch, which is the question they actually opened the page with.
+ */
+export function MeetingCard({
+  meeting,
+  action,
+}: {
+  meeting: PanelMeeting;
+  action?: ReactNode;
+}) {
+  const countdown = timeToStart(meeting.scheduledStart);
+  const place = meetingPlace(meeting.location);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="min-w-0 truncate text-sm font-medium text-[var(--text-strong)]">
+          {meeting.title}
+        </p>
+        <Badge tone={countdown.imminent ? "warn" : countdown.past ? "neutral" : "info"}>
+          {countdown.label}
+        </Badge>
+      </div>
+
+      <p className="flex items-center gap-1.5 text-sm text-[var(--text-muted)]">
+        <CalendarCheck className="size-4 shrink-0" aria-hidden="true" />
+        <ClientDate value={meeting.scheduledStart} mode="datetime" />
+      </p>
+
+      {place.kind === "map" ? (
+        <p className="flex items-start gap-1.5 text-sm text-[var(--text-muted)]">
+          <MapPin className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+          <span className="min-w-0">{place.text}</span>
+        </p>
+      ) : null}
+
+      {meeting.attendeeName ? (
+        <p className="text-sm text-[var(--text-muted)]">{meeting.attendeeName} is going</p>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        {place.kind === "join" ? (
+          <Button asChild size="sm" variant={countdown.imminent ? "primary" : "secondary"}>
+            <a href={place.url} target="_blank" rel="noreferrer">
+              <Video className="size-4" />
+              Join
+            </a>
+          </Button>
+        ) : null}
+        {place.kind === "map" ? (
+          <Button asChild size="sm" variant="secondary">
+            <a href={place.url} target="_blank" rel="noreferrer">
+              <MapPin className="size-4" />
+              Directions
+            </a>
+          </Button>
+        ) : null}
+        {action}
+      </div>
+    </div>
+  );
+}
+
+export type ActivityCount = { label: string; count: number; icon?: ReactNode };
+
+/**
+ * How much has been going on, at a glance.
+ *
+ * A strip rather than a chart: the question is "has anybody spoken to these
+ * people" and the answer is a handful of small numbers, which a chart would
+ * spend two hundred pixels failing to say more clearly.
+ */
+export function ActivityStrip({ counts }: { counts: ActivityCount[] }) {
+  const total = counts.reduce((sum, entry) => sum + entry.count, 0);
+
+  if (total === 0) {
+    return <p className="text-sm text-[var(--text-muted)]">Nothing logged yet.</p>;
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-1.5">
+      {counts
+        .filter((entry) => entry.count > 0)
+        .map((entry) => (
+          <li key={entry.label}>
+            <Chip asChild accent="gray" leading={entry.icon}>
+              <span>
+                <span className="font-mono">{entry.count}</span> {entry.label}
+              </span>
+            </Chip>
+          </li>
+        ))}
+    </ul>
+  );
+}
+
+export type PanelAttachment = {
+  id: string;
+  name: string;
+  url: string;
+  size?: number | null;
+  uploadedAt?: string | null;
+};
+
+/**
+ * Files, scannable by type.
+ *
+ * The coloured mark is doing real work: a rail of eleven attachments is
+ * searched for "the PDF" or "the photo", and colour answers that without
+ * reading a single filename.
+ */
+export function AttachmentsPanel({
+  attachments,
+  emptyMessage = "Nothing attached yet.",
+}: {
+  attachments: PanelAttachment[];
+  emptyMessage?: string;
+}) {
+  if (attachments.length === 0) {
+    return <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>;
+  }
+
+  return (
+    <Stack as="ul" gap="xs">
+      {attachments.map((attachment) => {
+        const mark = fileMark(attachment.name);
+        const size = formatFileSize(attachment.size);
+        return (
+          <li key={attachment.id}>
+            <a
+              href={attachment.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group flex items-center gap-2.5 rounded-[var(--radius-sm)] py-1 hover:bg-[var(--surface-hover)]"
+            >
+              <span
+                data-accent={mark.accent}
+                aria-hidden="true"
+                className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--accent-bg)] font-mono text-sm font-medium text-[var(--accent-fg)]"
+              >
+                {mark.label}
+              </span>
+
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm text-[var(--text-strong)]">
+                  {attachment.name}
+                </span>
+                <span className="block text-sm text-[var(--text-muted)]">
+                  {size}
+                  {size && attachment.uploadedAt ? " · " : ""}
+                  {attachment.uploadedAt ? <ClientDate value={attachment.uploadedAt} /> : null}
+                </span>
+              </span>
+
+              <Download
+                className="size-4 shrink-0 text-[var(--text-subtle)] opacity-0 group-hover:opacity-100"
+                aria-hidden="true"
+              />
+            </a>
+          </li>
+        );
+      })}
+    </Stack>
+  );
+}
+
+export type NextInteraction = {
+  kind: "task" | "visit" | "follow-up";
+  title: string;
+  at: string;
+  href?: string;
+  assigneeName?: string | null;
+};
+
+const INTERACTION_LABEL: Record<NextInteraction["kind"], string> = {
+  task: "Task",
+  visit: "Site visit",
+  "follow-up": "Follow-up",
+};
+
+/**
+ * The next thing due, whatever kind of thing it is.
+ *
+ * One card rather than three, because "what is next on this" does not care
+ * whether the answer is a task, a visit or a follow-up — and three panels each
+ * showing its own next item makes the reader do the comparison.
+ */
+export function NextInteractionCard({
+  interaction,
+  emptyMessage = "Nothing scheduled.",
+  action,
+}: {
+  interaction: NextInteraction | null;
+  emptyMessage?: string;
+  action?: ReactNode;
+}) {
+  if (!interaction) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>
+        {action}
+      </div>
+    );
+  }
+
+  const countdown = timeToStart(interaction.at);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm text-[var(--text-muted)]">
+          {INTERACTION_LABEL[interaction.kind]}
+        </span>
+        <Badge tone={countdown.past ? "danger" : countdown.imminent ? "warn" : "neutral"}>
+          {countdown.past ? `Overdue ${countdown.label}` : countdown.label}
+        </Badge>
+      </div>
+
+      {interaction.href ? (
+        <EntityLink href={interaction.href}>{interaction.title}</EntityLink>
+      ) : (
+        <p className="text-sm font-medium text-[var(--text-strong)]">{interaction.title}</p>
+      )}
+
+      <p className="text-sm text-[var(--text-muted)]">
+        <ClientDate value={interaction.at} mode="datetime" />
+        {interaction.assigneeName ? ` · ${interaction.assigneeName}` : ""}
+      </p>
+
+      {action}
+    </div>
+  );
+}
+
+export type PanelMessage = {
+  id: string;
+  subject: string | null;
+  body: string | null;
+  at: string;
+  actorName?: string | null;
+};
+
+/**
+ * The last email, enough of it to know whether to open it.
+ *
+ * Two lines of the body rather than none: a subject alone is how somebody
+ * clicks through to discover it was the automatic one.
+ */
+export function EmailPreview({
+  message,
+  href,
+  emptyMessage = "No email logged yet.",
+}: {
+  message: PanelMessage | null;
+  href?: string;
+  emptyMessage?: string;
+}) {
+  if (!message) {
+    return <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>;
+  }
+
+  const snippet = richTextToPlain(message.body ?? "", 160);
+
+  const inner = (
+    <>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <Mail className="size-4 shrink-0 text-[var(--text-subtle)]" aria-hidden="true" />
+          <span className="truncate text-sm font-medium text-[var(--text-strong)]">
+            {message.subject?.trim() || "No subject"}
+          </span>
+        </span>
+        <span className="shrink-0 text-sm text-[var(--text-muted)]">
+          <ClientDate value={message.at} />
+        </span>
+      </div>
+      {snippet ? (
+        <p className="mt-1 line-clamp-2 text-sm text-[var(--text-muted)]">{snippet}</p>
+      ) : null}
+      {message.actorName ? (
+        <p className="mt-1 text-sm text-[var(--text-subtle)]">{message.actorName}</p>
+      ) : null}
+    </>
+  );
+
+  return href ? (
+    <Link href={href} className="block rounded-[var(--radius-sm)] hover:bg-[var(--surface-hover)]">
+      {inner}
+    </Link>
+  ) : (
+    <div>{inner}</div>
+  );
+}
+
+export type PanelCall = {
+  id: string;
+  at: string;
+  actorName?: string | null;
+  summary?: string | null;
+  /** Somebody rang and nobody answered — worth showing differently. */
+  missed?: boolean;
+};
+
+/**
+ * Who has rung, and when.
+ *
+ * Separated from the timeline because "when did we last actually speak to
+ * them" is the question that decides whether to ring now, and answering it
+ * from a mixed feed means scrolling past every note and stage change.
+ */
+export function CallList({
+  calls,
+  emptyMessage = "Nobody has logged a call.",
+}: {
+  calls: PanelCall[];
+  emptyMessage?: string;
+}) {
+  if (calls.length === 0) {
+    return <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>;
+  }
+
+  return (
+    <Stack as="ul" gap="xs">
+      {calls.map((call) => (
+        <li key={call.id} className="flex items-start gap-2">
+          <Phone
+            className={cn(
+              "mt-0.5 size-4 shrink-0",
+              call.missed ? "text-[var(--status-error-text)]" : "text-[var(--text-subtle)]",
+            )}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1">
+            <span className="flex items-baseline justify-between gap-2">
+              <span className="truncate text-sm text-[var(--text-strong)]">
+                {call.actorName ?? "Someone"}
+                {call.missed ? " · no answer" : ""}
+              </span>
+              <span className="shrink-0 text-sm text-[var(--text-muted)]">
+                <ClientDate value={call.at} />
+              </span>
+            </span>
+            {call.summary ? (
+              <span className="block truncate text-sm text-[var(--text-muted)]">
+                {richTextToPlain(call.summary, 120)}
+              </span>
+            ) : null}
+          </span>
+        </li>
+      ))}
+    </Stack>
+  );
+}

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -6,6 +6,7 @@ import { CommentThread } from "@/components/crm/collaboration/comment-thread";
 import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-detail/activity-composer";
 import { RecordStory, type StoryEvent } from "./record-story";
+import { MentionsTab } from "./mentions-tab";
 import type { CollabEntity } from "@/lib/crm/collaboration";
 import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
 
@@ -126,6 +127,19 @@ export function commentsTab({
         currentUserId={currentUserId}
       />
     ),
+  };
+}
+
+/**
+ * Where this record has been written about elsewhere. Every kind gets it,
+ * because a reference to a site in a note on a deal is exactly the connection
+ * that was invisible before.
+ */
+export function mentionsTab({ ref }: { ref: RecordRef }): RecordTab {
+  return {
+    value: "mentions",
+    label: "Mentions",
+    content: <MentionsTab recordId={ref.id} />,
   };
 }
 

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -7,6 +7,7 @@ import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-detail/activity-composer";
 import { RecordStory, type StoryEvent } from "./record-story";
 import { MentionsTab } from "./mentions-tab";
+import { AutomationTab } from "./automation-tab";
 import type { CollabEntity } from "@/lib/crm/collaboration";
 import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
 
@@ -140,6 +141,31 @@ export function mentionsTab({ ref }: { ref: RecordRef }): RecordTab {
     value: "mentions",
     label: "Mentions",
     content: <MentionsTab recordId={ref.id} />,
+  };
+}
+
+/** The automation layer's name for the same record. */
+const AUTOMATION_ENTITY: Record<RecordKind, "LEAD" | "DEAL" | "PERSON" | "COMPANY" | "SITE"> = {
+  lead: "LEAD",
+  deal: "DEAL",
+  company: "COMPANY",
+  person: "PERSON",
+  site: "SITE",
+};
+
+/**
+ * What the workflows have done here, and what could still fire.
+ *
+ * On every kind rather than only the two that triggers currently reach: a
+ * company page saying "nothing is watching this record" is a useful answer,
+ * and a tab that appears and disappears depending on the record type is a tab
+ * people stop looking for.
+ */
+export function automationTab({ ref }: { ref: RecordRef }): RecordTab {
+  return {
+    value: "automation",
+    label: "Workflows",
+    content: <AutomationTab entity={AUTOMATION_ENTITY[ref.kind]} recordId={ref.id} />,
   };
 }
 

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { CommentThread } from "@/components/crm/collaboration/comment-thread";
+import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
+import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-detail/activity-composer";
+import { RecordStory, type StoryEvent } from "./record-story";
+import type { CollabEntity } from "@/lib/crm/collaboration";
+import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
+
+import type { RecordTab } from "./record-page-shell";
+
+/**
+ * The tabs every record has, written once.
+ *
+ * A record was implemented five times — lead, deal, company, person, site —
+ * each composing its own timeline, its own comments, its own tasks. So a fix
+ * to "the record page" landed on one of five and the report came back saying
+ * it was not there, correctly. Three rounds went that way.
+ *
+ * These build the tab from a `RecordRef`, so a change to what a timeline
+ * shows is a change to one function and appears on all five.
+ */
+
+export type RecordKind = "lead" | "deal" | "company" | "person" | "site";
+
+export type RecordRef = { kind: RecordKind; id: string };
+
+/** The collaboration layer's name for the same record. */
+const COLLAB: Record<RecordKind, CollabEntity> = {
+  lead: "LEAD",
+  deal: "DEAL",
+  company: "COMPANY",
+  person: "PERSON",
+  site: "SITE",
+};
+
+/** The task layer's name for the same record. */
+export function taskRef(ref: RecordRef): CrmTaskRecordRef {
+  switch (ref.kind) {
+    case "lead":
+      return { leadId: ref.id };
+    case "deal":
+      return { dealId: ref.id };
+    case "company":
+      return { clientId: ref.id };
+    case "person":
+      return { personId: ref.id };
+    case "site":
+      return { siteId: ref.id };
+  }
+}
+
+/**
+ * Which records somebody can write an activity against. A site is a place,
+ * not a correspondent — what happened there is logged on the visit or the
+ * deal, so its timeline reads without a composer rather than offering one
+ * that posts nowhere.
+ */
+function activityTarget(ref: RecordRef): ActivityTarget | null {
+  switch (ref.kind) {
+    case "lead":
+      return { kind: "lead", id: ref.id };
+    case "deal":
+      return { kind: "deal", id: ref.id };
+    case "person":
+      return { kind: "person", id: ref.id };
+    case "company":
+      return { kind: "company", id: ref.id };
+    case "site":
+      return null;
+  }
+}
+
+export function timelineTab({
+  ref,
+  events,
+  emptyMessage,
+}: {
+  ref: RecordRef;
+  events: StoryEvent[];
+  emptyMessage?: string;
+}): RecordTab {
+  const target = activityTarget(ref);
+  return {
+    value: "timeline",
+    label: "Timeline",
+    content: (
+      <div className="space-y-4">
+        {target ? <ActivityComposer target={target} /> : null}
+        <RecordStory events={events} emptyMessage={emptyMessage} />
+      </div>
+    ),
+  };
+}
+
+export function tasksTab({
+  ref,
+  currentUserId,
+}: {
+  ref: RecordRef;
+  currentUserId?: string;
+}): RecordTab {
+  return {
+    value: "tasks",
+    label: "Tasks",
+    content: <RecordTasksTab record={taskRef(ref)} currentUserId={currentUserId} />,
+  };
+}
+
+export function commentsTab({
+  ref,
+  currentUserId,
+}: {
+  ref: RecordRef;
+  currentUserId?: string;
+}): RecordTab {
+  return {
+    value: "comments",
+    label: "Comments",
+    content: (
+      <CommentThread
+        entity={COLLAB[ref.kind]}
+        recordId={ref.id}
+        currentUserId={currentUserId}
+      />
+    ),
+  };
+}
+
+/** A tab a single record type adds to the shared set. */
+export function extraTab(tab: {
+  value: string;
+  label: string;
+  count?: number;
+  content: ReactNode;
+}): RecordTab {
+  return tab;
+}

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -8,6 +8,8 @@ import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-det
 import { RecordStory, type StoryEvent } from "./record-story";
 import { MentionsTab } from "./mentions-tab";
 import { AutomationTab } from "./automation-tab";
+import { FilesTab } from "./files-tab";
+import type { FileOwnerKind } from "@/lib/crm/record-files";
 import type { CollabEntity } from "@/lib/crm/collaboration";
 import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
 
@@ -168,6 +170,31 @@ export function automationTab({ ref }: { ref: RecordRef }): RecordTab {
     content: <AutomationTab entity={AUTOMATION_ENTITY[ref.kind]} recordId={ref.id} />,
   };
 }
+
+/**
+ * Files that arrived from outside, on every kind.
+ *
+ * Separate from Documents, which is what the system raised and numbered. A
+ * signed contract and a quotation are both "a document" to a reader, but only
+ * one of them has a total and a status, and mixing them makes the register
+ * useless for either question.
+ */
+export function filesTab({ ref }: { ref: RecordRef }): RecordTab {
+  return {
+    value: "files",
+    label: "Files",
+    content: <FilesTab owner={FILE_OWNER[ref.kind]} ownerId={ref.id} />,
+  };
+}
+
+/** The file layer's name for the same record. */
+const FILE_OWNER: Record<RecordKind, FileOwnerKind> = {
+  lead: "lead",
+  deal: "deal",
+  company: "company",
+  person: "person",
+  site: "site",
+};
 
 /** A tab a single record type adds to the shared set. */
 export function extraTab(tab: {

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -15,6 +15,7 @@ import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
 
+import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
 import { commentsTab, tasksTab } from "./record-tabs";
@@ -212,6 +213,12 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               value: site.accessInstructions,
               placeholder: "No instructions",
             },
+            ...customFieldAttributes({
+              definitions,
+              values: site.customFields,
+              onCommit: (key, value) =>
+                edit.save.mutate({ customFields: { [key]: value } }),
+            }),
           ]}
         />
       }

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -18,7 +18,7 @@ import { formatMoney } from "@/components/crm/documents/document-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
@@ -281,6 +281,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
         tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "site", id: siteId } }),
+        automationTab({ ref: { kind: "site", id: siteId } }),
         {
           // Sites carry no activity trail of their own, so there is nothing to
           // filter history out of — the tab stays for consistency.

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -23,9 +23,9 @@ import { RecordAttributes } from "./record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
 import { EntityLink } from "./entity-link";
+import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 import { RailSection, RecordPageShell, RelatedList } from "./record-page-shell";
 import { SiteFormSheet } from "./site-form-sheet";
-import { RecordHistoryTab } from "./record-history-tab";
 
 import { Stack } from "@corelithzw/react";
 
@@ -284,11 +284,14 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
         filesTab({ ref: { kind: "site", id: siteId } }),
         automationTab({ ref: { kind: "site", id: siteId } }),
         {
-          // Sites carry no activity trail of their own, so there is nothing to
-          // filter history out of — the tab stays for consistency.
-          value: "history",
-          label: "History",
-          content: <RecordHistoryTab activities={[]} />,
+          // Was a History tab rendering an empty array, permanently: a site
+          // has no activity foreign key, so nothing could ever appear in it.
+          // A tab kept "for consistency" that can never answer its own
+          // question is worse than one that is absent. Field history is the
+          // history a site genuinely has — its edits are recorded.
+          value: "changes",
+          label: "Field history",
+          content: <FieldHistoryTab entity="SITE" recordId={siteId} />,
         },
       ]}
       rail={

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -18,7 +18,7 @@ import { formatMoney } from "@/components/crm/documents/document-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { commentsTab, tasksTab } from "./record-tabs";
+import { commentsTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
@@ -280,6 +280,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
         },
         tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
+        mentionsTab({ ref: { kind: "site", id: siteId } }),
         {
           // Sites carry no activity trail of their own, so there is nothing to
           // filter history out of — the tab stays for consistency.

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -18,7 +18,7 @@ import { formatMoney } from "@/components/crm/documents/document-types";
 import { customFieldAttributes } from "./custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
-import { automationTab, commentsTab, mentionsTab, tasksTab } from "./record-tabs";
+import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
@@ -281,6 +281,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
         tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         mentionsTab({ ref: { kind: "site", id: siteId } }),
+        filesTab({ ref: { kind: "site", id: siteId } }),
         automationTab({ ref: { kind: "site", id: siteId } }),
         {
           // Sites carry no activity trail of their own, so there is nothing to

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -14,11 +14,10 @@ import { Building2, MapPin, UserRound } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
-import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "./record-mark";
+import { commentsTab, tasksTab } from "./record-tabs";
 import { RecordAttributes } from "./record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "./use-attribute-editor";
@@ -272,18 +271,8 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
             />
           ),
         },
-        {
-          value: "tasks",
-          label: "Tasks",
-          content: <RecordTasksTab record={{ siteId }} currentUserId={session?.user?.id} />,
-        },
-        {
-          value: "comments",
-          label: "Comments",
-          content: (
-            <CommentThread entity="SITE" recordId={siteId} currentUserId={session?.user?.id} />
-          ),
-        },
+        tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
+        commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         {
           // Sites carry no activity trail of their own, so there is nothing to
           // filter history out of — the tab stays for consistency.

--- a/components/crm/records/tone-select.tsx
+++ b/components/crm/records/tone-select.tsx
@@ -92,14 +92,20 @@ export function ToneSelect({
         <Button
           variant="outline"
           size="sm"
-          className={cn("h-9 min-w-0 justify-between gap-2", className)}
+          // `min-w-0` let the toolbar shrink this below its own content, which
+          // wrapped the caret onto a second line and made the button taller
+          // than every other trigger in the row. It holds its width instead.
+          className={cn(
+            "h-9 shrink-0 flex-nowrap justify-between gap-2 whitespace-nowrap",
+            className,
+          )}
           aria-label={label}
         >
           <span className="flex min-w-0 items-center gap-2">
             {/* A multi-select trigger says WHICH question it answers, and
                 shows the choice as dots. Spelling out every chosen stage
                 turns a 9-item pick into a sentence that wraps the button. */}
-            <span className="truncate">
+            <span className="whitespace-nowrap">
               {multiple ? (label ?? placeholder) : (chosen[0]?.label ?? placeholder)}
             </span>
             {multiple && chosen.length > 0 ? (

--- a/components/crm/records/tone-select.tsx
+++ b/components/crm/records/tone-select.tsx
@@ -91,14 +91,12 @@ export function ToneSelect({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          size="sm"
-          // `min-w-0` let the toolbar shrink this below its own content, which
-          // wrapped the caret onto a second line and made the button taller
-          // than every other trigger in the row. It holds its width instead.
-          className={cn(
-            "h-9 shrink-0 flex-nowrap justify-between gap-2 whitespace-nowrap",
-            className,
-          )}
+          // `shrink-0` because the toolbar would otherwise squeeze this below
+          // its own content. The height and the gap come from the button, not
+          // from here: this used to carry `size="sm" h-9`, which is asking for
+          // a 30px control and then forcing 36px back onto it — the habit that
+          // left three different heights in one row.
+          className={cn("shrink-0 justify-between whitespace-nowrap", className)}
           aria-label={label}
         >
           <span className="flex min-w-0 items-center gap-2">

--- a/components/crm/records/use-attribute-editor.ts
+++ b/components/crm/records/use-attribute-editor.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useToast } from "@/components/ui/use-toast";
@@ -96,5 +97,21 @@ export function useAttributeEditor({
     },
   });
 
-  return { save, text, required, numeric };
+  /**
+   * A field whose value has to be one of a known set — an owner, a status, a
+   * stage. Empty means null: "unassigned" is a real answer, not a blank.
+   */
+  const choice = (
+    field: string,
+    value: string | null | undefined,
+    options: Array<{ value: string; label: string; leading?: ReactNode }>,
+    clearLabel?: string,
+  ) => ({
+    value: value ?? null,
+    options,
+    clearLabel,
+    onCommit: (next: string) => save.mutate({ [field]: next === "" ? null : next }),
+  });
+
+  return { save, text, required, numeric, choice };
 }

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -47,7 +47,11 @@ export function ViewToolbar({
       )}
     >
       {start}
-      <span className="min-w-2 flex-1" aria-hidden="true" />
+      {/* The spacer pushes search and display controls to the right of a
+          single row. Once the row wraps — which it always does on a phone —
+          a flex-1 spacer becomes a whole blank line between the filters and
+          the search, so it only exists at widths where the row fits. */}
+      <span className="hidden min-w-2 flex-1 sm:block" aria-hidden="true" />
       {search}
       {end}
     </div>

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -88,7 +88,10 @@ export function ViewToolbar({
                 the only way a nine-option filter reads on a phone. Labels go
                 to the left edge: a button centres its label, which is right
                 for a button you press and wrong for a row you read down. */}
-            <div className="flex flex-col items-stretch gap-2 [&>*]:w-full [&_.btn]:w-full [&_.btn]:justify-start">
+            {/* `w-full` on each control is what tells the button it is a row:
+                the left-aligned label and far-right caret come from that, in
+                globals.css, rather than from a rule written here. */}
+            <div className="flex flex-col items-stretch gap-2 [&>*]:w-full [&_.btn]:w-full">
               {start}
               {end}
             </div>

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { SlidersHorizontal } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 /**
@@ -20,6 +29,12 @@ import { cn } from "@/lib/utils";
  * whole point of it. Anything that only makes sense in one layout (a sort
  * button on a board, say) disappears from its slot rather than reshaping the
  * row.
+ *
+ * On a phone the row is not a row. Six controls at 36px wrap onto three
+ * lines and push the records themselves below the fold, and the reader has to
+ * read six labels before they can look at anything. So below `sm` the whole
+ * lot goes behind one button, and what stays on screen is what somebody came
+ * for: the search box, and the records under it.
  */
 export function ViewToolbar({
   start,
@@ -35,6 +50,9 @@ export function ViewToolbar({
   end?: ReactNode;
   className?: string;
 }) {
+  const [open, setOpen] = useState(false);
+  const hasControls = Boolean(start || end);
+
   return (
     <div
       className={cn(
@@ -46,14 +64,51 @@ export function ViewToolbar({
         className,
       )}
     >
-      {start}
+      {/* Phone: one button for every control, and the search beside it. */}
+      {hasControls ? (
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" className="sm:hidden" aria-label="View and filters">
+              <SlidersHorizontal className="size-4" aria-hidden="true" />
+              View
+            </Button>
+          </SheetTrigger>
+          {/* A sheet rather than a dropdown menu: these controls are
+              themselves popovers and selects, and a menu that closes the
+              moment one of them opens is a menu you cannot use. Bottom-
+              anchored, which is where a thumb is. */}
+          {/* `SheetContent` ships with no padding — call sites bring their
+              own — so without this the title sits against the left edge of
+              the screen and the controls run edge to edge. */}
+          <SheetContent side="bottom" size="md" className="p-4 sm:hidden">
+            <SheetHeader className="pb-3 text-left">
+              <SheetTitle>View and filters</SheetTitle>
+            </SheetHeader>
+            {/* Stacked and full width — each control gets a line, which is
+                the only way a nine-option filter reads on a phone. Labels go
+                to the left edge: a button centres its label, which is right
+                for a button you press and wrong for a row you read down. */}
+            <div className="flex flex-col items-stretch gap-2 [&>*]:w-full [&_.btn]:w-full [&_.btn]:justify-start">
+              {start}
+              {end}
+            </div>
+          </SheetContent>
+        </Sheet>
+      ) : null}
+
+      <div className="hidden flex-wrap items-center gap-2 sm:flex">{start}</div>
+
       {/* The spacer pushes search and display controls to the right of a
           single row. Once the row wraps — which it always does on a phone —
           a flex-1 spacer becomes a whole blank line between the filters and
           the search, so it only exists at widths where the row fits. */}
       <span className="hidden min-w-2 flex-1 sm:block" aria-hidden="true" />
-      {search}
-      {end}
+
+      {/* Search stays out of the sheet: it is how you find one record, which
+          is the most common reason to touch this row at all. */}
+      <div className="min-w-0 flex-1 sm:flex-none">{search}</div>
+
+      <div className="hidden flex-wrap items-center gap-2 sm:flex">{end}</div>
     </div>
   );
 }

--- a/components/crm/reports/report-card.tsx
+++ b/components/crm/reports/report-card.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { Card, Chip } from "@corelithzw/react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { IconButton } from "@/components/ui/icon-button";
+import { useToast } from "@/components/ui/use-toast";
+import { Building2, CopyLink, DotsThree, Funnel, History, RotateCcw, Users } from "@/lib/icons";
+import type { Accent } from "@corelithzw/react";
+
+/**
+ * One report, in its frame.
+ *
+ * Every card says which records it is counting, because "win rate" means one
+ * thing over deals and another over leads, and a reader who has to guess will
+ * eventually guess wrong in a meeting.
+ *
+ * Refresh sits on the card rather than only in the header: somebody staring at
+ * one number wants that number re-fetched, and hunting for a page-level button
+ * to do it is the kind of small friction that ends in a hard reload.
+ */
+
+export type ReportEntity = "deal" | "lead" | "person" | "company" | "activity";
+
+/** The same icons the sidebar uses, so a chip reads as the nav entry it names. */
+const ENTITY: Record<ReportEntity, { label: string; accent: Accent; icon: typeof Funnel }> = {
+  deal: { label: "Deals", accent: "violet", icon: Funnel },
+  lead: { label: "Leads", accent: "blue", icon: Funnel },
+  person: { label: "People", accent: "teal", icon: Users },
+  company: { label: "Companies", accent: "amber", icon: Building2 },
+  activity: { label: "Activity", accent: "green", icon: History },
+};
+
+export function EntityChip({ entity }: { entity: ReportEntity }) {
+  const { label, accent, icon: Icon } = ENTITY[entity];
+  return (
+    // A span, not the chip's default button: it says where the figures came
+    // from, it does not filter. Something that looks pressable and isn't is
+    // worse than a plain label.
+    <Chip asChild accent={accent} leading={<Icon className="size-3.5" aria-hidden="true" />}>
+      <span>{label}</span>
+    </Chip>
+  );
+}
+
+export function ReportCard({
+  title,
+  subtitle,
+  entity,
+  onRefresh,
+  refreshing,
+  /** Rows to copy when somebody wants these figures in a spreadsheet. */
+  copyRows,
+  onRemove,
+  children,
+}: {
+  title: string;
+  subtitle?: ReactNode;
+  entity: ReportEntity;
+  onRefresh: () => void;
+  refreshing?: boolean;
+  copyRows?: () => string[][];
+  onRemove?: () => void;
+  children: ReactNode;
+}) {
+  const { toast } = useToast();
+
+  const copy = async () => {
+    if (!copyRows) return;
+    const text = copyRows()
+      .map((row) => row.join("\t"))
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      toast({ title: "Copied", description: "Paste straight into a spreadsheet." });
+    } catch {
+      toast({
+        title: "Couldn't copy",
+        description: "The browser refused clipboard access.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Card
+      title={
+        <span className="flex flex-wrap items-center gap-2">
+          <span className="text-base font-semibold text-[var(--text-strong)]">{title}</span>
+          <EntityChip entity={entity} />
+        </span>
+      }
+      subtitle={subtitle}
+      actions={
+        <div className="flex items-center gap-1">
+          <IconButton
+            size="sm"
+            aria-label={`Refresh ${title}`}
+            onClick={onRefresh}
+            disabled={refreshing}
+          >
+            <RotateCcw className={refreshing ? "animate-spin" : undefined} />
+          </IconButton>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton size="sm" aria-label={`${title} options`}>
+                <DotsThree />
+              </IconButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {copyRows ? (
+                <DropdownMenuItem onClick={copy}>
+                  <CopyLink className="size-4" />
+                  Copy figures
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuItem onClick={onRefresh}>
+                <RotateCcw className="size-4" />
+                Refresh
+              </DropdownMenuItem>
+              {onRemove ? (
+                <DropdownMenuItem
+                  className="text-[var(--status-error-text)]"
+                  onClick={onRemove}
+                >
+                  Remove from this page
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      }
+    >
+      {children}
+    </Card>
+  );
+}

--- a/components/crm/reports/report-charts.tsx
+++ b/components/crm/reports/report-charts.tsx
@@ -197,6 +197,10 @@ export function TrendChart({
               key={index}
               className="h-full flex-1"
               onMouseEnter={() => setHovered(index)}
+              // A finger never hovers, so on touch the chart's values were
+              // simply unreadable. `onPointerDown` covers both — a mouse
+              // already had the hover, and a tap now reads the same figure.
+              onPointerDown={() => setHovered(index)}
             />
           ))}
         </div>
@@ -204,13 +208,18 @@ export function TrendChart({
         {hovered !== null ? (
           <div
             className={cn(
-              "pointer-events-none absolute top-0 z-10 min-w-36 -translate-x-1/2 rounded-[var(--radius-md)]",
+              "pointer-events-none absolute top-0 z-10 min-w-32 -translate-x-1/2 rounded-[var(--radius-md)]",
               "border border-[var(--border)] bg-[var(--surface)] p-2 shadow-[var(--shadow-md)]",
             )}
             style={{
-              // Clamped so the card at either end stays on the page rather
-              // than hanging off the side of the card it lives in.
-              left: `${Math.min(88, Math.max(12, (trendX(hovered, length) / TREND_WIDTH) * 100))}%`,
+              // Clamped in pixels rather than percent. A 12–88% window keeps
+              // the centre of a 144px card 43px from the edge of a 358px chart
+              // — which is 29px short, so it still overhung on a phone. Half
+              // the card's own width is the only bound that holds at every
+              // width.
+              left: `clamp(4rem, ${
+                (trendX(hovered, length) / TREND_WIDTH) * 100
+              }%, calc(100% - 4rem))`,
             }}
           >
             <p className="text-sm font-medium text-[var(--text-strong)]">

--- a/components/crm/reports/report-charts.tsx
+++ b/components/crm/reports/report-charts.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useState } from "react";
+
+import { Chart, ChartLegend, chartSeriesVar } from "@corelithzw/react";
+
+import { EmptyState } from "@corelithzw/react";
+import { formatRate, type FunnelStage, type ShareSlice } from "@/lib/crm/reports";
+import { cn } from "@/lib/utils";
+
+/**
+ * The charts the sales reports are made of.
+ *
+ * Drawn on the design system's chart primitives where they fit and hand-rolled
+ * where they don't — the palette comes from `--chart-1…10` either way, so a
+ * retinted theme retints these too rather than leaving one chart on last
+ * year's blue.
+ */
+
+export type FunnelStageWithDwell = FunnelStage & { medianDaysInStage: number | null };
+
+/**
+ * The pipeline, stage by stage.
+ *
+ * Horizontal rather than the classic tapering funnel: a tapering shape spends
+ * its width on decoration and makes the short stages unreadable, and the thing
+ * being compared is a set of lengths, which the eye reads best off a common
+ * baseline.
+ *
+ * Each row carries two numbers under it, because they answer different
+ * questions. Conversion says how many survive the stage. Time-in-stage says
+ * how long the survivors wait — and a stage everything survives but nothing
+ * leaves for a month is the one quietly costing the most.
+ */
+export function FunnelChart({ stages }: { stages: FunnelStageWithDwell[] }) {
+  if (stages.length === 0) {
+    return <EmptyState title="No deals in this period yet" />;
+  }
+
+  const top = stages[0]?.reached ?? 0;
+
+  return (
+    <ol className="space-y-3">
+      {stages.map((stage, index) => (
+        <li key={stage.key}>
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="truncate text-sm font-medium text-[var(--text-strong)]">
+              {stage.label}
+            </span>
+            <span className="shrink-0 font-mono text-sm text-[var(--text-strong)]">
+              {stage.reached}
+            </span>
+          </div>
+
+          <div
+            className="mt-1 h-2 overflow-hidden rounded-full bg-[var(--surface-muted)]"
+            role="img"
+            aria-label={`${stage.label}: ${stage.reached} of ${top}`}
+          >
+            <div
+              // A stage with a handful of deals still gets a visible sliver:
+              // a bar of literally zero width reads as a rendering bug rather
+              // than as a small number.
+              style={{
+                width: `${Math.max(1.5, stage.shareOfTotal * 100)}%`,
+                background: chartSeriesVar(index),
+              }}
+              className="h-full rounded-full"
+            />
+          </div>
+
+          <div className="mt-1 flex flex-wrap items-baseline gap-x-3 text-sm text-[var(--text-muted)]">
+            <span>
+              {index === 0
+                ? "Everything starts here"
+                : `${formatRate(stage.conversionFromPrevious)} of ${stages[index - 1].label}`}
+            </span>
+            <span>
+              {stage.medianDaysInStage === null
+                ? "No time recorded"
+                : `${stage.medianDaysInStage}d typically spent here`}
+            </span>
+            {index > 0 && stage.droppedFromPrevious > 0 ? (
+              <span className="font-mono">−{stage.droppedFromPrevious}</span>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export type TrendSeries = {
+  label: string;
+  points: { period: string; count: number; value: number }[];
+};
+
+/** Matches the design system's line geometry so the two look like one chart. */
+const TREND_WIDTH = 320;
+const TREND_HEIGHT = 120;
+const TREND_PAD = 10;
+
+function trendX(index: number, length: number): number {
+  return (index / Math.max(1, length - 1)) * (TREND_WIDTH - TREND_PAD * 2) + TREND_PAD;
+}
+
+function trendY(value: number, min: number, span: number): number {
+  return TREND_HEIGHT - TREND_PAD - ((value - min) / span) * (TREND_HEIGHT - TREND_PAD * 2);
+}
+
+/**
+ * Money over time, with the numbers readable rather than guessable.
+ *
+ * The design system's line chart draws the shape but has nowhere to put a
+ * value, so the reader is left estimating a figure off a curve. The geometry
+ * here is the design system's, exactly — same padding, same scaling — with a
+ * hover layer on top, so the line looks identical to every other line in the
+ * product and can also be read.
+ *
+ * Hovering targets a band rather than a point: a two-pixel vertex is a target
+ * nobody hits, and the question being asked is about a period, not a pixel.
+ */
+export function TrendChart({
+  series,
+  formatValue,
+  emptyMessage = "Nothing happened in this period",
+}: {
+  series: TrendSeries[];
+  formatValue: (value: number) => string;
+  emptyMessage?: string;
+}) {
+  const [hovered, setHovered] = useState<number | null>(null);
+
+  const length = series[0]?.points.length ?? 0;
+  const everything = series.flatMap((line) => line.points.map((point) => point.value));
+
+  if (length === 0 || everything.length === 0) {
+    return <EmptyState title={emptyMessage} />;
+  }
+
+  // Anchored at zero rather than at the lowest point: a chart floated off its
+  // own minimum turns a flat month into a mountain range.
+  const min = 0;
+  const max = Math.max(...everything, 0);
+  const span = max - min || 1;
+
+  const summary = series
+    .map((line) => `${line.label} peaking at ${formatValue(Math.max(...line.points.map((p) => p.value)))}`)
+    .join("; ");
+
+  return (
+    <div>
+      <div
+        className="relative"
+        onMouseLeave={() => setHovered(null)}
+      >
+        <svg
+          viewBox={`0 0 ${TREND_WIDTH} ${TREND_HEIGHT}`}
+          preserveAspectRatio="none"
+          className="h-32 w-full"
+          role="img"
+          aria-label={summary}
+        >
+          {series.map((line, lineIndex) => (
+            <polyline
+              key={line.label}
+              fill="none"
+              stroke={chartSeriesVar(lineIndex)}
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              points={line.points
+                .map((point, index) => `${trendX(index, length)},${trendY(point.value, min, span)}`)
+                .join(" ")}
+            />
+          ))}
+
+          {hovered !== null ? (
+            <line
+              x1={trendX(hovered, length)}
+              x2={trendX(hovered, length)}
+              y1={TREND_PAD}
+              y2={TREND_HEIGHT - TREND_PAD}
+              stroke="var(--border-strong, var(--border))"
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+          ) : null}
+        </svg>
+
+        {/* One band per period, laid over the drawing. Invisible, but it is
+            what the pointer is actually aiming at. */}
+        <div className="absolute inset-0 flex">
+          {Array.from({ length }, (_, index) => (
+            <div
+              key={index}
+              className="h-full flex-1"
+              onMouseEnter={() => setHovered(index)}
+            />
+          ))}
+        </div>
+
+        {hovered !== null ? (
+          <div
+            className={cn(
+              "pointer-events-none absolute top-0 z-10 min-w-36 -translate-x-1/2 rounded-[var(--radius-md)]",
+              "border border-[var(--border)] bg-[var(--surface)] p-2 shadow-[var(--shadow-md)]",
+            )}
+            style={{
+              // Clamped so the card at either end stays on the page rather
+              // than hanging off the side of the card it lives in.
+              left: `${Math.min(88, Math.max(12, (trendX(hovered, length) / TREND_WIDTH) * 100))}%`,
+            }}
+          >
+            <p className="text-sm font-medium text-[var(--text-strong)]">
+              {series[0].points[hovered]?.period}
+            </p>
+            {series.map((line, lineIndex) => (
+              <p
+                key={line.label}
+                className="mt-0.5 flex items-center gap-1.5 text-sm text-[var(--text-muted)]"
+              >
+                <span
+                  aria-hidden="true"
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ background: chartSeriesVar(lineIndex) }}
+                />
+                {line.label}
+                <span className="ml-auto font-mono text-[var(--text-strong)]">
+                  {formatValue(line.points[hovered]?.value ?? 0)}
+                </span>
+              </p>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <ChartLegend
+        className="mt-2"
+        items={series.map((line, index) => ({
+          label: line.label,
+          color: chartSeriesVar(index),
+        }))}
+      />
+    </div>
+  );
+}
+
+export type BarGroup = {
+  key: string;
+  label: string;
+  bars: { label: string; value: number }[];
+};
+
+/**
+ * Several measures per row, side by side.
+ *
+ * Grouped rather than stacked because the comparison people actually make is
+ * "did they win more than they lost", and a stacked bar answers a different
+ * question — how big the total is — while making the first one impossible.
+ *
+ * Laid out in CSS rather than SVG so the bars reflow with the card instead of
+ * being scaled up by a viewBox until the labels blur.
+ */
+export function GroupedBarChart({
+  groups,
+  emptyMessage = "Nothing to compare yet",
+}: {
+  groups: BarGroup[];
+  emptyMessage?: string;
+}) {
+  if (groups.length === 0) return <EmptyState title={emptyMessage} />;
+
+  const peak = Math.max(1, ...groups.flatMap((group) => group.bars.map((bar) => bar.value)));
+  const legend = groups[0]?.bars ?? [];
+
+  return (
+    <div>
+      <div className="flex items-end gap-4 overflow-x-auto pb-1">
+        {groups.map((group) => (
+          <div key={group.key} className="flex min-w-20 flex-1 flex-col items-center gap-1">
+            <div className="flex h-28 w-full items-end justify-center gap-1">
+              {group.bars.map((bar, index) => (
+                <div
+                  key={bar.label}
+                  title={`${group.label} — ${bar.label}: ${bar.value}`}
+                  className="w-3 rounded-t-[var(--radius-sm)]"
+                  style={{
+                    // A minimum sliver so a zero is visibly a zero rather than
+                    // a bar that failed to render.
+                    height: `${Math.max(2, (bar.value / peak) * 100)}%`,
+                    background: chartSeriesVar(index),
+                  }}
+                />
+              ))}
+            </div>
+            <span className="w-full truncate text-center text-sm text-[var(--text-muted)]">
+              {group.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <ChartLegend
+        className="mt-2"
+        items={legend.map((bar, index) => ({ label: bar.label, color: chartSeriesVar(index) }))}
+      />
+    </div>
+  );
+}
+
+/**
+ * Share of a total, as a pie.
+ *
+ * A pie is a poor way to compare two similar slices and a good way to say "one
+ * of these is most of it", which is the question asked of a source mix. The
+ * percentages are printed beside the labels rather than left to the eye,
+ * because reading an angle to within five percent is not a thing people do.
+ */
+export function SharePie({
+  slices,
+  formatValue,
+  emptyMessage = "Nothing won in this period",
+}: {
+  slices: ShareSlice[];
+  formatValue: (value: number) => string;
+  emptyMessage?: string;
+}) {
+  if (slices.length === 0) return <EmptyState title={emptyMessage} />;
+
+  return (
+    <div className="flex flex-wrap items-center gap-5">
+      <Chart.Pie
+        size={132}
+        className="shrink-0"
+        role="img"
+        aria-label={slices
+          .map((slice) => `${slice.label} ${formatRate(slice.share)}`)
+          .join(", ")}
+        data={slices.map((slice, index) => ({
+          value: slice.value,
+          label: slice.label,
+          color: chartSeriesVar(index),
+        }))}
+      />
+
+      <ul className="min-w-0 flex-1 space-y-1">
+        {slices.map((slice, index) => (
+          <li key={slice.key} className="flex items-baseline gap-2 text-sm">
+            <span
+              aria-hidden="true"
+              className="size-2 shrink-0 translate-y-px rounded-full"
+              style={{ background: chartSeriesVar(index) }}
+            />
+            <span className="min-w-0 flex-1 truncate text-[var(--text-strong)]">
+              {slice.label}
+            </span>
+            <span className="shrink-0 font-mono text-[var(--text-muted)]">
+              {formatRate(slice.share)}
+            </span>
+            <span className="shrink-0 font-mono text-[var(--text-strong)]">
+              {formatValue(slice.value)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/crm/reports/reports-content.tsx
+++ b/components/crm/reports/reports-content.tsx
@@ -1,59 +1,222 @@
 "use client";
 
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   Alert,
-  Card,
   EmptyState,
-  Progress,
   SegmentedControl,
   Skeleton,
   StatCard,
-  Stack,
 } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
+import { PageActions } from "@/components/layout/page-chrome";
+import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { Check, Grid3x3, Plus, RotateCcw } from "@/lib/icons";
 import { formatMoney } from "@/components/crm/documents/document-types";
 import {
   REPORT_RANGES,
   REPORT_RANGE_LABELS,
   biggestLeak,
   formatRate,
-  type FunnelStage,
   type GroupedPerformance,
   type ReportRange,
+  type ShareSlice,
 } from "@/lib/crm/reports";
+import type { OverviewScope, WidgetInstance } from "@/lib/crm/widgets";
 
-/** Bare, like every other report route — see the collections note. */
+import { WidgetGrid } from "../widgets/widget-grid";
+import {
+  FunnelChart,
+  GroupedBarChart,
+  SharePie,
+  TrendChart,
+  type FunnelStageWithDwell,
+} from "./report-charts";
+import { ReportCard, type ReportEntity } from "./report-card";
+
+type SeriesBucket = { period: string; count: number; value: number };
+
 type ReportResponse = {
-    range: ReportRange;
-    scope: "TEAM" | "MINE";
-    funnel: FunnelStage[];
-    counts: { won: number; lost: number; open: number };
-    winRate: number;
-    medianCycleDays: number | null;
-    forecast: { weighted: number; unweighted: number; count: number; estimated: number };
-    byOwner: GroupedPerformance[];
-    bySource: GroupedPerformance[];
-    activity: { period: string; count: number }[];
-    leads: { created: number; converted: number };
+  range: ReportRange;
+  scope: "TEAM" | "MINE";
+  funnel: FunnelStageWithDwell[];
+  counts: { won: number; lost: number; open: number };
+  winRate: number;
+  medianCycleDays: number | null;
+  forecast: { weighted: number; unweighted: number; count: number; estimated: number };
+  byOwner: GroupedPerformance[];
+  bySource: GroupedPerformance[];
+  sourceShare: ShareSlice[];
+  trend: { granularity: "day" | "week"; won: SeriesBucket[]; created: SeriesBucket[] };
+  activity: { period: string; count: number }[];
+  leads: { created: number; converted: number };
 };
 
-export function ReportsContent({ currency = "USD" }: { currency?: string }) {
-  const [range, setRange] = useState<ReportRange>("90d");
+type LayoutResponse = {
+  scope: OverviewScope;
+  widgets: WidgetInstance[];
+  isCustomised: boolean;
+};
 
-  const { data, isLoading, error } = useQuery({
+/**
+ * The sales reports, as a page somebody owns.
+ *
+ * Every card is a report and every report says which records it counted, so
+ * "win rate" is never ambiguous between deals and leads. The arrangement is
+ * saved per person the same way the overview is — the reason a reporting page
+ * gets ignored is usually that the one number somebody actually watches is
+ * three scrolls down.
+ *
+ * One fetch feeds every card. They are all cuts of the same period over the
+ * same deals, and separate requests would let two cards on one screen disagree
+ * about what "last 90 days" means.
+ */
+export function ReportsContent({ currency = "USD" }: { currency?: string }) {
+  const scope: OverviewScope = "REPORTS";
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [range, setRange] = useState<ReportRange>("90d");
+  const [editing, setEditing] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState<WidgetInstance[] | null>(null);
+
+  const layoutQuery = useQuery({
+    queryKey: ["crm", "overview-layout", scope],
+    queryFn: () => fetchJson<LayoutResponse>(`/api/v2/crm/overview-layout?scope=${scope}`),
+  });
+
+  const reportQuery = useQuery({
     queryKey: ["crm-reports", range],
     queryFn: () => fetchJson<ReportResponse>(`/api/v2/crm/reports?range=${range}`),
   });
 
-  const report = data;
-  const leak = report ? biggestLeak(report.funnel) : null;
-  const peak = Math.max(1, ...(report?.activity.map((bucket) => bucket.count) ?? [1]));
+  const save = useMutation({
+    mutationFn: (widgets: WidgetInstance[]) =>
+      fetchJson<LayoutResponse>("/api/v2/crm/overview-layout", {
+        method: "PUT",
+        body: JSON.stringify({ scope, widgets }),
+      }),
+    onSuccess: (result) => {
+      queryClient.setQueryData(["crm", "overview-layout", scope], result);
+      setEditing(false);
+      setAdding(false);
+      setDraft(null);
+      toast({ title: "Reports saved" });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not save the page",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const report = reportQuery.data;
+  const widgets = draft ?? layoutQuery.data?.widgets ?? [];
+
+  // Every card shares one query, so a card-level refresh refetches that query.
+  // Honest, and better than a per-card spinner over data that cannot move
+  // independently.
+  const refresh = () => reportQuery.refetch();
+
+  const money = (value: number) => formatMoney(value, currency);
+
+  if (layoutQuery.isLoading || reportQuery.isLoading) {
+    return (
+      <div className="grid grid-cols-12 gap-4" aria-busy="true">
+        {["col-span-12", "lg:col-span-8", "lg:col-span-4", "lg:col-span-8", "lg:col-span-4"].map(
+          (span, index) => (
+            <Skeleton key={index} height={160} className={`col-span-12 ${span}`} />
+          ),
+        )}
+      </div>
+    );
+  }
+
+  if (reportQuery.error) {
+    return (
+      <Alert tone="danger" title="Couldn't build the report">
+        {getApiErrorMessage(reportQuery.error)}
+      </Alert>
+    );
+  }
+
+  if (!report) return null;
+
+  const renderReport = (instance: WidgetInstance) =>
+    renderReportCard(instance.type, {
+      report,
+      money,
+      refresh,
+      refreshing: reportQuery.isFetching,
+      onRemove: editing
+        ? () => setDraft(widgets.filter((widget) => widget.id !== instance.id))
+        : undefined,
+    });
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
+      <PageActions>
+        {editing ? (
+          <>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setEditing(false);
+                setAdding(false);
+                setDraft(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button variant="ghost" onClick={() => setAdding(true)}>
+              <Plus className="size-4" />
+              Add report
+            </Button>
+            <Button onClick={() => save.mutate(widgets)} disabled={save.isPending}>
+              <Check className="size-4" />
+              Done
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="ghost" onClick={refresh} disabled={reportQuery.isFetching}>
+              <RotateCcw
+                className={reportQuery.isFetching ? "size-4 animate-spin" : "size-4"}
+              />
+              Refresh data
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setEditing(true);
+                setAdding(true);
+              }}
+            >
+              <Plus className="size-4" />
+              Add report
+            </Button>
+            <Button variant="ghost" onClick={() => setEditing(true)}>
+              <Grid3x3 className="size-4" />
+              Rearrange
+            </Button>
+          </>
+        )}
+      </PageActions>
+
+      {/* The description lives here rather than in the top app bar, which
+          carries a title and nothing else on every page in the product —
+          giving one page a subtitle up there would make the bar a different
+          height on that page alone. */}
+      <p className="text-sm text-[var(--text-muted)]">
+        How the pipeline is actually performing over a period you choose. Every card says
+        which records it counted; rearrange them and the arrangement is yours.
+      </p>
+
       <div className="flex flex-wrap items-center justify-between gap-2">
         <SegmentedControl
           options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
@@ -61,28 +224,54 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
           onValueChange={(value) => setRange(value as ReportRange)}
           aria-label="Reporting period"
         />
-
-        {report ? (
-          <p className="text-sm text-[var(--text-muted)]">
-            {report.scope === "TEAM" ? "Everyone" : "Your deals only"}
-          </p>
-        ) : null}
+        <p className="text-sm text-[var(--text-muted)]">
+          {report.scope === "TEAM"
+            ? "Everyone's numbers"
+            : "Your deals only — a manager sees the whole team"}
+        </p>
       </div>
 
-      {error ? (
-        <Alert tone="danger" title="Couldn't build the report">
-          {getApiErrorMessage(error)}
-        </Alert>
+      {widgets.length === 0 ? (
+        <EmptyState
+          title="No reports on this page"
+          body="Add one to start measuring something."
+        />
       ) : null}
 
-      {isLoading || !report ? (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {[0, 1, 2, 3].map((index) => (
-            <Skeleton key={index} height={96} />
-          ))}
-        </div>
-      ) : (
-        <>
+      <WidgetGrid
+        scope={scope}
+        widgets={widgets}
+        editing={editing}
+        noun="report"
+        adding={adding}
+        onAddingChange={setAdding}
+        onChange={setDraft}
+        renderWidget={renderReport}
+      />
+    </div>
+  );
+}
+
+type CardContext = {
+  report: ReportResponse;
+  money: (value: number) => string;
+  refresh: () => void;
+  refreshing: boolean;
+  onRemove?: () => void;
+};
+
+function renderReportCard(type: string, context: CardContext) {
+  const { report, money, refresh, refreshing, onRemove } = context;
+  const frame = (
+    props: Omit<Parameters<typeof ReportCard>[0], "onRefresh" | "refreshing" | "onRemove">,
+  ) => <ReportCard {...props} onRefresh={refresh} refreshing={refreshing} onRemove={onRemove} />;
+
+  switch (type) {
+    case "report-headline":
+      return frame({
+        title: "Headline figures",
+        entity: "deal",
+        children: (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <StatCard
               label="Win rate"
@@ -91,11 +280,11 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
             />
             <StatCard
               label="Weighted forecast"
-              value={formatMoney(report.forecast.weighted, currency)}
+              value={money(report.forecast.weighted)}
               footer={
                 report.forecast.estimated === 0
-                  ? `${formatMoney(report.forecast.unweighted, currency)} if everything lands`
-                  : `${formatMoney(report.forecast.unweighted, currency)} if everything lands · ${report.forecast.estimated} of ${report.forecast.count} at a default likelihood`
+                  ? `${money(report.forecast.unweighted)} if everything lands`
+                  : `${money(report.forecast.unweighted)} if everything lands · ${report.forecast.estimated} of ${report.forecast.count} at a default likelihood`
               }
             />
             <StatCard
@@ -109,107 +298,194 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
               footer={`${report.leads.converted} became deals`}
             />
           </div>
+        ),
+      });
 
-          <Card
-            title="Pipeline funnel"
-            subtitle={
-              leak && leak.droppedFromPrevious > 0
-                ? `Biggest drop-off at ${leak.label} — ${leak.droppedFromPrevious} lost from the stage before`
-                : undefined
-            }
-          >
-            {report.funnel.length === 0 ? (
-              <EmptyState title="No deals in this period yet" />
-            ) : (
-              <Stack as="ul" gap="sm">
-                {report.funnel.map((stage, index) => (
-                  <li key={stage.key} className="space-y-1">
-                    <div className="flex items-baseline justify-between gap-2 text-sm">
-                      <span>{stage.label}</span>
-                      <span className="text-[var(--text-muted)]">
-                        <span className="font-mono text-[var(--text-primary)]">
-                          {stage.reached}
-                        </span>
-                        {index > 0
-                          ? ` · ${formatRate(stage.conversionFromPrevious)} of previous`
-                          : ""}
-                      </span>
-                    </div>
-                    <Progress
-                      value={Math.max(2, stage.shareOfTotal * 100)}
-                      label={`${stage.label}: ${stage.reached} of ${report.funnel[0]?.reached ?? 0}`}
-                    />
-                  </li>
-                ))}
-              </Stack>
-            )}
-          </Card>
+    case "report-funnel": {
+      const leak = biggestLeak(report.funnel);
+      return frame({
+        title: "Stage funnel",
+        entity: "deal",
+        subtitle:
+          leak && leak.droppedFromPrevious > 0
+            ? `Biggest drop-off at ${leak.label} — ${leak.droppedFromPrevious} lost from the stage before`
+            : undefined,
+        copyRows: () => [
+          ["Stage", "Reached", "From previous", "Median days"],
+          ...report.funnel.map((stage) => [
+            stage.label,
+            String(stage.reached),
+            formatRate(stage.conversionFromPrevious),
+            stage.medianDaysInStage === null ? "" : String(stage.medianDaysInStage),
+          ]),
+        ],
+        children: <FunnelChart stages={report.funnel} />,
+      });
+    }
 
-          <div className="grid gap-4 lg:grid-cols-2">
-            <PerformanceTable title="By owner" rows={report.byOwner} currency={currency} />
-            <PerformanceTable title="By source" rows={report.bySource} currency={currency} />
+    case "report-source-share":
+      return frame({
+        title: "Where the money came from",
+        entity: "deal",
+        subtitle: "Won value, by source",
+        copyRows: () => [
+          ["Source", "Won value", "Share"],
+          ...report.sourceShare.map((slice) => [
+            slice.label,
+            String(slice.value),
+            formatRate(slice.share),
+          ]),
+        ],
+        children: <SharePie slices={report.sourceShare} formatValue={money} />,
+      });
+
+    case "report-trend":
+      return frame({
+        title: "Won over time",
+        entity: "deal",
+        subtitle:
+          report.trend.granularity === "week" ? "By week" : "By day",
+        copyRows: () => [
+          ["Period", "Won", "Opened"],
+          ...report.trend.won.map((bucket, index) => [
+            bucket.period,
+            String(bucket.value),
+            String(report.trend.created[index]?.value ?? 0),
+          ]),
+        ],
+        children: (
+          <TrendChart
+            formatValue={money}
+            series={[
+              { label: "Won", points: report.trend.won },
+              { label: "Opened", points: report.trend.created },
+            ]}
+          />
+        ),
+      });
+
+    case "report-by-owner":
+      return frame({
+        title: "Outcomes by owner",
+        entity: "person",
+        copyRows: () => [
+          ["Owner", "Won", "Lost", "Open"],
+          ...report.byOwner.map((row) => [
+            row.label,
+            String(row.won),
+            String(row.lost),
+            String(row.open),
+          ]),
+        ],
+        children: (
+          <GroupedBarChart
+            emptyMessage="Nobody has closed anything yet"
+            groups={report.byOwner.slice(0, 8).map((row) => ({
+              key: row.key,
+              label: row.label,
+              bars: [
+                { label: "Won", value: row.won },
+                { label: "Lost", value: row.lost },
+                { label: "Open", value: row.open },
+              ],
+            }))}
+          />
+        ),
+      });
+
+    case "report-owner-table":
+      return frame({
+        title: "Owner performance",
+        entity: "person",
+        copyRows: () => performanceRows(report.byOwner),
+        children: <PerformanceTable rows={report.byOwner} money={money} />,
+      });
+
+    case "report-source-table":
+      return frame({
+        title: "Source performance",
+        entity: "deal",
+        copyRows: () => performanceRows(report.bySource),
+        children: <PerformanceTable rows={report.bySource} money={money} />,
+      });
+
+    case "report-activity": {
+      const peak = Math.max(1, ...report.activity.map((bucket) => bucket.count));
+      return frame({
+        title: "Activity logged",
+        entity: "activity",
+        subtitle: `Calls, emails and notes. Peak ${peak} in a single period.`,
+        copyRows: () => [
+          ["Period", "Logged"],
+          ...report.activity.map((bucket) => [bucket.period, String(bucket.count)]),
+        ],
+        children: (
+          <div className="flex h-24 items-end gap-0.5">
+            {report.activity.map((bucket) => (
+              <div
+                key={bucket.period}
+                title={`${bucket.period}: ${bucket.count}`}
+                className="flex-1 rounded-t bg-[var(--surface-inverse)]"
+                // A quiet day is a visible gap rather than a straight line
+                // drawn through it.
+                style={{ height: `${(bucket.count / peak) * 100}%`, minHeight: "1px" }}
+              />
+            ))}
           </div>
+        ),
+      });
+    }
 
-          <Card title="Activity">
-            <div className="flex h-24 items-end gap-0.5">
-              {report.activity.map((bucket) => (
-                <div
-                  key={bucket.period}
-                  title={`${bucket.period}: ${bucket.count}`}
-                  className="flex-1 rounded-t bg-[var(--surface-inverse)]"
-                  // A quiet day is a visible gap rather than a straight line
-                  // drawn through it.
-                  style={{ height: `${(bucket.count / peak) * 100}%`, minHeight: "1px" }}
-                />
-              ))}
-            </div>
-            <p className="mt-2 text-sm text-[var(--text-muted)]">
-              Calls, emails and notes logged. Peak {peak} in a single period.
-            </p>
-          </Card>
-        </>
-      )}
-    </div>
-  );
+    default:
+      return null;
+  }
+}
+
+function performanceRows(rows: GroupedPerformance[]): string[][] {
+  return [
+    ["Name", "Won", "Lost", "Open", "Win rate", "Value won"],
+    ...rows.map((row) => [
+      row.label,
+      String(row.won),
+      String(row.lost),
+      String(row.open),
+      formatRate(row.winRate),
+      String(row.wonValue),
+    ]),
+  ];
 }
 
 function PerformanceTable({
-  title,
   rows,
-  currency,
+  money,
 }: {
-  title: string;
   rows: GroupedPerformance[];
-  currency: string;
+  money: (value: number) => string;
 }) {
+  if (rows.length === 0) return <EmptyState title="Nothing to show yet" />;
+
   return (
-    <Card title={title}>
-      {rows.length === 0 ? (
-        <EmptyState title="Nothing to show yet" />
-      ) : (
-        <table className="w-full text-sm">
-          <thead className="text-left text-sm font-medium text-[var(--text-muted)]">
-            <tr>
-              <th className="pb-1 font-medium">Name</th>
-              <th className="pb-1 text-right font-medium">Won</th>
-              <th className="pb-1 text-right font-medium">Rate</th>
-              <th className="pb-1 text-right font-medium">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.key} className="border-t border-[var(--border-subtle)]">
-                <td className="py-1.5">{row.label}</td>
-                <td className="py-1.5 text-right font-mono">{row.won}</td>
-                <td className="py-1.5 text-right font-mono">{formatRate(row.winRate)}</td>
-                <td className="py-1.5 text-right font-mono">
-                  {formatMoney(row.wonValue, currency)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </Card>
+    <table className="w-full text-sm">
+      <thead className="text-left text-sm font-medium text-[var(--text-muted)]">
+        <tr>
+          <th className="pb-1 font-medium">Name</th>
+          <th className="pb-1 text-right font-medium">Won</th>
+          <th className="pb-1 text-right font-medium">Rate</th>
+          <th className="pb-1 text-right font-medium">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.key} className="border-t border-[var(--border-subtle)]">
+            <td className="py-1.5">{row.label}</td>
+            <td className="py-1.5 text-right font-mono">{row.won}</td>
+            <td className="py-1.5 text-right font-mono">{formatRate(row.winRate)}</td>
+            <td className="py-1.5 text-right font-mono">{money(row.wonValue)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
+
+export type { ReportEntity };

--- a/components/crm/reports/reports-content.tsx
+++ b/components/crm/reports/reports-content.tsx
@@ -36,6 +36,7 @@ import {
   type FunnelStageWithDwell,
 } from "./report-charts";
 import { ReportCard, type ReportEntity } from "./report-card";
+import { MobileRow, MobileRows } from "../records/mobile-rows";
 
 type SeriesBucket = { period: string; count: number; value: number };
 
@@ -218,12 +219,17 @@ export function ReportsContent({ currency = "USD" }: { currency?: string }) {
       </p>
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <SegmentedControl
-          options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
-          value={range}
-          onValueChange={(value) => setRange(value as ReportRange)}
-          aria-label="Reporting period"
-        />
+        {/* "Last 12 months" and its neighbours run past 400px together, so on
+            a phone the control scrolls inside its own rail rather than
+            stretching the page. */}
+        <div className="scroll-rail max-w-full overflow-x-auto">
+          <SegmentedControl
+            options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
+            value={range}
+            onValueChange={(value) => setRange(value as ReportRange)}
+            aria-label="Reporting period"
+          />
+        </div>
         <p className="text-sm text-[var(--text-muted)]">
           {report.scope === "TEAM"
             ? "Everyone's numbers"
@@ -420,12 +426,15 @@ function renderReportCard(type: string, context: CardContext) {
           ...report.activity.map((bucket) => [bucket.period, String(bucket.count)]),
         ],
         children: (
-          <div className="flex h-24 items-end gap-0.5">
+          // Ninety `flex-1` bars in ~318px is a third of a pixel each — a grey
+          // smear with no bars in it. A floor of 8px and a scroll is what the
+          // insights version already does.
+          <div className="scroll-rail flex h-24 items-end gap-0.5 overflow-x-auto">
             {report.activity.map((bucket) => (
               <div
                 key={bucket.period}
                 title={`${bucket.period}: ${bucket.count}`}
-                className="flex-1 rounded-t bg-[var(--surface-inverse)]"
+                className="min-w-2 flex-1 rounded-t bg-[var(--surface-inverse)]"
                 // A quiet day is a visible gap rather than a straight line
                 // drawn through it.
                 style={{ height: `${(bucket.count / peak) * 100}%`, minHeight: "1px" }}
@@ -465,7 +474,28 @@ function PerformanceTable({
   if (rows.length === 0) return <EmptyState title="Nothing to show yet" />;
 
   return (
-    <table className="w-full text-sm">
+    <>
+    {/* Four columns of figures need about 320px of table before the numbers
+        start colliding, and a widget on a phone has roughly that much in
+        total. So a phone reads it as a list: who, the value they won, and
+        the counts underneath. */}
+    <MobileRows className="md:hidden">
+      {rows.map((row) => (
+        <MobileRow
+          key={row.key}
+          title={row.label}
+          subtitle={`${row.won} won · ${row.lost} lost · ${row.open} open`}
+          value={money(row.wonValue)}
+          status={
+            <span className="font-mono text-sm text-[var(--text-muted)]">
+              {formatRate(row.winRate)}
+            </span>
+          }
+        />
+      ))}
+    </MobileRows>
+
+    <table className="hidden w-full text-sm md:table">
       <thead className="text-left text-sm font-medium text-[var(--text-muted)]">
         <tr>
           <th className="pb-1 font-medium">Name</th>
@@ -485,6 +515,7 @@ function PerformanceTable({
         ))}
       </tbody>
     </table>
+    </>
   );
 }
 

--- a/components/crm/reps/rep-detail-page.tsx
+++ b/components/crm/reps/rep-detail-page.tsx
@@ -30,6 +30,7 @@ import { RecordMark } from "@/components/crm/records/record-mark";
 import { RecordAttributes } from "@/components/crm/records/record-attributes";
 import { HistoryFeed, type HistoryEvent } from "@/components/crm/records/history-feed";
 import { RecordPageShell } from "@/components/crm/records/record-page-shell";
+import { FilesTab } from "@/components/crm/records/files-tab";
 import { RepSettingsTab } from "@/components/crm/reps/rep-settings-tab";
 
 const ROLE_LABELS: Record<string, string> = {
@@ -345,6 +346,11 @@ export function RepDetailPage({ repId }: { repId: string }) {
               exportName={`${rep.name ?? "rep"}-activity`}
             />
           ),
+        },
+        {
+          value: "files",
+          label: "Files",
+          content: <FilesTab owner="rep" ownerId={rep.id} />,
         },
         {
           value: "settings",

--- a/components/crm/tasks/tasks-register-content.tsx
+++ b/components/crm/tasks/tasks-register-content.tsx
@@ -85,7 +85,6 @@ export function TasksRegisterContent() {
             <SegmentedControl
               value={scope}
               onValueChange={(value) => setScope(value as typeof scope)}
-              size="sm"
               options={[
                 { value: "ALL", label: "Everyone" },
                 { value: "MINE", label: "Mine" },

--- a/components/crm/templates/attribute-header.tsx
+++ b/components/crm/templates/attribute-header.tsx
@@ -159,7 +159,7 @@ export function AttributeHeader({
                   variant="ghost"
                   size="sm"
                   aria-label={`Remove ${key}`}
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  className="opacity-0 transition-opacity group-hover:opacity-100 pointer-coarse:opacity-100"
                   onClick={() => {
                     const next = { ...custom };
                     delete next[key];

--- a/components/crm/templates/attribute-header.tsx
+++ b/components/crm/templates/attribute-header.tsx
@@ -120,7 +120,7 @@ export function AttributeHeader({
           const Icon = row.icon;
           return (
             <div key={row.id} className="flex items-center gap-3">
-              <dt className="flex w-40 shrink-0 items-center gap-1.5 text-sm text-[var(--text-muted)]">
+              <dt className="flex w-28 shrink-0 items-center gap-1.5 text-sm text-[var(--text-muted)] sm:w-40">
                 {Icon ? <Icon className="size-4" aria-hidden="true" /> : null}
                 {row.label}
               </dt>
@@ -142,7 +142,7 @@ export function AttributeHeader({
 
         {customEntries.map(([key, value]) => (
           <div key={key} className="group flex items-center gap-3">
-            <dt className="w-40 shrink-0 truncate text-sm text-[var(--text-muted)]">{key}</dt>
+            <dt className="w-28 shrink-0 truncate text-sm text-[var(--text-muted)] sm:w-40">{key}</dt>
             <dd className="flex min-w-0 flex-1 items-center gap-1">
               <Input
                 aria-label={key}
@@ -180,7 +180,7 @@ export function AttributeHeader({
               aria-label="Property name"
               value={draftKey}
               placeholder="Property"
-              className="h-8 w-40 shrink-0"
+              className="h-8 w-28 shrink-0 sm:w-40"
               onChange={(event) => setDraftKey(event.target.value)}
               onKeyDown={(event) => {
                 if (event.key === "Enter") commitCustom();

--- a/components/crm/templates/block-editor.tsx
+++ b/components/crm/templates/block-editor.tsx
@@ -125,7 +125,7 @@ function FieldEditor({
             onChange({ fieldType: value as (typeof FIELD_TYPES)[number] })
           }
         >
-          <SelectTrigger className="w-40" aria-label="Answer type">
+          <SelectTrigger className="w-full max-w-40" aria-label="Answer type">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -254,7 +254,7 @@ function BlockEditorRow({
             value={String(block.level)}
             onValueChange={(value) => patch({ level: Number(value) })}
           >
-            <SelectTrigger className="w-24" aria-label="Heading level">
+            <SelectTrigger className="w-24 shrink-0" aria-label="Heading level">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -292,7 +292,7 @@ function BlockEditorRow({
 
       {block.type === "spacer" ? (
         <Select value={block.size} onValueChange={(value) => patch({ size: value })}>
-          <SelectTrigger className="w-32" aria-label="Space size">
+          <SelectTrigger className="w-full max-w-32" aria-label="Space size">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -306,7 +306,7 @@ function BlockEditorRow({
       {block.type === "image" ? (
         <div className="space-y-2">
           <Select value={block.source} onValueChange={(value) => patch({ source: value })}>
-            <SelectTrigger className="w-56" aria-label="Image source">
+            <SelectTrigger className="w-full max-w-56" aria-label="Image source">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -395,7 +395,7 @@ function BlockEditorRow({
             onChange={(event) => patch({ label: event.target.value })}
           />
           <Select value={block.party} onValueChange={(value) => patch({ party: value })}>
-            <SelectTrigger className="w-40" aria-label="Who signs">
+            <SelectTrigger className="w-full max-w-40 sm:w-40" aria-label="Who signs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/components/crm/templates/block-editor.tsx
+++ b/components/crm/templates/block-editor.tsx
@@ -76,14 +76,14 @@ function BlockInsert({
     <div className="group/insert relative flex h-4 items-center justify-center">
       <span
         aria-hidden="true"
-        className="absolute inset-x-0 top-1/2 h-px bg-[var(--border-subtle)] opacity-0 transition-opacity group-hover/insert:opacity-100"
+        className="absolute inset-x-0 top-1/2 h-px bg-[var(--border-subtle)] opacity-0 transition-opacity group-hover/insert:opacity-100 pointer-coarse:opacity-100"
       />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
             aria-label={label}
-            className="relative z-10 flex size-5 items-center justify-center rounded-full border border-dashed border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] opacity-0 transition-opacity hover:border-[var(--brand)] hover:text-[var(--text)] focus-visible:opacity-100 group-hover/insert:opacity-100"
+            className="relative z-10 flex size-5 items-center justify-center rounded-full border border-dashed border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] opacity-0 transition-opacity hover:border-[var(--brand)] hover:text-[var(--text)] focus-visible:opacity-100 group-hover/insert:opacity-100 pointer-coarse:opacity-100"
           >
             <Plus className="size-3" aria-hidden="true" />
           </button>
@@ -203,7 +203,7 @@ function BlockEditorRow({
 
   return (
     <div className="group relative rounded-[var(--radius-md)] px-2 py-2 transition-colors hover:bg-[var(--surface-subtle)]">
-      <div className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+      <div className="absolute right-1 top-1 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100">
         <Button
           type="button"
           variant="ghost"

--- a/components/crm/templates/block-editor.tsx
+++ b/components/crm/templates/block-editor.tsx
@@ -37,6 +37,7 @@ import {
   type BlockType,
   type TemplateKind,
 } from "@/lib/crm/blocks";
+import { starterBlocks, startersForKind } from "@/lib/crm/starter-templates";
 import { cn } from "@/lib/utils";
 
 import { VariablePicker } from "./variable-picker";
@@ -472,9 +473,35 @@ export function BlockEditor({
       ))}
 
       {blocks.length === 0 ? (
-        <p className="py-8 text-center text-sm text-[var(--text-muted)]">
-          Empty. Use the + above to add the first block.
-        </p>
+        <div className="py-6 text-center">
+          <p className="text-sm text-[var(--text-muted)]">
+            Empty. Use the + above to add the first block.
+          </p>
+
+          {/* Or don't start from nothing. Somebody who reached a blank
+              template did not necessarily choose one — they may have picked
+              Blank in the dialog and then discovered what that means. */}
+          {startersForKind(kind).length > 0 ? (
+            <div className="mt-4">
+              <p className="text-sm font-medium text-[var(--text-strong)]">Or start from</p>
+              <div className="mt-2 flex flex-wrap justify-center gap-2">
+                {startersForKind(kind).map((starter) => (
+                  <button
+                    key={starter.id}
+                    type="button"
+                    onClick={() => onChange(starterBlocks(starter, ""))}
+                    className="rounded-[var(--radius-md)] border border-[var(--border)] px-3 py-1.5 text-sm hover:border-[var(--interactive-primary)] hover:bg-[var(--surface-hover)]"
+                  >
+                    <span aria-hidden="true" className="mr-1.5">
+                      {starter.emoji}
+                    </span>
+                    {starter.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -256,7 +256,7 @@ export function VisitReportSheet({
       ) : (
         <div className="space-y-4">
           <section className="space-y-2">
-            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">
               On-site checklist
             </h3>
             <Stack as="ul" gap="xs">
@@ -296,7 +296,7 @@ export function VisitReportSheet({
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-base font-semibold text-[var(--text-strong)] text-[var(--text-muted)]">
+            <h3 className="text-base font-semibold text-[var(--text-strong)]">
               Measurements & specifications
             </h3>
             <p className="text-sm text-[var(--text-muted)]">

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -329,13 +329,14 @@ export function VisitReportSheet({
                     <CataloguePicker
                       value={item.description}
                       onChange={(value) => patchItem(index, { description: value })}
+                      aria-label={`Item ${index + 1} description`}
                       onPick={(pick) =>
                         patchItem(index, {
                           description: pick.description,
                           // Only fills a price nobody has typed. Somebody who
                           // has already priced this line measured it on site
                           // and knows something the list does not.
-                          ...(item.unitPrice.trim()
+                          ...(item.unitPrice.trim() || pick.unitPrice == null
                             ? {}
                             : { unitPrice: pick.unitPrice.toFixed(2) }),
                         })

--- a/components/crm/visits/visit-report-sheet.tsx
+++ b/components/crm/visits/visit-report-sheet.tsx
@@ -7,6 +7,7 @@ import { AttachmentCenter, Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { CataloguePicker } from "@/components/crm/documents/catalogue-picker";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -318,14 +319,28 @@ export function VisitReportSheet({
                       aria-label={`Item ${index + 1} category`}
                       maxLength={80}
                     />
-                    <Input
+                    {/* The same picker the quote builder uses. These
+                        descriptions become quotation lines verbatim, so this
+                        is where "aluminium sliding window" first gets typed
+                        three different ways at three remembered prices —
+                        which is exactly what the catalogue exists to stop.
+                        Free text still works: a visit finds things nobody
+                        has ever sold before. */}
+                    <CataloguePicker
                       value={item.description}
-                      onChange={(event) =>
-                        patchItem(index, { description: event.target.value })
+                      onChange={(value) => patchItem(index, { description: value })}
+                      onPick={(pick) =>
+                        patchItem(index, {
+                          description: pick.description,
+                          // Only fills a price nobody has typed. Somebody who
+                          // has already priced this line measured it on site
+                          // and knows something the list does not.
+                          ...(item.unitPrice.trim()
+                            ? {}
+                            : { unitPrice: pick.unitPrice.toFixed(2) }),
+                        })
                       }
                       placeholder="What is it? e.g. Aluminium sliding window"
-                      aria-label={`Item ${index + 1} description`}
-                      maxLength={300}
                     />
                     <Button
                       type="button"

--- a/components/crm/widgets/home-widgets.tsx
+++ b/components/crm/widgets/home-widgets.tsx
@@ -235,7 +235,10 @@ export function renderHomeWidget(type: string, data: HomeData): React.ReactNode 
                       href={`/crm/deals?stageId=${stage.id}`}
                       className="flex items-center gap-3 text-sm hover:underline"
                     >
-                      <span className="w-32 shrink-0 truncate">{stage.name}</span>
+                      {/* The name, the bar and the money share one row. 32rem of
+                          name leaves the money nowhere to go at phone width,
+                          so the label gives up a quarter of itself there. */}
+                      <span className="w-24 shrink-0 truncate sm:w-32">{stage.name}</span>
                       <span
                         className={cn(
                           "h-2 rounded-full",

--- a/components/crm/widgets/widget-grid.tsx
+++ b/components/crm/widgets/widget-grid.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState, type ReactNode } from "react";
 import {
   DndContext,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCenter,
   useSensor,
   useSensors,
@@ -130,7 +131,7 @@ function WidgetFrame({
           <button
             type="button"
             aria-label={`Move ${definition?.label ?? "widget"}`}
-            className="flex size-7 cursor-grab items-center justify-center rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface)] text-[var(--text-subtle)] active:cursor-grabbing"
+            className="flex size-7 cursor-grab touch-manipulation select-none items-center justify-center rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface)] text-[var(--text-subtle)] active:cursor-grabbing pointer-coarse:size-10"
             {...attributes}
             {...listeners}
           >
@@ -190,7 +191,13 @@ export function WidgetGrid({
   };
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    // MouseSensor and TouchSensor rather than PointerSensor. PointerSensor
+    // answers touch too, and its 6px threshold is crossed long before any
+    // long-press delay elapses — so with both registered, every attempt to
+    // swipe the board sideways started a drag instead. Splitting them lets a
+    // finger scroll immediately and drag only after a deliberate hold.
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 

--- a/components/crm/widgets/widget-grid.tsx
+++ b/components/crm/widgets/widget-grid.tsx
@@ -167,14 +167,27 @@ export function WidgetGrid({
   editing,
   onChange,
   renderWidget,
+  noun = "widget",
+  adding: controlledAdding,
+  onAddingChange,
 }: {
   scope: OverviewScope;
   widgets: WidgetInstance[];
   editing: boolean;
   onChange: (next: WidgetInstance[]) => void;
   renderWidget: (instance: WidgetInstance) => ReactNode;
+  /** What one of these is called here — "widget" on an overview, "report" on reports. */
+  noun?: string;
+  /** Controlled when the page has its own "Add …" button in the app bar. */
+  adding?: boolean;
+  onAddingChange?: (open: boolean) => void;
 }) {
-  const [adding, setAdding] = useState(false);
+  const [uncontrolledAdding, setUncontrolledAdding] = useState(false);
+  const adding = controlledAdding ?? uncontrolledAdding;
+  const setAdding = (next: boolean) => {
+    setUncontrolledAdding(next);
+    onAddingChange?.(next);
+  };
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -228,11 +241,11 @@ export function WidgetGrid({
             <div className="col-span-12 lg:col-span-4">
               <button
                 type="button"
-                onClick={() => setAdding((previous) => !previous)}
+                onClick={() => setAdding(!adding)}
                 className="flex h-full min-h-32 w-full flex-col items-center justify-center gap-1 rounded-[var(--card-radius)] border border-dashed border-[var(--border)] text-sm text-[var(--text-muted)] hover:border-[var(--interactive-primary)] hover:text-[var(--text)]"
               >
                 <Plus className="size-5" />
-                Add a widget
+                Add a {noun}
               </button>
             </div>
           ) : null}

--- a/components/crm/workflows/run-insights-panel.tsx
+++ b/components/crm/workflows/run-insights-panel.tsx
@@ -7,6 +7,7 @@ import { Alert, Card, EmptyState, Skeleton, StatCard } from "@corelithzw/react";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { formatRate, type ReportRange } from "@/lib/crm/reports";
 import { formatDuration, type FailureGroup, type RulePerformance, type RunTotals } from "@/lib/crm/run-insights";
+import { RecordList } from "@/components/crm/records/record-list";
 
 type Insights = {
   range: ReportRange;
@@ -116,7 +117,22 @@ export function RunInsightsPanel({ range }: { range: ReportRange }) {
           {insights.byRule.length === 0 ? (
             <EmptyState title="Nothing has run yet" />
           ) : (
-            <table className="w-full text-sm">
+            <>
+            {/* A phone reads this as the list it is: which workflow, how much
+                trouble it is in, and the run counts underneath. These rows go
+                somewhere, so they are links rather than plain rows. */}
+            <RecordList
+              className="md:hidden"
+              rows={insights.byRule.map((rule) => ({
+                id: rule.automationId,
+                href: `/crm/workflows/${rule.automationId}`,
+                title: rule.automationName,
+                subtitle: `${rule.runs} runs · typically ${formatDuration(rule.medianMs)}`,
+                facts: [{ value: formatRate(rule.troubleRate), mono: true }],
+              }))}
+            />
+
+            <table className="hidden w-full text-sm md:table">
               <thead className="text-left text-sm font-medium text-[var(--text-muted)]">
                 <tr>
                   <th className="pb-1 font-medium">Workflow</th>
@@ -153,6 +169,7 @@ export function RunInsightsPanel({ range }: { range: ReportRange }) {
                 ))}
               </tbody>
             </table>
+            </>
           )}
         </Card>
 

--- a/components/crm/workflows/run-insights-panel.tsx
+++ b/components/crm/workflows/run-insights-panel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+
+import { Alert, Card, EmptyState, Skeleton, StatCard } from "@corelithzw/react";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { formatRate, type ReportRange } from "@/lib/crm/reports";
+import { formatDuration, type FailureGroup, type RulePerformance, type RunTotals } from "@/lib/crm/run-insights";
+
+type Insights = {
+  range: ReportRange;
+  totals: RunTotals;
+  byRule: RulePerformance[];
+  failures: FailureGroup[];
+  truncated: boolean;
+};
+
+/** `ADD_TAG` is a database value; "Add tag" is what somebody reads. */
+function actionLabel(type: string): string {
+  return type
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
+/**
+ * Whether the workflows are going well.
+ *
+ * The run list says what happened, one line at a time. That answers "did this
+ * fire" and answers nothing about the forty identical failures three screens
+ * down, which are one problem wearing forty rows.
+ *
+ * There is no in-progress count and no credit meter here. This engine runs a
+ * rule synchronously the moment its event happens and meters nothing, so both
+ * would be a permanent zero pretending to be a measurement. What it does cost
+ * is actions carried out, and that is counted.
+ */
+export function RunInsightsPanel({ range }: { range: ReportRange }) {
+  const query = useQuery({
+    queryKey: ["crm-workflow-insights", range],
+    queryFn: () => fetchJson<Insights>(`/api/v2/crm/automations/insights?range=${range}`),
+  });
+
+  if (query.isLoading) {
+    return (
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4" aria-busy="true">
+        {[0, 1, 2, 3].map((index) => (
+          <Skeleton key={index} height={96} />
+        ))}
+      </div>
+    );
+  }
+
+  if (query.error) {
+    return (
+      <Alert tone="danger" title="Couldn't summarise the runs">
+        {getApiErrorMessage(query.error)}
+      </Alert>
+    );
+  }
+
+  const insights = query.data;
+  if (!insights) return null;
+  const { totals } = insights;
+
+  if (totals.runs === 0) {
+    return (
+      <EmptyState
+        title="Nothing has run in this period"
+        body="Once a workflow is live, how it is behaving shows up here."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Runs"
+          value={String(totals.runs)}
+          footer={`${totals.succeeded} clean · ${totals.partial} half done · ${totals.failed} failed`}
+        />
+        <StatCard
+          label="Went through cleanly"
+          value={formatRate(totals.cleanRate)}
+          // Partial counts against it: a rule that half-worked is a rule
+          // somebody has to go and finish by hand.
+          footer="A half-done run counts against this"
+        />
+        <StatCard
+          label="Typical runtime"
+          value={formatDuration(totals.medianMs)}
+          footer={
+            totals.untimed > 0
+              ? `Median · slowest ${formatDuration(totals.slowestMs)} · ${totals.untimed} not timed`
+              : `Median · slowest ${formatDuration(totals.slowestMs)}`
+          }
+        />
+        <StatCard
+          label="Actions carried out"
+          value={String(totals.actionsRun)}
+          footer="What these rules actually spend"
+        />
+      </div>
+
+      {insights.truncated ? (
+        <Alert tone="info" title="Showing a sample">
+          There were more runs in this period than this summary reads. The figures above are
+          drawn from the most recent of them.
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card title="Workflows that need attention" subtitle="Worst first, not busiest first">
+          {insights.byRule.length === 0 ? (
+            <EmptyState title="Nothing has run yet" />
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="text-left text-sm font-medium text-[var(--text-muted)]">
+                <tr>
+                  <th className="pb-1 font-medium">Workflow</th>
+                  <th className="pb-1 text-right font-medium">Runs</th>
+                  <th className="pb-1 text-right font-medium">Trouble</th>
+                  <th className="pb-1 text-right font-medium">Typical</th>
+                </tr>
+              </thead>
+              <tbody>
+                {insights.byRule.map((rule) => (
+                  <tr key={rule.automationId} className="border-t border-[var(--border-subtle)]">
+                    <td className="py-1.5">
+                      <Link
+                        href={`/crm/workflows/${rule.automationId}`}
+                        className="underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]"
+                      >
+                        {rule.automationName}
+                      </Link>
+                    </td>
+                    <td className="py-1.5 text-right font-mono">{rule.runs}</td>
+                    <td
+                      className={
+                        rule.troubleRate > 0
+                          ? "py-1.5 text-right font-mono text-[var(--status-error-text)]"
+                          : "py-1.5 text-right font-mono text-[var(--text-muted)]"
+                      }
+                    >
+                      {formatRate(rule.troubleRate)}
+                    </td>
+                    <td className="py-1.5 text-right font-mono">
+                      {formatDuration(rule.medianMs)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+
+        <Card
+          title="What keeps going wrong"
+          subtitle="Grouped, because the same message forty times is one problem"
+        >
+          {insights.failures.length === 0 ? (
+            <EmptyState title="Nothing has failed in this period" />
+          ) : (
+            <ul className="space-y-2">
+              {insights.failures.map((failure) => (
+                <li
+                  key={`${failure.action}-${failure.detail}`}
+                  className="flex items-baseline gap-2 border-b border-[var(--border-subtle)] pb-2 last:border-0 last:pb-0"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium text-[var(--text-strong)]">
+                      {actionLabel(failure.action)}
+                    </span>
+                    <span className="block text-sm text-[var(--text-muted)]">
+                      {failure.detail}
+                    </span>
+                  </span>
+                  <span className="shrink-0 font-mono text-sm text-[var(--status-error-text)]">
+                    ×{failure.count}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/crm/workflows/sequence-canvas.tsx
+++ b/components/crm/workflows/sequence-canvas.tsx
@@ -161,12 +161,17 @@ export function SequenceInsert({
       <span className="relative z-10 flex size-8 shrink-0 items-center justify-center">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
+            {/* The dashed circle stays 20px — it sits on a rail between
+                steps and a bigger one would read as a step itself. The
+                button around it is 32px, so a thumb has something to hit. */}
             <button
               type="button"
               aria-label={label}
-              className="flex size-5 items-center justify-center rounded-full border border-dashed border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition-colors hover:border-[var(--brand)] hover:text-[var(--text)]"
+              className="group/insert flex size-8 items-center justify-center rounded-full"
             >
-              <Plus className="size-3" aria-hidden="true" />
+              <span className="flex size-5 items-center justify-center rounded-full border border-dashed border-[var(--border)] bg-[var(--surface)] text-[var(--text-muted)] transition-colors group-hover/insert:border-[var(--brand)] group-hover/insert:text-[var(--text)]">
+                <Plus className="size-3" aria-hidden="true" />
+              </span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">

--- a/components/crm/workflows/workflow-editor.tsx
+++ b/components/crm/workflows/workflow-editor.tsx
@@ -452,7 +452,7 @@ export function WorkflowEditor({ workflowId }: { workflowId: string | null }) {
             >
               {action.type === "CREATE_TASK" ? (
                 <div className="space-y-2">
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <Input
                       className="flex-1"
                       value={action.title}
@@ -461,7 +461,7 @@ export function WorkflowEditor({ workflowId }: { workflowId: string | null }) {
                       onChange={(event) => patchAction(index, { title: event.target.value })}
                     />
                     <Input
-                      className="w-28"
+                      className="w-20 sm:w-28"
                       type="number"
                       min={0}
                       value={action.dueInDays}
@@ -471,7 +471,7 @@ export function WorkflowEditor({ workflowId }: { workflowId: string | null }) {
                       }
                     />
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <OptionSelect
                       className="flex-1"
                       value={action.taskType ?? "GENERAL"}
@@ -533,7 +533,7 @@ export function WorkflowEditor({ workflowId }: { workflowId: string | null }) {
               ) : null}
 
               {action.type === "SET_FIELD" ? (
-                <div className="flex gap-2">
+                <div className="flex flex-wrap gap-2">
                   <OptionSelect
                     className="flex-1"
                     value={action.field}

--- a/components/crm/workflows/workflow-runs-content.tsx
+++ b/components/crm/workflows/workflow-runs-content.tsx
@@ -99,12 +99,16 @@ export function WorkflowRunsContent() {
       <PageChrome title="Workflow activity" />
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <SegmentedControl
-          options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
-          value={range}
-          onValueChange={(value) => setRange(value as ReportRange)}
-          aria-label="Reporting period"
-        />
+        {/* Six range labels run past 400px together; the control scrolls
+            inside its own rail rather than stretching the page. */}
+        <div className="scroll-rail max-w-full overflow-x-auto">
+          <SegmentedControl
+            options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
+            value={range}
+            onValueChange={(value) => setRange(value as ReportRange)}
+            aria-label="Reporting period"
+          />
+        </div>
       </div>
 
       <RunInsightsPanel range={range} />

--- a/components/crm/workflows/workflow-runs-content.tsx
+++ b/components/crm/workflows/workflow-runs-content.tsx
@@ -4,15 +4,17 @@ import Link from "next/link";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { Alert, Badge, EmptyState, Stack } from "@corelithzw/react";
+import { Alert, Badge, EmptyState, SegmentedControl, Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
 import { ClientDate } from "@/components/ui/client-date";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageChrome } from "@/components/layout/page-chrome";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { TRIGGER_LABELS } from "@/lib/crm/automation";
+import { REPORT_RANGES, REPORT_RANGE_LABELS, type ReportRange } from "@/lib/crm/reports";
 import { Rule } from "@/lib/icons";
 
+import { RunInsightsPanel } from "./run-insights-panel";
 import { TRIGGER_ICON } from "./workflow-marks";
 
 type RunRow = {
@@ -80,6 +82,7 @@ function actionLabel(type: string): string {
  */
 export function WorkflowRunsContent() {
   const [status, setStatus] = useState<"all" | "SUCCEEDED" | "FAILED">("all");
+  const [range, setRange] = useState<ReportRange>("30d");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["crm-workflow-runs", status],
@@ -94,6 +97,19 @@ export function WorkflowRunsContent() {
   return (
     <div className="space-y-5">
       <PageChrome title="Workflow activity" />
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <SegmentedControl
+          options={REPORT_RANGES.map((value) => ({ value, label: REPORT_RANGE_LABELS[value] }))}
+          value={range}
+          onValueChange={(value) => setRange(value as ReportRange)}
+          aria-label="Reporting period"
+        />
+      </div>
+
+      <RunInsightsPanel range={range} />
+
+      <h2 className="text-base font-semibold text-[var(--text-strong)]">Every firing</h2>
 
       <div className="flex flex-wrap items-center gap-2">
         {(

--- a/components/crm/workflows/workflows-content.tsx
+++ b/components/crm/workflows/workflows-content.tsx
@@ -100,7 +100,7 @@ export function WorkflowsContent() {
   };
 
   return (
-    <div className="max-w-3xl space-y-4">
+    <div className="mx-auto max-w-3xl space-y-4">
       <PageChrome title="Workflows">
         <Button type="button" asChild>
           <Link href="/crm/workflows/new">

--- a/components/layout/command-bar/global-command-bar.tsx
+++ b/components/layout/command-bar/global-command-bar.tsx
@@ -470,7 +470,12 @@ export function GlobalCommandBar() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label="Search"
-        className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border)] px-2.5 py-1.5 text-sm text-[var(--text-muted)] transition-colors hover:bg-[var(--surface-subtle)] hover:text-[var(--text)]"
+        // `btn btn-secondary` rather than a hand-rolled box: this sits in the
+        // app bar between the notification bell and the page's own action,
+        // and drawing its own padding is how it ended up 30px tall against
+        // their 36. The height, radius and gap now come from the same place
+        // theirs do.
+        className="btn btn-secondary text-[var(--text-muted)] hover:text-[var(--text)]"
       >
         <Search className="size-4" aria-hidden="true" />
         <span className="hidden lg:inline">Search</span>

--- a/components/templates/template-library.tsx
+++ b/components/templates/template-library.tsx
@@ -28,7 +28,13 @@ import {
   TEMPLATE_KIND_LABELS,
   type TemplateKind,
 } from "@/lib/crm/blocks";
+import {
+  starterBlocks,
+  starterTemplate,
+  startersForKind,
+} from "@/lib/crm/starter-templates";
 import { FileText, Plus } from "@/lib/icons";
+import { cn } from "@/lib/utils";
 
 /**
  * Every template in the company, in one place.
@@ -119,6 +125,7 @@ export function TemplateLibrary() {
   const [createOpen, setCreateOpen] = useState(false);
   const [draftName, setDraftName] = useState("");
   const [draftKind, setDraftKind] = useState<TemplateKind>("FORM");
+  const [draftStarter, setDraftStarter] = useState<string | null>("site-brief");
   const [errors, setErrors] = useState<string[]>([]);
 
   const blocks = useQuery({
@@ -141,6 +148,9 @@ export function TemplateLibrary() {
     },
   });
 
+  const starters = startersForKind(draftKind);
+  const starter = draftStarter ? starterTemplate(draftStarter) : undefined;
+
   const create = useMutation({
     mutationFn: () =>
       fetchJson<{ id: string }>("/api/v2/crm/templates", {
@@ -148,29 +158,20 @@ export function TemplateLibrary() {
         body: JSON.stringify({
           name: draftName.trim(),
           kind: draftKind,
-          attributes: { custom: {} },
-          // A new template starts with one heading rather than empty: an empty
-          // canvas is where people put the thing down and never come back.
-          blocks: [
-            { id: "title", type: "heading", text: draftName.trim(), level: 1 },
-            ...(draftKind === "FORM"
-              ? [
-                  {
-                    id: "name",
-                    type: "field" as const,
-                    key: "name",
-                    label: "Your name",
-                    fieldType: "text" as const,
-                    required: true,
-                  },
-                ]
-              : []),
-          ],
+          attributes: { custom: {}, emoji: starter?.emoji ?? null },
+          // Starting from a finished document rather than a blank one. An
+          // empty canvas is where people put the thing down and never come
+          // back — and nobody should have to remember what an invoice needs
+          // on it before they can write one.
+          blocks: starter
+            ? starterBlocks(starter, draftName)
+            : [{ id: "title", type: "heading", text: draftName.trim(), level: 1 }],
         }),
       }),
     onSuccess: (created) => {
       setCreateOpen(false);
       setDraftName("");
+      setDraftStarter(null);
       queryClient.invalidateQueries({ queryKey: ["crm-templates"] });
       router.push(`/templates/${created.id}`);
     },
@@ -379,7 +380,17 @@ export function TemplateLibrary() {
 
         <div className="space-y-1.5">
           <Label>What is it for</Label>
-          <Select value={draftKind} onValueChange={(value) => setDraftKind(value as TemplateKind)}>
+          <Select
+            value={draftKind}
+            onValueChange={(value) => {
+              const kind = value as TemplateKind;
+              setDraftKind(kind);
+              // Whatever was picked belongs to the old kind. Defaulting to the
+              // first starter of the new one beats silently keeping a choice
+              // that no longer exists.
+              setDraftStarter(startersForKind(kind)[0]?.id ?? null);
+            }}
+          >
             <SelectTrigger aria-label="Template kind">
               <SelectValue />
             </SelectTrigger>
@@ -394,6 +405,55 @@ export function TemplateLibrary() {
           <p className="text-sm text-[var(--text-muted)]">
             {TEMPLATE_KIND_DESCRIPTIONS[draftKind]}
           </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Start from</Label>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {starters.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                aria-pressed={draftStarter === option.id}
+                onClick={() => setDraftStarter(option.id)}
+                className={cn(
+                  "rounded-[var(--radius-md)] border p-2.5 text-left",
+                  draftStarter === option.id
+                    ? "border-[var(--interactive-primary)] bg-[var(--surface-hover)]"
+                    : "border-[var(--border)] hover:border-[var(--interactive-primary)]",
+                )}
+              >
+                <span className="block text-sm font-medium text-[var(--text-strong)]">
+                  <span aria-hidden="true" className="mr-1.5">
+                    {option.emoji}
+                  </span>
+                  {option.name}
+                </span>
+                <span className="mt-0.5 block text-sm text-[var(--text-muted)]">
+                  {option.description}
+                </span>
+              </button>
+            ))}
+
+            <button
+              type="button"
+              aria-pressed={draftStarter === null}
+              onClick={() => setDraftStarter(null)}
+              className={cn(
+                "rounded-[var(--radius-md)] border p-2.5 text-left",
+                draftStarter === null
+                  ? "border-[var(--interactive-primary)] bg-[var(--surface-hover)]"
+                  : "border-dashed border-[var(--border)] hover:border-[var(--interactive-primary)]",
+              )}
+            >
+              <span className="block text-sm font-medium text-[var(--text-strong)]">
+                Blank
+              </span>
+              <span className="mt-0.5 block text-sm text-[var(--text-muted)]">
+                Just a title. Build the rest yourself.
+              </span>
+            </button>
+          </div>
         </div>
       </RecordDialog>
     </div>

--- a/components/ui/column-picker.tsx
+++ b/components/ui/column-picker.tsx
@@ -41,9 +41,11 @@ export function ColumnPicker({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        {/* h-9 gap-2, the same box as every other trigger in the view
-            toolbar — this was the one control in the row at its own height. */}
-        <Button type="button" variant="outline" size="sm" className="h-9 gap-2">
+        {/* No size and no height class: the design system's default control
+            height is what every other trigger in the toolbar is, and asking
+            for `sm` and then forcing 36px back on top is how the row ended up
+            with three different heights in it. */}
+        <Button type="button" variant="outline">
           <Eye className="size-4" aria-hidden="true" />
           {label}
           {/* The count alone. "2 hidden" spelt out makes the trigger a

--- a/components/ui/data-table-mobile.test.tsx
+++ b/components/ui/data-table-mobile.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DataTable } from "./data-table";
+
+/**
+ * The defect this pins down:
+ *
+ * `DataTable` hid its desktop table below `md` only when `mobileCardRenderer`
+ * was set. Every `mobileListRenderer` caller therefore rendered the mobile
+ * list *and* the full table, stacked, on a phone — the list, then the same
+ * records again as an eight-column grid nobody could read.
+ */
+const DATA = [{ id: "a", name: "Meikles Hotel" }];
+const COLUMNS = [{ id: "name", header: "Name", cell: () => "Meikles Hotel" }];
+
+function tableContainerHidden(html: string) {
+  // The table lives inside the last container the component renders; a
+  // `hidden md:block` anywhere in the markup is that container, since nothing
+  // else in a DataTable uses the pair.
+  return html.includes("hidden md:block");
+}
+
+describe("DataTable mobile renderers", () => {
+  it("hides the table below md when a list renderer is given", () => {
+    const html = renderToStaticMarkup(
+      <DataTable
+        data={DATA}
+        columns={COLUMNS}
+        mobileListRenderer={({ rows }) => <ul>{rows.map(() => null)}</ul>}
+      />,
+    );
+    expect(tableContainerHidden(html)).toBe(true);
+  });
+
+  it("still hides it for the card renderer", () => {
+    const html = renderToStaticMarkup(
+      <DataTable data={DATA} columns={COLUMNS} mobileCardRenderer={() => null} />,
+    );
+    expect(tableContainerHidden(html)).toBe(true);
+  });
+
+  it("leaves the table visible when neither is given", () => {
+    const html = renderToStaticMarkup(<DataTable data={DATA} columns={COLUMNS} />);
+    expect(tableContainerHidden(html)).toBe(false);
+  });
+});

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1279,7 +1279,10 @@ export function DataTable<TData, TValue>({
         className={cn(
           maxBodyHeight ? "overflow-auto" : undefined,
           tableContainerClassName,
-          mobileCardRenderer && "hidden md:block",
+          // Either mobile renderer replaces the table below `md`. Checking only
+          // `mobileCardRenderer` here left every `mobileListRenderer` caller
+          // stacking the list on top of the full table on a phone.
+          (mobileCardRenderer || mobileListRenderer) && "hidden md:block",
         )}
         style={maxBodyHeight ? { maxHeight: maxBodyHeight } : undefined}
       >

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -18,3 +18,26 @@ export function useIsMobile() {
 
   return Boolean(isMobile)
 }
+
+/**
+ * Below a given width, tracked live.
+ *
+ * `useIsMobile` is pinned to 768px, which is the phone question. This is the
+ * layout question — the width at which a record page stops having room for a
+ * rail beside its content — and that boundary is 1024px, the same one
+ * `.detail-grid` collapses at.
+ */
+export function useIsBelow(width: number) {
+  const [below, setBelow] = React.useState<boolean | null>(null)
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(`(max-width: ${width - 1}px)`)
+    const update = () => setBelow(mediaQuery.matches)
+
+    update()
+    mediaQuery.addEventListener("change", update)
+    return () => mediaQuery.removeEventListener("change", update)
+  }, [width])
+
+  return Boolean(below)
+}

--- a/lib/crm/automation-runner.ts
+++ b/lib/crm/automation-runner.ts
@@ -208,6 +208,10 @@ export async function runAutomations(event: AutomationEvent): Promise<void> {
 
       const actions = (rule.actions ?? []) as AutomationAction[];
       const outcomes: ActionOutcome[] = [];
+      // Measured rather than estimated: "this rule is slow" should be a fact
+      // somebody can check against the others, not a feeling about the rule
+      // that happens to run when the page is busy.
+      const startedAt = Date.now();
 
       for (const action of actions) {
         try {
@@ -234,6 +238,8 @@ export async function runAutomations(event: AutomationEvent): Promise<void> {
             recordId: event.recordId,
             status,
             result: outcomes as unknown as Prisma.InputJsonValue,
+            durationMs: Date.now() - startedAt,
+            actionCount: outcomes.length,
           },
         }),
         prisma.crmAutomation.update({

--- a/lib/crm/custom-fields-merge.test.ts
+++ b/lib/crm/custom-fields-merge.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { mergeCustomFields } from "./custom-fields";
+
+describe("mergeCustomFields, as the record page uses it", () => {
+  it("writing one property does not drop the others", () => {
+    // The attribute row commits a single key. A replace would wipe the rest.
+    const merged = mergeCustomFields(
+      { roofType: "IBR", accessNotes: "gate code 1234" },
+      { roofType: "Chromadek" },
+    );
+    expect(merged).toEqual({ roofType: "Chromadek", accessNotes: "gate code 1234" });
+  });
+
+  it("emptying a property keeps it present rather than forgetting it", () => {
+    const merged = mergeCustomFields({ roofType: "IBR" }, { roofType: null });
+    expect(merged).toEqual({ roofType: null });
+  });
+
+  it("starts from nothing when the record has never had one", () => {
+    expect(mergeCustomFields(null, { roofType: "IBR" })).toEqual({ roofType: "IBR" });
+  });
+});

--- a/lib/crm/panels.test.ts
+++ b/lib/crm/panels.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { fileMark, formatFileSize, meetingPlace, timeToStart } from "./panels";
+
+describe("timeToStart", () => {
+  const now = new Date("2026-03-15T09:00:00Z");
+
+  it("is exact where exactness matters and rounded where it does not", () => {
+    // Nobody needs "in 2 hours 43 minutes"; everybody needs "in 5 minutes"
+    // to be right.
+    expect(timeToStart("2026-03-15T09:05:00Z", now).label).toBe("in 5 minutes");
+    expect(timeToStart("2026-03-15T11:43:00Z", now).label).toBe("in 3 hours");
+    expect(timeToStart("2026-03-18T09:00:00Z", now).label).toBe("in 3 days");
+  });
+
+  it("says a meeting is now rather than in zero minutes", () => {
+    const soon = timeToStart("2026-03-15T09:00:30Z", now);
+    expect(soon.label).toBe("Starting now");
+    expect(soon.imminent).toBe(true);
+  });
+
+  it("flags the quarter hour before, so a panel can say so", () => {
+    expect(timeToStart("2026-03-15T09:10:00Z", now).imminent).toBe(true);
+    expect(timeToStart("2026-03-15T09:40:00Z", now).imminent).toBe(false);
+  });
+
+  it("reads a meeting that has already started as past, not imminent", () => {
+    const late = timeToStart("2026-03-15T08:50:00Z", now);
+    expect(late.label).toBe("10 minutes ago");
+    expect(late.past).toBe(true);
+    expect(late.imminent).toBe(false);
+  });
+
+  it("singularises so it does not say 1 minutes", () => {
+    expect(timeToStart("2026-03-15T09:01:00Z", now).label).toBe("in 1 minute");
+    expect(timeToStart("2026-03-16T09:00:00Z", now).label).toBe("in 1 day");
+  });
+
+  it("says the time is unknown rather than NaN", () => {
+    expect(timeToStart("not a date", now).label).toBe("Time unknown");
+  });
+});
+
+describe("meetingPlace", () => {
+  it("offers a join for a video link", () => {
+    expect(meetingPlace("https://meet.example.com/abc-defg")).toMatchObject({ kind: "join" });
+  });
+
+  it("offers a map for an address", () => {
+    const place = meetingPlace("8 Enterprise Road, Harare");
+    expect(place.kind).toBe("map");
+    if (place.kind === "map") {
+      expect(place.text).toBe("8 Enterprise Road, Harare");
+      expect(place.url).toContain("Enterprise%20Road");
+    }
+  });
+
+  it("offers nothing when there is nowhere to go", () => {
+    // A button that opens a map of nowhere is worse than no button.
+    expect(meetingPlace(null).kind).toBe("none");
+    expect(meetingPlace("   ").kind).toBe("none");
+  });
+
+  it("does not treat a bare scheme as somewhere to join", () => {
+    expect(meetingPlace("https://").kind).toBe("map");
+  });
+
+  it("does not open a javascript url", () => {
+    expect(meetingPlace("javascript:alert(1)").kind).toBe("map");
+  });
+});
+
+describe("fileMark", () => {
+  it("colours by what a thing is, not by its extension", () => {
+    // A .jpg and a .heic are both a photo; nobody cares which camera made it.
+    expect(fileMark("site.jpg")).toEqual(fileMark("site.heic"));
+    expect(fileMark("quote.pdf").label).toBe("PDF");
+    expect(fileMark("prices.csv").label).toBe("XLS");
+  });
+
+  it("ignores case and path", () => {
+    expect(fileMark("SCAN.PDF").label).toBe("PDF");
+  });
+
+  it("uses the last extension, not the first", () => {
+    expect(fileMark("archive.tar.gz").label).toBe("ZIP");
+  });
+
+  it("does not read a hidden file's name as an extension", () => {
+    expect(fileMark(".gitignore").label).toBe("FILE");
+  });
+
+  it("falls back rather than throwing on nothing", () => {
+    expect(fileMark(null).label).toBe("FILE");
+    expect(fileMark("README").label).toBe("FILE");
+  });
+});
+
+describe("formatFileSize", () => {
+  it("uses the units the operating system on the desk reports", () => {
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1024)).toBe("1.0 KB");
+    expect(formatFileSize(1024 * 1024 * 2.5)).toBe("2.5 MB");
+  });
+
+  it("stops showing decimals once they are noise", () => {
+    // "941.3 MB" is three digits of nothing.
+    expect(formatFileSize(1024 * 1024 * 941.3)).toBe("941 MB");
+  });
+
+  it("says nothing when the size is not known", () => {
+    expect(formatFileSize(null)).toBe("");
+    expect(formatFileSize(undefined)).toBe("");
+    expect(formatFileSize(-1)).toBe("");
+  });
+});

--- a/lib/crm/panels.ts
+++ b/lib/crm/panels.ts
@@ -1,0 +1,161 @@
+import type { Accent } from "@corelithzw/react";
+
+/**
+ * The small facts the record panels are made of.
+ *
+ * Pure, because every one of them is a thing that reads correctly for months
+ * and then gets a date wrong on the day of, or rounds 1024 bytes to "1KB" in
+ * one panel and "1.0 KB" in another. Cheaper to pin down here than to notice
+ * in a screenshot.
+ */
+
+export type Countdown = {
+  label: string;
+  /** Whether this wants attention now. */
+  imminent: boolean;
+  past: boolean;
+};
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * How long until a meeting, in the words somebody would use.
+ *
+ * Rounded to the unit that matters: nobody needs "in 2 hours 43 minutes", and
+ * everybody needs "in 5 minutes" to be exact. Something within a quarter of an
+ * hour is called imminent so a panel can say so rather than leaving the reader
+ * to compare a timestamp against their own watch.
+ */
+export function timeToStart(start: Date | string, now: Date = new Date()): Countdown {
+  const at = typeof start === "string" ? new Date(start) : start;
+  if (Number.isNaN(at.getTime())) {
+    return { label: "Time unknown", imminent: false, past: false };
+  }
+
+  const delta = at.getTime() - now.getTime();
+  const past = delta < 0;
+  const magnitude = Math.abs(delta);
+
+  if (magnitude < MINUTE) {
+    return { label: "Starting now", imminent: true, past };
+  }
+
+  const say = (value: number, unit: string) =>
+    `${value} ${unit}${value === 1 ? "" : "s"}`;
+
+  let phrase: string;
+  if (magnitude < HOUR) phrase = say(Math.round(magnitude / MINUTE), "minute");
+  else if (magnitude < DAY) phrase = say(Math.round(magnitude / HOUR), "hour");
+  else phrase = say(Math.round(magnitude / DAY), "day");
+
+  return {
+    label: past ? `${phrase} ago` : `in ${phrase}`,
+    imminent: !past && delta <= 15 * MINUTE,
+    past,
+  };
+}
+
+/**
+ * A meeting's location, resolved into something to press.
+ *
+ * The field is one free-text box because that is what people want — sometimes
+ * a video link, usually an address, occasionally "the blue gate on Enterprise
+ * Road". So it is read rather than configured: a URL becomes Join, anything
+ * else becomes a maps search, and empty becomes nothing at all rather than a
+ * button that opens a map of nowhere.
+ */
+export type MeetingPlace =
+  | { kind: "join"; url: string }
+  | { kind: "map"; url: string; text: string }
+  | { kind: "none" };
+
+export function meetingPlace(location: string | null | undefined): MeetingPlace {
+  const text = location?.trim();
+  if (!text) return { kind: "none" };
+
+  if (/^https?:\/\//i.test(text)) {
+    try {
+      // Parsed rather than pattern-matched: "https://" alone passes a regex
+      // and opens a blank tab.
+      const url = new URL(text);
+      if (url.hostname) return { kind: "join", url: url.toString() };
+    } catch {
+      // Not a URL after all — treat it as a place.
+    }
+  }
+
+  return {
+    kind: "map",
+    text,
+    url: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(text)}`,
+  };
+}
+
+export type FileMark = { label: string; accent: Accent };
+
+/**
+ * A coloured mark per file type.
+ *
+ * Colour carries the type so a list of eleven attachments can be scanned for
+ * "the PDF" without reading eleven filenames. Grouped by what a thing is
+ * rather than by extension — a .jpg and a .heic are both a photo, and nobody
+ * cares which camera produced which.
+ */
+const MARKS: Array<{ accent: Accent; label: string; extensions: string[] }> = [
+  { accent: "red", label: "PDF", extensions: ["pdf"] },
+  { accent: "blue", label: "DOC", extensions: ["doc", "docx", "rtf", "odt", "pages"] },
+  { accent: "green", label: "XLS", extensions: ["xls", "xlsx", "csv", "ods", "numbers"] },
+  { accent: "orange", label: "PPT", extensions: ["ppt", "pptx", "key", "odp"] },
+  {
+    accent: "violet",
+    label: "IMG",
+    extensions: ["png", "jpg", "jpeg", "gif", "webp", "heic", "heif", "avif", "svg", "bmp"],
+  },
+  { accent: "teal", label: "VID", extensions: ["mp4", "mov", "avi", "mkv", "webm", "m4v"] },
+  { accent: "cyan", label: "AUD", extensions: ["mp3", "wav", "m4a", "aac", "ogg"] },
+  { accent: "amber", label: "ZIP", extensions: ["zip", "rar", "7z", "tar", "gz"] },
+  { accent: "indigo", label: "TXT", extensions: ["txt", "md", "json", "xml", "log"] },
+];
+
+const BY_EXTENSION = new Map<string, FileMark>(
+  MARKS.flatMap((mark) =>
+    mark.extensions.map(
+      (extension) => [extension, { label: mark.label, accent: mark.accent }] as const,
+    ),
+  ),
+);
+
+export function fileMark(filename: string | null | undefined): FileMark {
+  const name = filename?.trim() ?? "";
+  const dot = name.lastIndexOf(".");
+  // A leading dot is a hidden file, not an extension: ".gitignore" is not a
+  // "GITIGNORE file".
+  const extension = dot > 0 ? name.slice(dot + 1).toLowerCase() : "";
+  return BY_EXTENSION.get(extension) ?? { label: "FILE", accent: "gray" };
+}
+
+/**
+ * A file size somebody can read.
+ *
+ * Binary units, because that is what every operating system on the desk
+ * reports and a file that says 2.1 MB here and 2.0 MB in Finder starts an
+ * argument about whether it uploaded properly.
+ */
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  // One decimal below ten, none above: "9.4 MB" is useful precision and
+  // "941.3 MB" is three digits of noise.
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}

--- a/lib/crm/quote-suggestions.test.ts
+++ b/lib/crm/quote-suggestions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSuggestions,
+  catalogueSuggestions,
+  visitSuggestions,
+  type CatalogueProduct,
+  type VisitItemOption,
+} from "./quote-suggestions";
+
+function visitItem(overrides: Partial<VisitItemOption> = {}): VisitItemOption {
+  return {
+    id: "v1",
+    description: "Aluminium sliding window",
+    quantity: 3,
+    unit: "each",
+    unitPrice: 240,
+    visitLabel: "Roof survey",
+    ...overrides,
+  };
+}
+
+function product(overrides: Partial<CatalogueProduct> = {}): CatalogueProduct {
+  return {
+    id: "p1",
+    code: "WIN-ALU-12",
+    name: "Aluminium window 1200mm",
+    isActive: true,
+    line: {
+      description: "Aluminium window 1200mm",
+      unitPrice: 260,
+      taxRate: 15,
+      priceSource: "standard",
+    },
+    ...overrides,
+  };
+}
+
+describe("visitSuggestions", () => {
+  it("carries the measured quantity onto the line", () => {
+    // The point of measuring three windows is not typing "3" again.
+    const [suggestion] = visitSuggestions([visitItem()], "");
+    expect(suggestion.pick).toMatchObject({
+      description: "Aluminium sliding window",
+      unitPrice: 240,
+      quantity: 3,
+    });
+  });
+
+  it("passes an unpriced measurement through as null, not as free", () => {
+    // Somebody wrote down a size and left the pricing for later. 0.00 in the
+    // box would look like a decision nobody made.
+    const [suggestion] = visitSuggestions([visitItem({ unitPrice: null })], "");
+    expect(suggestion.pick.unitPrice).toBeNull();
+    expect(suggestion.trailing).toBeNull();
+  });
+
+  it("says which visit it was measured on, so two surveys stay apart", () => {
+    const [suggestion] = visitSuggestions([visitItem()], "");
+    expect(suggestion.detail).toBe("3 each · Roof survey");
+  });
+
+  it("matches on a substring from the first keystroke", () => {
+    const items = [
+      visitItem({ id: "a", description: "Aluminium sliding window" }),
+      visitItem({ id: "b", description: "Timber door frame" }),
+    ];
+    expect(visitSuggestions(items, "door").map((s) => s.pick.description)).toEqual([
+      "Timber door frame",
+    ]);
+  });
+
+  it("is case-insensitive, because nobody types the way it was written down", () => {
+    expect(visitSuggestions([visitItem()], "ALUMINIUM")).toHaveLength(1);
+  });
+
+  it("offers everything before anything is typed", () => {
+    const items = [visitItem({ id: "a" }), visitItem({ id: "b" })];
+    expect(visitSuggestions(items, "   ")).toHaveLength(2);
+  });
+
+  it("drops a measurement with no description — there is nothing to quote", () => {
+    expect(visitSuggestions([visitItem({ description: "   " })], "")).toEqual([]);
+  });
+
+  it("caps the list so the catalogue is still reachable below it", () => {
+    const many = Array.from({ length: 20 }, (_, i) => visitItem({ id: `v${i}` }));
+    expect(visitSuggestions(many, "")).toHaveLength(6);
+  });
+});
+
+describe("catalogueSuggestions", () => {
+  it("carries price and tax, which is the whole reason to pick from a list", () => {
+    const [suggestion] = catalogueSuggestions([product()]);
+    expect(suggestion.pick).toMatchObject({
+      productId: "p1",
+      description: "Aluminium window 1200mm",
+      unitPrice: 260,
+      taxRate: 15,
+    });
+  });
+
+  it("says when a price came off a named list rather than the standard rate", () => {
+    const [suggestion] = catalogueSuggestions([
+      product({ line: { ...product().line, priceSource: "trade" } }),
+    ]);
+    expect(suggestion.detail).toBe("WIN-ALU-12 · trade price");
+  });
+
+  it("shows the bare code when the price is the standard one", () => {
+    expect(catalogueSuggestions([product()])[0].detail).toBe("WIN-ALU-12");
+  });
+
+  it("falls back to the product name when the line has no description", () => {
+    const [suggestion] = catalogueSuggestions([
+      product({ line: { ...product().line, description: "" } }),
+    ]);
+    expect(suggestion.pick.description).toBe("Aluminium window 1200mm");
+  });
+
+  it("never offers a retired product", () => {
+    expect(catalogueSuggestions([product({ isActive: false })])).toEqual([]);
+  });
+
+  it("sets no quantity — a catalogue item has no measured amount", () => {
+    expect(catalogueSuggestions([product()])[0].pick.quantity).toBeUndefined();
+  });
+});
+
+describe("buildSuggestions", () => {
+  it("puts what was measured above what is on the shelf", () => {
+    // On a job that had a survey, the first arrow-down should land on the
+    // thing somebody stood in front of.
+    const suggestions = buildSuggestions({
+      visitItems: [visitItem()],
+      products: [product()],
+      query: "alu",
+    });
+    expect(suggestions.map((s) => s.source)).toEqual(["visit", "catalogue"]);
+  });
+
+  it("gives every suggestion a distinct key, since they are list keys", () => {
+    const suggestions = buildSuggestions({
+      visitItems: [visitItem({ id: "1" })],
+      products: [product({ id: "1" })],
+      query: "",
+    });
+    expect(new Set(suggestions.map((s) => s.key)).size).toBe(suggestions.length);
+  });
+
+  it("returns nothing rather than throwing when there is nothing to offer", () => {
+    expect(buildSuggestions({ visitItems: [], products: [], query: "anything" })).toEqual([]);
+  });
+});

--- a/lib/crm/quote-suggestions.ts
+++ b/lib/crm/quote-suggestions.ts
@@ -1,0 +1,135 @@
+/**
+ * What to offer on a quote line, from the two places a line can come from.
+ *
+ * Pulled out of the picker so it can be tested. The component around it is a
+ * text box, a popover and some keyboard handling — none of which is where the
+ * mistakes are. The mistakes are here: which source wins, what a suggestion
+ * carries into the line, and what happens to a measured item that nobody
+ * priced. Those are worth pinning down, especially since the last rewrite of
+ * this field shipped a bug that made it untypeable for weeks.
+ */
+
+export type VisitItemOption = {
+  id: string;
+  description: string;
+  quantity: number;
+  unit: string | null;
+  unitPrice: number | null;
+  /** Which visit it was measured on, so two surveys stay distinguishable. */
+  visitLabel: string;
+};
+
+export type CatalogueProduct = {
+  id: string;
+  code: string;
+  name: string;
+  isActive: boolean;
+  line: {
+    description: string;
+    unitPrice: number;
+    taxRate: number;
+    priceSource: string;
+  };
+};
+
+export type LinePick = {
+  productId?: string;
+  description: string;
+  /** Null when nobody has priced it yet — not zero, which reads as free. */
+  unitPrice: number | null;
+  taxRate?: number;
+  quantity?: number;
+};
+
+export type Suggestion = {
+  key: string;
+  source: "catalogue" | "visit";
+  title: string;
+  detail: string;
+  trailing: string | null;
+  pick: LinePick;
+};
+
+const VISIT_LIMIT = 6;
+const CATALOGUE_LIMIT = 8;
+
+function money(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function visitSuggestions(
+  items: VisitItemOption[],
+  query: string,
+): Suggestion[] {
+  const needle = query.trim().toLowerCase();
+
+  return items
+    .filter((item) => item.description.trim())
+    .filter((item) => !needle || item.description.toLowerCase().includes(needle))
+    .slice(0, VISIT_LIMIT)
+    .map((item) => ({
+      key: `visit-${item.id}`,
+      source: "visit" as const,
+      title: item.description,
+      detail: [
+        item.quantity ? `${item.quantity}${item.unit ? ` ${item.unit}` : ""}` : null,
+        item.visitLabel,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      trailing: item.unitPrice != null ? money(item.unitPrice) : null,
+      pick: {
+        description: item.description,
+        // Carried through as null rather than coerced. A measurement taken
+        // without a price is a size somebody wrote down, and filling the box
+        // with 0.00 would look like a decision nobody made.
+        unitPrice: item.unitPrice,
+        quantity: item.quantity,
+      },
+    }));
+}
+
+export function catalogueSuggestions(products: CatalogueProduct[]): Suggestion[] {
+  return products
+    .filter((product) => product.isActive)
+    .slice(0, CATALOGUE_LIMIT)
+    .map((product) => ({
+      key: `product-${product.id}`,
+      source: "catalogue" as const,
+      title: product.name,
+      // A price off a named list is worth saying so: somebody reading the
+      // quote later needs to know it was not the standard rate.
+      detail:
+        product.line.priceSource !== "standard"
+          ? `${product.code} · ${product.line.priceSource} price`
+          : product.code,
+      trailing: money(product.line.unitPrice),
+      pick: {
+        productId: product.id,
+        description: product.line.description || product.name,
+        unitPrice: product.line.unitPrice,
+        taxRate: product.line.taxRate,
+      },
+    }));
+}
+
+/**
+ * Both sources, measured first.
+ *
+ * On a job that had a survey, the thing being quoted is almost always the
+ * thing somebody stood in front of and measured — so those go at the top,
+ * where the first arrow-down lands.
+ */
+export function buildSuggestions(params: {
+  visitItems: VisitItemOption[];
+  products: CatalogueProduct[];
+  query: string;
+}): Suggestion[] {
+  return [
+    ...visitSuggestions(params.visitItems, params.query),
+    ...catalogueSuggestions(params.products),
+  ];
+}

--- a/lib/crm/record-files.test.ts
+++ b/lib/crm/record-files.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FILE_OWNERS,
+  ownerColumn,
+  ownerWhere,
+  recordFileSchema,
+} from "./record-files";
+
+describe("ownerColumn", () => {
+  it("keeps a rep apart from a customer contact", () => {
+    // A rep is somebody who works here, not somebody we sell to. Squeezing
+    // both into personId is how a rep's signed policy turns up on a
+    // customer's profile.
+    expect(ownerColumn("rep")).toBe("userId");
+    expect(ownerColumn("person")).toBe("personId");
+  });
+
+  it("uses the column the company record actually has", () => {
+    // The company record is CrmClient; "company" is what a reader calls it.
+    expect(ownerColumn("company")).toBe("clientId");
+  });
+
+  it("names a column for every owner it accepts", () => {
+    for (const owner of FILE_OWNERS) {
+      expect(ownerColumn(owner)).toMatch(/Id$/);
+    }
+  });
+
+  it("gives every owner a distinct column", () => {
+    const columns = FILE_OWNERS.map(ownerColumn);
+    expect(new Set(columns).size).toBe(columns.length);
+  });
+});
+
+describe("ownerWhere", () => {
+  it("sets exactly one column", () => {
+    const where = ownerWhere({ kind: "deal", id: "d1" });
+    expect(where).toEqual({ dealId: "d1" });
+    expect(Object.keys(where)).toHaveLength(1);
+  });
+});
+
+describe("recordFileSchema", () => {
+  const valid = {
+    owner: "company" as const,
+    ownerId: "0f9d5b6c-1c2a-4b3d-8e7f-1a2b3c4d5e6f",
+    name: "Signed contract.pdf",
+    url: "https://blob.example.com/signed-contract.pdf",
+  };
+
+  it("accepts a file with just a name and a url", () => {
+    expect(recordFileSchema.parse(valid)).toMatchObject({ name: "Signed contract.pdf" });
+  });
+
+  it("refuses a url that is not one", () => {
+    // The url is rendered as a link and opened in a new tab. Anything that is
+    // not a real url either does nothing or does something worse.
+    expect(() => recordFileSchema.parse({ ...valid, url: "not a url" })).toThrow();
+  });
+
+  it("refuses a file with no name to show", () => {
+    expect(() => recordFileSchema.parse({ ...valid, name: "   " })).toThrow();
+  });
+
+  it("refuses an owner it has no column for", () => {
+    expect(() => recordFileSchema.parse({ ...valid, owner: "invoice" })).toThrow();
+  });
+
+  it("refuses an owner id that is not an id", () => {
+    expect(() => recordFileSchema.parse({ ...valid, ownerId: "42" })).toThrow();
+  });
+
+  it("treats a missing size as unknown rather than zero", () => {
+    const parsed = recordFileSchema.parse(valid);
+    expect(parsed.size).toBeUndefined();
+  });
+});

--- a/lib/crm/record-files.ts
+++ b/lib/crm/record-files.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * Files that belong to a record.
+ *
+ * The CRM could already raise a quote and could already photograph a site
+ * visit, and between those two there was nowhere to put the signed contract,
+ * the tax clearance certificate or the scan of the customer's purchase order.
+ * Those arrived by email and stayed there, which is to say they were held by
+ * whoever happened to receive them.
+ *
+ * The owner is one nullable column per kind rather than an `entity` string
+ * and an id, so the database enforces that the record exists and cascades a
+ * delete. It costs a wider table and buys the guarantee that no file survives
+ * the record it describes.
+ */
+
+export const FILE_OWNERS = ["lead", "deal", "company", "person", "site", "rep"] as const;
+export type FileOwnerKind = (typeof FILE_OWNERS)[number];
+
+export type FileOwner = { kind: FileOwnerKind; id: string };
+
+export const fileOwnerSchema = z.object({
+  owner: z.enum(FILE_OWNERS),
+  ownerId: z.string().uuid(),
+});
+
+export const recordFileSchema = z.object({
+  owner: z.enum(FILE_OWNERS),
+  ownerId: z.string().uuid(),
+  name: z.string().trim().min(1).max(300),
+  url: z.string().trim().url().max(2000),
+  size: z.number().int().min(0).max(2_000_000_000).nullish(),
+  contentType: z.string().trim().max(200).nullish(),
+  note: z.string().trim().max(500).nullish(),
+});
+
+export type RecordFileInput = z.infer<typeof recordFileSchema>;
+
+/**
+ * The column this owner writes to.
+ *
+ * A rep is a User rather than a CRM record — the profile page is a person who
+ * works here, not a person we sell to — so it gets its own column instead of
+ * being squeezed into `personId` and quietly colliding with a customer contact
+ * of the same name.
+ */
+export function ownerColumn(owner: FileOwnerKind): string {
+  switch (owner) {
+    case "lead":
+      return "leadId";
+    case "deal":
+      return "dealId";
+    case "company":
+      return "clientId";
+    case "person":
+      return "personId";
+    case "site":
+      return "siteId";
+    case "rep":
+      return "userId";
+  }
+}
+
+/** The `where`/`data` fragment for one owner. Always exactly one column set. */
+export function ownerWhere(owner: FileOwner): Record<string, string> {
+  return { [ownerColumn(owner.kind)]: owner.id };
+}

--- a/lib/crm/reports.test.ts
+++ b/lib/crm/reports.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   biggestLeak,
   bucketByPeriod,
+  bucketSeries,
   buildFunnel,
   forecast,
   medianCycleDays,
+  medianDaysInStage,
   rangeToDates,
+  shareSlices,
   summarizeGroups,
   winRate,
 } from "./reports";
@@ -230,5 +233,142 @@ describe("rangeToDates", () => {
     const { from } = rangeToDates("12m", now);
     expect(from.getFullYear()).toBe(2025);
     expect(from.getMonth()).toBe(2);
+  });
+});
+
+describe("bucketSeries", () => {
+  const range = { from: new Date("2026-03-01T00:00:00Z"), to: new Date("2026-03-05T00:00:00Z") };
+
+  it("sums a value alongside the count", () => {
+    const buckets = bucketSeries(
+      [
+        { at: "2026-03-02T09:00:00Z", value: 1200 },
+        { at: "2026-03-02T17:00:00Z", value: 300 },
+      ],
+      range,
+    );
+    const day = buckets.find((bucket) => bucket.period === "2026-03-02");
+    expect(day).toEqual({ period: "2026-03-02", count: 2, value: 1500 });
+  });
+
+  it("treats a missing value as nothing rather than as a hole", () => {
+    const buckets = bucketSeries([{ at: "2026-03-03T09:00:00Z" }], range);
+    const day = buckets.find((bucket) => bucket.period === "2026-03-03");
+    expect(day).toEqual({ period: "2026-03-03", count: 1, value: 0 });
+  });
+});
+
+describe("medianDaysInStage", () => {
+  const now = new Date("2026-03-20T00:00:00Z");
+
+  it("measures each span from when the deal entered the stage", () => {
+    const result = medianDaysInStage(
+      [
+        {
+          id: "d1",
+          createdAt: "2026-03-01T00:00:00Z",
+          closedAt: "2026-03-11T00:00:00Z",
+          currentStageId: "won",
+        },
+      ],
+      [
+        { dealId: "d1", fromStageId: "new", toStageId: "quoted", at: "2026-03-03T00:00:00Z" },
+        { dealId: "d1", fromStageId: "quoted", toStageId: "won", at: "2026-03-10T00:00:00Z" },
+      ],
+      now,
+    );
+
+    expect(result.new).toBe(2);
+    expect(result.quoted).toBe(7);
+    expect(result.won).toBe(1);
+  });
+
+  it("counts a deal that has never moved as still sitting where it is", () => {
+    const result = medianDaysInStage(
+      [
+        {
+          id: "d1",
+          createdAt: "2026-03-15T00:00:00Z",
+          closedAt: null,
+          currentStageId: "new",
+        },
+      ],
+      [],
+      now,
+    );
+
+    expect(result.new).toBe(5);
+  });
+
+  it("keeps counting an open deal, because a deal parked for weeks is the point", () => {
+    const result = medianDaysInStage(
+      [{ id: "d1", createdAt: "2026-01-01T00:00:00Z", closedAt: null, currentStageId: "s1" }],
+      [{ dealId: "d1", fromStageId: "s1", toStageId: "s2", at: "2026-01-05T00:00:00Z" }],
+      now,
+    );
+
+    expect(result.s1).toBe(4);
+    expect(result.s2).toBeGreaterThan(70);
+  });
+
+  it("takes the median so one stalled deal does not redefine normal", () => {
+    const deals = [1, 2, 3].map((n) => ({
+      id: `d${n}`,
+      createdAt: "2026-03-01T00:00:00Z",
+      closedAt: null,
+      currentStageId: "s1",
+    }));
+    const changes = [
+      { dealId: "d1", fromStageId: "s1", toStageId: "s2", at: "2026-03-02T00:00:00Z" },
+      { dealId: "d2", fromStageId: "s1", toStageId: "s2", at: "2026-03-04T00:00:00Z" },
+      { dealId: "d3", fromStageId: "s1", toStageId: "s2", at: "2026-06-01T00:00:00Z" },
+    ];
+
+    expect(medianDaysInStage(deals, changes, now).s1).toBe(3);
+  });
+
+  it("ignores a change with no destination recorded", () => {
+    const result = medianDaysInStage(
+      [{ id: "d1", createdAt: "2026-03-10T00:00:00Z", closedAt: null, currentStageId: "s1" }],
+      [{ dealId: "d1", fromStageId: "s1", toStageId: null, at: "2026-03-12T00:00:00Z" }],
+      now,
+    );
+
+    expect(result.s1).toBe(10);
+  });
+});
+
+describe("shareSlices", () => {
+  it("folds everything past the limit into one slice so the shares still sum", () => {
+    const slices = shareSlices(
+      [
+        { key: "a", label: "A", value: 50 },
+        { key: "b", label: "B", value: 30 },
+        { key: "c", label: "C", value: 10 },
+        { key: "d", label: "D", value: 6 },
+        { key: "e", label: "E", value: 4 },
+      ],
+      3,
+    );
+
+    expect(slices).toHaveLength(4);
+    expect(slices[3].label).toBe("Other (2)");
+    expect(slices[3].value).toBe(10);
+    expect(slices.reduce((sum, slice) => sum + slice.share, 0)).toBeCloseTo(1);
+  });
+
+  it("drops a slice of nothing, which has no angle to draw", () => {
+    const slices = shareSlices([
+      { key: "a", label: "A", value: 10 },
+      { key: "b", label: "B", value: 0 },
+      { key: "c", label: "C", value: -5 },
+    ]);
+
+    expect(slices.map((slice) => slice.key)).toEqual(["a"]);
+    expect(slices[0].share).toBe(1);
+  });
+
+  it("returns nothing rather than a pie of zeros", () => {
+    expect(shareSlices([{ key: "a", label: "A", value: 0 }])).toEqual([]);
   });
 });

--- a/lib/crm/reports.ts
+++ b/lib/crm/reports.ts
@@ -166,20 +166,28 @@ export function forecast(
 
 export type ActivityBucket = { period: string; count: number };
 
+export type SeriesPoint = { at: Date | string; value?: number | null };
+export type SeriesBucket = { period: string; count: number; value: number };
+
 /**
- * Roll timestamps into day or week buckets, filling the gaps.
+ * Roll timestamped points into day or week buckets, filling the gaps.
  *
  * Empty periods are emitted as zero rather than skipped: a chart that omits a
  * quiet week draws a straight line through it and hides exactly the thing
  * somebody opened the chart to see.
+ *
+ * Each bucket carries both a count and a summed value, because the two
+ * questions asked of a trend — "how many" and "how much" — are the same walk
+ * over the same rows, and computing them separately is how they end up
+ * disagreeing.
  */
-export function bucketByPeriod(
-  timestamps: (Date | string)[],
+export function bucketSeries(
+  points: SeriesPoint[],
   range: { from: Date; to: Date },
   granularity: "day" | "week" = "day",
-): ActivityBucket[] {
+): SeriesBucket[] {
   const step = granularity === "week" ? 7 : 1;
-  const buckets = new Map<string, number>();
+  const buckets = new Map<string, { count: number; value: number }>();
 
   const cursor = new Date(range.from);
   cursor.setHours(0, 0, 0, 0);
@@ -187,13 +195,13 @@ export function bucketByPeriod(
   end.setHours(0, 0, 0, 0);
 
   while (cursor <= end) {
-    buckets.set(cursor.toISOString().slice(0, 10), 0);
+    buckets.set(cursor.toISOString().slice(0, 10), { count: 0, value: 0 });
     cursor.setDate(cursor.getDate() + step);
   }
 
   const keys = Array.from(buckets.keys());
-  for (const stamp of timestamps) {
-    const date = toDate(stamp);
+  for (const point of points) {
+    const date = toDate(point.at);
     if (Number.isNaN(date.getTime())) continue;
     const day = new Date(date);
     day.setHours(0, 0, 0, 0);
@@ -206,10 +214,163 @@ export function bucketByPeriod(
       if (key <= iso) bucketKey = key;
       else break;
     }
-    if (bucketKey) buckets.set(bucketKey, (buckets.get(bucketKey) ?? 0) + 1);
+    if (!bucketKey) continue;
+    const bucket = buckets.get(bucketKey)!;
+    bucket.count += 1;
+    bucket.value += point.value ?? 0;
   }
 
-  return Array.from(buckets.entries()).map(([period, count]) => ({ period, count }));
+  return Array.from(buckets.entries()).map(([period, bucket]) => ({
+    period,
+    count: bucket.count,
+    value: Math.round(bucket.value * 100) / 100,
+  }));
+}
+
+/** Counts only, for callers that never had a value to sum. */
+export function bucketByPeriod(
+  timestamps: (Date | string)[],
+  range: { from: Date; to: Date },
+  granularity: "day" | "week" = "day",
+): ActivityBucket[] {
+  return bucketSeries(
+    timestamps.map((at) => ({ at })),
+    range,
+    granularity,
+  ).map(({ period, count }) => ({ period, count }));
+}
+
+export type StageChange = {
+  dealId: string;
+  /** Null when the metadata predates stage ids being recorded. */
+  toStageId: string | null;
+  fromStageId: string | null;
+  at: Date | string;
+};
+
+export type DealLife = {
+  id: string;
+  createdAt: Date | string;
+  /** Won or lost; null while it is still running. */
+  closedAt: Date | string | null;
+  currentStageId: string;
+};
+
+/**
+ * How long a deal typically sits in each stage.
+ *
+ * A funnel says how many survive each step; it says nothing about the step
+ * that everything survives and nothing leaves for five weeks. That stage is
+ * usually the expensive one, and it is invisible until it is measured.
+ *
+ * Reconstructed from the stage-change trail rather than stored on the deal:
+ * a `daysInStage` column would only ever describe the stage a deal is in now,
+ * and the question is about the stages it has already been through.
+ *
+ * The stage a deal opened in is taken from the first change's `fromStageId`,
+ * falling back to where it sits now for a deal that has never moved. The last
+ * span runs to the close, or to now for a deal still in flight — a deal that
+ * has been parked in Quoted for six weeks is precisely the thing worth
+ * counting, so excluding open deals would hide it.
+ *
+ * The median, not the mean, for the same reason as the cycle time: one deal
+ * that sat in a stage for a year should not redefine "normal".
+ */
+export function medianDaysInStage(
+  deals: DealLife[],
+  changes: StageChange[],
+  now: Date = new Date(),
+): Record<string, number> {
+  const byDeal = new Map<string, StageChange[]>();
+  for (const change of changes) {
+    const list = byDeal.get(change.dealId);
+    if (list) list.push(change);
+    else byDeal.set(change.dealId, [change]);
+  }
+
+  const durations = new Map<string, number[]>();
+  const push = (stageId: string, days: number) => {
+    if (!Number.isFinite(days)) return;
+    const list = durations.get(stageId);
+    if (list) list.push(Math.max(0, days));
+    else durations.set(stageId, [Math.max(0, days)]);
+  };
+
+  for (const deal of deals) {
+    const moves = (byDeal.get(deal.id) ?? [])
+      .filter((change) => change.toStageId)
+      .sort((a, b) => toDate(a.at).getTime() - toDate(b.at).getTime());
+
+    let stageId = moves[0]?.fromStageId ?? deal.currentStageId;
+    let enteredAt = toDate(deal.createdAt).getTime();
+
+    for (const move of moves) {
+      const at = toDate(move.at).getTime();
+      push(stageId, (at - enteredAt) / 86_400_000);
+      stageId = move.toStageId!;
+      enteredAt = at;
+    }
+
+    const end = deal.closedAt ? toDate(deal.closedAt).getTime() : now.getTime();
+    push(stageId, (end - enteredAt) / 86_400_000);
+  }
+
+  const result: Record<string, number> = {};
+  for (const [stageId, days] of durations) {
+    const sorted = days.sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    const median =
+      sorted.length % 2 === 0
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle];
+    result[stageId] = Math.round(median * 10) / 10;
+  }
+  return result;
+}
+
+export type ShareSlice = { key: string; label: string; value: number; share: number };
+
+/**
+ * The top slices of a total, with everything else folded into one.
+ *
+ * A pie with nineteen slivers is a legend, not a chart. Past the limit the
+ * remainder becomes a single "Other" so the shares still sum to one — dropping
+ * the tail instead would draw a pie that quietly lies about the total.
+ *
+ * Zero and negative values are excluded: a slice of nothing has no angle, and
+ * a negative one would eat somebody else's.
+ */
+export function shareSlices(
+  rows: { key: string; label: string; value: number }[],
+  limit = 5,
+): ShareSlice[] {
+  const positive = rows
+    .filter((row) => row.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  const total = positive.reduce((sum, row) => sum + row.value, 0);
+  if (total <= 0) return [];
+
+  const head = positive.slice(0, limit);
+  const tail = positive.slice(limit);
+  const slices = head.map((row) => ({
+    key: row.key,
+    label: row.label,
+    value: row.value,
+    share: row.value / total,
+  }));
+
+  if (tail.length > 0) {
+    const rest = tail.reduce((sum, row) => sum + row.value, 0);
+    slices.push({
+      key: "__other",
+      label: `Other (${tail.length})`,
+      value: rest,
+      share: rest / total,
+    });
+  }
+
+  return slices;
 }
 
 /** Percent for display, without pretending to precision the data lacks. */

--- a/lib/crm/run-insights.test.ts
+++ b/lib/crm/run-insights.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  armedRules,
+  failureGroups,
+  formatDuration,
+  rulePerformance,
+  runTotals,
+  triggerAppliesTo,
+  type RunRecord,
+} from "./run-insights";
+
+function run(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    automationId: "a1",
+    automationName: "Chase new leads",
+    status: "SUCCEEDED",
+    durationMs: 100,
+    actionCount: 1,
+    createdAt: "2026-03-01T00:00:00Z",
+    result: [{ type: "CREATE_TASK", ok: true }],
+    ...overrides,
+  };
+}
+
+describe("runTotals", () => {
+  it("counts a half-worked run against the clean rate", () => {
+    // A rule that half-worked is a rule somebody has to finish by hand, which
+    // is the thing automation was supposed to remove.
+    const totals = runTotals([
+      run(),
+      run({ status: "PARTIAL" }),
+      run({ status: "FAILED" }),
+      run({ status: "SUCCEEDED" }),
+    ]);
+
+    expect(totals.succeeded).toBe(2);
+    expect(totals.partial).toBe(1);
+    expect(totals.failed).toBe(1);
+    expect(totals.cleanRate).toBe(0.5);
+  });
+
+  it("totals the actions carried out, not just the firings", () => {
+    // A rule that fires rarely and does eight things costs more than one that
+    // fires often and sets a field.
+    const totals = runTotals([run({ actionCount: 8 }), run({ actionCount: 1 })]);
+    expect(totals.runs).toBe(2);
+    expect(totals.actionsRun).toBe(9);
+  });
+
+  it("reports median, average and slowest from timed runs only", () => {
+    const totals = runTotals([
+      run({ durationMs: 100 }),
+      run({ durationMs: 200 }),
+      run({ durationMs: 5_000 }),
+    ]);
+
+    expect(totals.medianMs).toBe(200);
+    expect(totals.averageMs).toBe(1767);
+    expect(totals.slowestMs).toBe(5_000);
+  });
+
+  it("does not count an untimed run as instant", () => {
+    // Runs recorded before duration was measured have no duration. Treating
+    // that as zero drags every average toward a number nobody observed.
+    const totals = runTotals([run({ durationMs: null }), run({ durationMs: 400 })]);
+
+    expect(totals.averageMs).toBe(400);
+    expect(totals.medianMs).toBe(400);
+    expect(totals.untimed).toBe(1);
+  });
+
+  it("says nothing rather than zero when nothing was timed", () => {
+    const totals = runTotals([run({ durationMs: null })]);
+    expect(totals.medianMs).toBeNull();
+    expect(totals.averageMs).toBeNull();
+    expect(totals.slowestMs).toBeNull();
+  });
+
+  it("divides by nothing safely", () => {
+    expect(runTotals([])).toMatchObject({ runs: 0, cleanRate: 0, medianMs: null });
+  });
+});
+
+describe("rulePerformance", () => {
+  it("ranks by how often a rule goes wrong, not by how often it runs", () => {
+    const rows = rulePerformance([
+      ...Array.from({ length: 100 }, () => run({ automationId: "busy", automationName: "Busy" })),
+      run({ automationId: "broken", automationName: "Broken", status: "FAILED" }),
+      run({ automationId: "broken", automationName: "Broken", status: "SUCCEEDED" }),
+    ]);
+
+    expect(rows[0].automationId).toBe("broken");
+    expect(rows[0].troubleRate).toBe(0.5);
+    expect(rows[1].runs).toBe(100);
+  });
+
+  it("counts partial runs as trouble too", () => {
+    const [row] = rulePerformance([run({ status: "PARTIAL" }), run()]);
+    expect(row.partial).toBe(1);
+    expect(row.troubleRate).toBe(0.5);
+  });
+
+  it("breaks a tie on trouble by how much of it there is", () => {
+    const rows = rulePerformance([
+      run({ automationId: "small", automationName: "Small", status: "FAILED" }),
+      run({ automationId: "big", automationName: "Big", status: "FAILED" }),
+      run({ automationId: "big", automationName: "Big", status: "FAILED" }),
+    ]);
+
+    expect(rows[0].automationId).toBe("big");
+  });
+});
+
+describe("failureGroups", () => {
+  it("turns forty failures into the one problem they are", () => {
+    const runs = Array.from({ length: 40 }, () =>
+      run({
+        status: "FAILED",
+        result: [{ type: "ASSIGN_OWNER", ok: false, detail: "User not found" }],
+      }),
+    );
+
+    expect(failureGroups(runs)).toEqual([
+      { action: "ASSIGN_OWNER", detail: "User not found", count: 40 },
+    ]);
+  });
+
+  it("keeps the same message from different actions apart", () => {
+    const groups = failureGroups([
+      run({
+        status: "PARTIAL",
+        result: [
+          { type: "ASSIGN_OWNER", ok: false, detail: "Record not found" },
+          { type: "SET_FIELD", ok: false, detail: "Record not found" },
+        ],
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+  });
+
+  it("ignores the actions that worked", () => {
+    const groups = failureGroups([
+      run({
+        status: "PARTIAL",
+        result: [
+          { type: "CREATE_TASK", ok: true },
+          { type: "NOTIFY", ok: false, detail: "No recipients" },
+        ],
+      }),
+    ]);
+
+    expect(groups).toEqual([{ action: "NOTIFY", detail: "No recipients", count: 1 }]);
+  });
+
+  it("survives a result the runner never wrote", () => {
+    expect(failureGroups([run({ result: null }), run({ result: "broken" })])).toEqual([]);
+  });
+});
+
+describe("formatDuration", () => {
+  it("reads in the units somebody thinks in", () => {
+    expect(formatDuration(120)).toBe("120ms");
+    expect(formatDuration(1_500)).toBe("1.5s");
+    expect(formatDuration(45_000)).toBe("45s");
+    expect(formatDuration(180_000)).toBe("3m");
+  });
+
+  it("says nothing rather than zero when there is nothing to say", () => {
+    expect(formatDuration(null)).toBe("—");
+  });
+});
+
+describe("armedRules", () => {
+  const rules = [
+    { id: "r1", name: "Chase new leads", trigger: "LEAD_CREATED", isEnabled: true },
+    { id: "r2", name: "Thank on payment", trigger: "PAYMENT_RECEIVED", isEnabled: true },
+    { id: "r3", name: "Nudge idle", trigger: "RECORD_IDLE", isEnabled: true },
+    { id: "r4", name: "Turned off", trigger: "LEAD_CREATED", isEnabled: false },
+  ];
+
+  it("does not promise a lead something only a deal can trigger", () => {
+    // The document triggers fire against a deal and read nothing like it.
+    // Listing them on a lead would promise something the engine never does.
+    expect(armedRules(rules, "LEAD").map((rule) => rule.id)).toEqual(["r1", "r3"]);
+  });
+
+  it("lists what can still fire on a deal", () => {
+    expect(armedRules(rules, "DEAL").map((rule) => rule.id)).toEqual(["r2", "r3"]);
+  });
+
+  it("leaves a disabled rule out — it is not waiting, it is off", () => {
+    expect(armedRules(rules, "LEAD").some((rule) => rule.id === "r4")).toBe(false);
+  });
+
+  it("arms nothing on a record type no trigger reaches", () => {
+    expect(armedRules(rules, "SITE")).toEqual([]);
+  });
+
+  it("treats a trigger it has never heard of as reaching nothing", () => {
+    expect(triggerAppliesTo("INVENTED_TRIGGER", "LEAD")).toBe(false);
+  });
+});

--- a/lib/crm/run-insights.ts
+++ b/lib/crm/run-insights.ts
@@ -1,0 +1,225 @@
+/**
+ * What the workflows have been costing and where they break.
+ *
+ * A run count next to a rule says it fired. It does not say whether the last
+ * forty firings did anything, which action keeps failing, or which rule is
+ * quietly taking two seconds off every stage change. Those are the three
+ * questions somebody has when they open this screen, and none of them was
+ * answerable.
+ *
+ * Everything here is arithmetic over rows the caller fetched, for the same
+ * reason the sales reports are: the interesting part is which denominator you
+ * chose, and that is an argument settled by a test rather than by reading SQL.
+ */
+
+export type RunStatus = "SUCCEEDED" | "PARTIAL" | "FAILED";
+
+export type RunRecord = {
+  automationId: string;
+  automationName: string;
+  status: RunStatus;
+  /** Null for runs recorded before duration was measured. */
+  durationMs: number | null;
+  actionCount: number;
+  createdAt: Date | string;
+  /** Per-action outcomes, as the runner stored them. */
+  result: unknown;
+};
+
+export type RunTotals = {
+  runs: number;
+  succeeded: number;
+  partial: number;
+  failed: number;
+  /** Share of runs that did everything they set out to. */
+  cleanRate: number;
+  /** Actions carried out — the unit of work these rules actually spend. */
+  actionsRun: number;
+  /** Null when nothing in the window carried a measured duration. */
+  medianMs: number | null;
+  averageMs: number | null;
+  slowestMs: number | null;
+  /** How many runs predate timing, so an average is not read as complete. */
+  untimed: number;
+};
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[middle - 1] + sorted[middle]) / 2)
+    : sorted[middle];
+}
+
+export function runTotals(runs: RunRecord[]): RunTotals {
+  const succeeded = runs.filter((run) => run.status === "SUCCEEDED").length;
+  const partial = runs.filter((run) => run.status === "PARTIAL").length;
+  const failed = runs.filter((run) => run.status === "FAILED").length;
+
+  const timed = runs
+    .map((run) => run.durationMs)
+    .filter((value): value is number => typeof value === "number" && value >= 0);
+
+  return {
+    runs: runs.length,
+    succeeded,
+    partial,
+    failed,
+    // Partial counts against it. A rule that half-worked is a rule somebody
+    // has to go and finish by hand, which is the thing automation was for.
+    cleanRate: runs.length > 0 ? succeeded / runs.length : 0,
+    actionsRun: runs.reduce((sum, run) => sum + (run.actionCount || 0), 0),
+    medianMs: median(timed),
+    averageMs:
+      timed.length > 0
+        ? Math.round(timed.reduce((sum, value) => sum + value, 0) / timed.length)
+        : null,
+    slowestMs: timed.length > 0 ? Math.max(...timed) : null,
+    untimed: runs.length - timed.length,
+  };
+}
+
+export type RulePerformance = {
+  automationId: string;
+  automationName: string;
+  runs: number;
+  failed: number;
+  partial: number;
+  actionsRun: number;
+  medianMs: number | null;
+  /** Failed and partial together, over runs. */
+  troubleRate: number;
+};
+
+/**
+ * Per rule, worst first.
+ *
+ * Sorted by how often a rule goes wrong rather than by how often it runs: the
+ * rule that fires a thousand times a week and never fails is not the one that
+ * needs attention, however impressive the number next to it.
+ */
+export function rulePerformance(runs: RunRecord[]): RulePerformance[] {
+  const byRule = new Map<string, RunRecord[]>();
+  for (const run of runs) {
+    const list = byRule.get(run.automationId);
+    if (list) list.push(run);
+    else byRule.set(run.automationId, [run]);
+  }
+
+  return Array.from(byRule.entries())
+    .map(([automationId, rows]) => {
+      const failed = rows.filter((row) => row.status === "FAILED").length;
+      const partial = rows.filter((row) => row.status === "PARTIAL").length;
+      return {
+        automationId,
+        automationName: rows[0].automationName,
+        runs: rows.length,
+        failed,
+        partial,
+        actionsRun: rows.reduce((sum, row) => sum + (row.actionCount || 0), 0),
+        medianMs: median(
+          rows
+            .map((row) => row.durationMs)
+            .filter((value): value is number => typeof value === "number" && value >= 0),
+        ),
+        troubleRate: (failed + partial) / rows.length,
+      };
+    })
+    .sort((a, b) => b.troubleRate - a.troubleRate || b.runs - a.runs);
+}
+
+export type FailureGroup = {
+  /** The action type, as the runner recorded it. */
+  action: string;
+  detail: string;
+  count: number;
+};
+
+/**
+ * The failures, grouped by what actually went wrong.
+ *
+ * A list of failed runs is a list; the same message forty times is one
+ * problem. Grouping by action and message turns "forty failures" into "one
+ * rule cannot find a user", which is a thing somebody can go and fix.
+ */
+export function failureGroups(runs: RunRecord[], limit = 8): FailureGroup[] {
+  const counts = new Map<string, FailureGroup>();
+
+  for (const run of runs) {
+    if (!Array.isArray(run.result)) continue;
+    for (const outcome of run.result) {
+      if (!outcome || typeof outcome !== "object") continue;
+      const record = outcome as { ok?: unknown; type?: unknown; detail?: unknown };
+      if (record.ok !== false) continue;
+
+      const action = typeof record.type === "string" ? record.type : "UNKNOWN";
+      const detail = typeof record.detail === "string" ? record.detail : "Action failed";
+      const key = `${action}::${detail}`;
+      const existing = counts.get(key);
+      if (existing) existing.count += 1;
+      else counts.set(key, { action, detail, count: 1 });
+    }
+  }
+
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+export type EnrolmentEntity = "LEAD" | "DEAL" | "PERSON" | "COMPANY" | "SITE" | "WORK_ORDER";
+
+/**
+ * Which kinds of record each trigger can ever fire on.
+ *
+ * Named explicitly rather than inferred from the trigger's name, because the
+ * two document triggers fire against a deal and read nothing like it. Without
+ * this, a lead's page would list "When a payment is received" as something
+ * waiting to happen to it, which is a promise the engine will never keep.
+ */
+const TRIGGER_ENTITIES: Record<string, EnrolmentEntity[]> = {
+  LEAD_CREATED: ["LEAD"],
+  LEAD_STAGE_CHANGED: ["LEAD"],
+  DEAL_CREATED: ["DEAL"],
+  DEAL_STAGE_CHANGED: ["DEAL"],
+  DOCUMENT_APPROVED: ["DEAL"],
+  PAYMENT_RECEIVED: ["DEAL"],
+  TASK_OVERDUE: ["LEAD", "DEAL"],
+  RECORD_IDLE: ["LEAD", "DEAL"],
+};
+
+export function triggerAppliesTo(trigger: string, entity: EnrolmentEntity): boolean {
+  return (TRIGGER_ENTITIES[trigger] ?? []).includes(entity);
+}
+
+export type ArmedRule = {
+  id: string;
+  name: string;
+  trigger: string;
+  isEnabled: boolean;
+};
+
+/**
+ * The rules that could still fire on this record.
+ *
+ * There is no queue behind this: the engine runs a rule the moment its event
+ * happens, so nothing is literally sitting in a pending state. What somebody
+ * asking "what happens next to this lead" actually wants is which rules are
+ * armed and pointed at it, and that is what this answers — honestly, rather
+ * than by drawing a spinner next to something that is not running.
+ *
+ * A rule already fired against this record is still listed: most triggers can
+ * fire again, and a stage-change rule that ran on Tuesday will run again on
+ * Thursday.
+ */
+export function armedRules(rules: ArmedRule[], entity: EnrolmentEntity): ArmedRule[] {
+  return rules.filter((rule) => rule.isEnabled && triggerAppliesTo(rule.trigger, entity));
+}
+
+/** Milliseconds, in the units somebody reads them in. */
+export function formatDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+  return `${Math.round(ms / 60_000)}m`;
+}

--- a/lib/crm/sign-off.test.ts
+++ b/lib/crm/sign-off.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildSignOffJob, canAskForSignOff, signOffSubmissionSchema } from "./sign-off";
+
+const base = {
+  workOrderNo: "JOB-0007",
+  title: "Reroof the store",
+  description: null,
+  completedAt: "2026-08-01T14:00:00.000Z",
+  addressLine: "12 Sam Nujoma",
+  signOffAt: null,
+  signOffName: null,
+  client: { name: "Hurudza Labs" },
+  site: null,
+  items: [{ description: "Strip old sheeting" }, { description: "  " }, { description: "Fit IBR" }],
+};
+
+describe("client sign-off", () => {
+  it("will not accept an anonymous signature", () => {
+    expect(signOffSubmissionSchema.safeParse({ name: " " }).success).toBe(false);
+    expect(signOffSubmissionSchema.safeParse({ name: "A" }).success).toBe(false);
+    expect(signOffSubmissionSchema.safeParse({ name: "Rudo M" }).success).toBe(true);
+  });
+
+  it("accepts a sign-off with no rating — done is not the same as praised", () => {
+    const parsed = signOffSubmissionSchema.safeParse({ name: "Rudo M", notes: "All good" });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("refuses a rating outside 1–5", () => {
+    expect(signOffSubmissionSchema.safeParse({ name: "Rudo M", rating: 0 }).success).toBe(false);
+    expect(signOffSubmissionSchema.safeParse({ name: "Rudo M", rating: 6 }).success).toBe(false);
+  });
+
+  it("only asks for sign-off on a job that has actually started", () => {
+    expect(canAskForSignOff("DRAFT")).toBe(false);
+    expect(canAskForSignOff("SCHEDULED")).toBe(false);
+    expect(canAskForSignOff("IN_PROGRESS")).toBe(true);
+    expect(canAskForSignOff("COMPLETED")).toBe(true);
+  });
+
+  it("lists what was done, skipping blanks", () => {
+    expect(buildSignOffJob(base).items).toEqual(["Strip old sheeting", "Fit IBR"]);
+  });
+
+  it("carries no money — the client is confirming the work, not the price", () => {
+    const job = buildSignOffJob(base);
+    expect(JSON.stringify(job)).not.toMatch(/value|price|amount|invoice|margin/i);
+  });
+
+  it("reports an answered sign-off so the page shows a receipt, not the form again", () => {
+    const job = buildSignOffJob({
+      ...base,
+      signOffAt: "2026-08-02T08:00:00.000Z",
+      signOffName: "Rudo M",
+    });
+    expect(job.signedOffAt).toBe("2026-08-02T08:00:00.000Z");
+    expect(job.signedOffName).toBe("Rudo M");
+  });
+});

--- a/lib/crm/sign-off.ts
+++ b/lib/crm/sign-off.ts
@@ -1,0 +1,94 @@
+import { randomBytes } from "crypto";
+import { z } from "zod";
+
+/**
+ * Client sign-off on a finished job.
+ *
+ * A job was marked done by whoever did it, which is the one person whose
+ * opinion is not evidence. The dispute three weeks later — "that was never
+ * finished", "nobody told us it was done" — has no record to settle it with.
+ *
+ * So the client says so, on their own phone, without an account: they type
+ * their name, optionally rate the work, optionally say something. The typed
+ * name is the signature; a canvas scribble on a phone is not more binding and
+ * is far more annoying to produce.
+ *
+ * Signing off is once. A second submission is refused rather than
+ * overwriting — the first answer is the record, and letting a link re-answer
+ * would mean whoever holds it can rewrite history.
+ */
+
+export function generateSignOffToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export const signOffSubmissionSchema = z.object({
+  /** Who is signing. Required — an anonymous sign-off settles nothing. */
+  name: z.string().trim().min(2).max(120),
+  /** 1–5. Optional, because a job can be accepted without being praised. */
+  rating: z.number().int().min(1).max(5).nullish(),
+  notes: z.string().trim().max(2000).nullish(),
+});
+
+export type SignOffSubmission = z.infer<typeof signOffSubmissionSchema>;
+
+/** Statuses where asking for a sign-off makes sense. */
+const SIGN_OFF_READY = new Set(["IN_PROGRESS", "COMPLETED"]);
+
+export function canAskForSignOff(status: string): boolean {
+  return SIGN_OFF_READY.has(status);
+}
+
+export type SignOffJobSource = {
+  workOrderNo: string;
+  title: string;
+  description: string | null;
+  completedAt: Date | string | null;
+  addressLine: string | null;
+  signOffAt: Date | string | null;
+  signOffName: string | null;
+  client: { name: string } | null;
+  site: { name: string; addressLine: string | null; city: string | null } | null;
+  items?: Array<{ description: string; isDone?: boolean }> | null;
+};
+
+export type SignOffJob = {
+  reference: string;
+  title: string;
+  description: string | null;
+  completedAt: string | null;
+  where: string | null;
+  customerName: string | null;
+  /** What was actually done, so somebody can check it against the place. */
+  items: string[];
+  /** Already answered — the page shows the receipt rather than the form. */
+  signedOffAt: string | null;
+  signedOffName: string | null;
+};
+
+function isoOf(value: Date | string | null): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export function buildSignOffJob(source: SignOffJobSource): SignOffJob {
+  const where =
+    [source.site?.name, source.site?.addressLine ?? source.addressLine, source.site?.city]
+      .map((part) => part?.trim())
+      .filter(Boolean)
+      .join(", ") || null;
+
+  return {
+    reference: source.workOrderNo,
+    title: source.title,
+    description: source.description,
+    completedAt: isoOf(source.completedAt),
+    where,
+    customerName: source.client?.name ?? null,
+    items: (source.items ?? [])
+      .map((item) => item.description?.trim())
+      .filter((description): description is string => Boolean(description)),
+    signedOffAt: isoOf(source.signOffAt),
+    signedOffName: source.signOffName,
+  };
+}

--- a/lib/crm/starter-templates.test.ts
+++ b/lib/crm/starter-templates.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BLOCKS_FOR_KIND,
+  blockSchema,
+  fieldBlocks,
+  templateProblems,
+} from "./blocks";
+import { unknownVariables } from "./template-variables";
+import {
+  STARTER_TEMPLATES,
+  starterBlocks,
+  starterTemplate,
+  startersForKind,
+} from "./starter-templates";
+
+/**
+ * The point of these: a starter is the one template nobody proofreads, because
+ * it arrived looking finished. So it is checked here instead — a starter that
+ * fails the builder's own validation would hand somebody a broken document on
+ * their first day and blame them for it.
+ */
+describe("starter templates", () => {
+  it.each(STARTER_TEMPLATES.map((starter) => [starter.id, starter] as const))(
+    "%s is a valid document",
+    (_id, starter) => {
+      for (const block of starter.blocks) {
+        expect(() => blockSchema.parse(block)).not.toThrow();
+      }
+      expect(templateProblems(starter.kind, starter.blocks)).toEqual([]);
+    },
+  );
+
+  it.each(STARTER_TEMPLATES.map((starter) => [starter.id, starter] as const))(
+    "%s only uses blocks its kind allows",
+    (_id, starter) => {
+      const allowed = new Set(BLOCKS_FOR_KIND[starter.kind]);
+      for (const block of starter.blocks) {
+        expect(allowed.has(block.type)).toBe(true);
+      }
+    },
+  );
+
+  it.each(STARTER_TEMPLATES.map((starter) => [starter.id, starter] as const))(
+    "%s uses no variable that nothing will fill",
+    (_id, starter) => {
+      // A variable nothing fills renders as a dash the sender never notices
+      // and the customer reads as a letter addressed to nobody.
+      const text = JSON.stringify(starter.blocks);
+      expect(unknownVariables(text)).toEqual([]);
+    },
+  );
+
+  it("gives every block a unique id, since ids are the drag and edit keys", () => {
+    for (const starter of STARTER_TEMPLATES) {
+      const ids: string[] = [];
+      for (const block of starter.blocks) {
+        ids.push(block.id);
+        if (block.type === "columns") {
+          ids.push(...block.left.map((child) => child.id));
+          ids.push(...block.right.map((child) => child.id));
+        }
+      }
+      expect(new Set(ids).size, `${starter.id} has a duplicate block id`).toBe(ids.length);
+    }
+  });
+
+  it("gives every starter a distinct id", () => {
+    const ids = STARTER_TEMPLATES.map((starter) => starter.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("ships a form somebody can actually fill in", () => {
+    for (const starter of startersForKind("FORM")) {
+      expect(fieldBlocks(starter.blocks).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers the documents a job actually needs", () => {
+    // Named explicitly rather than counted: the test should fail when one of
+    // these is dropped, not when an unrelated starter is added.
+    for (const id of ["site-brief", "quotation", "invoice", "receipt"]) {
+      expect(starterTemplate(id), `${id} is missing`).toBeDefined();
+    }
+  });
+
+  it("shows the balance on the receipt, not only what was paid", () => {
+    // A receipt that shows only the payment is how a deposit gets remembered
+    // as the whole thing.
+    const receipt = starterTemplate("receipt")!;
+    expect(JSON.stringify(receipt.blocks)).toContain("document.balance");
+  });
+});
+
+describe("starterBlocks", () => {
+  it("renames the document to whatever somebody called it", () => {
+    const starter = starterTemplate("site-brief")!;
+    const blocks = starterBlocks(starter, "  Roof survey  ");
+    const title = blocks.find((block) => block.id === "title");
+
+    expect(title).toMatchObject({ type: "heading", text: "Roof survey" });
+  });
+
+  it("leaves the starter alone when there is no name yet", () => {
+    const starter = starterTemplate("invoice")!;
+    expect(starterBlocks(starter, "   ")).toEqual(starter.blocks);
+  });
+
+  it("does not mutate the shared starter", () => {
+    const starter = starterTemplate("quotation")!;
+    const before = JSON.stringify(starter.blocks);
+    starterBlocks(starter, "Renamed");
+    expect(JSON.stringify(starter.blocks)).toBe(before);
+  });
+});

--- a/lib/crm/starter-templates.ts
+++ b/lib/crm/starter-templates.ts
@@ -1,0 +1,519 @@
+import type { Block, TemplateKind } from "@/lib/crm/blocks";
+
+/**
+ * Somewhere to start.
+ *
+ * A new template used to open as a heading and, for a form, one question
+ * asking for a name. That is not a starting point, it is an empty room with a
+ * light on: whoever opened it now has to know what an invoice needs on it,
+ * remember the tax line, decide where the terms go, and do that before they
+ * get to the thing they actually came to write.
+ *
+ * These are the documents a small contractor sends. They are complete enough
+ * to use unedited on the first day and obvious enough to edit on the second —
+ * every one is real blocks, so nothing here is a preview of something that
+ * has to be built again later.
+ *
+ * Wording is deliberately plain. A starter that opens with three paragraphs
+ * of legalese gets deleted; a starter that opens with a sentence somebody
+ * would actually say gets kept and adjusted.
+ */
+
+export type StarterTemplate = {
+  id: string;
+  kind: TemplateKind;
+  name: string;
+  emoji: string;
+  /** What this is for, in the words somebody would use asking for it. */
+  description: string;
+  blocks: Block[];
+};
+
+/** Branding then title: every document this company sends looks like itself. */
+function letterhead(titleText: string): Block[] {
+  return [
+    { id: "logo", type: "image", source: "branding.logo", alt: "{{company.name}}", width: 160 },
+    { id: "title", type: "heading", text: titleText, level: 1 },
+  ];
+}
+
+const PAYMENT_TERMS =
+  "Payment is due within 14 days of the invoice date. Please quote the invoice number on the transfer so we can match it against your account. If anything on this invoice looks wrong, tell us before paying it — sorting it out afterwards takes longer for both of us.";
+
+const QUOTE_TERMS =
+  "This quotation is valid until {{document.validUntil}}. Prices assume the site is accessible during normal working hours and that the conditions are as we found them. If we uncover something that changes the work, we will stop and tell you what it costs before carrying on — you will not be billed for anything you have not agreed to.";
+
+export const STARTER_TEMPLATES: StarterTemplate[] = [
+  // --- what somebody fills in ------------------------------------------
+  {
+    id: "site-brief",
+    kind: "FORM",
+    name: "Site brief",
+    emoji: "📍",
+    description:
+      "What the person going out needs to know, and what they should bring back. Fill it in before the visit, finish it on site.",
+    blocks: [
+      ...letterhead("Site brief"),
+      {
+        id: "intro",
+        type: "text",
+        text: "For {{customer.name}} — {{record.title}}. Fill in what you can before you leave; the rest is for on site.",
+      },
+      { id: "d1", type: "divider" },
+      { id: "h-where", type: "heading", text: "Where and when", level: 2 },
+      {
+        id: "cols-where",
+        type: "columns",
+        left: [
+          {
+            id: "f-address",
+            type: "field",
+            key: "address",
+            label: "Site address",
+            fieldType: "text",
+            required: true,
+            prefill: "customer.address",
+            help: "The address a driver can follow, not the billing address.",
+          },
+          {
+            id: "f-access",
+            type: "field",
+            key: "access",
+            label: "How do we get in?",
+            fieldType: "longText",
+            required: false,
+            placeholder: "Gate code, who to ask for, where to park",
+          },
+        ],
+        right: [
+          {
+            id: "f-date",
+            type: "field",
+            key: "visitDate",
+            label: "Date of visit",
+            fieldType: "date",
+            required: true,
+          },
+          {
+            id: "f-contact",
+            type: "field",
+            key: "siteContact",
+            label: "Who is meeting us",
+            fieldType: "text",
+            required: false,
+            prefill: "contact.name",
+          },
+          {
+            id: "f-phone",
+            type: "field",
+            key: "siteContactPhone",
+            label: "Their phone",
+            fieldType: "phone",
+            required: false,
+            prefill: "contact.phone",
+          },
+        ],
+      },
+      { id: "d2", type: "divider" },
+      { id: "h-work", type: "heading", text: "What we are there for", level: 2 },
+      {
+        id: "f-scope",
+        type: "field",
+        key: "scope",
+        label: "What the customer has asked for",
+        fieldType: "longText",
+        required: true,
+        placeholder: "In their words, not ours",
+      },
+      {
+        id: "f-measure",
+        type: "field",
+        key: "measurements",
+        label: "Measurements taken",
+        fieldType: "longText",
+        required: false,
+        help: "Anything the quote will be priced off. Say what you measured, not just the number.",
+      },
+      {
+        id: "f-condition",
+        type: "field",
+        key: "condition",
+        label: "Condition on arrival",
+        fieldType: "select",
+        required: false,
+        options: ["Good", "Fair", "Poor", "Unsafe — stopped work"],
+      },
+      {
+        id: "f-risks",
+        type: "field",
+        key: "risks",
+        label: "Anything that will slow the job down",
+        fieldType: "longText",
+        required: false,
+        placeholder: "Height, live power, occupied rooms, animals, no water",
+      },
+      {
+        id: "f-photos",
+        type: "field",
+        key: "photos",
+        label: "Photos",
+        fieldType: "file",
+        required: false,
+        help: "Wide shot first, then the detail. A photo now saves an argument later.",
+      },
+      { id: "d3", type: "divider" },
+      {
+        id: "f-next",
+        type: "field",
+        key: "nextStep",
+        label: "What happens next",
+        fieldType: "select",
+        required: true,
+        options: [
+          "Quote it",
+          "Needs a second visit",
+          "Refer out — not our work",
+          "Customer is not proceeding",
+        ],
+      },
+      {
+        id: "sign",
+        type: "signature",
+        label: "Attended by",
+        party: "us",
+      },
+    ],
+  },
+  {
+    id: "enquiry",
+    kind: "FORM",
+    name: "New enquiry",
+    emoji: "📥",
+    description:
+      "A public form that turns a stranger into a lead. Short on purpose — every extra question loses somebody.",
+    blocks: [
+      ...letterhead("Tell us about the job"),
+      {
+        id: "intro",
+        type: "text",
+        text: "Fill this in and we will come back to you. It takes about a minute.",
+      },
+      {
+        id: "cols-who",
+        type: "columns",
+        left: [
+          {
+            id: "f-name",
+            type: "field",
+            key: "name",
+            label: "Your name",
+            fieldType: "text",
+            required: true,
+          },
+          {
+            id: "f-phone",
+            type: "field",
+            key: "phone",
+            label: "Phone",
+            fieldType: "phone",
+            required: true,
+            help: "The fastest way to get an answer.",
+          },
+        ],
+        right: [
+          {
+            id: "f-email",
+            type: "field",
+            key: "email",
+            label: "Email",
+            fieldType: "email",
+            required: false,
+          },
+          {
+            id: "f-company",
+            type: "field",
+            key: "company",
+            label: "Company",
+            fieldType: "text",
+            required: false,
+            placeholder: "Leave blank if this is for your home",
+          },
+        ],
+      },
+      {
+        id: "f-what",
+        type: "field",
+        key: "description",
+        label: "What needs doing?",
+        fieldType: "longText",
+        required: true,
+        placeholder: "A sentence is plenty — we will call to get the detail.",
+      },
+      {
+        id: "f-where",
+        type: "field",
+        key: "address",
+        label: "Where is it?",
+        fieldType: "text",
+        required: false,
+      },
+      {
+        id: "f-when",
+        type: "field",
+        key: "urgency",
+        label: "How soon?",
+        fieldType: "select",
+        required: false,
+        options: ["It is an emergency", "This week", "This month", "Just getting prices"],
+      },
+      {
+        id: "f-photos",
+        type: "field",
+        key: "photos",
+        label: "Photos, if you have any",
+        fieldType: "file",
+        required: false,
+        help: "A photo usually saves a visit.",
+      },
+    ],
+  },
+  {
+    id: "handover",
+    kind: "FORM",
+    name: "Job handover",
+    emoji: "✅",
+    description:
+      "Signed off at the end of a job, on site, by whoever is standing there. What was done, what was left, and their name on it.",
+    blocks: [
+      ...letterhead("Job handover"),
+      {
+        id: "intro",
+        type: "text",
+        text: "{{record.title}} for {{customer.name}}, completed {{date.today}}.",
+      },
+      { id: "d1", type: "divider" },
+      {
+        id: "f-done",
+        type: "field",
+        key: "workDone",
+        label: "What was done",
+        fieldType: "longText",
+        required: true,
+      },
+      {
+        id: "f-outstanding",
+        type: "field",
+        key: "outstanding",
+        label: "Anything left outstanding",
+        fieldType: "longText",
+        required: false,
+        help: "Say it here rather than hoping nobody notices. A known gap is a follow-up; a hidden one is a complaint.",
+      },
+      {
+        id: "f-tidied",
+        type: "field",
+        key: "siteClear",
+        label: "Site left clear and safe",
+        fieldType: "checkbox",
+        required: false,
+      },
+      {
+        id: "f-rating",
+        type: "field",
+        key: "rating",
+        label: "How did we do?",
+        fieldType: "rating",
+        required: false,
+      },
+      {
+        id: "f-comments",
+        type: "field",
+        key: "comments",
+        label: "Anything you want to tell us",
+        fieldType: "longText",
+        required: false,
+      },
+      { id: "d2", type: "divider" },
+      {
+        id: "terms",
+        type: "terms",
+        text: "Signing confirms the work described above was carried out. It is not agreement to a price — anything about the invoice is a separate conversation and nothing here changes it.",
+      },
+      { id: "sign", type: "signature", label: "Signed on site", party: "both" },
+    ],
+  },
+
+  // --- what a customer is sent -----------------------------------------
+  {
+    id: "quotation",
+    kind: "QUOTE",
+    name: "Quotation",
+    emoji: "📄",
+    description:
+      "Priced work, with what is included spelled out and what happens if the job changes.",
+    blocks: [
+      ...letterhead("Quotation {{document.number}}"),
+      {
+        id: "cols-parties",
+        type: "columns",
+        left: [
+          { id: "h-to", type: "heading", text: "For", level: 3 },
+          {
+            id: "t-to",
+            type: "text",
+            text: "{{customer.name}}\n{{contact.name}}\n{{customer.address}}\n{{contact.email}}",
+          },
+        ],
+        right: [
+          { id: "h-from", type: "heading", text: "From", level: 3 },
+          {
+            id: "t-from",
+            type: "text",
+            text: "{{company.name}}\n{{company.address}}\n{{company.phone}}\nTax number {{company.taxNumber}}",
+          },
+        ],
+      },
+      { id: "d1", type: "divider" },
+      { id: "h-job", type: "heading", text: "{{record.title}}", level: 2 },
+      {
+        id: "t-summary",
+        type: "text",
+        text: "Prepared {{date.today}} by {{user.name}}. Valid until {{document.validUntil}}.",
+      },
+      { id: "items", type: "lineItems", showTax: true, showDiscount: true },
+      { id: "totals", type: "totals", showTax: true, showPaid: false },
+      { id: "sp", type: "spacer", size: "md" },
+      { id: "h-terms", type: "heading", text: "What this covers", level: 3 },
+      { id: "terms", type: "terms", text: QUOTE_TERMS },
+      { id: "sign", type: "signature", label: "Accepted by", party: "customer" },
+    ],
+  },
+  {
+    id: "invoice",
+    kind: "INVOICE",
+    name: "Invoice",
+    emoji: "🧾",
+    description:
+      "What is owed, when it is due, and how to pay it — with the reference somebody needs to quote on the transfer.",
+    blocks: [
+      ...letterhead("Invoice {{document.number}}"),
+      {
+        id: "cols-parties",
+        type: "columns",
+        left: [
+          { id: "h-to", type: "heading", text: "Bill to", level: 3 },
+          {
+            id: "t-to",
+            type: "text",
+            text: "{{customer.name}}\n{{customer.address}}\n{{customer.email}}\nAccount {{customer.reference}}",
+          },
+        ],
+        right: [
+          { id: "h-from", type: "heading", text: "From", level: 3 },
+          {
+            id: "t-from",
+            type: "text",
+            text: "{{company.name}}\n{{company.address}}\n{{company.phone}}\nTax number {{company.taxNumber}}",
+          },
+        ],
+      },
+      { id: "d1", type: "divider" },
+      { id: "h-job", type: "heading", text: "{{record.title}}", level: 2 },
+      { id: "t-dated", type: "text", text: "Invoiced {{date.today}}." },
+      { id: "items", type: "lineItems", showTax: true, showDiscount: false },
+      // Paid shown even at zero: the balance is the number the reader came
+      // for, and a deposit already taken must be visible or they pay twice.
+      { id: "totals", type: "totals", showTax: true, showPaid: true },
+      { id: "sp", type: "spacer", size: "md" },
+      { id: "h-pay", type: "heading", text: "How to pay", level: 3 },
+      {
+        id: "t-pay",
+        type: "text",
+        text: "Balance owing: {{document.balance}} {{document.currency}}. Please quote {{document.number}} on the payment.",
+      },
+      { id: "terms", type: "terms", text: PAYMENT_TERMS },
+    ],
+  },
+  {
+    id: "receipt",
+    kind: "RECEIPT",
+    name: "Receipt",
+    emoji: "💵",
+    description:
+      "Proof a payment was taken, and what is still outstanding after it. One page, no ambiguity.",
+    blocks: [
+      ...letterhead("Receipt {{document.number}}"),
+      {
+        id: "t-intro",
+        type: "text",
+        text: "Received from {{customer.name}} on {{date.today}}, with thanks.",
+      },
+      { id: "d1", type: "divider" },
+      { id: "h-what", type: "heading", text: "{{record.title}}", level: 2 },
+      {
+        id: "t-amount",
+        type: "text",
+        text: "Amount received: {{document.total}} {{document.currency}}.",
+      },
+      // Balance on the receipt, not only on the invoice: a receipt that shows
+      // only what was paid is how a part-payment gets remembered as the whole
+      // thing.
+      {
+        id: "t-balance",
+        type: "text",
+        text: "Balance still owing after this payment: {{document.balance}} {{document.currency}}.",
+      },
+      { id: "totals", type: "totals", showTax: true, showPaid: true },
+      { id: "sp", type: "spacer", size: "md" },
+      {
+        id: "terms",
+        type: "terms",
+        text: "Keep this receipt. If the balance above does not match your records, contact us on {{company.phone}} before the next payment falls due.",
+      },
+    ],
+  },
+
+  // --- what gets sent about a record ------------------------------------
+  {
+    id: "quote-follow-up",
+    kind: "EMAIL",
+    name: "Quote follow-up",
+    emoji: "✉️",
+    description:
+      "The chase that does not read like a chase. Sent a few days after a quote goes out.",
+    blocks: [
+      { id: "h", type: "heading", text: "Following up on {{document.number}}", level: 2 },
+      {
+        id: "body",
+        type: "text",
+        text: "Hi {{contact.firstName}},\n\nJust checking you got the quote for {{record.title}} — {{document.total}}, valid until {{document.validUntil}}.\n\nNo rush, and no pressure. If anything in it needs changing, or if the timing is wrong, tell me and I will adjust it rather than send it again unchanged.\n\n{{user.name}}\n{{company.name}} · {{company.phone}}",
+      },
+    ],
+  },
+];
+
+export function starterTemplate(id: string): StarterTemplate | undefined {
+  return STARTER_TEMPLATES.find((starter) => starter.id === id);
+}
+
+export function startersForKind(kind: TemplateKind): StarterTemplate[] {
+  return STARTER_TEMPLATES.filter((starter) => starter.kind === kind);
+}
+
+/**
+ * The starter, with its title changed to what somebody named it.
+ *
+ * A template called "Roof survey" whose first heading still says "Site brief"
+ * is the sort of thing that reaches a customer, because the person who named
+ * it never scrolled back up.
+ */
+export function starterBlocks(starter: StarterTemplate, name: string): Block[] {
+  const trimmed = name.trim();
+  if (!trimmed) return starter.blocks;
+
+  return starter.blocks.map((block) =>
+    block.type === "heading" && block.level === 1 && block.id === "title"
+      ? { ...block, text: trimmed }
+      : block,
+  );
+}

--- a/lib/crm/story-activities.test.ts
+++ b/lib/crm/story-activities.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { activityEvents } from "./story";
+
+const base = { occurredAt: "2026-07-29T03:07:00.000Z", createdBy: { id: "u1", name: "JN" } };
+
+describe("activityEvents", () => {
+  it("renders a legacy note through the body, not as a plain-text subject", () => {
+    // Everything logged before the composer stopped splitting on the first
+    // newline has its prose in `subject` — those rows printed the raw token.
+    const [event] = activityEvents([
+      {
+        id: "a1",
+        type: "NOTE",
+        subject: "@[James Nyabadza](534a7770-d36c-4d68-adb9-3ae22514b8d1) check the website",
+        body: null,
+        ...base,
+      },
+    ]);
+    expect(event.title).toBe("Note");
+    expect(event.body).toContain("@[James Nyabadza]");
+  });
+
+  it("does not print a written note twice", () => {
+    const [event] = activityEvents([
+      { id: "a2", type: "CALL", subject: "Rang about the quote", body: "Rang about the quote", ...base },
+    ]);
+    expect(event.title).toBe("Call");
+    expect(event.body).toBe("Rang about the quote");
+  });
+
+  it("leaves a generated entry as the one-liner it is", () => {
+    const [event] = activityEvents([
+      { id: "a3", type: "STAGE_CHANGE", subject: "Moved to Quoted", body: null, ...base },
+    ]);
+    expect(event.title).toBe("Moved to Quoted");
+    expect(event.body).toBeNull();
+  });
+});

--- a/lib/crm/story.ts
+++ b/lib/crm/story.ts
@@ -75,15 +75,51 @@ const ACTIVITY_KIND: Record<string, StoryEvent["kind"]> = {
   SYSTEM: "system",
 };
 
+/**
+ * The types somebody writes prose into. Their content is written in the CRM's
+ * text format — mentions, emphasis — so it has to reach the renderer, and it
+ * must not also be printed as a heading above itself.
+ */
+const WRITTEN_LABEL: Record<string, string> = {
+  NOTE: "Note",
+  CALL: "Call",
+  EMAIL: "Email",
+  WHATSAPP: "WhatsApp",
+  MEETING: "Meeting",
+};
+
 export function activityEvents(activities: ActivityLike[]): StoryEvent[] {
-  return activities.map((activity) => ({
-    id: activity.id,
-    kind: ACTIVITY_KIND[activity.type] ?? "system",
-    title: activity.subject,
-    body: activity.body,
-    occurredAt: activity.occurredAt,
-    actorName: activity.createdBy?.name ?? null,
-  }));
+  return activities.map((activity) => {
+    const written = WRITTEN_LABEL[activity.type];
+    const body = activity.body?.trim() ? activity.body : null;
+
+    // A written activity shows its type as the heading and its prose as the
+    // body, so the body is the thing that runs through the renderer. Where
+    // there is no body the subject IS the prose — that is every note logged
+    // before the composer stopped splitting on the first newline, and those
+    // rows were printing `@[Name](uuid)` at the reader.
+    if (written) {
+      return {
+        id: activity.id,
+        kind: ACTIVITY_KIND[activity.type] ?? "system",
+        title: written,
+        body: body ?? activity.subject,
+        occurredAt: activity.occurredAt,
+        actorName: activity.createdBy?.name ?? null,
+      };
+    }
+
+    // Generated entries — a stage change, a document raised — are one-liners
+    // written by the system, with nothing to render.
+    return {
+      id: activity.id,
+      kind: ACTIVITY_KIND[activity.type] ?? "system",
+      title: activity.subject,
+      body,
+      occurredAt: activity.occurredAt,
+      actorName: activity.createdBy?.name ?? null,
+    };
+  });
 }
 
 /**

--- a/lib/crm/visit-brief.test.ts
+++ b/lib/crm/visit-brief.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  briefChecklist,
+  briefWhere,
+  buildVisitBrief,
+  isBriefExpired,
+} from "./visit-brief";
+
+const base = {
+  appointmentNo: "SVT-0014",
+  title: "Measure the roof",
+  scheduledStart: "2026-08-04T06:00:00.000Z",
+  scheduledEnd: null,
+  location: null,
+  latitude: null,
+  longitude: null,
+  briefExpiresAt: null,
+  assignedTo: { name: "James Nyabadza" },
+  site: null,
+  client: { name: "Hurudza Labs" },
+  checklist: null,
+};
+
+describe("the public visit brief", () => {
+  it("reads the site as one line a driver can be told", () => {
+    expect(
+      briefWhere({
+        ...base,
+        site: { name: "Warehouse 3", addressLine: "12 Sam Nujoma", city: "Harare" },
+      }),
+    ).toBe("Warehouse 3, 12 Sam Nujoma, Harare");
+  });
+
+  it("falls back to the typed location when the visit is not at a recorded site", () => {
+    expect(briefWhere({ ...base, location: "  Corner shop, Chitungwiza " }))
+      .toBe("Corner shop, Chitungwiza");
+  });
+
+  it("carries checklist labels but never the team's notes on them", () => {
+    const labels = briefChecklist([
+      { key: "ladder", label: "Bring the long ladder", checked: false, notes: "the one that isn't bent" },
+      { key: "meter", label: "Damp meter", checked: true },
+      { nonsense: true },
+    ]);
+    expect(labels).toEqual(["Bring the long ladder", "Damp meter"]);
+    expect(JSON.stringify(labels)).not.toContain("bent");
+  });
+
+  it("offers a map only when the place is actually pinned", () => {
+    expect(buildVisitBrief(base).mapUrl).toBeNull();
+    expect(buildVisitBrief({ ...base, latitude: -17.82, longitude: 31.05 }).mapUrl)
+      .toContain("-17.82,31.05");
+  });
+
+  it("treats a link with no expiry as one that still stands", () => {
+    expect(isBriefExpired(null)).toBe(false);
+    expect(isBriefExpired("2020-01-01T00:00:00.000Z")).toBe(true);
+    expect(isBriefExpired("2999-01-01T00:00:00.000Z")).toBe(false);
+  });
+
+  it("does not leak the deal's value — the brief has no field for it", () => {
+    const brief = buildVisitBrief(base);
+    expect(Object.keys(brief)).not.toContain("value");
+    expect(JSON.stringify(brief)).not.toMatch(/value|margin|probability/i);
+  });
+});

--- a/lib/crm/visit-brief.ts
+++ b/lib/crm/visit-brief.ts
@@ -1,0 +1,111 @@
+import { randomBytes } from "crypto";
+
+/**
+ * The public brief for a site visit.
+ *
+ * A visit was only legible to somebody with an account. But the people who
+ * most need to know where to be at 8am — the customer expecting a van, a
+ * subcontractor with a ladder — are exactly the people who do not have one,
+ * and the answer until now was somebody retyping the address into WhatsApp.
+ *
+ * So a visit can be shared as a link, the same shape as a document approval:
+ * one token, no session, revocable by rotating it.
+ *
+ * What the brief shows is deliberately narrow. Where, when, who is coming and
+ * what the job is. Not the value of the deal, not the margin, not the notes
+ * the team wrote each other — a link that gets forwarded should not carry
+ * anything that would embarrass the sender.
+ */
+
+export function generateBriefToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export type VisitBriefSource = {
+  appointmentNo: string;
+  title: string;
+  scheduledStart: Date | string;
+  scheduledEnd: Date | string | null;
+  location: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  briefExpiresAt: Date | string | null;
+  assignedTo: { name: string | null } | null;
+  site: { name: string; addressLine: string | null; city: string | null } | null;
+  client: { name: string } | null;
+  checklist: unknown;
+};
+
+export type VisitBrief = {
+  reference: string;
+  title: string;
+  scheduledStart: string;
+  scheduledEnd: string | null;
+  /** One line somebody can read out to a driver. */
+  where: string | null;
+  /** A maps link, when the place is pinned. */
+  mapUrl: string | null;
+  attendingName: string | null;
+  customerName: string | null;
+  /** What to bring or check — labels only, never the team's notes. */
+  checklist: string[];
+};
+
+function isoOf(value: Date | string | null): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+/** Has the link stopped working? Expiry is optional; absent means it stands. */
+export function isBriefExpired(
+  expiresAt: Date | string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!expiresAt) return false;
+  const at = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+  if (Number.isNaN(at.getTime())) return false;
+  return at.getTime() <= now.getTime();
+}
+
+/** The address as one readable line: the site's, or whatever was typed. */
+export function briefWhere(source: VisitBriefSource): string | null {
+  if (source.site) {
+    const parts = [source.site.name, source.site.addressLine, source.site.city]
+      .map((part) => part?.trim())
+      .filter(Boolean);
+    if (parts.length > 0) return parts.join(", ");
+  }
+  return source.location?.trim() || null;
+}
+
+/**
+ * Checklist labels only. The stored checklist carries per-item notes the team
+ * wrote for each other, and those are not for a forwarded link.
+ */
+export function briefChecklist(checklist: unknown): string[] {
+  if (!Array.isArray(checklist)) return [];
+  return checklist
+    .map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const label = (item as { label?: unknown }).label;
+      return typeof label === "string" && label.trim() ? label.trim() : null;
+    })
+    .filter((label): label is string => label !== null);
+}
+
+export function buildVisitBrief(source: VisitBriefSource): VisitBrief {
+  const pinned = source.latitude != null && source.longitude != null;
+  return {
+    reference: source.appointmentNo,
+    title: source.title,
+    scheduledStart: isoOf(source.scheduledStart) as string,
+    scheduledEnd: isoOf(source.scheduledEnd),
+    where: briefWhere(source),
+    mapUrl: pinned
+      ? `https://www.google.com/maps/search/?api=1&query=${source.latitude},${source.longitude}`
+      : null,
+    attendingName: source.assignedTo?.name ?? null,
+    customerName: source.client?.name ?? null,
+    checklist: briefChecklist(source.checklist),
+  };
+}

--- a/lib/crm/widgets.ts
+++ b/lib/crm/widgets.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 export const OVERVIEW_SCOPES = [
   "HOME",
+  "REPORTS",
   "RECORD_DEAL",
   "RECORD_LEAD",
   "RECORD_COMPANY",
@@ -59,6 +60,7 @@ export type WidgetDefinition = {
 };
 
 const HOME = ["HOME"] as const;
+const REPORTS = ["REPORTS"] as const;
 const RECORDS = [
   "RECORD_DEAL",
   "RECORD_LEAD",
@@ -247,6 +249,76 @@ export const WIDGET_CATALOGUE: WidgetDefinition[] = [
     defaultSpan: 6,
   },
 
+  // --- the reports page ----------------------------------------------
+  // Its own scope rather than more HOME widgets: the overview answers "what
+  // should I do today" from live counts, and a report answers "what has been
+  // happening" over a period somebody chose. Mixing them means one page where
+  // half the cards silently ignore the date range.
+  {
+    type: "report-headline",
+    label: "Headline figures",
+    description: "Win rate, forecast, typical cycle and leads, for the chosen period.",
+    kind: "metric",
+    scopes: REPORTS,
+    defaultSpan: 12,
+  },
+  {
+    type: "report-funnel",
+    label: "Stage funnel",
+    description: "How many survive each stage, what converts, and how long each stage takes.",
+    kind: "chart",
+    scopes: REPORTS,
+    defaultSpan: 8,
+  },
+  {
+    type: "report-source-share",
+    label: "Where the money came from",
+    description: "Won value split by source, as shares of one total.",
+    kind: "chart",
+    scopes: REPORTS,
+    defaultSpan: 4,
+  },
+  {
+    type: "report-trend",
+    label: "Won over time",
+    description: "Value won and value opened across the period, with the figures on hover.",
+    kind: "chart",
+    scopes: REPORTS,
+    defaultSpan: 8,
+  },
+  {
+    type: "report-by-owner",
+    label: "Won, lost and open by owner",
+    description: "Each rep's outcomes side by side.",
+    kind: "chart",
+    scopes: REPORTS,
+    defaultSpan: 4,
+  },
+  {
+    type: "report-owner-table",
+    label: "Owner performance",
+    description: "Win rate and value won, per rep.",
+    kind: "list",
+    scopes: REPORTS,
+    defaultSpan: 6,
+  },
+  {
+    type: "report-source-table",
+    label: "Source performance",
+    description: "Win rate and value won, per source.",
+    kind: "list",
+    scopes: REPORTS,
+    defaultSpan: 6,
+  },
+  {
+    type: "report-activity",
+    label: "Activity logged",
+    description: "Calls, emails and notes recorded across the period.",
+    kind: "chart",
+    scopes: REPORTS,
+    defaultSpan: 12,
+  },
+
   // --- what has been happening ---------------------------------------
   {
     type: "activity-summary",
@@ -293,6 +365,15 @@ export const DEFAULT_LAYOUTS: Record<OverviewScope, WidgetInstance[]> = {
     { id: "w-ageing", type: "ageing", span: 4 },
     { id: "w-tasks", type: "my-tasks", span: 6 },
     { id: "w-activity", type: "activity-summary", span: 6 },
+  ],
+  REPORTS: [
+    { id: "r-headline", type: "report-headline", span: 12 },
+    { id: "r-funnel", type: "report-funnel", span: 8 },
+    { id: "r-source-share", type: "report-source-share", span: 4 },
+    { id: "r-trend", type: "report-trend", span: 8 },
+    { id: "r-by-owner", type: "report-by-owner", span: 4 },
+    { id: "r-owner-table", type: "report-owner-table", span: 6 },
+    { id: "r-source-table", type: "report-source-table", span: 6 },
   ],
   RECORD_DEAL: [
     { id: "w-value", type: "record-value", span: 4 },

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -26,20 +26,28 @@ function getIconComponent(iconName: string) {
 /**
  * Marks that are strokes rather than shapes.
  *
- * A chevron is two strokes meeting at a point. Phosphor's `fill` weight turns
- * `CaretDown` into a solid triangle — a different mark entirely, and the one
- * that had been shipping in every dropdown trigger, select, disclosure and
- * "show more" in the product. The rest of the set stays filled, which is how
- * the product is drawn; this is only about the ones that are meant to be a
- * line.
+ * A chevron is two strokes meeting at a point; an X is two strokes crossing;
+ * a plus is two strokes meeting at right angles. Phosphor's `fill` weight has
+ * nothing to fill in a glyph made only of lines, so it fills the *box* — a
+ * solid triangle where the chevron should be, a solid rounded square with the
+ * X or the + knocked out of it. That is what had been shipping in every
+ * dropdown trigger, every close button and every "New …" button in the
+ * product.
+ *
+ * Exact names rather than prefixes: `XCircle`, `PlusCircle` and `CheckCircle`
+ * are genuinely shapes — a circle carrying a mark — and are meant to be
+ * filled. Only the bare marks belong here. Everything else in the set keeps
+ * the fill weight, which is how the product is drawn.
  */
-const STROKE_WEIGHT_ICONS = /^Caret/;
+const STROKE_WEIGHT_PREFIX = /^Caret/;
+const STROKE_WEIGHT_EXACT = new Set(["X", "Plus", "Minus", "Check", "Checks", "Equals"]);
 
 function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
   const IconComponent = getIconComponent(iconName);
-  const defaultWeight: PhosphorIconProps["weight"] = STROKE_WEIGHT_ICONS.test(iconName)
-    ? "bold"
-    : "fill";
+  const defaultWeight: PhosphorIconProps["weight"] =
+    STROKE_WEIGHT_PREFIX.test(iconName) || STROKE_WEIGHT_EXACT.has(iconName)
+      ? "bold"
+      : "fill";
 
   const Icon = ({
     className,

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -23,8 +23,23 @@ function getIconComponent(iconName: string) {
   return iconRegistry[iconName] ?? Phosphor.Question;
 }
 
+/**
+ * Marks that are strokes rather than shapes.
+ *
+ * A chevron is two strokes meeting at a point. Phosphor's `fill` weight turns
+ * `CaretDown` into a solid triangle — a different mark entirely, and the one
+ * that had been shipping in every dropdown trigger, select, disclosure and
+ * "show more" in the product. The rest of the set stays filled, which is how
+ * the product is drawn; this is only about the ones that are meant to be a
+ * line.
+ */
+const STROKE_WEIGHT_ICONS = /^Caret/;
+
 function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
   const IconComponent = getIconComponent(iconName);
+  const defaultWeight: PhosphorIconProps["weight"] = STROKE_WEIGHT_ICONS.test(iconName)
+    ? "bold"
+    : "fill";
 
   const Icon = ({
     className,
@@ -52,7 +67,7 @@ function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
           color: "currentColor",
           ...style,
         }}
-        weight={weight ?? "fill"}
+        weight={weight ?? defaultWeight}
       />
     );
   };
@@ -152,6 +167,7 @@ export const ArrowDownward = createPhosphorIcon("ArrowDown", "ArrowDownward");
 export const ArrowUpward = createPhosphorIcon("ArrowUp", "ArrowUpward");
 export const BarChart3 = createPhosphorIcon("ChartBar", "BarChart3");
 export const Funnel = createPhosphorIcon("Funnel", "Funnel");
+export const SlidersHorizontal = createPhosphorIcon("Sliders", "SlidersHorizontal");
 export const AddressBook = createPhosphorIcon("AddressBook", "AddressBook");
 export const Megaphone = createPhosphorIcon("Megaphone", "Megaphone");
 export const CalendarCheck = createPhosphorIcon("CalendarCheck", "CalendarCheck");

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -61,6 +61,7 @@ function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
   return Icon;
 }
 
+export const Share = createPhosphorIcon("ShareNetwork", "Share");
 export const Smiley = createPhosphorIcon("Smiley", "Smiley");
 
 export const MedusaAcademicCapIcon = createPhosphorIcon(

--- a/prisma/migrations/20260729100000_add_visit_location_and_brief/migration.sql
+++ b/prisma/migrations/20260729100000_add_visit_location_and_brief/migration.sql
@@ -1,0 +1,9 @@
+-- A visit can be somewhere that is not a recorded site, and can be shared
+-- with somebody who has no account.
+ALTER TABLE "CrmAppointment" ADD COLUMN "latitude" DOUBLE PRECISION;
+ALTER TABLE "CrmAppointment" ADD COLUMN "longitude" DOUBLE PRECISION;
+ALTER TABLE "CrmAppointment" ADD COLUMN "briefToken" TEXT;
+ALTER TABLE "CrmAppointment" ADD COLUMN "briefSharedAt" TIMESTAMP(3);
+ALTER TABLE "CrmAppointment" ADD COLUMN "briefExpiresAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "CrmAppointment_briefToken_key" ON "CrmAppointment"("briefToken");

--- a/prisma/migrations/20260729110000_add_work_order_sign_off/migration.sql
+++ b/prisma/migrations/20260729110000_add_work_order_sign_off/migration.sql
@@ -1,0 +1,9 @@
+-- A job is finished when the person paying agrees it is.
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffToken" TEXT;
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffAskedAt" TIMESTAMP(3);
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffAt" TIMESTAMP(3);
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffName" TEXT;
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffRating" INTEGER;
+ALTER TABLE "CrmWorkOrder" ADD COLUMN "signOffNotes" TEXT;
+
+CREATE UNIQUE INDEX "CrmWorkOrder_signOffToken_key" ON "CrmWorkOrder"("signOffToken");

--- a/prisma/migrations/20260730100000_add_automation_run_timing/migration.sql
+++ b/prisma/migrations/20260730100000_add_automation_run_timing/migration.sql
@@ -1,0 +1,7 @@
+-- How long a rule took, and how much it did.
+--
+-- Both nullable/defaulted so existing rows stay valid: a run recorded before
+-- this migration genuinely has no measured duration, and reporting it as zero
+-- would drag every average toward a number nobody observed.
+ALTER TABLE "CrmAutomationRun" ADD COLUMN "durationMs" INTEGER;
+ALTER TABLE "CrmAutomationRun" ADD COLUMN "actionCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20260731100000_add_crm_record_files/migration.sql
+++ b/prisma/migrations/20260731100000_add_crm_record_files/migration.sql
@@ -1,0 +1,40 @@
+-- Files attached to a record, as opposed to billing documents the system
+-- raised. The owner is a nullable column per kind rather than an entity+id
+-- pair, so the database can cascade a delete and refuse a file pointing at a
+-- record that does not exist — a string id pointing at nothing is how
+-- orphaned files outlive the customer who sent them.
+CREATE TABLE "CrmRecordFile" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "size" INTEGER,
+    "contentType" TEXT,
+    "note" TEXT,
+    "leadId" TEXT,
+    "dealId" TEXT,
+    "clientId" TEXT,
+    "personId" TEXT,
+    "siteId" TEXT,
+    "userId" TEXT,
+    "uploadedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CrmRecordFile_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "CrmRecordFile_companyId_leadId_createdAt_idx" ON "CrmRecordFile"("companyId", "leadId", "createdAt");
+CREATE INDEX "CrmRecordFile_companyId_dealId_createdAt_idx" ON "CrmRecordFile"("companyId", "dealId", "createdAt");
+CREATE INDEX "CrmRecordFile_companyId_clientId_createdAt_idx" ON "CrmRecordFile"("companyId", "clientId", "createdAt");
+CREATE INDEX "CrmRecordFile_companyId_personId_createdAt_idx" ON "CrmRecordFile"("companyId", "personId", "createdAt");
+CREATE INDEX "CrmRecordFile_companyId_siteId_createdAt_idx" ON "CrmRecordFile"("companyId", "siteId", "createdAt");
+CREATE INDEX "CrmRecordFile_companyId_userId_createdAt_idx" ON "CrmRecordFile"("companyId", "userId", "createdAt");
+
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_leadId_fkey" FOREIGN KEY ("leadId") REFERENCES "CrmLead"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_dealId_fkey" FOREIGN KEY ("dealId") REFERENCES "CrmDeal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "CrmClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_personId_fkey" FOREIGN KEY ("personId") REFERENCES "CrmPerson"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "CrmSite"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CrmRecordFile" ADD CONSTRAINT "CrmRecordFile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6707,6 +6707,18 @@ model CrmAppointment {
   reportNotes       String?
   reportCompletedAt DateTime?
 
+  /// Where the visit actually is, when it is not at a recorded site — an
+  /// address somebody typed, optionally pinned so a phone can navigate to it.
+  latitude  Float?
+  longitude Float?
+
+  /// A tokenised public brief (/v/<token>): what the job is, when, where and
+  /// who is coming. Handed to the customer, or to a subcontractor who has no
+  /// account. Null until somebody shares it.
+  briefToken     String?   @unique
+  briefSharedAt  DateTime?
+  briefExpiresAt DateTime?
+
   company    Company            @relation(fields: [companyId], references: [id], onDelete: Cascade)
   lead       CrmLead?           @relation(fields: [leadId], references: [id], onDelete: SetNull)
   client     CrmClient?         @relation(fields: [clientId], references: [id], onDelete: SetNull)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8309,6 +8309,18 @@ model CrmWorkOrder {
   assignedToId String?
   crewIds      String[]  @default([])
 
+  /// Client sign-off (/s/<token>). A job is not finished because the crew
+  /// says so; it is finished when the person paying agrees it is. Null until
+  /// somebody asks for the sign-off.
+  signOffToken     String?   @unique
+  signOffAskedAt   DateTime?
+  signOffAt        DateTime?
+  /// Typed by the client on their own phone — the name IS the signature.
+  signOffName      String?
+  /// 1–5, optional. A job can be signed off without being rated.
+  signOffRating    Int?
+  signOffNotes     String?
+
   addressLine String?
   accessNotes String?
   contactName  String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,7 @@ model Company {
   crmListMembers                CrmListMember[]
   crmTasks                      CrmTask[]
   crmComments                   CrmComment[]
+  crmRecordFiles                CrmRecordFile[]
   crmMentions                   CrmMention[]
   crmFollowers                  CrmFollower[]
   crmAutomations                CrmAutomation[]
@@ -996,6 +997,8 @@ model User {
   crmTasksCreated                   CrmTask[]                      @relation("CrmTaskCreatedBy")
   crmCommentsCreated                CrmComment[]                   @relation("CrmCommentCreatedBy")
   crmCommentsResolved               CrmComment[]                   @relation("CrmCommentResolvedBy")
+  crmRecordFilesUploaded            CrmRecordFile[]                @relation("CrmRecordFileUploadedBy")
+  crmRecordFilesAbout               CrmRecordFile[]                @relation("CrmRecordFileSubject")
   crmMentions                       CrmMention[]                   @relation("CrmMentionUser")
   crmFollowing                      CrmFollower[]                  @relation("CrmFollowerUser")
   crmAutomationsCreated             CrmAutomation[]                @relation("CrmAutomationCreatedBy")
@@ -6462,6 +6465,7 @@ model CrmClient {
   people            CrmPerson[]           @relation("CrmPersonPrimaryCompany")
   tasks             CrmTask[]
   comments          CrmComment[]
+  files             CrmRecordFile[]
   personLinks       CrmPersonCompany[]
   deals             CrmDeal[]
   sites             CrmSite[]
@@ -6541,6 +6545,7 @@ model CrmLead {
   convertedBy       User?                 @relation("CrmLeadConvertedBy", fields: [convertedById], references: [id])
   tasks             CrmTask[]
   comments          CrmComment[]
+  files             CrmRecordFile[]
 
   @@unique([companyId, leadNo])
   @@index([companyId, stage, updatedAt])
@@ -7498,6 +7503,7 @@ model CrmPerson {
   leadsConverted CrmLead[]          @relation("CrmLeadConvertedPerson")
   tasks          CrmTask[]
   comments       CrmComment[]
+  files             CrmRecordFile[]
 
   @@unique([companyId, personNo])
   @@index([companyId, fullName])
@@ -7564,6 +7570,7 @@ model CrmSite {
   appointments   CrmAppointment[]
   tasks          CrmTask[]
   comments       CrmComment[]
+  files             CrmRecordFile[]
 
   workOrders     CrmWorkOrder[]
 
@@ -7631,6 +7638,7 @@ model CrmDeal {
   leadsConverted CrmLead[]         @relation("CrmLeadConvertedDeal")
   tasks             CrmTask[]
   comments          CrmComment[]
+  files             CrmRecordFile[]
 
   workOrders     CrmWorkOrder[]
 
@@ -7971,6 +7979,57 @@ model CrmComment {
   @@index([companyId, dealId, createdAt])
   @@index([companyId, leadId, createdAt])
   @@index([companyId, parentId])
+}
+
+/// A file somebody attached to a record.
+///
+/// Distinct from CrmLeadDocument, which is a billing document the system
+/// raised and numbered. This is the signed contract, the tax clearance, the
+/// photo of the damaged unit — things that arrive from outside and belong to
+/// a record rather than to an invoice.
+///
+/// The owner is a nullable column per kind rather than an entity+id pair, so
+/// the database can cascade a delete and enforce that the record exists. A
+/// string id pointing at nothing is how orphaned files outlive the customer
+/// who sent them.
+model CrmRecordFile {
+  id          String  @id @default(uuid())
+  companyId   String
+  /// What it is called to a reader — the original filename unless renamed.
+  name        String
+  url         String
+  /// Bytes, when the uploader reported it.
+  size        Int?
+  contentType String?
+  /// Why it is here. Optional; a filename is usually enough.
+  note        String?
+
+  leadId   String?
+  dealId   String?
+  clientId String?
+  personId String?
+  siteId   String?
+  /// A rep's own profile — a certificate, a licence, a signed policy.
+  userId   String?
+
+  uploadedById String?
+  createdAt    DateTime @default(now())
+
+  company    Company    @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  uploadedBy User?      @relation("CrmRecordFileUploadedBy", fields: [uploadedById], references: [id])
+  lead       CrmLead?   @relation(fields: [leadId], references: [id], onDelete: Cascade)
+  deal       CrmDeal?   @relation(fields: [dealId], references: [id], onDelete: Cascade)
+  client     CrmClient? @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  person     CrmPerson? @relation(fields: [personId], references: [id], onDelete: Cascade)
+  site       CrmSite?   @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  user       User?      @relation("CrmRecordFileSubject", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, leadId, createdAt])
+  @@index([companyId, dealId, createdAt])
+  @@index([companyId, clientId, createdAt])
+  @@index([companyId, personId, createdAt])
+  @@index([companyId, siteId, createdAt])
+  @@index([companyId, userId, createdAt])
 }
 
 model CrmMention {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8049,6 +8049,13 @@ model CrmAutomationRun {
   status       CrmAutomationRunStatus @default(SUCCEEDED)
   /// Per-action outcomes, and the message when one failed.
   result       Json?
+  /// Wall-clock time the actions took. Measured rather than estimated, so
+  /// "this rule is slow" is a fact somebody can check rather than a feeling.
+  durationMs   Int?
+  /// How many actions this firing actually carried out. The unit of work a
+  /// rule spends — a rule that fires rarely but does eight things each time
+  /// costs more than one that fires often and sets a field.
+  actionCount  Int      @default(0)
   createdAt    DateTime @default(now())
 
   company    Company       @relation(fields: [companyId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
A lead, a deal, a company, a person and a site are the same kind of thing wearing different labels, but the code did not believe that. Lead detail was 469 hand-rolled lines that did not use the record shell the other four already used, which is why a fix made on the deal page never showed up on the lead page — and why "editable properties" had been reported done while the two record types people actually open still had none.

This makes the record one surface, clears the backlog that was waiting behind it, and then makes the whole module usable on a phone. Every remaining CRM item is now closed.

## The one to read first

**A quote line could not be typed into.** Reported by customers as "we can only add items from the site visit", and they were being precise.

`PopoverTrigger asChild` merges a `type="button"` prop onto its child. `type` was not among the props written on the Input, so it survived the Slot merge — and the description field rendered as an input element carrying `type="button"`, `class="input"`, the placeholder, and the description as its `value`.

That is a button. It cannot be typed into at all: the value shows as its label and the placeholder is silently dropped. So the only descriptions that could ever reach a quote were ones set programmatically — a visit prefill or a catalogue pick. Which is exactly what was reported.

It typechecked, it rendered, and it passed every test, because nothing had ever asserted on the element that came out. Now five tests do, including one that fails if `type="button"` ever reappears. The fix is a `PopoverAnchor`, which positions the popover and imposes no button semantics.

A line can now be filled from all three sources, which is what a real quote needs: what was measured on site, what we sell off the shelf, and whatever somebody types. The last is the default and always wins. Measured items were previously available only as a one-shot prefill at the moment a report was completed — no use for the quote needing three measured items, one catalogue product and a one-off, or for a second quote raised a week later.

## One record surface

**A lead is a record like any other** — lead detail moves onto `RecordPageShell`, gaining editable value, probability, company, contact, phone, email and source, which it never had. The stage stepper survives as a `beforeTabs` slot, because a lead genuinely has a pipeline and the others do not.

**A record's tabs are written once** — `record-tabs.tsx` builds timeline, tasks, comments, mentions, files and workflows from a `{kind, id}` reference. Each kind's quirks live in one place: how it maps onto a task's foreign key, and the fact that a site has no activity target because a site is a place, not somebody you correspond with. Everything below that adds a tab lands on all five by adding one function here.

**Editing has a hook** — `use-attribute-editor.ts`, which nothing had. `text` accepts blank as null, `required` refuses to clear, `numeric` refuses what will not parse. Single relations become repointable: a site's company, a deal's company, read as a link until you press them.

## Records

- **Custom fields are properties** (#75) on all five kinds. Text and numbers get real editors; selects, dates and booleans stay formatted, because a text box accepting "next tuesday" into a date column is worse than no editor.
- **Backlinks** — a Mentions tab finding every comment and activity that references this record, wherever it was written.
- **Files** (#77) — the signed contract, the tax clearance, the scan of a purchase order, on leads, deals, companies, people, sites and a rep's own profile. Kept apart from Documents, which is what the system raised and numbered. The owner is one nullable column per kind rather than an entity string, so the database enforces the record exists and cascades the delete; a rep gets its own column rather than borrowing `personId`.
- **Workflows** (#91) — what has run against this record, what each action did or why it did not, and which enabled rules could still fire at it.
- **The rail does the reading** (#86) — meetings carry a countdown and a Join or Directions button depending on what was typed in the location box; files carry a coloured mark by type; "Next task" and "Next visit" become one "Up next"; calls get their own short list.

## Surfaces

**Site visits** (#61) — a visit gets a location and a shareable brief at `/v/[token]`: when, where, who is coming, what it covers, address as a maps link. The brief carries no value, no margin and none of the team's notes; the `select` in the public route is the security boundary. Expired links 404 rather than 403 — a revoked link should not confirm it existed.

**Client sign-off** (#62) — the client confirms a finished job at `/s/[token]` without an account. Once only: a second submission is refused rather than overwriting, because letting the link re-answer means whoever holds it can rewrite history. It carries no money — they are confirming the work, not the price.

**Reports** (#85) — a grid of report cards people own and arrange, each naming the records it counted. The funnel now says how long each stage takes as well as how many survive it, reconstructed from the stage-change trail. The trend line can be read rather than estimated: the design system's exact geometry with a hover layer over it, targeting a band rather than a vertex.

**Starter templates** (#63) — a new document opens as a document. A site brief that asks where the gate code is, a quotation that says what happens when the job turns out bigger, an invoice showing the balance after a deposit, a receipt showing what is still owed. Every starter is checked in tests against the builder's own validation, because a starter is the one template nobody proofreads.

**Catalogue when quoting** (#76) — the picker reached the site visit too, which is where a description is actually first typed. It fills description and, when nobody has typed a price yet, the price.

## The CRM on a phone

Six commits of UI only — no new features, no schema, no behaviour beyond what a phone requires.

**Every record page was broken at phone width.** `.detail-grid` is a hard `1fr 320px` with no media query anywhere. At 390px that crushed the content column to about eighteen pixels beside a full-width rail. One CSS rule fixes all five record pages at once — the payoff of the record work above. The design system's own docblock claims the class collapses under 720px; that CSS does not ship, which is why reading the component would have missed it. Stacked, the rail goes above the tabs rather than below, because it holds what somebody opened the record to find and underneath a fifty-entry timeline nobody would reach it.

**Nothing could be dragged by thumb.** All four dnd-kit sites registered only `PointerSensor`, which answers touch and crosses its six-pixel threshold long before any long-press delay — so every attempt to swipe a board sideways started a drag. Split into `MouseSensor` plus `TouchSensor`, a finger scrolls immediately and drags only after a deliberate hold.

**A board is a desk instrument.** It works because you can see four columns at once; at 390px you see one, and swiping between them means losing your place in a strip with no landmarks. Below `lg` the three boards now render what a board is actually for: a row of stage chips with counts, and the selected stage as one full-width list. Restaging is not lost — tapping a row opens the record, where the stage control already lives.

**Every collection speaks one grammar on a phone**: one row per item, at most two lines in it, rows separated by whitespace rather than ruled off or boxed in. The deals and leads tables were rendering bordered three-line cards and now render the same list every other CRM surface uses. Four report and insight tables stop scrolling sideways and become lists too — you cannot compare a column you have to drag into view, and the row labels leave the screen as soon as you drag it.

**Two shared defects surfaced on the way.** `DataTable` hid its desktop table below `md` only when `mobileCardRenderer` was set, so every `mobileListRenderer` caller stacked the mobile list on top of the full table — that also fixes two scrap-metal surfaces. And `RecordList` dropped every fact below `sm`, which is right for the second and third but not the first: a deal with no value says less than the card it replaced.

**The notes composer was zooming iOS in and never back out** — a contenteditable at fourteen pixels. The global sixteen-pixel rule cannot reach it: that rule sits in `@layer app` and Tailwind utilities are a later layer, so the `text-sm` at the call site won. Fixed at the call site, with a test asserting on the emitted element, because a cascade question is exactly the kind that reads correct and renders wrong.

Also: hover-only controls become visible on touch, quote lines become labelled cards when they stack, fixed pixel widths give way, the trend chart answers a tap, and touch targets reach forty-four pixels.

## Things reported done that were not

- **The timeline printed raw reference tokens** on every existing row. The earlier fix only touched newly written notes while every row in the database has its prose in `subject`.
- **Leads recorded no field changes at all.** Every other record type wrote a trail on each edit; the lead route never called it. So "who dropped the value from 40k to 12k" was answerable everywhere except the record type people open most.
- **The site's History tab rendered an empty array — always.** A site has no activity foreign key, so nothing could ever appear there. The comment beside it said the tab stayed "for consistency".
- **Every rail section heading carried two contradictory colour utilities**, so which applied was decided by stylesheet order rather than intent. Eight places.
- **The Stage trigger's caret wrapped** to a second line, because `min-w-0` let the toolbar shrink it below its content.
- **A lead with only a contact name could not be quoted.**

## Not built, and why

The workflow insights have no in-progress count and no credit meter, though both were asked for. This engine runs a rule synchronously the moment its event happens and meters nothing, so both would be a permanent zero pretending to be a measurement. Actions carried out is the real cost, and that is counted. Similarly, "what is waiting" on a record is derived from which rules are armed rather than read from a queue, because there is no queue.

## Verification

`npx tsc --noEmit` clean. `npx eslint` clean across `components/crm`, `components/templates`, `lib/crm`, `app/crm`, `app/api/v2/crm`, `app/api/public` and `app/s` — the errors elsewhere in the repo predate this branch.

`npm test` — **988 passing across 89 files**, up from 853 when this branch left main. New suites cover the visit brief, sign-off, reporting maths, starter-template validation, run insights, panel helpers, record-file ownership, quote-line suggestions, the picker's rendered markup, and the mobile row grammar.

A full `next build` also passes, with every new route in the manifest.

**Five migrations**, all additive and nullable: document deposit and layout, visit location and brief, work-order sign-off, automation run timing, and the record-files table.

**Seen rendered this time.** Unlike the earlier rounds, the mobile pass was checked against a running production build with a seeded local database, photographed at 390x844 with touch and at 768x1024. Sixteen CRM surfaces, no horizontal overflow at either width. Two defects came out of the screenshots that reading the code did not find: board loading skeletons were a column strip that pushed the page sideways, and a board with no stages rendered nothing at all on a phone.

**What is still unverified.** The record areas would not leave their loading state in that harness — every CRM query stayed pending at both phone and desktop width, on a production build, while the same endpoint returned real data when called directly from the page. So populated lists, boards and record pages were not photographed, and the offline layer is the likeliest suspect. Worth a look independently of this branch, since it reproduces where none of this branch's code is active.

The quote-line fix remains the cheapest thing to check and the most worth checking: open a lead or deal, start a quotation, click into a line's description and type.