### PR TITLE
fix(crm): make the module read on a phone, and give a lead an ending

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(git *)",
       "Bash(DATABASE_URL=\"postgresql://huchu:huchu_dev@localhost:5432/huchu_test\" npx prisma *)",
       "Bash(npx vitest *)",
-      "Bash(pnpm install *)"
+      "Bash(pnpm install *)",
+      "mcp__Claude_Code_Remote__send_later"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(DATABASE_URL=\"postgresql://huchu:huchu_dev@localhost:5432/huchu_test\" npx prisma *)",
       "Bash(npx vitest *)",
       "Bash(pnpm install *)",
-      "mcp__Claude_Code_Remote__send_later"
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__Claude_Code_Remote__list_triggers"
     ]
   }
 }

--- a/app/api/v2/crm/dashboard/route.ts
+++ b/app/api/v2/crm/dashboard/route.ts
@@ -148,6 +148,10 @@ export async function GET(request: NextRequest) {
           companyId,
           stage: { notIn: ["WON", "LOST"] },
           firstContactAt: null,
+          // A lead somebody put away is not waiting on a reply, and one that
+          // became a deal is being worked as the deal. Neither is an
+          // unanswered enquiry, which is what this tile counts.
+          archivedAt: null,
           ...scope,
         },
         select: { id: true, createdAt: true },

--- a/app/api/v2/crm/deals/[id]/route.ts
+++ b/app/api/v2/crm/deals/[id]/route.ts
@@ -69,7 +69,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         documents: {
           orderBy: { createdAt: "desc" },
           include: {
-            approval: { select: { token: true, status: true, respondedAt: true } },
+            approval: {
+              select: {
+                token: true,
+                status: true,
+                respondedAt: true,
+                // What the customer actually said, and whether they have so
+                // much as opened it. All four have been stored since the
+                // approval link shipped; none of them were ever read back.
+                responseNote: true,
+                responderName: true,
+                firstViewedAt: true,
+              },
+            },
             // The document list needs the underlying record's own status and
             // balance — a CrmLeadDocument only knows the amount it was cut for,
             // not what has since been paid against it.

--- a/app/api/v2/crm/leads/[id]/archive/route.ts
+++ b/app/api/v2/crm/leads/[id]/archive/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { canEditRecord } from "@/lib/crm/permissions";
+
+/**
+ * Put a lead away, or take it back out.
+ *
+ * A lead had no ending short of dragging it to Lost, which is a claim about
+ * the business — somebody looked at it and said no — and a duplicate, a test
+ * row or a wrong number is not that. Archiving is the ending for those: the
+ * record survives, so the enquiry still counts in "where did our leads come
+ * from", but it leaves every list, board and total.
+ *
+ * Reversible on purpose, and by the same permission that archived it. The
+ * irreversible option is DELETE on the lead itself, which is a different
+ * capability.
+ */
+const bodySchema = z.object({
+  archived: z.boolean(),
+  /** Why it was put away — kept on the record's own trail. */
+  reason: z.string().trim().max(500).optional(),
+});
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const companyId = session.user.companyId;
+    const { id } = await params;
+
+    const existing = await prisma.crmLead.findFirst({
+      where: { id, companyId },
+      select: {
+        id: true,
+        leadNo: true,
+        assignedToId: true,
+        archivedAt: true,
+        convertedAt: true,
+        convertedDealId: true,
+      },
+    });
+    if (!existing) return errorResponse("Lead not found", 404);
+    if (!(await canEditRecord(session, existing.assignedToId))) {
+      return errorResponse("You can only archive leads assigned to you", 403);
+    }
+
+    const { archived, reason } = bodySchema.parse(await request.json());
+
+    // Restoring a converted lead would put the deal's own origin back into the
+    // pipeline beside it — the exact double-count archiving on conversion
+    // exists to prevent.
+    if (!archived && existing.convertedAt) {
+      return errorResponse(
+        "This lead became a deal. Its deal is where the work is now, so it stays archived.",
+        409,
+      );
+    }
+
+    if (Boolean(existing.archivedAt) === archived) {
+      return successResponse({ id, archived });
+    }
+
+    const now = new Date();
+    const [updated] = await prisma.$transaction([
+      prisma.crmLead.update({
+        where: { id },
+        data: archived
+          ? { archivedAt: now, archivedById: session.user.id }
+          : { archivedAt: null, archivedById: null },
+      }),
+      prisma.crmActivity.create({
+        data: {
+          companyId,
+          type: "SYSTEM",
+          leadId: id,
+          subject: archived
+            ? `Lead ${existing.leadNo} archived`
+            : `Lead ${existing.leadNo} restored`,
+          body: reason || null,
+          occurredAt: now,
+          createdById: session.user.id,
+        },
+      }),
+    ]);
+
+    return successResponse(updated);
+  } catch (error) {
+    if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
+    console.error("[API] POST /api/v2/crm/leads/[id]/archive error:", error);
+    return errorResponse("Failed to archive lead");
+  }
+}

--- a/app/api/v2/crm/leads/[id]/route.ts
+++ b/app/api/v2/crm/leads/[id]/route.ts
@@ -4,7 +4,7 @@ import { errorResponse, successResponse, validateSession } from "@/lib/api-utils
 import { scoreLead } from "@/lib/crm/lead-scoring";
 import { prisma } from "@/lib/prisma";
 import { recordFieldChanges } from "@/lib/crm/history";
-import { canEditRecord } from "@/lib/crm/permissions";
+import { canEditRecord, canUser, denialMessage } from "@/lib/crm/permissions";
 import { crmLeadChannelSchema } from "@/lib/crm/views";
 import {
   buildCustomFieldValues,
@@ -224,5 +224,54 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     if (error instanceof z.ZodError) return errorResponse("Validation failed", 400, error.issues);
     console.error("[API] PATCH /api/v2/crm/leads/[id] error:", error);
     return errorResponse("Failed to update lead");
+  }
+}
+
+/**
+ * Destroy a lead and everything hanging off it.
+ *
+ * Leads had no removal of any kind: a duplicate typed twice, a test row, a
+ * number somebody entered wrong stayed in the pipeline for good. Archiving
+ * covers almost every one of those and is what the record page offers first —
+ * this is the other case, where the row should never have existed and keeping
+ * it is worse than losing it.
+ *
+ * Activities, follow-ups, appointments, comments and files go with it; the
+ * schema cascades them. A converted lead is refused, because a deal points
+ * back at it for attribution and the whole reason the lead is kept after
+ * conversion is that source reporting reads it.
+ */
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { id } = await params;
+
+    const existing = await prisma.crmLead.findFirst({
+      where: { id, companyId: session.user.companyId },
+      select: { id: true, assignedToId: true, convertedAt: true, convertedDealId: true },
+    });
+    if (!existing) return errorResponse("Lead not found", 404);
+    if (!(await canEditRecord(session, existing.assignedToId))) {
+      return errorResponse("You can only delete leads assigned to you", 403);
+    }
+    // Owning a record and being allowed to destroy it are separate decisions.
+    if (!(await canUser(session, "records.delete"))) {
+      return errorResponse(denialMessage("records.delete"), 403);
+    }
+
+    if (existing.convertedAt) {
+      return errorResponse(
+        "This lead became a deal, and the deal still credits it for where the business came from. It is already archived.",
+        409,
+      );
+    }
+
+    await prisma.crmLead.delete({ where: { id } });
+    return successResponse({ id, deleted: true });
+  } catch (error) {
+    console.error("[API] DELETE /api/v2/crm/leads/[id] error:", error);
+    return errorResponse("Failed to delete lead");
   }
 }

--- a/app/api/v2/crm/leads/[id]/route.ts
+++ b/app/api/v2/crm/leads/[id]/route.ts
@@ -48,7 +48,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         documents: {
           orderBy: { createdAt: "desc" },
           include: {
-            approval: { select: { token: true, status: true, respondedAt: true } },
+            approval: {
+              select: {
+                token: true,
+                status: true,
+                respondedAt: true,
+                // What the customer actually said, and whether they have so
+                // much as opened it. All four have been stored since the
+                // approval link shipped; none of them were ever read back.
+                responseNote: true,
+                responderName: true,
+                firstViewedAt: true,
+              },
+            },
             // The document list needs the underlying record's own status and
             // balance — a CrmLeadDocument only knows the amount it was cut for,
             // not what has since been paid against it.

--- a/app/api/v2/crm/leads/bulk/route.ts
+++ b/app/api/v2/crm/leads/bulk/route.ts
@@ -21,6 +21,13 @@ const bulkSchema = z.discriminatedUnion("action", [
     stage: crmLeadStageSchema,
     lostReason: z.string().trim().max(500).optional(),
   }),
+  // Tidying up is a bulk job by nature — an import that went in twice, a
+  // morning of spam through the web form. One at a time, nobody does it.
+  z.object({
+    action: z.literal("archive"),
+    ids: z.array(z.string().uuid()).min(1).max(MAX_BULK_IDS),
+    archived: z.boolean(),
+  }),
 ]);
 
 export async function POST(request: NextRequest) {
@@ -41,6 +48,8 @@ export async function POST(request: NextRequest) {
         // Same fields the single-lead route selects: a bulk stage move
         // promotes to a deal exactly as a drag on the board does.
         convertedDealId: true,
+        convertedAt: true,
+        archivedAt: true,
         leadNo: true,
         title: true,
         estimatedValue: true,
@@ -92,6 +101,51 @@ export async function POST(request: NextRequest) {
       });
 
       return successResponse({ updated: editable.length, skipped, notFound });
+    }
+
+    if (body.action === "archive") {
+      // Restoring a converted lead would put a deal's own origin back in the
+      // pipeline beside it. Those are left where they are and reported as
+      // unchanged rather than failing the batch around them.
+      const targets = editable.filter((lead) => {
+        if (Boolean(lead.archivedAt) === body.archived) return false;
+        return body.archived || !lead.convertedAt;
+      });
+
+      if (targets.length > 0) {
+        const now = new Date();
+        await prisma.$transaction(async (tx) => {
+          await tx.crmLead.updateMany({
+            where: {
+              id: { in: targets.map((lead) => lead.id) },
+              companyId: session.user.companyId,
+            },
+            data: body.archived
+              ? { archivedAt: now, archivedById: session.user.id }
+              : { archivedAt: null, archivedById: null },
+          });
+          await tx.crmActivity.createMany({
+            data: targets.map((lead) => ({
+              companyId: session.user.companyId,
+              type: "SYSTEM" as const,
+              leadId: lead.id,
+              clientId: lead.clientId ?? undefined,
+              subject: body.archived
+                ? `Lead ${lead.leadNo} archived`
+                : `Lead ${lead.leadNo} restored`,
+              occurredAt: now,
+              createdById: session.user.id,
+            })),
+          });
+        });
+      }
+
+      return successResponse({
+        updated: targets.length,
+        unchanged: editable.length - targets.length,
+        skipped,
+        notFound,
+      });
     }
 
     // Stage moves run through the shared service so bulk history matches what

--- a/app/api/v2/crm/reps/[id]/route.ts
+++ b/app/api/v2/crm/reps/[id]/route.ts
@@ -55,7 +55,15 @@ export async function GET(
     const [leads, deals, tasks, activities, documents, wonCount, lostCount] =
       await Promise.all([
         prisma.crmLead.findMany({
-          where: { companyId, assignedToId: id, stage: { notIn: ["WON", "LOST"] } },
+          // The rep's live pipeline. A converted lead is archived and its deal
+          // is listed right beside this, so an archived row here would show
+          // the same opportunity twice on one person's page.
+          where: {
+            companyId,
+            assignedToId: id,
+            archivedAt: null,
+            stage: { notIn: ["WON", "LOST"] },
+          },
           select: {
             id: true,
             leadNo: true,

--- a/app/api/v2/crm/reps/route.ts
+++ b/app/api/v2/crm/reps/route.ts
@@ -43,7 +43,10 @@ export async function GET(request: NextRequest) {
       getRepPerformance(companyId, { from, to, repId: isManager ? null : session.user.id }),
       prisma.crmLead.groupBy({
         by: ["assignedToId"],
-        where: { companyId, stage: { notIn: ["WON", "LOST"] } },
+        // What somebody is actually carrying. A converted lead is archived and
+        // its deal is counted beside this figure, so leaving archived rows in
+        // would credit one piece of business to a rep twice.
+        where: { companyId, archivedAt: null, stage: { notIn: ["WON", "LOST"] } },
         _count: { _all: true },
         _sum: { estimatedValue: true },
       }),

--- a/app/globals.css
+++ b/app/globals.css
@@ -648,6 +648,10 @@
   .segmented {
     grid-auto-columns: minmax(max-content, 1fr);
     overflow-x: auto;
+    /* Stated, not left to the spec's default: a single `overflow-x` makes the
+       other axis compute to `auto`, which is a vertical scrollbar waiting to
+       appear on a 34px-tall control. */
+    overflow-y: hidden;
     overscroll-behavior-x: contain;
     scrollbar-width: none;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -661,17 +661,40 @@
       color var(--motion-duration-fast, 120ms) var(--motion-ease-standard, ease);
   }
 
+  /* Hover and active must not be the same paint.
+
+     Both were `--surface-muted`, so pointing at a rail put a second row in
+     exactly the selected state — two items that look chosen, and no way to
+     tell which one you are actually on. Hover is now the lighter tint, and
+     selection is carried by a sunken ground plus a brand bar down the leading
+     edge, which is a mark hovering never produces. */
   .settings-rail .rail-item:hover,
   .nav-rail .rail-item:hover {
-    background: var(--surface-muted);
+    background: var(--surface-subtle, var(--surface-muted));
     color: var(--text-strong);
   }
 
   .settings-rail .rail-item.active,
-  .nav-rail .rail-item.active {
+  .nav-rail .rail-item.active,
+  .settings-rail .rail-item[aria-current="page"],
+  .nav-rail .rail-item[aria-current="page"] {
+    position: relative;
     background: var(--surface-muted);
     color: var(--text-strong);
     font-weight: 600;
+  }
+
+  .settings-rail .rail-item.active::before,
+  .nav-rail .rail-item.active::before,
+  .settings-rail .rail-item[aria-current="page"]::before,
+  .nav-rail .rail-item[aria-current="page"]::before {
+    content: "";
+    position: absolute;
+    inset-block: 6px;
+    inset-inline-start: 0;
+    width: 2px;
+    border-radius: 2px;
+    background: var(--action-primary-bg, var(--brand));
   }
 
   .settings-rail .rail-item:disabled,

--- a/app/globals.css
+++ b/app/globals.css
@@ -246,6 +246,54 @@
     }
   }
 
+  /* A stat tile is half a phone wide, and its number has to fit in it.
+
+     `.stat-tile .val` and `.b-sh-lead .v` ship at 32px and 40px with no media
+     query, which is right for a tile on a desk and wrong for one at 173px:
+     "USD 108,500" overflowed its own box, which is why every stat grid in this
+     repo used to stack one-per-row on a phone and spend three screens saying
+     six numbers. The tiles are two-up now, so the numerals come down to the
+     size that fits. Padding follows — 18px of it either side of a 137px
+     column is a quarter of the tile spent on air.
+
+     Nothing else about the tile changes: same label, same delta, same tone. */
+  @media (max-width: 639.98px) {
+    .stat-tile {
+      padding: 12px 14px;
+    }
+
+    .stat-tile .val {
+      font-size: 24px;
+    }
+
+    /* `StatHero` is drawn with inline styles rather than classes, so its 24px
+       padding and its change/subtitle row can only be reached from here — and
+       only with `!important`, which is what an inline style costs. The row
+       holds a delta and a sentence side by side with no wrap, which at 390px
+       becomes two ~170px columns of two-word lines. Wrapping puts the sentence
+       back on its own line. */
+    .b-stat-hero {
+      padding: 16px !important;
+    }
+
+    .b-stat-hero > div:last-child {
+      flex-wrap: wrap;
+    }
+
+    /* The same trade for the KPI cell, which is what a metric widget on the
+       CRM overview is made of. Two-up at 390px gives it ~165px; a display-sm
+       numeral needs more than that for anything with a thousands separator
+       in it. */
+    .kpi-cell {
+      padding: var(--space-3);
+      gap: var(--space-1);
+    }
+
+    .kpi-cell-val {
+      font: var(--type-section-title);
+    }
+  }
+
   /* --- Control geometry -------------------------------------------------
      Everything that reads as a button is built like one: same height, same
      gap, same radius. Three places where that had drifted.
@@ -548,6 +596,39 @@
   .nav-rail[data-orientation="responsive"] .rail-item-label { overflow: visible; }
   /* A group heading only reads as one once the rail is a column again. */
   .nav-rail[data-orientation="responsive"] > .group-label { display: none; }
+
+  /* On a phone the strip runs to the edges of the screen. Cut short of the
+     gutter, the last tab looked clipped by a bug; cut by the screen itself, a
+     half-visible tab is the platform's own way of saying "this scrolls". Snap
+     so a swipe lands on a tab rather than halfway through one. */
+  @media (max-width: 639.98px) {
+    .nav-rail[data-orientation="responsive"] {
+      margin-inline: calc(var(--content-gutter-x) * -1);
+      padding-inline: var(--content-gutter-x);
+      scroll-padding-inline: var(--content-gutter-x);
+      scroll-snap-type: x proximity;
+    }
+    .nav-rail[data-orientation="responsive"] .rail-item { scroll-snap-align: start; }
+  }
+
+  /* ── Segmented control ───────────────────────────────────────────────────
+     `.segmented` is an equal-columns grid at `width: 100%`, which is right
+     until the labels stop fitting: six segments on a 390px screen gave each
+     62px, and "On site" wrapped to two lines *inside its own pill* while the
+     strip still ran off the right of the page. Both halves of that are fixed
+     here — a label never wraps, and a strip that cannot fit scrolls instead of
+     squashing. `minmax(max-content, 1fr)` keeps the equal widths whenever
+     there is room for them, so nothing changes on a desktop. */
+  .segmented {
+    grid-auto-columns: minmax(max-content, 1fr);
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+  }
+
+  .segmented::-webkit-scrollbar { display: none; }
+
+  .segmented-item { white-space: nowrap; }
 
   @media (min-width: 1024px) {
     .nav-rail[data-orientation="responsive"] {

--- a/app/globals.css
+++ b/app/globals.css
@@ -317,16 +317,42 @@
   /*    A button stretched to full width is a row, not a centred label: a
         sheet of stacked controls, a form field filling its column. The words
         start at the left edge and a trailing caret goes to the *right* edge,
-        which is where the eye looks for it and where a thumb reaches. Only a
-        trailing `svg` is pushed over — a button whose last child is text
-        keeps its label beside the rest of the label. */
+        which is where the eye looks for it and where a thumb reaches.
+
+        `:not(:only-child)` is doing real work. `:last-child` counts elements
+        only, so in `<span class="btn-label"><svg/>Filter</span>` — an icon
+        followed by a text node, which is how ~200 call sites pass an icon —
+        the icon is both the first and the last *element*, and the auto margin
+        shoved the icon and its label together against the right edge. A
+        genuine trailing caret has a sibling element before it. */
   .btn:where(.w-full) {
     justify-content: flex-start;
   }
   .btn:where(.w-full) > .btn-label {
     flex: 1 1 auto;
   }
-  .btn:where(.w-full) > .btn-label > svg:last-child {
+  .btn:where(.w-full) > .btn-label > svg:last-child:not(:only-child) {
+    margin-inline-start: auto;
+  }
+
+  /*    The same grammar for a column of controls a parent stretches, where
+        the class lands on nothing the parent owns. A sheet of filters is the
+        case: it stacks components it was handed, so it can set their width
+        but cannot put `w-full` on the button inside each one — which is why
+        that sheet rendered six centred labels where it meant to render six
+        rows. Named rather than repeated inline so the two stay in step. */
+  .stacked-controls > *,
+  .stacked-controls .btn,
+  .stacked-controls .segmented {
+    width: 100%;
+  }
+  .stacked-controls .btn {
+    justify-content: flex-start;
+  }
+  .stacked-controls .btn > .btn-label {
+    flex: 1 1 auto;
+  }
+  .stacked-controls .btn > .btn-label > svg:last-child:not(:only-child) {
     margin-inline-start: auto;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -616,9 +616,37 @@
     background: var(--accent-bg);
     color: var(--accent-fg);
   }
+
+  /* ── Solid marks ────────────────────────────────────────────────────────
+     The filled discs that carry a colour code: a record's timeline chips, the
+     mark beside each row of "contact so far", and any avatar filled solid.
+
+     `--accent-solid` reverses white on ten of the thirteen hues. On orange,
+     amber and yellow it does not — white lands at 3.4, 2.9 and 2.5 to one —
+     which is why the package pairs those three with a near-black `--accent-on`
+     instead. That pairing passes as a *number* and fails as a *mark*: a 14px
+     stroked glyph in #3D2800 on #D08A05 is mud, and two initials in it are
+     worse, because thin strokes need far more separation than the body text
+     those ratios were derived for.
+
+     So those three take `--accent-fg` — the same hue, darkened to the value the
+     package already uses for text — and reverse white out of it at 5.5 to one,
+     better than the teal and red solids already in service. Every mark in the
+     product is now a white glyph on a solid fill, and no hue is dropped to get
+     there. */
+  .solid-mark,
   .avatar.avatar-accent.avatar-accent-solid {
     background: var(--accent-solid);
     color: var(--accent-on);
+  }
+  [data-accent="orange"].solid-mark,
+  [data-accent="amber"].solid-mark,
+  [data-accent="yellow"].solid-mark,
+  .avatar[data-accent="orange"].avatar-accent-solid,
+  .avatar[data-accent="amber"].avatar-accent-solid,
+  .avatar[data-accent="yellow"].avatar-accent-solid {
+    background: var(--accent-fg);
+    color: #fff;
   }
 
   .settings-layout {

--- a/app/globals.css
+++ b/app/globals.css
@@ -205,7 +205,109 @@
   }
 }
 
+/* ── Overlay stacking order ─────────────────────────────────────────────────
+   One scale, declared once, read by every overlay in the app.
+
+   Before this, every overlay primitive in `components/ui` carried a bare
+   `z-50` — sheet, dialog, alert dialog, popover, menu, select — while the
+   design system painted its own drawer at 1100 and its toast viewport at 1200.
+   With six surfaces tied at 50 the winner was whichever portal happened to
+   mount last, and against the DS's 1100 they simply lost: opening the sidebar
+   on a phone and then tapping the workspace switcher put the menu *behind* the
+   sidebar, which is what a screenshot of it showed.
+
+   `docs/design-system/05-rules.md` publishes a rung per overlay kind — drawer
+   80, popover 90, modal 100. Every fixed order of those three is wrong in one
+   direction or the other, because this product nests them both ways: a filter
+   sheet made of popovers and a form dialog whose client picker is a sheet say
+   popover-and-drawer-over-modal, while a "discard these changes?" dialog
+   raised from inside a form sheet says the opposite. Measured, not reasoned
+   about: with drawers pinned below modals the client picker opened *behind*
+   the dialog that asked for it.
+
+   So every dismissable overlay shares one rung and **open order decides**,
+   which is the only rule that is right in both directions — a portal mounts
+   when it opens, so the newest layer is last in the DOM and paints on top.
+   Within a single overlay the scrim is written before its panel, so the panel
+   still covers its own scrim.
+
+   What keeps its own rung is the chrome that is never nested: the sidebar and
+   the app bar below, toasts above (they have to be readable over a modal). */
+:root {
+  --z-sidebar: 50;
+  --z-nav: 60;
+  --z-overlay: 100;
+  --z-toast: 200;
+}
+
 @layer app {
+  /* The design system's own drawer and toast, brought onto the scale. Its
+     `Sidebar` shell renders a `p-drawer` on mobile, so this is the rule that
+     decides whether a menu opened inside the sidebar can be seen at all.
+
+     `!important` because the package writes `zIndex: 1100` as an *inline
+     style* on the overlay (`src/primitives/Drawer.tsx`), and an inline style
+     outranks every layer. Verified in the browser: with a plain rule the
+     workspace menu still painted behind the sidebar. */
+  .p-drawer-overlay {
+    z-index: var(--z-overlay) !important;
+  }
+
+  .p-drawer {
+    z-index: var(--z-overlay);
+  }
+
+  .toast-viewport {
+    z-index: var(--z-toast);
+  }
+
+  /* ── Bottom sheets ───────────────────────────────────────────────────────
+     A bottom sheet is as tall as what is in it.
+
+     `.drawer-bottom` takes a fixed `height: var(--drawer-size)` from the
+     design system, so every bottom sheet in the product opened at exactly
+     420px whatever it held — half a phone screen, with the controls in the top
+     third and dead space under them. That is the "modals launch in half
+     screen" this fixes. The size now bounds the sheet rather than fixing it:
+     short content hugs, long content scrolls at the cap.
+
+     The rounded top corners and the safe-area padding come with it. A sheet
+     that meets the bottom edge of the screen with square corners reads as a
+     panel that failed to finish, and on a phone with a home indicator its last
+     row sits under the bar. */
+  .drawer.drawer-bottom {
+    height: auto;
+    max-height: min(var(--drawer-size, 420px), calc(100dvh - 3rem));
+    border-top-left-radius: var(--radius-2xl);
+    border-top-right-radius: var(--radius-2xl);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .drawer.drawer-top {
+    height: auto;
+    max-height: min(var(--drawer-size, 420px), calc(100dvh - 3rem));
+    border-bottom-left-radius: var(--radius-2xl);
+    border-bottom-right-radius: var(--radius-2xl);
+  }
+
+  /* The grabber. Not draggable — it is the standing convention for "this came
+     up from the bottom edge and goes back down", and a sheet without one reads
+     as a page that half-loaded. Drawn on the sheet rather than added to every
+     call site's markup. */
+  .drawer.drawer-bottom::before {
+    content: "";
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: block;
+    width: 2.25rem;
+    height: 0.25rem;
+    margin: 0.5rem auto 0.25rem;
+    flex: none;
+    border-radius: var(--radius-full);
+    background: var(--border-strong);
+  }
+
   body {
     position: relative;
     background-image: var(--app-canvas-wash);

--- a/app/globals.css
+++ b/app/globals.css
@@ -261,6 +261,23 @@
     z-index: var(--z-toast);
   }
 
+  /* No desktop rail on a phone, not even for one frame.
+
+     The design system's `Sidebar` decides between a pinned `<aside>` and a
+     drawer with `useMediaQuery`, which cannot know the answer during server
+     rendering or before hydration — so the first paint of every cold load on a
+     phone was the desktop rail with the page squeezed into what was left
+     beside it. Caught on `/crm/clients`, which redirects and so paints that
+     frame for long enough to photograph.
+
+     The drawer keeps its copy: the same `<aside>` renders inside `.p-drawer`
+     when the sidebar is opened, and that one is the phone's sidebar. */
+  @media (max-width: 767.98px) {
+    .sidebar:not(.p-drawer .sidebar) {
+      display: none;
+    }
+  }
+
   /* ── Bottom sheets ───────────────────────────────────────────────────────
      A bottom sheet is as tall as what is in it.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -599,6 +599,28 @@
     --shell-max: 1536px;
   }
 
+  /* ── Avatars get their colour back ──────────────────────────────────────
+     The package hashes a name onto one of thirteen hues, stamps it on the
+     element as `data-accent`, and paints it with `.avatar-accent`. It then
+     emits its plain `.avatar` rule — `background: var(--surface-sunken)` —
+     twenty thousand characters *later* in the same bundle. Two single-class
+     selectors of equal specificity in one layer: the last one wins, so every
+     avatar in the product came out the same grey, and a timeline or a comment
+     thread showed four colleagues as four identical discs.
+
+     `@layer app` outranks `corelith` whatever the order inside it, and the
+     two-class selector keeps this above the package's own rule if the bundle
+     is ever fixed. `data-accent` sits on the avatar itself, so the hue is its
+     own and not inherited from a tinted ancestor. */
+  .avatar.avatar-accent {
+    background: var(--accent-bg);
+    color: var(--accent-fg);
+  }
+  .avatar.avatar-accent.avatar-accent-solid {
+    background: var(--accent-solid);
+    color: var(--accent-on);
+  }
+
   .settings-layout {
     display: grid;
     grid-template-columns: var(--rail-w, 220px) minmax(0, 1fr);

--- a/app/stores/catalogue/page.tsx
+++ b/app/stores/catalogue/page.tsx
@@ -19,7 +19,7 @@ export default async function StoresCataloguePage() {
 
   return (
     <StoresShell activeTab="catalogue">
-      <CataloguePanel />
+      <CataloguePanel actionInBar />
     </StoresShell>
   );
 }

--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -427,6 +427,19 @@
   --content-gutter-x: var(--space-4);
   --section-gutter-x: var(--space-4);
   --table-gutter-x:   var(--space-3);
+
+  /* The app bar's height, and the padding `main` puts above and below a page.
+     Named because any page that wants to fill the screen has to subtract them
+     — and three copies of "3.5rem" in three files is exactly how that breaks
+     silently the next time the bar changes. `Navbar` and `AppShell`'s `main`
+     read these, so `--content-viewport` cannot drift from what a page
+     actually has. */
+  --app-bar-h:        3.5rem;
+  --content-gutter-y: var(--space-4);
+  --content-viewport: calc(
+    100dvh - var(--app-bar-h) - env(safe-area-inset-top, 0px)
+      - (var(--content-gutter-y) * 2)
+  );
   --table-row-min-h:  calc(var(--h-control-md) + var(--space-3));    /* 48 */
   --table-head-min-h: calc(var(--h-control-md) + var(--space-1));    /* 40 */
 
@@ -592,6 +605,7 @@
   :root {
     --content-gutter-x: var(--gutter-x);
     --section-gutter-x: var(--gutter-x);
+    --content-gutter-y: var(--space-6);
   }
 }
 

--- a/components/crm/collaboration/conversation-composer.tsx
+++ b/components/crm/collaboration/conversation-composer.tsx
@@ -10,49 +10,60 @@ import { useToast } from "@/components/ui/use-toast";
 import { createCrmComment } from "@/lib/crm/crm-v2";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { richTextToPlain } from "@/lib/crm/rich-text";
+import { ChatCircle, Mail, Phone, Users } from "@/lib/icons";
 import type { CollabEntity } from "@/lib/crm/collaboration";
+import { cn } from "@/lib/utils";
 
 /**
  * One box for everything anybody says about a record.
  *
- * There were two, in two different sections. The activity composer logged what
- * happened with the client — a call, an email, a note — and lived at the top of
- * the timeline. The comment box was internal chatter and lived seven sections
- * along under Comments. Both are somebody typing a paragraph about this record,
- * and asking which of two screens to type it on is a question nobody should
- * have to answer: the difference is *who it is about*, not where it goes.
+ * There were two, in two different sections: the activity composer logged what
+ * happened with the client and lived at the top of the timeline; the comment
+ * box was internal chatter and lived seven sections along. Both are somebody
+ * typing a paragraph about this record.
  *
- * So one composer, and the segmented control says which kind. Comment is first
- * and is the default, because it is the one with no other home — everything
- * else is a record of something that already happened elsewhere.
+ * ## The mistake this shape exists to prevent
+ *
+ * Merging them creates a new hazard, and it is the serious one: an internal
+ * remark filed as a customer contact, or a customer's words filed where nobody
+ * looking at the customer timeline will find them. "Careful, we underquoted
+ * this site last time" is a sentence you do not want sitting in the record of
+ * what you told the client.
+ *
+ * Six equal segments — Comment, Note, Call, Email, WhatsApp, Meeting — do not
+ * prevent that. They are one row of peers, so the difference that matters
+ * (internal or not) is carried by nothing more than the position of the first
+ * chip, and the consequence is never stated.
+ *
+ * So the choice is made twice, at two different sizes:
+ *
+ *   1. **A binary**, first and largest: is this for the team, or a record of
+ *      contact with the client. Two options cannot be misread the way six can.
+ *   2. **The kind of contact**, only once the second is chosen, and only
+ *      because "a call" and "an email" are genuinely different facts.
+ *
+ * And the consequence is written where the eye already is — beside the button
+ * that commits it, in a sentence rather than a label. The button names the act
+ * too: "Post comment" and "Log the call" are hard to press by accident when
+ * you meant the other.
  */
-const KINDS = [
-  { value: "COMMENT", label: "Comment" },
-  { value: "NOTE", label: "Note" },
-  { value: "CALL", label: "Call" },
-  { value: "EMAIL", label: "Email" },
-  { value: "WHATSAPP", label: "WhatsApp" },
-  { value: "MEETING", label: "Meeting" },
+const CONTACT_KINDS = [
+  { value: "NOTE", label: "Note", icon: ChatCircle, verb: "Log the note" },
+  { value: "CALL", label: "Call", icon: Phone, verb: "Log the call" },
+  { value: "EMAIL", label: "Email", icon: Mail, verb: "Log the email" },
+  { value: "WHATSAPP", label: "WhatsApp", icon: ChatCircle, verb: "Log the message" },
+  { value: "MEETING", label: "Meeting", icon: Users, verb: "Log the meeting" },
 ] as const;
 
-type Kind = (typeof KINDS)[number]["value"];
+type ContactKind = (typeof CONTACT_KINDS)[number]["value"];
+type Mode = "COMMENT" | "CONTACT";
 
-const PLACEHOLDERS: Record<Kind, string> = {
-  COMMENT: "Leave a note for the team. Type @ to bring someone in.",
-  NOTE: "What should the team know?",
+const CONTACT_PLACEHOLDERS: Record<ContactKind, string> = {
+  NOTE: "What happened, in the words you would use to the client?",
   CALL: "What was said on the call?",
   EMAIL: "What did you send, and what came back?",
   WHATSAPP: "What was agreed on WhatsApp?",
   MEETING: "What came out of the meeting?",
-};
-
-const VERBS: Record<Kind, string> = {
-  COMMENT: "Comment",
-  NOTE: "Log it",
-  CALL: "Log it",
-  EMAIL: "Log it",
-  WHATSAPP: "Log it",
-  MEETING: "Log it",
 };
 
 export type ConversationTarget =
@@ -83,15 +94,19 @@ const COLLAB: Record<ConversationTarget["kind"], CollabEntity> = {
 export function ConversationComposer({ target }: { target: ConversationTarget }) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const canLogActivity = TARGET_KEYS[target.kind] !== null;
-  const [kind, setKind] = useState<Kind>("COMMENT");
+  const canLogContact = TARGET_KEYS[target.kind] !== null;
+  const [mode, setMode] = useState<Mode>("COMMENT");
+  const [contactKind, setContactKind] = useState<ContactKind>("CALL");
   const [text, setText] = useState("");
+
+  const kind = CONTACT_KINDS.find((entry) => entry.value === contactKind) ?? CONTACT_KINDS[0];
+  const isComment = mode === "COMMENT" || !canLogContact;
 
   const post = useMutation({
     mutationFn: () => {
       const trimmed = text.trim();
 
-      if (kind === "COMMENT") {
+      if (isComment) {
         return createCrmComment({
           entity: COLLAB[target.kind],
           recordId: target.id,
@@ -105,7 +120,7 @@ export function ConversationComposer({ target }: { target: ConversationTarget })
       return fetchJson("/api/v2/crm/activities", {
         method: "POST",
         body: JSON.stringify({
-          type: kind,
+          type: contactKind,
           subject: richTextToPlain(trimmed, 200),
           body: trimmed,
           [TARGET_KEYS[target.kind] as string]: target.id,
@@ -123,48 +138,116 @@ export function ConversationComposer({ target }: { target: ConversationTarget })
     },
     onError: (error) =>
       toast({
-        title: kind === "COMMENT" ? "Could not post that" : "Could not log that",
+        title: isComment ? "Could not post that" : "Could not log that",
         description: getApiErrorMessage(error),
         variant: "destructive",
       }),
   });
 
-  const options = canLogActivity ? KINDS : KINDS.filter((entry) => entry.value === "COMMENT");
-
   return (
-    <div className="space-y-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3">
-      {options.length > 1 ? (
-        <SegmentedControl
-          value={kind}
-          onValueChange={(value) => setKind(value as Kind)}
-          options={options.map((entry) => ({ value: entry.value, label: entry.label }))}
-          size="sm"
-          ariaLabel="What are you writing"
-        />
+    <div
+      className={cn(
+        "overflow-hidden rounded-[var(--card-radius)] border transition-colors",
+        // The surface itself says which of the two this is. A tinted panel is
+        // read before any label on it, so an internal note never looks like a
+        // customer record even at a glance across the room.
+        isComment
+          ? "border-[var(--border)] bg-[var(--surface-muted)]/40"
+          : "border-[var(--action-primary-bg)]/30 bg-[var(--surface-base)]",
+      )}
+    >
+      {canLogContact ? (
+        <div className="border-b border-[var(--border-subtle)] px-3 pb-2.5 pt-3">
+          <SegmentedControl
+            value={mode}
+            onValueChange={(value) => setMode(value as Mode)}
+            options={[
+              { value: "COMMENT", label: "Note to the team" },
+              { value: "CONTACT", label: "Record of contact" },
+            ]}
+            size="sm"
+            ariaLabel="What are you writing"
+          />
+
+          {/* Only once the answer is "contact", because until then the kind is
+              a question about something that is not happening. */}
+          {!isComment ? (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {CONTACT_KINDS.map((entry) => {
+                const Icon = entry.icon;
+                const active = entry.value === contactKind;
+                return (
+                  <button
+                    key={entry.value}
+                    type="button"
+                    onClick={() => setContactKind(entry.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "inline-flex min-h-8 items-center gap-1.5 rounded-[var(--radius-pill)] px-2.5 text-sm transition-colors",
+                      active
+                        ? "bg-[var(--action-primary-bg)] font-medium text-[var(--action-primary-text)]"
+                        : "text-[var(--text-muted)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-strong)]",
+                    )}
+                  >
+                    <Icon className="size-3.5" aria-hidden="true" />
+                    {entry.label}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
       ) : null}
 
-      <RichTextComposer
-        value={text}
-        onChange={setText}
-        // Cmd/Ctrl+Enter submits — this box gets used dozens of times a day.
-        onSubmit={() => {
-          if (text.trim()) post.mutate();
-        }}
-        placeholder={PLACEHOLDERS[kind]}
-        rows={3}
-      />
+      <div className="space-y-2 p-3">
+        <RichTextComposer
+          value={text}
+          onChange={setText}
+          // Cmd/Ctrl+Enter submits — this box gets used dozens of times a day.
+          onSubmit={() => {
+            if (text.trim()) post.mutate();
+          }}
+          placeholder={
+            isComment
+              ? "Leave a note for the team. Type @ to bring someone in."
+              : CONTACT_PLACEHOLDERS[contactKind]
+          }
+          rows={3}
+        />
 
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        {/* The keyboard shortcut is the second half of this line and means
-            nothing on a touch keyboard, so a phone reads the first half only
-            and the button stays on the same row. */}
-        <p className="text-sm text-[var(--text-muted)]">
-          Type @ to link a person or record.
-          <span className="hidden sm:inline"> ⌘/Ctrl + Enter to save.</span>
-        </p>
-        <Button size="sm" onClick={() => post.mutate()} disabled={!text.trim() || post.isPending}>
-          {post.isPending ? "Saving…" : VERBS[kind]}
-        </Button>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          {/* The consequence, in a sentence, next to the button that commits
+              it — not a label on a chip somewhere above. This is the whole
+              mistake-prevention mechanism: you cannot file an internal remark
+              as a customer record without reading a line that says it is one. */}
+          <p
+            className={cn(
+              "text-sm",
+              isComment ? "text-[var(--text-muted)]" : "text-[var(--action-primary-bg)]",
+            )}
+          >
+            {isComment ? (
+              <>
+                Only your team sees this.
+                <span className="hidden sm:inline"> Type @ to bring someone in.</span>
+              </>
+            ) : (
+              <>
+                Goes on this record&rsquo;s history as {kind.label.toLowerCase() === "email" ? "an" : "a"}{" "}
+                {kind.label.toLowerCase()}.
+              </>
+            )}
+          </p>
+
+          <Button
+            size="sm"
+            variant={isComment ? "secondary" : "primary"}
+            onClick={() => post.mutate()}
+            disabled={!text.trim() || post.isPending}
+          >
+            {post.isPending ? "Saving…" : isComment ? "Post comment" : kind.verb}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/components/crm/collaboration/conversation-composer.tsx
+++ b/components/crm/collaboration/conversation-composer.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { RichTextComposer } from "@/components/crm/collaboration/rich-text-composer";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { useToast } from "@/components/ui/use-toast";
+import { createCrmComment } from "@/lib/crm/crm-v2";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { richTextToPlain } from "@/lib/crm/rich-text";
+import type { CollabEntity } from "@/lib/crm/collaboration";
+
+/**
+ * One box for everything anybody says about a record.
+ *
+ * There were two, in two different sections. The activity composer logged what
+ * happened with the client — a call, an email, a note — and lived at the top of
+ * the timeline. The comment box was internal chatter and lived seven sections
+ * along under Comments. Both are somebody typing a paragraph about this record,
+ * and asking which of two screens to type it on is a question nobody should
+ * have to answer: the difference is *who it is about*, not where it goes.
+ *
+ * So one composer, and the segmented control says which kind. Comment is first
+ * and is the default, because it is the one with no other home — everything
+ * else is a record of something that already happened elsewhere.
+ */
+const KINDS = [
+  { value: "COMMENT", label: "Comment" },
+  { value: "NOTE", label: "Note" },
+  { value: "CALL", label: "Call" },
+  { value: "EMAIL", label: "Email" },
+  { value: "WHATSAPP", label: "WhatsApp" },
+  { value: "MEETING", label: "Meeting" },
+] as const;
+
+type Kind = (typeof KINDS)[number]["value"];
+
+const PLACEHOLDERS: Record<Kind, string> = {
+  COMMENT: "Leave a note for the team. Type @ to bring someone in.",
+  NOTE: "What should the team know?",
+  CALL: "What was said on the call?",
+  EMAIL: "What did you send, and what came back?",
+  WHATSAPP: "What was agreed on WhatsApp?",
+  MEETING: "What came out of the meeting?",
+};
+
+const VERBS: Record<Kind, string> = {
+  COMMENT: "Comment",
+  NOTE: "Log it",
+  CALL: "Log it",
+  EMAIL: "Log it",
+  WHATSAPP: "Log it",
+  MEETING: "Log it",
+};
+
+export type ConversationTarget =
+  | { kind: "lead"; id: string }
+  | { kind: "deal"; id: string }
+  | { kind: "person"; id: string }
+  | { kind: "company"; id: string }
+  | { kind: "site"; id: string };
+
+const TARGET_KEYS: Record<ConversationTarget["kind"], string | null> = {
+  lead: "leadId",
+  deal: "dealId",
+  person: "personId",
+  company: "clientId",
+  // A site is a place, not a correspondent: what happened there is logged on
+  // the visit or the deal. It can still be commented on.
+  site: null,
+};
+
+const COLLAB: Record<ConversationTarget["kind"], CollabEntity> = {
+  lead: "LEAD",
+  deal: "DEAL",
+  company: "COMPANY",
+  person: "PERSON",
+  site: "SITE",
+};
+
+export function ConversationComposer({ target }: { target: ConversationTarget }) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const canLogActivity = TARGET_KEYS[target.kind] !== null;
+  const [kind, setKind] = useState<Kind>("COMMENT");
+  const [text, setText] = useState("");
+
+  const post = useMutation({
+    mutationFn: () => {
+      const trimmed = text.trim();
+
+      if (kind === "COMMENT") {
+        return createCrmComment({
+          entity: COLLAB[target.kind],
+          recordId: target.id,
+          body: trimmed,
+        });
+      }
+
+      // What was written goes in the body, always. The subject is a flattened
+      // reading of the same words, for the places that cannot run the renderer
+      // — notifications, search snippets.
+      return fetchJson("/api/v2/crm/activities", {
+        method: "POST",
+        body: JSON.stringify({
+          type: kind,
+          subject: richTextToPlain(trimmed, 200),
+          body: trimmed,
+          [TARGET_KEYS[target.kind] as string]: target.id,
+        }),
+      });
+    },
+    onSuccess: () => {
+      setText("");
+      // Both halves of the feed, because either kind lands in it.
+      queryClient.invalidateQueries({ queryKey: ["crm-lead", target.id] });
+      queryClient.invalidateQueries({ queryKey: ["crm", target.kind, target.id] });
+      queryClient.invalidateQueries({
+        queryKey: ["crm-comments", COLLAB[target.kind], target.id],
+      });
+    },
+    onError: (error) =>
+      toast({
+        title: kind === "COMMENT" ? "Could not post that" : "Could not log that",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const options = canLogActivity ? KINDS : KINDS.filter((entry) => entry.value === "COMMENT");
+
+  return (
+    <div className="space-y-2 rounded-[var(--card-radius)] border border-[var(--border)] p-3">
+      {options.length > 1 ? (
+        <SegmentedControl
+          value={kind}
+          onValueChange={(value) => setKind(value as Kind)}
+          options={options.map((entry) => ({ value: entry.value, label: entry.label }))}
+          size="sm"
+          ariaLabel="What are you writing"
+        />
+      ) : null}
+
+      <RichTextComposer
+        value={text}
+        onChange={setText}
+        // Cmd/Ctrl+Enter submits — this box gets used dozens of times a day.
+        onSubmit={() => {
+          if (text.trim()) post.mutate();
+        }}
+        placeholder={PLACEHOLDERS[kind]}
+        rows={3}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {/* The keyboard shortcut is the second half of this line and means
+            nothing on a touch keyboard, so a phone reads the first half only
+            and the button stays on the same row. */}
+        <p className="text-sm text-[var(--text-muted)]">
+          Type @ to link a person or record.
+          <span className="hidden sm:inline"> ⌘/Ctrl + Enter to save.</span>
+        </p>
+        <Button size="sm" onClick={() => post.mutate()} disabled={!text.trim() || post.isPending}>
+          {post.isPending ? "Saving…" : VERBS[kind]}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/crm/collections/collections-content.tsx
+++ b/components/crm/collections/collections-content.tsx
@@ -87,7 +87,11 @@ export function CollectionsContent({ currency = "USD" }: { currency?: string }) 
         <Skeleton height={128} />
       ) : (
         <>
-          <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          {/* Two-up on a phone. Stacked, these seven ageing bands were seven
+              screens of "USD 0.00" before the chase list itself came into
+              view — the tiles are the summary of the list, not a page of
+              their own. */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
             <StatCard
               label="Outstanding"
               value={formatMoney(report.totalOutstanding, currency)}

--- a/components/crm/crm-follow-ups-content.tsx
+++ b/components/crm/crm-follow-ups-content.tsx
@@ -106,7 +106,10 @@ export function CrmFollowUpsContent() {
 
   return (
     <div className="max-w-3xl space-y-4">
-      <div className="grid gap-3 sm:grid-cols-3">
+      {/* Three counts read as one triptych, so they stay three-up at every
+          width — stacked they cost the whole first screen and the queue
+          underneath started below the fold. */}
+      <div className="grid grid-cols-3 gap-2 sm:gap-3">
         {HEADLINE_QUEUES.map((value, index) => {
           const count = headline[index]?.data?.pagination?.total ?? 0;
           return (

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -104,7 +104,7 @@ export function CrmFormsContent() {
 
   return (
     <div className="space-y-5">
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatCard label="Live forms" value={totals.live} footer={`${rows.length} in total`} />
         <StatCard label="Submissions" value={totals.submissions} footer="All time" />
         <StatCard

--- a/components/crm/crm-forms-content.tsx
+++ b/components/crm/crm-forms-content.tsx
@@ -127,15 +127,21 @@ export function CrmFormsContent() {
             assigned and scored on the way in.
           </p>
         </div>
-        <Button
-          variant="primary"
-          size="sm"
-          startIcon={<Plus className="size-4" />}
-          disabled={create.isPending}
-          onClick={() => create.mutate()}
-        >
-          New form
-        </Button>
+        {/* Hidden while there is nothing here: the empty state below carries
+            the same action in the same colour, and two brand-blue buttons
+            offering one thing is the "one primary action per surface" rule
+            broken on the screen where it matters most — the first one. */}
+        {rows.length > 0 ? (
+          <Button
+            variant="primary"
+            size="sm"
+            startIcon={<Plus className="size-4" />}
+            disabled={create.isPending}
+            onClick={() => create.mutate()}
+          >
+            New form
+          </Button>
+        ) : null}
       </div>
 
       {forms.isLoading ? (

--- a/components/crm/documents/approval-feedback.test.tsx
+++ b/components/crm/documents/approval-feedback.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ApprovalFeedback } from "./document-list";
+
+/**
+ * What the customer did with a quote.
+ *
+ * The approval record has carried `firstViewedAt`, `respondedAt`,
+ * `responderName` and `responseNote` since approval links shipped, and the
+ * document list read none of them — the status chip said "Declined" and
+ * stopped. These are the four states worth telling apart, because each one is
+ * a different next move: nothing to chase, chase the email, chase the person,
+ * or read what they said and re-quote.
+ */
+describe("ApprovalFeedback", () => {
+  it("says nothing when the document was never sent", () => {
+    expect(renderToStaticMarkup(<ApprovalFeedback approval={null} />)).toBe("");
+  });
+
+  it("separates sent-but-unopened from opened-and-silent", () => {
+    const unopened = renderToStaticMarkup(
+      <ApprovalFeedback
+        approval={{ token: "t", status: "PENDING", respondedAt: null, firstViewedAt: null }}
+      />,
+    );
+    expect(unopened).toContain("not opened yet");
+
+    const opened = renderToStaticMarkup(
+      <ApprovalFeedback
+        approval={{
+          token: "t",
+          status: "PENDING",
+          respondedAt: null,
+          firstViewedAt: "2026-08-01T09:00:00.000Z",
+        }}
+      />,
+    );
+    expect(opened).toContain("no answer yet");
+    expect(opened).not.toContain("not opened yet");
+  });
+
+  it("quotes the reason a customer gave for declining, and names them", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalFeedback
+        approval={{
+          token: "t",
+          status: "DECLINED",
+          respondedAt: "2026-08-02T09:00:00.000Z",
+          responderName: "Chipo Marange",
+          responseNote: "Too high against the other bid.",
+        }}
+      />,
+    );
+    expect(html).toContain("Chipo Marange");
+    expect(html).toContain("declined");
+    expect(html).toContain("Too high against the other bid.");
+    // Red is reserved for the answer that needs acting on.
+    expect(html).toContain("--status-error-text");
+  });
+
+  it("draws an acceptance in the confirming colour, not the alarming one", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalFeedback
+        approval={{
+          token: "t",
+          status: "APPROVED",
+          respondedAt: "2026-08-02T09:00:00.000Z",
+          responderName: "Chipo Marange",
+          responseNote: null,
+        }}
+      />,
+    );
+    expect(html).toContain("accepted");
+    expect(html).toContain("--status-success-text");
+    expect(html).not.toContain("--status-error-text");
+  });
+});

--- a/components/crm/documents/document-list.tsx
+++ b/components/crm/documents/document-list.tsx
@@ -18,12 +18,26 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
-import { Download, DotsThree, FileText, Plus, ReceiptLong } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+import {
+  Check,
+  Download,
+  DotsThree,
+  Eye,
+  FileText,
+  Mail,
+  Payments,
+  Plus,
+  ReceiptLong,
+  Send,
+  X,
+} from "@/lib/icons";
 
 import { DocumentBuilderSheet } from "./document-builder-sheet";
 import { RecordPaymentSheet } from "./record-payment-sheet";
@@ -44,6 +58,72 @@ import { Stack } from "@corelithzw/react";
 function KindIcon({ type }: { type: LeadDocument["type"] }) {
   const Icon = type === "RECEIPT" ? ReceiptLong : FileText;
   return <Icon className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />;
+}
+
+/**
+ * What the customer did with it, and what they said.
+ *
+ * The approval record has carried `firstViewedAt`, `respondedAt`,
+ * `responderName` and `responseNote` since the day approval links shipped, and
+ * the record page read none of them — so "have they seen the quote?" and "why
+ * did they turn it down?" were questions the system knew the answer to and
+ * would not tell anybody. The status chip said "Declined" and stopped.
+ *
+ * Sent-but-unopened is its own state and worth showing: chasing somebody who
+ * has not opened the email is a different conversation from chasing somebody
+ * who read it a week ago and went quiet.
+ */
+export function ApprovalFeedback({ approval }: { approval: LeadDocument["approval"] }) {
+  if (!approval) return null;
+
+  const declined = approval.status === "DECLINED";
+  const approved = approval.status === "APPROVED";
+  const who = approval.responderName?.trim();
+
+  if (!approval.respondedAt) {
+    return (
+      <p className="mt-1 flex items-center gap-1.5 text-sm text-[var(--text-subtle)]">
+        <Eye className="size-3.5 shrink-0" aria-hidden="true" />
+        {approval.firstViewedAt ? (
+          <>
+            Opened <ClientDate value={approval.firstViewedAt} />, no answer yet
+          </>
+        ) : (
+          "Sent, not opened yet"
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "mt-1.5 border-l-2 pl-2.5 text-sm",
+        declined ? "border-[var(--status-error-border)]" : "border-[var(--status-success-border)]",
+      )}
+    >
+      <p
+        className={cn(
+          "flex items-center gap-1.5 font-medium",
+          declined ? "text-[var(--status-error-text)]" : "text-[var(--status-success-text)]",
+        )}
+      >
+        {declined ? (
+          <X className="size-3.5 shrink-0" aria-hidden="true" />
+        ) : (
+          <Check className="size-3.5 shrink-0" aria-hidden="true" />
+        )}
+        {who ? `${who} ` : ""}
+        {declined ? "declined" : approved ? "accepted" : "responded"} this{" "}
+        <ClientDate value={approval.respondedAt} />
+      </p>
+      {approval.responseNote?.trim() ? (
+        <p className="mt-0.5 whitespace-pre-wrap text-[var(--text-body)]">
+          “{approval.responseNote.trim()}”
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 export function DocumentList({
@@ -99,6 +179,46 @@ export function DocumentList({
     onError: (error) =>
       toast({
         title: "Could not create the approval link",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  /**
+   * Hand the document to whatever the reader sends mail with.
+   *
+   * Not a server-side send: this platform has no outbound mail — no provider,
+   * no API key, nowhere to queue a retry — and the honest version of "email
+   * this" under those conditions is a composed draft in the reader's own
+   * client, not a button that appears to send and does not. It mints the
+   * approval link first, so what lands in the customer's inbox is a link they
+   * can act on rather than a bare PDF.
+   *
+   * When outbound mail does arrive, this is the call site to change.
+   */
+  const emailToClient = useMutation({
+    mutationFn: async (doc: LeadDocument) => {
+      const approval = await fetchJson<{ token: string; path: string }>(
+        `${basePath}/documents/${doc.id}/approval`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      return { doc, url: `${window.location.origin}${approval.path}` };
+    },
+    onSuccess: ({ doc, url }) => {
+      const kind = DOCUMENT_KIND_LABELS[doc.type].toLowerCase();
+      const subject = `${DOCUMENT_KIND_LABELS[doc.type]} ${documentNumber(doc)}`;
+      const body = [
+        `Please find our ${kind} ${documentNumber(doc)} for ${formatMoney(doc.amount, doc.currency)}.`,
+        "",
+        `You can review and respond to it here: ${url}`,
+        "",
+      ].join("\n");
+      window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      refreshAfterDocumentChange(queryClient);
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not prepare the email",
         description: getApiErrorMessage(error),
         variant: "destructive",
       }),
@@ -210,6 +330,8 @@ export function DocumentList({
                     {canPay ? ` · ${formatMoney(outstanding, doc.currency)} outstanding` : ""}
                     {doc.revisionNote ? ` · ${doc.revisionNote}` : ""}
                   </div>
+
+                  <ApprovalFeedback approval={doc.approval} />
                 </div>
 
                 <span className="font-mono text-sm tabular-nums">
@@ -224,7 +346,8 @@ export function DocumentList({
                       <DotsThree />
                     </IconButton>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
+                  <DropdownMenuContent align="end" className="min-w-56">
+                    <DropdownMenuLabel>{documentNumber(doc)}</DropdownMenuLabel>
                     <DropdownMenuItem asChild>
                       <a
                         href={`${basePath}/documents/${doc.id}/pdf`}
@@ -232,7 +355,7 @@ export function DocumentList({
                         rel="noreferrer"
                         className="flex items-center gap-2"
                       >
-                        <FileText className="h-4 w-4" />
+                        <FileText />
                         View PDF
                       </a>
                     </DropdownMenuItem>
@@ -241,7 +364,7 @@ export function DocumentList({
                         href={`${basePath}/documents/${doc.id}/pdf?download=1`}
                         className="flex items-center gap-2"
                       >
-                        <Download className="h-4 w-4" />
+                        <Download />
                         Download PDF
                       </a>
                     </DropdownMenuItem>
@@ -249,14 +372,32 @@ export function DocumentList({
                     {doc.type !== "RECEIPT" ? (
                       <>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => shareApproval.mutate(doc.id)}>
+                        <DropdownMenuItem
+                          variant="primary"
+                          onClick={() => shareApproval.mutate(doc.id)}
+                        >
+                          <Send />
                           {doc.approval ? "Copy approval link" : "Send for approval"}
+                        </DropdownMenuItem>
+                        {/* Straight into whatever the reader sends mail with,
+                            subject and link already written. The platform has
+                            no outbound mail of its own — no provider, no
+                            secret, nowhere to queue — and a menu item that
+                            silently does nothing is worse than one that hands
+                            off honestly. */}
+                        <DropdownMenuItem
+                          variant="primary"
+                          onClick={() => emailToClient.mutate(doc)}
+                        >
+                          <Mail />
+                          Email to the client
                         </DropdownMenuItem>
                       </>
                     ) : null}
 
                     {canConvert ? (
                       <>
+                        <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onClick={() =>
                             setBuilder({
@@ -265,9 +406,11 @@ export function DocumentList({
                             })
                           }
                         >
+                          <ReceiptLong />
                           Convert to invoice
                         </DropdownMenuItem>
                         <DropdownMenuItem onClick={() => setDepositFor(doc)}>
+                          <Payments />
                           Request a deposit
                         </DropdownMenuItem>
                       </>
@@ -275,17 +418,21 @@ export function DocumentList({
 
                     {canPay ? (
                       <>
+                        <DropdownMenuSeparator />
                         <DropdownMenuItem onClick={() => setPaymentFor(doc)}>
-                          Record payment
+                          <Payments />
+                          Record a part payment
                         </DropdownMenuItem>
                         {/* The whole balance, one click, receipt raised. The
                             sheet is for a part payment or a deposit — this is
                             for the invoice that has simply been settled. */}
                         <DropdownMenuItem
+                          variant="positive"
                           disabled={markPaid.isPending}
                           onClick={() => markPaid.mutate(doc)}
                         >
-                          Mark as paid ({formatMoney(outstanding, doc.currency)})
+                          <Check />
+                          Settle in full ({formatMoney(outstanding, doc.currency)})
                         </DropdownMenuItem>
                       </>
                     ) : null}

--- a/components/crm/documents/document-types.ts
+++ b/components/crm/documents/document-types.ts
@@ -17,7 +17,16 @@ export type LeadDocument = {
   supersedesId: string | null;
   revisionNote: string | null;
   createdAt: string;
-  approval: { token: string; status: string; respondedAt: string | null } | null;
+  approval: {
+    token: string;
+    status: string;
+    respondedAt: string | null;
+    /** What the customer wrote when they accepted or declined. */
+    responseNote?: string | null;
+    responderName?: string | null;
+    /** Whether they have opened it at all — the answer to "have they seen it?". */
+    firstViewedAt?: string | null;
+  } | null;
   quotation: {
     id: string;
     quotationNumber: string;

--- a/components/crm/documents/documents-list-content.tsx
+++ b/components/crm/documents/documents-list-content.tsx
@@ -132,6 +132,8 @@ export function DocumentsListContent({
               : []),
             {
               label: "Total",
+              // The figure a phone keeps: what the document is for.
+              primary: true,
               value: formatMoney(document.total, document.currency),
               mono: true,
             },

--- a/components/crm/import/import-wizard.tsx
+++ b/components/crm/import/import-wizard.tsx
@@ -121,11 +121,15 @@ export function ImportWizard() {
 
       <section className="space-y-3 rounded-[var(--card-radius)] border border-[var(--border)] p-4">
         <h2 className="text-base font-semibold text-[var(--text-strong)]">1. What are you importing?</h2>
-        <div className="flex flex-wrap items-end gap-3">
+        {/* Both controls fill the width on a phone. `items-end` on a wrapping
+            row left the file picker hanging off the end of a half-width select
+            with a native "No file chosen" beside it, which at 390px is a
+            control you have to aim at. */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
           <div className="space-y-1.5">
             <Label>Record type</Label>
             <Select value={entity} onValueChange={(value) => changeEntity(value as ImportEntity)}>
-              <SelectTrigger className="w-48">
+              <SelectTrigger className="w-full sm:w-48">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -144,7 +148,7 @@ export function ImportWizard() {
               id="import-file"
               type="file"
               accept=".csv,text/csv"
-              className="block text-sm file:mr-3 file:rounded-[var(--radius-sm)] file:border file:border-[var(--border)] file:bg-[var(--surface-subtle)] file:px-3 file:py-1.5 file:text-sm"
+              className="block w-full text-sm file:mr-3 file:min-h-9 file:rounded-[var(--radius-sm)] file:border file:border-[var(--border)] file:bg-[var(--surface-subtle)] file:px-3 file:text-sm"
               onChange={(event) => {
                 const file = event.target.files?.[0];
                 if (file) void readFile(file);

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -55,7 +55,6 @@ import {
   useRecordComments,
 } from "@/components/crm/records/record-tabs";
 import {
-  ActivityStrip,
   ContactList,
   EmailPreview,
   MeetingCard,
@@ -247,29 +246,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
     );
   })();
 
-  // Kinds, not just labels: the strip takes its glyph and colour from the same
-  // table the timeline does, so "4 emails" up here and an email down there are
-  // visibly the same fact.
-  const activityCounts = (
-    [
-      { label: "calls", type: "CALL", kind: "call" },
-      { label: "emails", type: "EMAIL", kind: "email" },
-      { label: "notes", type: "NOTE", kind: "note" },
-      { label: "meetings", type: "MEETING", kind: "meeting" },
-      { label: "messages", type: "WHATSAPP", kind: "whatsapp" },
-    ] as const
-  ).map((entry) => ({
-    label: entry.label,
-    kind: entry.kind,
-    count: lead.activities.filter((a) => a.type === entry.type).length,
-  }));
-
   // Every kind of contact, newest first — not calls only. The panel is titled
   // "contact so far", and showing three calls under a strip that counts five
   // kinds made a record whose last month was all email read as silent.
   const recentContact = lead.activities
     .filter((activity) => activity.type in CONTACT_ACTIVITY_KIND)
-    .slice(0, 4)
+    .slice(0, 6)
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
@@ -600,12 +582,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           ) : null}
 
           <RailSection title="Contact so far">
-            <ActivityStrip counts={activityCounts} />
-            {recentContact.length > 0 ? (
-              <div className="mt-3">
-                <ContactList contacts={recentContact} />
-              </div>
-            ) : null}
+            <ContactList contacts={recentContact} />
           </RailSection>
 
           <RailSection title="Last email">

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -259,6 +259,9 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
+      // The API has always included who logged it; the panel just never asked,
+      // so every call in the summary was attributed to "Someone".
+      actorName: activity.createdBy?.name ?? null,
       summary: activity.body ?? activity.subject,
     }));
 

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -16,7 +16,11 @@ import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   ArrowRight,
   Building2,
+  CalendarCheck,
+  Clock,
+  FileText,
   Funnel,
+  History,
   Payments,
   TrendingUp,
   UserRound,
@@ -429,8 +433,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
       onTabChange={setTab}
       tabs={[
         {
+          // Named Overview, because on a phone the summary is rendered above
+          // it and the two read as one thing: what this lead is worth and what
+          // is next, then what has actually happened to it.
           value: "timeline",
-          label: "Timeline",
+          label: "Overview",
+          icon: Clock,
           content: (
             <div className="space-y-4">
               <ActivityComposer target={{ kind: "lead", id: leadId }} />
@@ -450,9 +458,13 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             </div>
           ),
         },
+        // Second, and deliberately: talking about the record is the thing
+        // people come back to a record to do, and it was seven tabs along.
+        commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
         {
           value: "documents",
           label: "Documents",
+          icon: FileText,
           count: lead.documents.length,
           content: (
             <DocumentList
@@ -470,7 +482,13 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         {
           value: "visits",
           label: "Visits",
+          icon: CalendarCheck,
           count: lead.appointments.length,
+          // A visit that has happened and has not been written up is the thing
+          // on a lead most likely to be forgotten.
+          attention: lead.appointments.some(
+            (visit) => visit.status === "SCHEDULED" && new Date(visit.scheduledStart) < new Date(),
+          ),
           content: (
             <VisitsTab
               appointments={lead.appointments}
@@ -479,10 +497,15 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             />
           ),
         },
-        tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
-        commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
-        mentionsTab({ ref: { kind: "lead", id: leadId } }),
+        {
+          ...tasksTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
+          count: lead.followUps.filter((task) => task.status === "PENDING").length,
+          attention: lead.followUps.some(
+            (task) => task.status === "PENDING" && new Date(task.dueAt) < new Date(),
+          ),
+        },
         filesTab({ ref: { kind: "lead", id: leadId } }),
+        mentionsTab({ ref: { kind: "lead", id: leadId } }),
         automationTab({ ref: { kind: "lead", id: leadId } }),
         {
           // Leads had neither history tab, while deals, companies, people and
@@ -490,11 +513,13 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           // no answer to "who changed this".
           value: "history",
           label: "History",
+          icon: History,
           content: <RecordHistoryTab activities={lead.activities} />,
         },
         {
           value: "changes",
           label: "Field history",
+          icon: History,
           content: <FieldHistoryTab entity="LEAD" recordId={leadId} />,
         },
       ]}

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -18,9 +18,7 @@ import {
   Building2,
   CalendarCheck,
   Clock,
-  FileText,
   Funnel,
-  History,
   Payments,
   TrendingUp,
   UserRound,
@@ -44,14 +42,18 @@ import {
   CRM_STAGE_STATUS,
   formatLeadValue,
 } from "@/components/crm/leads/stage-config";
+import { ConversationComposer } from "@/components/crm/collaboration/conversation-composer";
 import { ConvertLeadSheet } from "@/components/crm/leads/convert-lead-sheet";
 import { VisitReportSheet, type MeasurementDraft } from "@/components/crm/visits/visit-report-sheet";
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 
-import { ActivityComposer } from "./activity-composer";
-import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "@/components/crm/records/record-tabs";
-import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
-import { RecordHistoryTab } from "@/components/crm/records/record-history-tab";
+import {
+  automationTab,
+  historyTab,
+  paperworkTab,
+  tasksTab,
+  useRecordComments,
+} from "@/components/crm/records/record-tabs";
 import {
   ActivityStrip,
   CallList,
@@ -127,6 +129,8 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   });
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
+  // Comments join the story rather than sitting in a section of their own.
+  const comments = useRecordComments({ kind: "lead", id: leadId });
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const lead = leadQuery.data;
 
@@ -437,11 +441,11 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
           // it and the two read as one thing: what this lead is worth and what
           // is next, then what has actually happened to it.
           value: "timeline",
-          label: "Overview",
+          label: "Conversation",
           icon: Clock,
           content: (
             <div className="space-y-4">
-              <ActivityComposer target={{ kind: "lead", id: leadId }} />
+              <ConversationComposer target={{ kind: "lead", id: leadId }} />
               {/* The whole story, not just the activity table: visits, tasks,
                   documents and the day it arrived, in one order. */}
               <RecordStory
@@ -450,6 +454,9 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
                   tasks: lead.followUps,
                   visits: lead.appointments,
                   documents: lead.documents,
+                  // What people said belongs in the same order as what
+                  // happened. `buildStory` has always taken comments.
+                  comments,
                   createdAt: lead.createdAt,
                   createdLabel: `Lead ${lead.leadNo} came in`,
                 })}
@@ -458,15 +465,10 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             </div>
           ),
         },
-        // Second, and deliberately: talking about the record is the thing
-        // people come back to a record to do, and it was seven tabs along.
-        commentsTab({ ref: { kind: "lead", id: leadId }, currentUserId }),
-        {
-          value: "documents",
-          label: "Documents",
-          icon: FileText,
-          count: lead.documents.length,
-          content: (
+        paperworkTab({
+          ref: { kind: "lead", id: leadId },
+          documentCount: lead.documents.length,
+          documents: (
             <DocumentList
               basePath={`/api/v2/crm/leads/${leadId}`}
               currency={lead.currency}
@@ -478,7 +480,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
               onPrefillConsumed={() => setQuotationPrefill(undefined)}
             />
           ),
-        },
+        }),
         {
           value: "visits",
           label: "Visits",
@@ -504,24 +506,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             (task) => task.status === "PENDING" && new Date(task.dueAt) < new Date(),
           ),
         },
-        filesTab({ ref: { kind: "lead", id: leadId } }),
-        mentionsTab({ ref: { kind: "lead", id: leadId } }),
         automationTab({ ref: { kind: "lead", id: leadId } }),
-        {
-          // Leads had neither history tab, while deals, companies, people and
-          // sites had both. The record type people open most was the one with
-          // no answer to "who changed this".
-          value: "history",
-          label: "History",
-          icon: History,
-          content: <RecordHistoryTab activities={lead.activities} />,
-        },
-        {
-          value: "changes",
-          label: "Field history",
-          icon: History,
-          content: <FieldHistoryTab entity="LEAD" recordId={leadId} />,
-        },
+        historyTab({
+          ref: { kind: "lead", id: leadId },
+          entity: "LEAD",
+          activities: lead.activities,
+        }),
       ]}
       rail={
         <>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -252,6 +252,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
               mono: true,
               placeholder: "Not sized",
               ...edit.numeric("estimatedValue", lead.estimatedValue),
+              // With its currency, through the same helper the board and the
+              // list use, so one lead's value never reads two ways.
+              formatted:
+                lead.estimatedValue == null
+                  ? null
+                  : formatLeadValue(lead.estimatedValue, lead.currency),
             },
             {
               id: "probability",

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -56,12 +56,13 @@ import {
 } from "@/components/crm/records/record-tabs";
 import {
   ActivityStrip,
-  CallList,
+  ContactList,
   EmailPreview,
   MeetingCard,
   NextInteractionCard,
   type NextInteraction,
 } from "@/components/crm/records/record-panels";
+import { CONTACT_ACTIVITY_KIND } from "@/components/crm/records/event-kind";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { customFieldAttributes } from "@/components/records/custom-field-attributes";
 import { RecordAttributes } from "@/components/records/record-attributes";
@@ -246,21 +247,35 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
     );
   })();
 
-  const activityCounts = [
-    { label: "calls", count: lead.activities.filter((a) => a.type === "CALL").length },
-    { label: "emails", count: lead.activities.filter((a) => a.type === "EMAIL").length },
-    { label: "notes", count: lead.activities.filter((a) => a.type === "NOTE").length },
-    { label: "meetings", count: lead.activities.filter((a) => a.type === "MEETING").length },
-  ];
+  // Kinds, not just labels: the strip takes its glyph and colour from the same
+  // table the timeline does, so "4 emails" up here and an email down there are
+  // visibly the same fact.
+  const activityCounts = (
+    [
+      { label: "calls", type: "CALL", kind: "call" },
+      { label: "emails", type: "EMAIL", kind: "email" },
+      { label: "notes", type: "NOTE", kind: "note" },
+      { label: "meetings", type: "MEETING", kind: "meeting" },
+      { label: "messages", type: "WHATSAPP", kind: "whatsapp" },
+    ] as const
+  ).map((entry) => ({
+    label: entry.label,
+    kind: entry.kind,
+    count: lead.activities.filter((a) => a.type === entry.type).length,
+  }));
 
-  const recentCalls = lead.activities
-    .filter((activity) => activity.type === "CALL")
-    .slice(0, 3)
+  // Every kind of contact, newest first — not calls only. The panel is titled
+  // "contact so far", and showing three calls under a strip that counts five
+  // kinds made a record whose last month was all email read as silent.
+  const recentContact = lead.activities
+    .filter((activity) => activity.type in CONTACT_ACTIVITY_KIND)
+    .slice(0, 4)
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
+      kind: CONTACT_ACTIVITY_KIND[activity.type],
       // The API has always included who logged it; the panel just never asked,
-      // so every call in the summary was attributed to "Someone".
+      // so every row in the summary was attributed to "Someone".
       actorName: activity.createdBy?.name ?? null,
       summary: activity.body ?? activity.subject,
     }));
@@ -586,9 +601,9 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
 
           <RailSection title="Contact so far">
             <ActivityStrip counts={activityCounts} />
-            {recentCalls.length > 0 ? (
+            {recentContact.length > 0 ? (
               <div className="mt-3">
-                <CallList calls={recentCalls} />
+                <ContactList contacts={recentContact} />
               </div>
             ) : null}
           </RailSection>

--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import type { CrmLeadStage } from "@prisma/client";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { dsConfirm } from "@/components/ui/ds-confirm";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
@@ -87,6 +90,7 @@ function draftsToLines(drafts: MeasurementDraft[]): CrmDocumentLineInput[] {
 
 export function LeadDetailPage({ leadId }: { leadId: string }) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const { toast } = useToast();
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
@@ -121,6 +125,61 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const lead = leadQuery.data;
+
+  const archive = useMutation({
+    mutationFn: (archived: boolean) =>
+      fetchJson(`/api/v2/crm/leads/${leadId}/archive`, {
+        method: "POST",
+        body: JSON.stringify({ archived }),
+      }),
+    onSuccess: (_result, archived) => {
+      queryClient.invalidateQueries({ queryKey: ["crm-lead", leadId] });
+      queryClient.invalidateQueries({ queryKey: ["crm", "leads"] });
+      queryClient.invalidateQueries({ queryKey: ["crm", "board"] });
+      toast({
+        title: archived ? "Archived" : "Back in the pipeline",
+        description: archived
+          ? "It is out of the lists and the board. Restore it from this menu."
+          : undefined,
+      });
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not archive that lead",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => fetchJson(`/api/v2/crm/leads/${leadId}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["crm", "leads"] });
+      queryClient.invalidateQueries({ queryKey: ["crm", "board"] });
+      toast({ title: "Deleted" });
+      // Nothing left to look at — the record this page is about is gone.
+      router.push("/crm/leads");
+    },
+    onError: (error) =>
+      toast({
+        title: "Could not delete that lead",
+        description: getApiErrorMessage(error),
+        variant: "destructive",
+      }),
+  });
+
+  const setArchived = (archived: boolean) => archive.mutate(archived);
+
+  const confirmDelete = async () => {
+    const confirmed = await dsConfirm({
+      title: "Delete this lead for good?",
+      description:
+        "Its calls, notes, visits, tasks and files go with it, and none of it comes back. Archiving keeps the record and takes it out of the pipeline.",
+      confirmLabel: "Delete",
+      variant: "danger",
+    });
+    if (confirmed) remove.mutate();
+  };
 
   const changeStage = useMutation({
     mutationFn: ({ stage, lostReason }: { stage: CrmLeadStage; lostReason?: string }) =>
@@ -217,7 +276,14 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
       backLabel="All leads"
       title={lead.title ?? lead.leadNo}
       reference={lead.leadNo}
-      status={{ status: CRM_STAGE_STATUS[lead.stage], label: CRM_STAGE_LABELS[lead.stage] }}
+      // An archived lead that looks exactly like a live one is how somebody
+      // spends ten minutes working a record that is not in anybody's pipeline.
+      // The chip is the first thing read on the page, so it says so there.
+      status={
+        lead.archivedAt
+          ? { status: "inactive", label: lead.convertedAt ? "Converted" : "Archived" }
+          : { status: CRM_STAGE_STATUS[lead.stage], label: CRM_STAGE_LABELS[lead.stage] }
+      }
       subtitle={
         <>
           <EntityLink href={lead.clientId ? `/crm/companies/${lead.clientId}` : null} muted>
@@ -230,15 +296,39 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
         </>
       }
       primaryAction={
-        // Converting is the one thing a qualified lead exists to do.
-        <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
-          <ArrowRight className="h-3.5 w-3.5" />
-          Convert to deal
-        </Button>
+        // Converting is the one thing a qualified lead exists to do — until it
+        // has done it. A converted lead is history, and the useful move from
+        // here is following the business to where it went, so the bar offers
+        // that instead of a verb that would now fail.
+        lead.convertedDealId ? (
+          <Button asChild size="sm" variant="secondary" className="gap-1.5">
+            <Link href={`/crm/deals/${lead.convertedDealId}`}>
+              Open the deal
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        ) : (
+          <Button size="sm" className="gap-1.5" onClick={() => setConvertOpen(true)}>
+            <ArrowRight className="h-3.5 w-3.5" />
+            Convert to deal
+          </Button>
+        )
       }
       actions={[
         { label: "Edit", onSelect: () => setEditOpen(true) },
         { label: "Schedule a visit", onSelect: () => setScheduleOpen(true) },
+        // A lead had no ending short of dragging it to Lost, which is a claim
+        // about the business. A duplicate or a wrong number is not lost, it is
+        // just not wanted — so archiving is offered first, and deleting sits
+        // under it for the row that should never have existed.
+        lead.archivedAt
+          ? { label: "Restore from archive", onSelect: () => setArchived(false) }
+          : { label: "Archive", onSelect: () => setArchived(true) },
+        {
+          label: "Delete",
+          destructive: true,
+          onSelect: () => confirmDelete(),
+        },
       ]}
       attributes={
         // A lead had no property list at all, which is why nothing on it
@@ -264,8 +354,12 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
               label: "Likelihood",
               icon: TrendingUp,
               mono: true,
-              placeholder: "0",
+              placeholder: "Not scored",
               ...edit.numeric("probability", lead.probability),
+              // A bare "0" beside the word Likelihood is not a percentage,
+              // it is a number nobody can act on — the same rule that makes
+              // money carry its currency. Editing still opens on the number.
+              formatted: lead.probability == null ? null : `${lead.probability}%`,
             },
             {
               id: "company",
@@ -418,8 +512,13 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
             <p className="mt-1 font-mono text-3xl leading-none tracking-tight text-[var(--text-strong)]">
               {formatLeadValue(lead.estimatedValue, lead.currency)}
             </p>
+            {/* A lead with no likelihood on it is not 0% likely — nobody has
+                said. The property list above reads "Not scored", and this line
+                used to sit two hundred pixels below it saying "0% likely"
+                about the same field. */}
             <p className="mt-2 text-sm text-[var(--text-muted)]">
-              {lead.probability ?? 0}% likely · {CRM_STAGE_LABELS[lead.stage]}
+              {lead.probability == null ? "Not scored" : `${lead.probability}% likely`} ·{" "}
+              {CRM_STAGE_LABELS[lead.stage]}
             </p>
 
             {lead.scoreBreakdown ? (

--- a/components/crm/lead-detail/lead-score-card.tsx
+++ b/components/crm/lead-detail/lead-score-card.tsx
@@ -20,8 +20,13 @@ const BAND_TONE: Record<LeadScore["band"], string> = {
 export function LeadScoreCard({ score }: { score: LeadScore }) {
   return (
     <div className="space-y-2">
+      {/* The number carries the band's colour, not just the word beside it.
+          A score is read at a glance and then, occasionally, argued with —
+          so the glance gets the colour and the argument gets the list. */}
       <div className="flex items-baseline gap-2">
-        <span className="font-mono text-xl leading-none text-[var(--text-strong)]">{score.total}</span>
+        <span className={cn("font-mono text-xl leading-none", BAND_TONE[score.band])}>
+          {score.total}
+        </span>
         <span className={cn("text-sm font-medium", BAND_TONE[score.band])}>
           {SCORE_BAND_LABELS[score.band]}
         </span>
@@ -32,17 +37,22 @@ export function LeadScoreCard({ score }: { score: LeadScore }) {
           Nothing on this lead has scored yet.
         </p>
       ) : (
+        // Evidence, muted. These four rows used to be drawn as darkly as the
+        // figures in the panel above them, so a lead's summary was a wall of
+        // equally loud numbers and nothing in it led. Only a signal counting
+        // *against* the lead keeps a colour, because that is the one worth
+        // stopping on.
         <Stack as="ul" gap="xs">
           {score.signals.map((signal) => (
             <li
               key={signal.key}
-              className="flex items-baseline justify-between gap-2 text-sm"
+              className="flex items-baseline justify-between gap-2 text-sm text-[var(--text-subtle)]"
             >
-              <span className="text-[var(--text-muted)]">{signal.label}</span>
+              <span>{signal.label}</span>
               <span
                 className={cn(
                   "font-mono tabular-nums",
-                  signal.points < 0 ? "text-[var(--status-error-text)]" : "",
+                  signal.points < 0 && "font-medium text-[var(--status-error-text)]",
                 )}
               >
                 {signal.points > 0 ? `+${signal.points}` : signal.points}

--- a/components/crm/lead-detail/lead-types.ts
+++ b/components/crm/lead-detail/lead-types.ts
@@ -67,6 +67,11 @@ export type LeadDetail = {
   firstContactAt: string | null;
   wonAt: string | null;
   lostAt: string | null;
+  /** Out of the working set. Set by archiving, and by conversion. */
+  archivedAt: string | null;
+  /** When this lead became a deal, and which deal it became. */
+  convertedAt: string | null;
+  convertedDealId: string | null;
   createdAt: string;
   updatedAt: string;
   clientId: string | null;

--- a/components/crm/lead-detail/lead-types.ts
+++ b/components/crm/lead-detail/lead-types.ts
@@ -10,6 +10,8 @@ export type LeadActivity = {
   body: string | null;
   metadata: unknown;
   occurredAt: string;
+  /** Who logged it. The API has always sent this; nothing used to ask. */
+  createdBy?: { id: string; name: string | null } | null;
 };
 
 export type LeadFollowUp = {

--- a/components/crm/lead-detail/stage-progress.tsx
+++ b/components/crm/lead-detail/stage-progress.tsx
@@ -144,13 +144,17 @@ export function StageProgress({
         ))}
       </div>
 
-      <p className="text-sm text-[var(--text-muted)]">
-        {isWon
-          ? "Won"
-          : isLost
-            ? "Lost — reopen it from the stage menu"
-            : `Step ${currentIndex + 1} of ${PATH_STAGES.length}`}
-      </p>
+      {/* "Step 1 of 6" is gone: the six segments directly above already say
+          it, and the band was stating the same stage three ways — the heading,
+          the track, and a sentence counting the track. Screen readers still
+          get the count, from the track's own label. What is left here is the
+          one case the track cannot show: a lost lead is not at a step, and
+          somebody looking at a drained track needs telling how to reopen it. */}
+      {isLost ? (
+        <p className="text-sm text-[var(--text-muted)]">
+          Lost — reopen it from the stage menu
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/components/crm/leads/leads-board.tsx
+++ b/components/crm/leads/leads-board.tsx
@@ -232,6 +232,7 @@ export function LeadsBoard({
           so restaging stays reachable without dragging anything. */}
       <MobileBoard
         className="lg:hidden"
+        noun={{ one: "lead", many: "leads" }}
         emptyTitle="No leads in this stage"
         stages={columns.map((column) => ({
           id: column.stage,
@@ -253,7 +254,11 @@ export function LeadsBoard({
               .filter(Boolean)
               .join(" · "),
             facts: [
-              { value: formatLeadValue(lead.estimatedValue, lead.currency ?? currency), mono: true },
+              {
+                value: formatLeadValue(lead.estimatedValue, lead.currency ?? currency),
+                mono: true,
+                primary: true,
+              },
             ],
           })),
         }))}

--- a/components/crm/leads/leads-filters.tsx
+++ b/components/crm/leads/leads-filters.tsx
@@ -432,6 +432,19 @@ export function LeadsFilters({
           >
             Overdue
           </Button>
+
+          {/* Without this, archiving is a one-way trip: the lead leaves every
+              list and there is no door back to it. Not counted as an active
+              filter, because it swaps which set is being looked at rather than
+              narrowing the live one — and "Clear all" should not silently drag
+              somebody out of the archive they went to on purpose. */}
+          <Button
+            variant={filters.archived ? "default" : "outline"}
+            size="sm"
+            onClick={() => patch({ archived: filters.archived ? undefined : true })}
+          >
+            Archived
+          </Button>
         </div>
 
         {activeCount > 0 ? (

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -98,6 +98,8 @@ export function LeadsTable({
   onSortChange,
   onBulkAssign,
   onBulkStage,
+  onBulkArchive,
+  showingArchived = false,
   hiddenColumns,
 }: {
   leads: CrmLeadListRecord[];
@@ -111,6 +113,9 @@ export function LeadsTable({
   onSortChange: (sort: LeadSort) => void;
   onBulkAssign: (ids: string[], assignedToId: string | null, done: () => void) => void;
   onBulkStage: (ids: string[], stage: CrmLeadStage, done: () => void) => void;
+  onBulkArchive: (ids: string[], archived: boolean, done: () => void) => void;
+  /** Whether these rows are the archive, which flips Archive into Restore. */
+  showingArchived?: boolean;
   /** Column ids the reader has switched off. */
   hiddenColumns?: string[];
 }) {
@@ -294,6 +299,18 @@ export function LeadsTable({
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>
+
+              {/* Tidying up is a bulk job by nature — an import that ran
+                  twice, a morning of spam through the web form. Restoring is
+                  the same control read the other way round, so the archived
+                  view has a way back. */}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onBulkArchive(ids, !showingArchived, clearSelection)}
+              >
+                {showingArchived ? "Restore" : "Archive"}
+              </Button>
             </div>
           );
         },

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ChevronDown } from "@/lib/icons";
+import { Archive, ChevronDown, Funnel, UserRound } from "@/lib/icons";
 import type { CrmLeadListRecord } from "@/lib/crm/crm-v2";
 import type { LeadSort } from "@/lib/crm/views";
 import type { ColumnOption } from "@/lib/ui/visible-columns";
@@ -271,11 +271,13 @@ export function LeadsTable({
                       key={owner.id}
                       onClick={() => onBulkAssign(ids, owner.id, clearSelection)}
                     >
+                      <UserRound />
                       {owner.name ?? "Unnamed"}
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={() => onBulkAssign(ids, null, clearSelection)}>
+                    <UserRound />
                     Leave unassigned
                   </DropdownMenuItem>
                 </DropdownMenuContent>
@@ -292,8 +294,12 @@ export function LeadsTable({
                   {CRM_LEAD_STAGES.map((stage: CrmLeadStage) => (
                     <DropdownMenuItem
                       key={stage}
+                      // Lost is the one stage move that is a claim about the
+                      // business rather than progress along it.
+                      variant={stage === "LOST" ? "destructive" : "default"}
                       onClick={() => onBulkStage(ids, stage, clearSelection)}
                     >
+                      <Funnel />
                       {CRM_STAGE_LABELS[stage]}
                     </DropdownMenuItem>
                   ))}
@@ -307,8 +313,10 @@ export function LeadsTable({
               <Button
                 size="sm"
                 variant="outline"
+                className="gap-1.5"
                 onClick={() => onBulkArchive(ids, !showingArchived, clearSelection)}
               >
+                <Archive className="size-4" />
                 {showingArchived ? "Restore" : "Archive"}
               </Button>
             </div>

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -318,7 +318,11 @@ export function LeadsTable({
               />
             ),
             facts: [
-              { value: formatLeadValue(row.estimatedValue, row.currency), mono: true },
+              {
+                value: formatLeadValue(row.estimatedValue, row.currency),
+                mono: true,
+                primary: true,
+              },
             ],
           }))}
         />

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -202,6 +202,13 @@ export function LeadsWorkspace({
     [bulk],
   );
 
+  const handleBulkArchive = useCallback(
+    (ids: string[], archived: boolean, done: () => void) => {
+      bulk.mutate({ action: "archive", ids, archived }, { onSuccess: done });
+    },
+    [bulk],
+  );
+
   const leads = leadsQuery.data?.data ?? [];
   const total = leadsQuery.data?.pagination?.total ?? leads.length;
 
@@ -328,6 +335,8 @@ export function LeadsWorkspace({
           }}
           onBulkAssign={handleBulkAssign}
           onBulkStage={handleBulkStage}
+          onBulkArchive={handleBulkArchive}
+          showingArchived={Boolean(activeFilters.archived)}
           hiddenColumns={tableColumns.hidden}
         />
       ) : (

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -12,7 +12,9 @@ import { Funnel, Plus } from "@/lib/icons";
 import { PageChrome } from "@/components/layout/page-chrome";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { PipelineSwitcher } from "@/components/crm/records/pipeline-switcher";
+import { ListSearch } from "@/components/crm/records/list-search";
 import { ViewToolbar } from "@/components/crm/records/view-toolbar";
+import { useDebounced } from "@/hooks/use-debounced";
 import {
   bulkUpdateCrmLeads,
   fetchCrmLeads,
@@ -71,6 +73,10 @@ export function LeadsWorkspace({
   const tableColumns = useVisibleColumns("crm.leads.table", LEAD_TABLE_COLUMNS);
   const boardFields = useVisibleColumns("crm.leads.board", LEAD_CARD_FIELDS);
   const [filters, setFilters] = useState<LeadViewFilters>(initialFilters);
+  // Held apart from `filters` so typing does not re-key the board query on
+  // every keystroke, and debounced at the 300ms every other list here uses.
+  const [search, setSearch] = useState(initialFilters.q ?? "");
+  const debouncedSearch = useDebounced(search, 300);
   const [sort, setSort] = useState<LeadSort>(DEFAULT_LEAD_SORT);
   const [page, setPage] = useState(1);
   const [activeViewKey, setActiveViewKey] = useState<string>(
@@ -97,9 +103,20 @@ export function LeadsWorkspace({
     queryFn: () => fetchCrmSavedViews(),
   });
 
+  // The text box is a filter like any other by the time a query sees it — it
+  // is only held apart in state so that typing does not re-key the board on
+  // every keystroke. `q` is dropped rather than sent empty so a saved view
+  // that carries its own text is not silently overwritten by a blank box.
+  const activeFilters = useMemo<LeadViewFilters>(() => {
+    const trimmed = debouncedSearch.trim();
+    const rest = { ...filters };
+    delete rest.q;
+    return trimmed ? { ...rest, q: trimmed } : rest;
+  }, [filters, debouncedSearch]);
+
   const leadsQuery = useQuery({
-    queryKey: ["crm", "leads", filters, sort, page],
-    queryFn: () => fetchCrmLeads({ filters, sort, page, limit: PAGE_SIZE }),
+    queryKey: ["crm", "leads", activeFilters, sort, page],
+    queryFn: () => fetchCrmLeads({ filters: activeFilters, sort, page, limit: PAGE_SIZE }),
     enabled: viewType === "TABLE",
     placeholderData: (previous) => previous,
   });
@@ -130,6 +147,7 @@ export function LeadsWorkspace({
       setActiveViewKey(linked.key);
       setViewType(linked.layout);
       setFilters(linked.filters);
+      setSearch(linked.filters.q ?? "");
       setSort(linked.sort ?? DEFAULT_LEAD_SORT);
     }
   }
@@ -222,6 +240,7 @@ export function LeadsWorkspace({
                 setActiveViewKey(view.key);
                 setViewType(view.layout);
                 setFilters(view.filters);
+                setSearch(view.filters.q ?? "");
                 setSort(view.sort ?? DEFAULT_LEAD_SORT);
                 setPage(1);
               }}
@@ -254,6 +273,17 @@ export function LeadsWorkspace({
               />
             ) : null}
           </>
+        }
+        search={
+          <ListSearch
+            value={search}
+            onChange={(value) => {
+              setSearch(value);
+              setPage(1);
+            }}
+            placeholder="Search leads by title, number or contact"
+            noun="leads"
+          />
         }
         end={
           <>
@@ -302,7 +332,7 @@ export function LeadsWorkspace({
         />
       ) : (
         <BoardFieldsProvider hidden={boardFields.hidden}>
-          <LeadsBoard filters={filters} className="min-h-0 flex-1" />
+          <LeadsBoard filters={activeFilters} className="min-h-0 flex-1" />
         </BoardFieldsProvider>
       )}
 

--- a/components/crm/records/board-mobile.test.tsx
+++ b/components/crm/records/board-mobile.test.tsx
@@ -46,9 +46,46 @@ describe("MobileBoard", () => {
     expect(html).toContain('aria-pressed="true"');
   });
 
-  it("shows the picked stage's total", () => {
-    const html = renderToStaticMarkup(<MobileBoard stages={STAGES} />);
+  it("says what the picked stage holds, in words, before the total", () => {
+    const html = renderToStaticMarkup(
+      <MobileBoard stages={STAGES} noun={{ one: "deal", many: "deals" }} />,
+    );
+    // The line used to be the bare total the caller passed, with nothing
+    // saying whether it was the stage's, the board's or the page's.
+    expect(html).toContain("deals in");
+    expect(html).toContain("Quoted");
     expect(html).toContain("USD 18,000");
+  });
+
+  it("counts one of something in the singular", () => {
+    const html = renderToStaticMarkup(
+      <MobileBoard
+        stages={[
+          {
+            id: "NEW",
+            label: "Discovery",
+            count: 1,
+            rows: [{ id: "a", href: "/a", title: "Tenant billing portal" }],
+          },
+        ]}
+        noun={{ one: "deal", many: "deals" }}
+      />,
+    );
+    // The count sits in its own tabular-numerals span, so the assertion is on
+    // the words that follow it.
+    expect(html).toContain("deal in Discovery");
+    expect(html).not.toContain("deals in");
+  });
+
+  it("still names the stage when the caller passes no total", () => {
+    const html = renderToStaticMarkup(
+      <MobileBoard
+        stages={[{ id: "NEW", label: "New", count: 3, rows: [] }]}
+        noun={{ one: "lead", many: "leads" }}
+      />,
+    );
+    expect(html).toContain("leads in");
+    expect(html).toContain("New");
   });
 
   it("falls back to the first stage when every one is empty", () => {

--- a/components/crm/records/board-mobile.tsx
+++ b/components/crm/records/board-mobile.tsx
@@ -33,11 +33,18 @@ export type MobileBoardStage = {
 
 export function MobileBoard({
   stages,
+  noun = { one: "record", many: "records" },
   emptyTitle = "Nothing in this stage",
   emptyBody,
   className,
 }: {
   stages: MobileBoardStage[];
+  /**
+   * What the rows are, for the line under the picker. Both forms, because a
+   * stage holding one of something is common enough that "1 deals in
+   * Discovery" would be on screen most of the time.
+   */
+  noun?: { one: string; many: string };
   emptyTitle?: string;
   emptyBody?: string;
   className?: string;
@@ -67,7 +74,17 @@ export function MobileBoard({
 
   return (
     <div className={cn("space-y-3", className)}>
-      <div className="scroll-rail -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+      {/* Full-bleed, so a stage that does not fit is cut by the edge of the
+          screen rather than by a gutter eight pixels inside it. A chip clipped
+          at the screen edge is the phone's own idiom for "this scrolls"; one
+          clipped short of it just looks broken, which is what the inset rail
+          looked like. Snapping means a swipe lands on a chip rather than
+          halfway through one. */}
+      <div
+        role="group"
+        aria-label="Stages"
+        className="scroll-rail -mx-[var(--content-gutter-x)] flex snap-x snap-proximity gap-2 px-[var(--content-gutter-x)] pb-1"
+      >
         {stages.map((stage) => {
           const selected = stage.id === active.id;
           return (
@@ -77,7 +94,7 @@ export function MobileBoard({
               onClick={() => setPicked(stage.id)}
               aria-pressed={selected}
               className={cn(
-                "flex min-h-9 shrink-0 items-center gap-2 rounded-full border px-3 text-sm transition-colors",
+                "flex min-h-9 shrink-0 snap-start items-center gap-2 rounded-full border px-3 text-sm transition-colors",
                 selected
                   ? "border-[var(--border-strong)] bg-[var(--surface-muted)] font-medium text-[var(--text-strong)]"
                   : "border-[var(--border)] text-[var(--text-muted)]",
@@ -98,9 +115,14 @@ export function MobileBoard({
         })}
       </div>
 
-      {active.meta ? (
-        <p className="text-sm text-[var(--text-muted)]">{active.meta}</p>
-      ) : null}
+      {/* What the stage holds, said in words. This line used to be the bare
+          total the caller passed — "USD 4,050" under a row of chips, with
+          nothing saying whether that was the stage, the board, or the page. */}
+      <p className="text-sm text-[var(--text-muted)]">
+        <span className="font-mono tabular-nums">{active.count}</span>{" "}
+        {active.count === 1 ? noun.one : noun.many} in {active.label}
+        {active.meta ? <> · {active.meta}</> : null}
+      </p>
 
       <RecordList rows={active.rows} emptyTitle={emptyTitle} emptyBody={emptyBody} />
     </div>

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -72,7 +72,15 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
 
   const companiesQuery = useQuery({
     queryKey: ["crm", "companies", debouncedSearch, page],
-    queryFn: () => fetchCrmCompanies({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
+    queryFn: () =>
+      fetchCrmCompanies({
+        filters: { q: debouncedSearch },
+        // By name: the list below groups by first letter, and grouping a list
+        // ordered by `updatedAt` produces headings in no order at all.
+        sort: { field: "name", direction: "asc" },
+        page,
+        limit: PAGE_SIZE,
+      }),
     placeholderData: (previous) => previous,
   });
 
@@ -207,10 +215,17 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
                 label={ACCOUNT_STATUS_LABELS[company.accountStatus] ?? company.accountStatus}
               />
             ) : null}
+            {/* Two chips beside a company name wrap onto a line of their own
+                at phone width, which turns a two-line row into a three-line
+                one and costs the list a third of its rows per screen. Account
+                standing is the one worth the space — "on hold" changes what
+                you do next; "Customer" is what nearly every row says. */}
             {fields.isVisible("type") ? (
-              <Badge tone="neutral" size="sm">
-                {COMPANY_TYPE_LABELS[company.companyType] ?? company.companyType}
-              </Badge>
+              <span className="hidden sm:contents">
+                <Badge tone="neutral" size="sm">
+                  {COMPANY_TYPE_LABELS[company.companyType] ?? company.companyType}
+                </Badge>
+              </span>
             ) : null}
           </>
         ),
@@ -280,6 +295,7 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
           columns={boardColumns}
           cards={boardCards}
           isLoading={companiesQuery.isLoading}
+          noun={{ one: "company", many: "companies" }}
           emptyLabel="None in this state"
           onMove={(id, accountStatus) => moveAccountStatus.mutate({ id, accountStatus })}
           className="min-h-[24rem]"

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -6,10 +6,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
-import { Building2, Globe, Mail, MapPin, Phone, UserRound } from "@/lib/icons";
+import { Building2, Globe, Mail, MapPin, Phone, Plus, UserRound } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
@@ -27,6 +28,7 @@ import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
 import { CompanyFormSheet } from "./company-form-sheet";
+import { DealFormSheet } from "./deal-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
 import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
@@ -95,6 +97,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   const { data: session } = useSession();
   const [mergeOpen, setMergeOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [dealOpen, setDealOpen] = useState(false);
   const [tab, setTab] = useState("people");
 
   const companyQuery = useQuery({
@@ -190,6 +193,16 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
       icon={Building2}
       backHref="/crm/companies"
       backLabel="All companies"
+      primaryAction={
+        // A company is an account you sell to. The record had no primary
+        // action at all, so the bar on a phone was a back arrow, a search
+        // icon, a bell and an overflow menu — nothing to do, on the page
+        // where the next piece of business gets started.
+        <Button size="sm" className="gap-1.5" onClick={() => setDealOpen(true)}>
+          <Plus className="h-3.5 w-3.5" />
+          New deal
+        </Button>
+      }
       actions={[
         { label: "Edit", onSelect: () => setEditOpen(true) },
         { label: "Merge a duplicate", onSelect: () => setMergeOpen(true) },
@@ -435,6 +448,13 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
       survivorLabel={company.name}
       open={mergeOpen}
       onOpenChange={setMergeOpen}
+    />
+
+    <DealFormSheet
+      open={dealOpen}
+      onOpenChange={setDealOpen}
+      defaultClientId={companyId}
+      onCreated={() => companyQuery.refetch()}
     />
     </>
   );

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -10,7 +10,19 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
-import { Building2, Globe, Mail, MapPin, Phone, Plus, UserRound } from "@/lib/icons";
+import {
+  Building2,
+  Clock,
+  Funnel,
+  Globe,
+  History,
+  Mail,
+  MapPin,
+  Phone,
+  Plus,
+  UserRound,
+  Users,
+} from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
@@ -98,7 +110,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   const [mergeOpen, setMergeOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [dealOpen, setDealOpen] = useState(false);
-  const [tab, setTab] = useState("people");
+  const [tab, setTab] = useState("timeline");
 
   const companyQuery = useQuery({
     queryKey: ["crm", "company", companyId],
@@ -298,14 +310,34 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
       onTabChange={setTab}
       tabs={[
         {
+          value: "timeline",
+          label: "Overview",
+          icon: Clock,
+          content: (
+            <RecordStory
+              events={buildStory({
+                activities: company.activities,
+                createdLabel: "Company added",
+              })}
+            />
+          ),
+        },
+        commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
+        // The company's own graph: who works there, what is being sold to
+        // them, and where. These sit directly after the summary because they
+        // are what an account page is *for* — a company is mostly a way in to
+        // the records hanging off it.
+        {
           value: "people",
           label: "People",
+          icon: Users,
           count: company.people.length,
           content: <CompanyPeopleTab companyId={companyId} people={company.people} />,
         },
         {
           value: "deals",
           label: "Deals",
+          icon: Funnel,
           count: company.deals.length,
           content: (
             <RelatedList
@@ -323,6 +355,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
         {
           value: "sites",
           label: "Sites",
+          icon: MapPin,
           count: company.sites.length,
           content: (
             <RelatedList
@@ -336,31 +369,20 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
             />
           ),
         },
-        {
-          value: "timeline",
-          label: "Timeline",
-          content: (
-            <RecordStory
-              events={buildStory({
-                activities: company.activities,
-                createdLabel: "Company added",
-              })}
-            />
-          ),
-        },
         tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
-        commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
-        mentionsTab({ ref: { kind: "company", id: companyId } }),
         filesTab({ ref: { kind: "company", id: companyId } }),
+        mentionsTab({ ref: { kind: "company", id: companyId } }),
         automationTab({ ref: { kind: "company", id: companyId } }),
         {
           value: "history",
           label: "History",
+          icon: History,
           content: <RecordHistoryTab activities={company.activities} />,
         },
         {
           value: "changes",
           label: "Field history",
+          icon: History,
           content: <FieldHistoryTab entity="CLIENT" recordId={companyId} />,
         },
       ]}

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -15,7 +15,6 @@ import {
   Clock,
   Funnel,
   Globe,
-  History,
   Mail,
   MapPin,
   Phone,
@@ -33,17 +32,22 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { customFieldAttributes } from "@/components/records/custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "@/components/records/record-mark";
+import { ConversationComposer } from "@/components/crm/collaboration/conversation-composer";
 import { CompanyPeopleTab } from "./company-people-tab";
-import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
+import {
+  automationTab,
+  historyTab,
+  paperworkTab,
+  tasksTab,
+  useRecordComments,
+} from "./record-tabs";
 import { RecordAttributes } from "@/components/records/record-attributes";
 import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
 import { CompanyFormSheet } from "./company-form-sheet";
 import { DealFormSheet } from "./deal-form-sheet";
-import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
-import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 
 const ACCOUNT_STATUS_PRESENTATION: Record<string, { label: string; status: CanonicalUiStatus }> = {
   ACTIVE: { label: "Active", status: "passing" },
@@ -136,6 +140,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
+  const comments = useRecordComments({ kind: "company", id: companyId });
   const company = companyQuery.data;
 
   if (companyQuery.isLoading) {
@@ -311,18 +316,21 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
       tabs={[
         {
           value: "timeline",
-          label: "Overview",
+          label: "Conversation",
           icon: Clock,
           content: (
-            <RecordStory
-              events={buildStory({
-                activities: company.activities,
-                createdLabel: "Company added",
-              })}
-            />
+            <div className="space-y-4">
+              <ConversationComposer target={{ kind: "company", id: companyId }} />
+              <RecordStory
+                events={buildStory({
+                  activities: company.activities,
+                  comments,
+                  createdLabel: "Company added",
+                })}
+              />
+            </div>
           ),
         },
-        commentsTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
         // The company's own graph: who works there, what is being sold to
         // them, and where. These sit directly after the summary because they
         // are what an account page is *for* — a company is mostly a way in to
@@ -370,21 +378,13 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
           ),
         },
         tasksTab({ ref: { kind: "company", id: companyId }, currentUserId: session?.user?.id }),
-        filesTab({ ref: { kind: "company", id: companyId } }),
-        mentionsTab({ ref: { kind: "company", id: companyId } }),
+        paperworkTab({ ref: { kind: "company", id: companyId } }),
         automationTab({ ref: { kind: "company", id: companyId } }),
-        {
-          value: "history",
-          label: "History",
-          icon: History,
-          content: <RecordHistoryTab activities={company.activities} />,
-        },
-        {
-          value: "changes",
-          label: "Field history",
-          icon: History,
-          content: <FieldHistoryTab entity="CLIENT" recordId={companyId} />,
-        },
+        historyTab({
+          ref: { kind: "company", id: companyId },
+          entity: "CLIENT",
+          activities: company.activities,
+        }),
       ]}
       rail={
         <>

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -18,7 +18,6 @@ import {
   Clock,
   FileText,
   Funnel,
-  History,
   MapPin,
   Payments,
   Plus,
@@ -32,11 +31,17 @@ import { visitItemsToQuotationLines } from "@/lib/crm/site-visits";
 import type { CrmDocumentLineInput } from "@/lib/crm/accounting-bridge";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
+import { ConversationComposer } from "@/components/crm/collaboration/conversation-composer";
 import { DocumentList } from "@/components/crm/documents/document-list";
 import { formatMoney, invoiceOutstanding } from "@/components/crm/documents/document-types";
 import type { LeadDocument } from "@/components/crm/documents/document-types";
-import { ActivityComposer } from "@/components/crm/lead-detail/activity-composer";
-import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
+import {
+  automationTab,
+  historyTab,
+  paperworkTab,
+  tasksTab,
+  useRecordComments,
+} from "./record-tabs";
 import {
   ActivityStrip,
   CallList,
@@ -64,8 +69,6 @@ import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
 import { DealStageBar } from "./deal-stage-bar";
 import { RailSection, RecordPageShell } from "@/components/records/record-page-shell";
-import { RecordHistoryTab } from "./record-history-tab";
-import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 
 import { Stack } from "@corelithzw/react";
 
@@ -172,6 +175,8 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
   });
 
   const owners = useMemo(() => teamQuery.data?.data ?? [], [teamQuery.data]);
+  // Comments join the story rather than sitting in a section of their own.
+  const comments = useRecordComments({ kind: "deal", id: dealId });
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const deal = dealQuery.data;
 
@@ -445,17 +450,18 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             // two read as one thing — what this deal is worth and what is
             // next, then what has actually happened to it.
             value: "timeline",
-            label: "Overview",
+            label: "Conversation",
             icon: Clock,
             content: (
               <div className="space-y-4">
-                <ActivityComposer target={{ kind: "deal", id: dealId }} />
+                <ConversationComposer target={{ kind: "deal", id: dealId }} />
                 <RecordStory
                   events={buildStory({
                     activities: deal.activities,
                     tasks: deal.followUps,
                     visits: deal.appointments,
                     documents: deal.documents,
+                    comments,
                     createdLabel: `Deal ${deal.dealNo} opened`,
                   })}
                   emptyMessage="Nothing has happened on this deal yet."
@@ -463,15 +469,10 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               </div>
             ),
           },
-          // Second, and deliberately: talking about the record is what people
-          // come back to a record to do, and it was seven tabs along.
-          commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
-          {
-            value: "documents",
-            label: "Documents",
-            icon: FileText,
-            count: deal.documents.length,
-            content: (
+          paperworkTab({
+            ref: { kind: "deal", id: dealId },
+            documentCount: deal.documents.length,
+            documents: (
               <DocumentList
                 basePath={`/api/v2/crm/deals/${dealId}`}
                 currency={deal.currency}
@@ -481,7 +482,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 onPrefillConsumed={() => setQuotationPrefill(undefined)}
               />
             ),
-          },
+          }),
           {
             value: "people",
             label: "People",
@@ -513,21 +514,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               (task) => task.status === "PENDING" && new Date(task.dueAt) < new Date(),
             ),
           },
-          filesTab({ ref: { kind: "deal", id: dealId } }),
-          mentionsTab({ ref: { kind: "deal", id: dealId } }),
           automationTab({ ref: { kind: "deal", id: dealId } }),
-          {
-            value: "history",
-            label: "History",
-            icon: History,
-            content: <RecordHistoryTab activities={deal.activities} />,
-          },
-          {
-            value: "changes",
-            label: "Field history",
-            icon: History,
-            content: <FieldHistoryTab entity="DEAL" recordId={dealId} />,
-          },
+          historyTab({
+            ref: { kind: "deal", id: dealId },
+            entity: "DEAL",
+            activities: deal.activities,
+          }),
         ]}
         rail={
           <>

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -43,7 +43,6 @@ import {
   useRecordComments,
 } from "./record-tabs";
 import {
-  ActivityStrip,
   ContactList,
   EmailPreview,
   MeetingCard,
@@ -224,29 +223,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
     );
   })();
 
-  // Kinds, not just labels: the strip takes its glyph and colour from the same
-  // table the timeline does, so "4 emails" up here and an email down there are
-  // visibly the same fact.
-  const activityCounts = (
-    [
-      { label: "calls", type: "CALL", kind: "call" },
-      { label: "emails", type: "EMAIL", kind: "email" },
-      { label: "notes", type: "NOTE", kind: "note" },
-      { label: "meetings", type: "MEETING", kind: "meeting" },
-      { label: "messages", type: "WHATSAPP", kind: "whatsapp" },
-    ] as const
-  ).map((entry) => ({
-    label: entry.label,
-    kind: entry.kind,
-    count: deal.activities.filter((a) => a.type === entry.type).length,
-  }));
-
   // Every kind of contact, newest first — not calls only. The panel is titled
   // "contact so far", and showing three calls under a strip that counts five
   // kinds made a record whose last month was all email read as silent.
   const recentContact = deal.activities
     .filter((activity) => activity.type in CONTACT_ACTIVITY_KIND)
-    .slice(0, 4)
+    .slice(0, 6)
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
@@ -583,12 +565,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             ) : null}
 
             <RailSection title="Contact so far">
-              <ActivityStrip counts={activityCounts} />
-              {recentContact.length > 0 ? (
-                <div className="mt-3">
-                  <ContactList contacts={recentContact} />
-                </div>
-              ) : null}
+              <ContactList contacts={recentContact} />
             </RailSection>
 
             <RailSection title="Last email">

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -14,13 +14,17 @@ import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
   Building2,
   Calendar,
+  CalendarCheck,
+  Clock,
   FileText,
   Funnel,
+  History,
   MapPin,
   Payments,
   Plus,
   TrendingUp,
   UserRound,
+  Users,
 } from "@/lib/icons";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
 import { isDealStale } from "@/lib/crm/pipelines";
@@ -437,8 +441,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
         onTabChange={setTab}
         tabs={[
           {
+            // Named Overview: on a phone the summary renders above it, and the
+            // two read as one thing — what this deal is worth and what is
+            // next, then what has actually happened to it.
             value: "timeline",
-            label: "Timeline",
+            label: "Overview",
+            icon: Clock,
             content: (
               <div className="space-y-4">
                 <ActivityComposer target={{ kind: "deal", id: dealId }} />
@@ -455,9 +463,13 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               </div>
             ),
           },
+          // Second, and deliberately: talking about the record is what people
+          // come back to a record to do, and it was seven tabs along.
+          commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
           {
             value: "documents",
             label: "Documents",
+            icon: FileText,
             count: deal.documents.length,
             content: (
               <DocumentList
@@ -471,9 +483,21 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
             ),
           },
           {
+            value: "people",
+            label: "People",
+            icon: Users,
+            count: deal.contacts.length,
+            content: <DealContactsTab dealId={dealId} contacts={deal.contacts} />,
+          },
+          {
             value: "visits",
             label: "Visits",
+            icon: CalendarCheck,
             count: deal.appointments.length,
+            attention: deal.appointments.some(
+              (visit) =>
+                visit.status === "SCHEDULED" && new Date(visit.scheduledStart) < new Date(),
+            ),
             content: (
               <VisitsTab
                 appointments={deal.appointments}
@@ -482,25 +506,26 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               />
             ),
           },
-          tasksTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
           {
-            value: "people",
-            label: "People",
-            count: deal.contacts.length,
-            content: <DealContactsTab dealId={dealId} contacts={deal.contacts} />,
+            ...tasksTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
+            count: deal.followUps.filter((task) => task.status === "PENDING").length,
+            attention: deal.followUps.some(
+              (task) => task.status === "PENDING" && new Date(task.dueAt) < new Date(),
+            ),
           },
-          commentsTab({ ref: { kind: "deal", id: dealId }, currentUserId }),
-        mentionsTab({ ref: { kind: "deal", id: dealId } }),
-        filesTab({ ref: { kind: "deal", id: dealId } }),
-        automationTab({ ref: { kind: "deal", id: dealId } }),
+          filesTab({ ref: { kind: "deal", id: dealId } }),
+          mentionsTab({ ref: { kind: "deal", id: dealId } }),
+          automationTab({ ref: { kind: "deal", id: dealId } }),
           {
             value: "history",
             label: "History",
+            icon: History,
             content: <RecordHistoryTab activities={deal.activities} />,
           },
           {
             value: "changes",
             label: "Field history",
+            icon: History,
             content: <FieldHistoryTab entity="DEAL" recordId={dealId} />,
           },
         ]}

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -44,12 +44,13 @@ import {
 } from "./record-tabs";
 import {
   ActivityStrip,
-  CallList,
+  ContactList,
   EmailPreview,
   MeetingCard,
   NextInteractionCard,
   type NextInteraction,
 } from "./record-panels";
+import { CONTACT_ACTIVITY_KIND } from "@/components/crm/records/event-kind";
 import { RecordStory } from "@/components/crm/records/record-story";
 import { buildStory } from "@/lib/crm/story";
 import { VisitsTab } from "@/components/crm/lead-detail/visits-tab";
@@ -223,21 +224,35 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
     );
   })();
 
-  const activityCounts = [
-    { label: "calls", count: deal.activities.filter((a) => a.type === "CALL").length },
-    { label: "emails", count: deal.activities.filter((a) => a.type === "EMAIL").length },
-    { label: "notes", count: deal.activities.filter((a) => a.type === "NOTE").length },
-    { label: "meetings", count: deal.activities.filter((a) => a.type === "MEETING").length },
-  ];
+  // Kinds, not just labels: the strip takes its glyph and colour from the same
+  // table the timeline does, so "4 emails" up here and an email down there are
+  // visibly the same fact.
+  const activityCounts = (
+    [
+      { label: "calls", type: "CALL", kind: "call" },
+      { label: "emails", type: "EMAIL", kind: "email" },
+      { label: "notes", type: "NOTE", kind: "note" },
+      { label: "meetings", type: "MEETING", kind: "meeting" },
+      { label: "messages", type: "WHATSAPP", kind: "whatsapp" },
+    ] as const
+  ).map((entry) => ({
+    label: entry.label,
+    kind: entry.kind,
+    count: deal.activities.filter((a) => a.type === entry.type).length,
+  }));
 
-  const recentCalls = deal.activities
-    .filter((activity) => activity.type === "CALL")
-    .slice(0, 3)
+  // Every kind of contact, newest first — not calls only. The panel is titled
+  // "contact so far", and showing three calls under a strip that counts five
+  // kinds made a record whose last month was all email read as silent.
+  const recentContact = deal.activities
+    .filter((activity) => activity.type in CONTACT_ACTIVITY_KIND)
+    .slice(0, 4)
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
+      kind: CONTACT_ACTIVITY_KIND[activity.type],
       // The API has always included who logged it; the panel just never asked,
-      // so every call in the summary was attributed to "Someone".
+      // so every row in the summary was attributed to "Someone".
       actorName: activity.createdBy?.name ?? null,
       summary: activity.body ?? activity.subject,
     }));
@@ -569,9 +584,9 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
 
             <RailSection title="Contact so far">
               <ActivityStrip counts={activityCounts} />
-              {recentCalls.length > 0 ? (
+              {recentContact.length > 0 ? (
                 <div className="mt-3">
-                  <CallList calls={recentCalls} />
+                  <ContactList contacts={recentContact} />
                 </div>
               ) : null}
             </RailSection>

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -236,6 +236,9 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
     .map((activity) => ({
       id: activity.id,
       at: activity.occurredAt,
+      // The API has always included who logged it; the panel just never asked,
+      // so every call in the summary was attributed to "Someone".
+      actorName: activity.createdBy?.name ?? null,
       summary: activity.body ?? activity.subject,
     }));
 

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -333,6 +333,11 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 placeholder: "Not sized",
                 mono: true,
                 ...edit.numeric("value", deal.value),
+                // A bare "9800" beside a deal in a workspace that bills in two
+                // currencies is a number you have to go and check. Editing
+                // still opens on the raw figure.
+                formatted:
+                  deal.value == null ? null : formatMoney(deal.value, deal.currency),
               },
               {
                 id: "stage",

--- a/components/crm/records/deals-board.tsx
+++ b/components/crm/records/deals-board.tsx
@@ -424,6 +424,7 @@ export function DealsBoard({
         page's stage bar, so nothing is lost by not dragging here. */}
     <MobileBoard
       className="lg:hidden"
+      noun={{ one: "deal", many: "deals" }}
       emptyTitle="No deals in this stage"
       stages={board.columns.map((column) => ({
         id: column.stage.id,
@@ -436,7 +437,7 @@ export function DealsBoard({
           href: `/crm/deals/${deal.id}`,
           title: deal.title,
           subtitle: `${deal.dealNo} · ${deal.client?.name ?? "No company"}`,
-          facts: [{ value: money(deal.value, deal.currency), mono: true }],
+          facts: [{ value: money(deal.value, deal.currency), mono: true, primary: true }],
         })),
       }))}
     />

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -325,7 +325,7 @@ export function DealsContent({
                   label={row.stage.name}
                 />
               ),
-              facts: [{ value: formatMoney(row.value, row.currency), mono: true }],
+              facts: [{ value: formatMoney(row.value, row.currency), mono: true, primary: true }],
             }))}
           />
         )}

--- a/components/crm/records/event-kind.tsx
+++ b/components/crm/records/event-kind.tsx
@@ -1,0 +1,138 @@
+import type { Accent } from "@corelithzw/react";
+
+import {
+  ArrowRight,
+  Calendar,
+  ChatCircle,
+  Checklist,
+  FileText,
+  Mail,
+  MapPin,
+  NoteAdd,
+  Payments,
+  Phone,
+  Send,
+  User,
+} from "@/lib/icons";
+
+/**
+ * What each kind of thing that happens to a record looks like.
+ *
+ * One table, in one file, because the same event is drawn in three places —
+ * the timeline, the "contact so far" strip, and the recent-contact list beside
+ * it — and a call that is blue on the timeline and grey in the summary teaches
+ * the reader nothing. Colour only becomes a shortcut once it is the *same*
+ * shortcut everywhere; until then it is decoration.
+ *
+ * The hues are assigned by what the event *is*, not by taste:
+ *
+ *   - **Talking to the client** takes the cool half of the wheel — call,
+ *     email, meeting, WhatsApp — because that is the bulk of a record and it
+ *     should read as one family with four members.
+ *   - **Being somewhere** (a site visit) takes orange: it is the one kind that
+ *     costs a morning, and it should stand out of a scrolled feed.
+ *   - **Ours, not theirs** — an internal comment — takes pink, the one hue no
+ *     client-facing event uses, so an internal remark is never mistaken for a
+ *     record of contact at a glance. That is the same mistake the composer is
+ *     shaped to prevent, carried through to how it reads afterwards.
+ *   - **Paperwork and money** take brown and green.
+ *   - **Things the system did to the record** — a stage move, a created-at
+ *     line — take gray, which is the point: they are context, not news.
+ *
+ * Colour is never the only channel. Every kind also has its own glyph and its
+ * own word, so the coding is a third cue for people who read colour and no cue
+ * lost for people who do not.
+ */
+export type EventKind =
+  | "note"
+  | "call"
+  | "email"
+  | "whatsapp"
+  | "meeting"
+  | "stage"
+  | "document"
+  | "payment"
+  | "task"
+  | "visit"
+  | "comment"
+  | "intake"
+  | "system";
+
+export type EventKindStyle = {
+  /** The word for this kind, singular. */
+  label: string;
+  icon: typeof NoteAdd;
+  accent: Accent;
+};
+
+export const EVENT_KIND: Record<EventKind, EventKindStyle> = {
+  call: { label: "Call", icon: Phone, accent: "blue" },
+  email: { label: "Email", icon: Mail, accent: "indigo" },
+  whatsapp: { label: "WhatsApp", icon: Send, accent: "teal" },
+  meeting: { label: "Meeting", icon: Calendar, accent: "violet" },
+  visit: { label: "Site visit", icon: MapPin, accent: "orange" },
+  note: { label: "Note", icon: NoteAdd, accent: "amber" },
+  comment: { label: "Comment", icon: ChatCircle, accent: "pink" },
+  task: { label: "Task", icon: Checklist, accent: "cyan" },
+  document: { label: "Document", icon: FileText, accent: "brown" },
+  payment: { label: "Payment", icon: Payments, accent: "green" },
+  intake: { label: "Enquiry", icon: User, accent: "yellow" },
+  stage: { label: "Stage", icon: ArrowRight, accent: "gray" },
+  system: { label: "Update", icon: ArrowRight, accent: "gray" },
+};
+
+/**
+ * Which events are context and which are news.
+ *
+ * A stage change is worth knowing and worth passing over quickly; a note
+ * somebody wrote is the thing you came to read. The quiet ones keep their
+ * place in the order but not the reader's attention.
+ */
+export const QUIET_KINDS: ReadonlySet<EventKind> = new Set([
+  "stage",
+  "system",
+  "document",
+  "payment",
+]);
+
+/**
+ * The activity types the API stores, mapped onto the kinds above.
+ *
+ * `CrmActivity.type` is the wire format; `EventKind` is what the reader sees.
+ * Anything unknown reads as `system`.
+ */
+export const ACTIVITY_KIND: Record<string, EventKind> = {
+  NOTE: "note",
+  CALL: "call",
+  EMAIL: "email",
+  WHATSAPP: "whatsapp",
+  MEETING: "meeting",
+  STAGE_CHANGE: "stage",
+  INTAKE_SUBMISSION: "intake",
+  DOCUMENT_CREATED: "document",
+  DOCUMENT_SENT: "document",
+  DOCUMENT_APPROVED: "document",
+  DOCUMENT_DECLINED: "document",
+  PAYMENT_RECORDED: "payment",
+};
+
+/**
+ * The subset of those that mean *a person dealt with another person*.
+ *
+ * Deliberately narrower than `ACTIVITY_KIND`: a stage move and a raised
+ * quotation are things that happened to the record, not contact with anybody,
+ * and counting them under "contact so far" would answer "have we spoken to
+ * them" with paperwork.
+ */
+export const CONTACT_ACTIVITY_KIND: Record<string, EventKind> = {
+  NOTE: "note",
+  CALL: "call",
+  EMAIL: "email",
+  WHATSAPP: "whatsapp",
+  MEETING: "meeting",
+};
+
+export function eventKindStyle(kind: EventKind | string | null | undefined): EventKindStyle {
+  if (kind && kind in EVENT_KIND) return EVENT_KIND[kind as EventKind];
+  return EVENT_KIND.system;
+}

--- a/components/crm/records/files-tab.tsx
+++ b/components/crm/records/files-tab.tsx
@@ -166,7 +166,7 @@ export function FilesTab({
                 <span
                   data-accent={mark.accent}
                   aria-hidden="true"
-                  className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--accent-bg)] font-mono text-sm font-medium text-[var(--accent-fg)]"
+                  className="solid-mark flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-sm)] font-mono text-sm font-semibold"
                 >
                   {mark.label}
                 </span>

--- a/components/crm/records/list-search.tsx
+++ b/components/crm/records/list-search.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Input } from "@corelithzw/react";
+
+import { useIsBelow } from "@/hooks/use-mobile";
+import { Search } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * The search box every CRM list and board sits under.
+ *
+ * Two things it fixes over the bare `Input` each page used to build for
+ * itself. The placeholder was written for a desktop toolbar — "Search deals by
+ * title, number or customer" — and on a phone it renders as "Search deals by
+ * title, number or c…", which reads as a broken control rather than a hint.
+ * So the long form is the accessible name, always, and the placeholder shortens
+ * to the noun below `sm` where the width is the constraint.
+ *
+ * And the magnifier. A bare rounded rectangle beside a "View" button is two
+ * unlabelled boxes; the icon is what says which one is search, at the size a
+ * phone reads it.
+ */
+export function ListSearch({
+  value,
+  onChange,
+  placeholder,
+  /**
+   * What this list is a list of — "deals", "people". The phone placeholder,
+   * because "Search deals" is the whole hint at 390px. Left off, the phone
+   * shows "Search".
+   */
+  noun,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  /** The full hint, used on wider screens and as the accessible name. */
+  placeholder: string;
+  noun?: string;
+  className?: string;
+}) {
+  const compact = useIsBelow(640);
+
+  return (
+    <div className={cn("relative flex min-w-0 items-center", className)}>
+      <Search
+        className="pointer-events-none absolute left-2.5 size-4 text-[var(--text-subtle)]"
+        aria-hidden="true"
+      />
+      <Input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={compact ? (noun ? `Search ${noun}` : "Search") : placeholder}
+        aria-label={placeholder}
+        className="w-full pl-8 sm:w-64"
+      />
+    </div>
+  );
+}

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -60,7 +60,17 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
 
   const peopleQuery = useQuery({
     queryKey: ["crm", "people", debouncedSearch, page],
-    queryFn: () => fetchCrmPeople({ filters: { q: debouncedSearch }, page, limit: PAGE_SIZE }),
+    queryFn: () =>
+      fetchCrmPeople({
+        filters: { q: debouncedSearch },
+        // By name, because the page below groups by first letter. On the
+        // default `updatedAt` order the headings came out A, S, C, N, F — an
+        // alphabet applied to a list that was not in alphabetical order, which
+        // is worse than no headings at all. Sort first, then group.
+        sort: { field: "fullName", direction: "asc" },
+        page,
+        limit: PAGE_SIZE,
+      }),
     placeholderData: (previous) => previous,
   });
 
@@ -291,6 +301,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
           columns={boardColumns}
           cards={boardCards}
           isLoading={peopleQuery.isLoading}
+          noun={{ one: "person", many: "people" }}
           emptyLabel="No one of this kind"
           onMove={(id, contactType) => moveContactType.mutate({ id, contactType })}
           className="min-h-[24rem]"

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -19,7 +19,13 @@ import type { LeadActivity } from "@/components/crm/lead-detail/lead-types";
 import { customFieldAttributes } from "@/components/records/custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "@/components/records/record-mark";
-import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
+import {
+  automationTab,
+  historyTab,
+  paperworkTab,
+  tasksTab,
+  useRecordComments,
+} from "./record-tabs";
 import { RecordAttributes } from "@/components/records/record-attributes";
 import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
@@ -28,7 +34,6 @@ import {
   Building2,
   Clock,
   Funnel,
-  History,
   Mail,
   Phone,
   Plus,
@@ -37,11 +42,10 @@ import {
 } from "@/lib/icons";
 
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
+import { ConversationComposer } from "@/components/crm/collaboration/conversation-composer";
 import { DealFormSheet } from "./deal-form-sheet";
 import { PersonFormSheet } from "./person-form-sheet";
-import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
-import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 
 import { Stack } from "@corelithzw/react";
 
@@ -149,6 +153,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
   });
 
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
+  const comments = useRecordComments({ kind: "person", id: personId });
   const person = personQuery.data;
 
   if (personQuery.isLoading) {
@@ -358,18 +363,21 @@ export function PersonDetailPage({ personId }: { personId: string }) {
       tabs={[
         {
           value: "timeline",
-          label: "Overview",
+          label: "Conversation",
           icon: Clock,
           content: (
-            <RecordStory
-              events={buildStory({
-                activities: person.activities,
-                createdLabel: "Person added",
-              })}
-            />
+            <div className="space-y-4">
+              <ConversationComposer target={{ kind: "person", id: personId }} />
+              <RecordStory
+                events={buildStory({
+                  activities: person.activities,
+                  comments,
+                  createdLabel: "Person added",
+                })}
+              />
+            </div>
           ),
         },
-        commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         {
           value: "deals",
           label: "Deals",
@@ -395,21 +403,13 @@ export function PersonDetailPage({ personId }: { personId: string }) {
           ),
         },
         tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
-        filesTab({ ref: { kind: "person", id: personId } }),
-        mentionsTab({ ref: { kind: "person", id: personId } }),
+        paperworkTab({ ref: { kind: "person", id: personId } }),
         automationTab({ ref: { kind: "person", id: personId } }),
-        {
-          value: "history",
-          label: "History",
-          icon: History,
-          content: <RecordHistoryTab activities={person.activities} />,
-        },
-        {
-          value: "changes",
-          label: "Field history",
-          icon: History,
-          content: <FieldHistoryTab entity="PERSON" recordId={personId} />,
-        },
+        historyTab({
+          ref: { kind: "person", id: personId },
+          entity: "PERSON",
+          activities: person.activities,
+        }),
       ]}
       rail={rail}
     />

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
@@ -27,11 +28,13 @@ import {
   Building2,
   Mail,
   Phone,
+  Plus,
   UserRound,
   Users,
 } from "@/lib/icons";
 
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
+import { DealFormSheet } from "./deal-form-sheet";
 import { PersonFormSheet } from "./person-form-sheet";
 import { RecordHistoryTab } from "./record-history-tab";
 import { MergeDialog } from "./merge-dialog";
@@ -112,7 +115,11 @@ export function PersonDetailPage({ personId }: { personId: string }) {
   const router = useRouter();
   const { data: session } = useSession();
   const [mergeOpen, setMergeOpen] = useState(false);
+  // `editOpen` had no way of ever becoming true: the sheet was mounted and the
+  // state was declared, but no action set it, so a person's edit form was
+  // unreachable. It is in the overflow menu now, beside Merge.
   const [editOpen, setEditOpen] = useState(false);
+  const [dealOpen, setDealOpen] = useState(false);
   const [tab, setTab] = useState("timeline");
 
   const personQuery = useQuery({
@@ -199,13 +206,57 @@ export function PersonDetailPage({ personId }: { personId: string }) {
     </>
   );
 
+  /**
+   * The rail, or nothing at all.
+   *
+   * Both its sections are conditional — a second company, and the
+   * administrator's own fields — and most people have neither. Passed as an
+   * always-present fragment, that produced an "Overview" tab on a phone with
+   * four hundred pixels of blank under it, landed on by default: you opened a
+   * person and were shown an empty screen. `undefined` is how the shell is
+   * told there is no summary to offer, and it opens on the timeline instead.
+   */
+  const railSections = [
+    person.companyLinks.length > 1 ? (
+      <RailSection key="companies" title="Companies">
+        <Stack as="ul" gap="xs">
+          {person.companyLinks.map((link) => (
+            <li key={link.id} className="text-sm">
+              <EntityLink href={`/crm/companies/${link.client.id}`}>{link.client.name}</EntityLink>
+              {link.jobTitle ? (
+                <span className="text-sm text-[var(--text-muted)]"> · {link.jobTitle}</span>
+              ) : null}
+            </li>
+          ))}
+        </Stack>
+      </RailSection>
+    ) : null,
+    definitions.length > 0 ? (
+      <CustomFieldDisplay key="custom" definitions={definitions} values={person.customFields} />
+    ) : null,
+  ].filter(Boolean);
+
+  const rail = railSections.length > 0 ? <>{railSections}</> : undefined;
+
   return (
     <>
     <RecordPageShell
       icon={Users}
       backHref="/crm/people"
       backLabel="All people"
-      actions={[{ label: "Merge a duplicate", onSelect: () => setMergeOpen(true) }]}
+      primaryAction={
+        // The same verb as a company, because a person is who you sell
+        // through — and the deal opens already attached to whichever company
+        // they belong to, which is the whole reason to start it from here.
+        <Button size="sm" className="gap-1.5" onClick={() => setDealOpen(true)}>
+          <Plus className="h-3.5 w-3.5" />
+          New deal
+        </Button>
+      }
+      actions={[
+        { label: "Edit", onSelect: () => setEditOpen(true) },
+        { label: "Merge a duplicate", onSelect: () => setMergeOpen(true) },
+      ]}
       leading={
         <RecordMark
           kind="person"
@@ -353,28 +404,7 @@ export function PersonDetailPage({ personId }: { personId: string }) {
           content: <FieldHistoryTab entity="PERSON" recordId={personId} />,
         },
       ]}
-      rail={
-        <>
-          {person.companyLinks.length > 1 ? (
-            <RailSection title="Companies">
-              <Stack as="ul" gap="xs">
-                {person.companyLinks.map((link) => (
-                  <li key={link.id} className="text-sm">
-                    <EntityLink href={`/crm/companies/${link.client.id}`}>
-                      {link.client.name}
-                    </EntityLink>
-                    {link.jobTitle ? (
-                      <span className="text-sm text-[var(--text-muted)]"> · {link.jobTitle}</span>
-                    ) : null}
-                  </li>
-                ))}
-              </Stack>
-            </RailSection>
-          ) : null}
-
-          <CustomFieldDisplay definitions={definitions} values={person.customFields} />
-        </>
-      }
+      rail={rail}
     />
 
     <PersonFormSheet
@@ -405,6 +435,13 @@ export function PersonDetailPage({ personId }: { personId: string }) {
       survivorLabel={person.fullName}
       open={mergeOpen}
       onOpenChange={setMergeOpen}
+    />
+
+    <DealFormSheet
+      open={dealOpen}
+      onOpenChange={setDealOpen}
+      defaultClientId={person.client?.id}
+      onCreated={() => personQuery.refetch()}
     />
     </>
   );

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -26,6 +26,9 @@ import { EntityLink } from "@/components/records/entity-link";
 import {
   AddressBook,
   Building2,
+  Clock,
+  Funnel,
+  History,
   Mail,
   Phone,
   Plus,
@@ -355,7 +358,8 @@ export function PersonDetailPage({ personId }: { personId: string }) {
       tabs={[
         {
           value: "timeline",
-          label: "Timeline",
+          label: "Overview",
+          icon: Clock,
           content: (
             <RecordStory
               events={buildStory({
@@ -365,9 +369,11 @@ export function PersonDetailPage({ personId }: { personId: string }) {
             />
           ),
         },
+        commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
         {
           value: "deals",
           label: "Deals",
+          icon: Funnel,
           count: person.dealContacts.length,
           content: (
             <RelatedList
@@ -389,18 +395,19 @@ export function PersonDetailPage({ personId }: { personId: string }) {
           ),
         },
         tasksTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
-        commentsTab({ ref: { kind: "person", id: personId }, currentUserId: session?.user?.id }),
-        mentionsTab({ ref: { kind: "person", id: personId } }),
         filesTab({ ref: { kind: "person", id: personId } }),
+        mentionsTab({ ref: { kind: "person", id: personId } }),
         automationTab({ ref: { kind: "person", id: personId } }),
         {
           value: "history",
           label: "History",
+          icon: History,
           content: <RecordHistoryTab activities={person.activities} />,
         },
         {
           value: "changes",
           label: "Field history",
+          icon: History,
           content: <FieldHistoryTab entity="PERSON" recordId={personId} />,
         },
       ]}

--- a/components/crm/records/record-board.tsx
+++ b/components/crm/records/record-board.tsx
@@ -167,6 +167,7 @@ export function RecordBoard({
   cards,
   isLoading,
   emptyLabel = "Drop one here",
+  noun,
   onMove,
   className,
 }: {
@@ -174,6 +175,8 @@ export function RecordBoard({
   cards: RecordBoardCard[];
   isLoading?: boolean;
   emptyLabel?: string;
+  /** What the cards are, for the phone board's summary line. */
+  noun?: { one: string; many: string };
   /** Called when a card lands in a different column. */
   onMove?: (cardId: string, columnId: string) => void;
   className?: string;
@@ -241,6 +244,7 @@ export function RecordBoard({
     <>
     <MobileBoard
       className="lg:hidden"
+      noun={noun}
       emptyTitle={emptyLabel}
       stages={columns.map((column) => ({
         id: column.id,

--- a/components/crm/records/record-list-shell.tsx
+++ b/components/crm/records/record-list-shell.tsx
@@ -2,11 +2,12 @@
 
 import { useMemo, type ReactNode } from "react";
 
-import { Alert, Button, Input } from "@corelithzw/react";
+import { Alert, Button } from "@corelithzw/react";
 import { PageChrome } from "@/components/layout/page-chrome";
 import { Plus } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
+import { ListSearch } from "./list-search";
 import { ViewToolbar } from "./view-toolbar";
 import { getApiErrorMessage } from "@/lib/api-client";
 
@@ -26,6 +27,7 @@ export function RecordListShell({
   search,
   onSearchChange,
   searchPlaceholder,
+  searchNoun,
   filters,
   display,
   createLabel,
@@ -38,6 +40,12 @@ export function RecordListShell({
   search: string;
   onSearchChange: (value: string) => void;
   searchPlaceholder: string;
+  /**
+   * What the phone's placeholder says after "Search". Defaults to the page's
+   * own title, which is the right noun on every list here — pass one only
+   * where the title is not what the rows are ("Collections" holding invoices).
+   */
+  searchNoun?: string;
   filters?: ReactNode;
   /** Display controls — column picker, card fields — right-aligned with search. */
   display?: ReactNode;
@@ -75,12 +83,11 @@ export function RecordListShell({
       <ViewToolbar
         start={filters}
         search={
-          <Input
+          <ListSearch
             value={search}
-            onChange={(event) => onSearchChange(event.target.value)}
+            onChange={onSearchChange}
             placeholder={searchPlaceholder}
-            className="w-full sm:w-64"
-            aria-label={searchPlaceholder}
+            noun={searchNoun ?? title.toLowerCase()}
           />
         }
         end={display}

--- a/components/crm/records/record-list.test.tsx
+++ b/components/crm/records/record-list.test.tsx
@@ -6,11 +6,13 @@ import { RecordList } from "./record-list";
 /**
  * What these pin down:
  *
- * A phone gets one row per record, two lines inside it, and the one number the
- * row is about on the right. That number used to be dropped entirely below
- * `sm` — every fact was `hidden sm:flex` — so converting the deals and leads
- * tables to this list would have shown a deal with no value at all, which is
- * less than the bordered card it replaced.
+ * A phone gets one row per record, two lines inside it, and — when the caller
+ * has named one — the single number the row is about on the right. Facts used
+ * to be dropped entirely below `sm`, which showed a deal with no value at all;
+ * then the *first* fact was kept whatever it was, which put a bare "0" at the
+ * end of a person's name because their first fact happened to be a deal count
+ * with its label stripped. Naming the fact is the fix: a value that survives
+ * without its label has to be one that means something without it.
  *
  * These assert on the emitted markup rather than on the source, because the
  * previous round's untypeable `<input type="button">` typechecked, rendered,
@@ -23,7 +25,7 @@ const ROWS = [
     title: "Aluminium shopfront",
     subtitle: "DL-0012 · Meikles Hotel",
     facts: [
-      { label: "Value", value: "USD 12,400", mono: true },
+      { label: "Value", value: "USD 12,400", mono: true, primary: true },
       { label: "Owner", value: "Tendai" },
       { label: "Stage", value: "Quoted" },
     ],
@@ -31,19 +33,65 @@ const ROWS = [
 ];
 
 describe("RecordList facts", () => {
-  it("shows the leading fact on a phone and hides the rest", () => {
+  it("shows the primary fact on a phone and hides the rest", () => {
     const html = renderToStaticMarkup(<RecordList rows={ROWS} />);
 
     // The mobile span: visible by default, hidden from `sm` up.
     expect(html).toContain("sm:hidden");
-    // It carries the first fact's value…
+    // It carries the primary fact's value…
     expect(html.match(/USD 12,400/g)).toHaveLength(2); // mobile span + desktop cluster
-    // …and only the first: the other two live solely in the `sm:flex` cluster.
+    // …and only that one: the others live solely in the `sm:flex` cluster.
     expect(html.match(/Tendai/g)).toHaveLength(1);
     expect(html.match(/Quoted/g)).toHaveLength(1);
   });
 
-  it("does not repeat the leading fact's label on a phone", () => {
+  it("takes the primary fact wherever it sits in the list", () => {
+    const html = renderToStaticMarkup(
+      <RecordList
+        rows={[
+          {
+            id: "invoice-1",
+            href: "/crm/invoices/invoice-1",
+            title: "Meikles Hotel",
+            facts: [
+              { label: "Raised", value: "12 Aug" },
+              { label: "Total", value: "USD 900", mono: true, primary: true },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(html.match(/USD 900/g)).toHaveLength(2);
+    expect(html.match(/12 Aug/g)).toHaveLength(1);
+  });
+
+  it("shows no facts on a phone when none is primary", () => {
+    // A directory row's facts are a deal count and an owner. Stripped of their
+    // labels — which is all a phone has room for — they are a bare "0" and a
+    // name floating at the end of the row, neither of which says what it is.
+    const html = renderToStaticMarkup(
+      <RecordList
+        rows={[
+          {
+            id: "person-1",
+            href: "/crm/people/person-1",
+            title: "Tendai Moyo",
+            facts: [
+              { label: "Deals", value: 0, mono: true },
+              { label: "Owner", value: "Ada" },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(html).not.toContain("sm:hidden");
+    expect(html).toContain("Tendai Moyo");
+    // The desktop cluster still carries them, labelled.
+    expect(html).toContain("sm:flex");
+    expect(html).toContain("Deals");
+  });
+
+  it("does not repeat the primary fact's label on a phone", () => {
     const html = renderToStaticMarkup(<RecordList rows={ROWS} />);
     // "Value" is a desktop column heading; the phone row has no room to
     // explain a number that is already the only one there.

--- a/components/crm/records/record-list.tsx
+++ b/components/crm/records/record-list.tsx
@@ -30,6 +30,16 @@ export type RecordListFact = {
   value: ReactNode;
   /** Numerals line up when this is set — codes, money, counts. */
   mono?: boolean;
+  /**
+   * The one fact worth keeping when the row has no room for labels — a deal's
+   * value, an invoice's balance. A phone shows this and nothing else.
+   *
+   * Left off on purpose for counts and owners: stripped of its label, "Deals:
+   * 0" renders as a bare "0" at the end of a person's name, which reads as a
+   * figure about them without saying which. A row that says less is better
+   * than one that says something ambiguous.
+   */
+  primary?: boolean;
 };
 
 export type RecordListRow = {
@@ -105,7 +115,9 @@ export function RecordList({
       // anything to look at, and the rows stop reading as a ruled ledger.
       className={cn("space-y-1", className)}
     >
-      {rows.map((row) => (
+      {rows.map((row) => {
+        const primaryFact = row.facts?.find((fact) => fact.primary);
+        return (
         <li
           key={row.id}
           className={cn(
@@ -151,20 +163,20 @@ export function RecordList({
             </span>
 
             {/* Facts are supporting detail, so they are the first thing to go
-                when the row runs out of room — but not all of them. On a phone
-                the leading fact survives and its label does not: callers put
-                the number the row is about first (a balance, a pipeline, a
-                count), and a row that drops it entirely says less than the
-                card it replaced. Two and three go; three labelled columns
-                will not fit beside a title at 390px. */}
-            {row.facts?.length ? (
+                when the row runs out of room. On a phone the one marked
+                `primary` survives without its label — a value, a balance, the
+                figure the row is about — and the rest go, because three
+                labelled columns will not fit beside a title at 390px. A row
+                with nothing marked shows no facts on a phone at all: an
+                unlabelled number is worse than a missing one. */}
+            {primaryFact ? (
               <span
                 className={cn(
                   "flex-none text-right text-sm text-[var(--text-body)] sm:hidden",
-                  row.facts[0].mono ? "font-mono tabular-nums" : "",
+                  primaryFact.mono ? "font-mono tabular-nums" : "",
                 )}
               >
-                {row.facts[0].value}
+                {primaryFact.value}
               </span>
             ) : null}
 
@@ -195,7 +207,8 @@ export function RecordList({
 
           {row.actions ? <span className="flex-none">{row.actions}</span> : null}
         </li>
-      ))}
+        );
+      })}
     </ul>
 
     {selection && selectedIds.length > 0 ? (

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -362,11 +362,11 @@ export function ContactList({
           <li key={contact.id} className="flex items-start gap-2.5">
             {/* Solid, like the chip on the timeline: this is the same coding
                 doing the same job, and at 20px a tint has nothing left to
-                spend. `--accent-on` carries the hue's own contrast. */}
+                spend. `.solid-mark` carries the fill-and-glyph pairing. */}
             <span
               data-accent={contact.missed ? "red" : accent}
               title={label}
-              className="mt-px flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-solid)] text-[var(--accent-on)]"
+              className="solid-mark mt-px flex size-5 shrink-0 items-center justify-center rounded-full"
             >
               <KindIcon className="size-3" aria-hidden="true" />
             </span>

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -393,8 +393,12 @@ export function CallList({
                 {call.actorName ?? "Someone"}
                 {call.missed ? " · no answer" : ""}
               </span>
+              {/* The day, not the second. This is a three-line "when did we
+                  last speak" summary in a narrow column, and a full
+                  "8/4/2026, 9:06:53 PM" both wraps and answers a question
+                  nobody asked. The exact time is on the timeline. */}
               <span className="shrink-0 text-sm text-[var(--text-muted)]">
-                <ClientDate value={call.at} />
+                <ClientDate value={call.at} mode="date" />
               </span>
             </span>
             {call.summary ? (

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -7,6 +7,7 @@ import { Badge, Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
 import { ClientDate } from "@/components/ui/client-date";
 import { EntityLink } from "@/components/records/entity-link";
+import { eventKindStyle, type EventKind } from "@/components/crm/records/event-kind";
 import { richTextToPlain } from "@/lib/crm/rich-text";
 import { fileMark, formatFileSize, meetingPlace, timeToStart } from "@/lib/crm/panels";
 import {
@@ -14,7 +15,6 @@ import {
   Download,
   Mail,
   MapPin,
-  Phone,
   Video,
 } from "@/lib/icons";
 import { cn } from "@/lib/utils";
@@ -108,7 +108,13 @@ export function MeetingCard({
   );
 }
 
-export type ActivityCount = { label: string; count: number; icon?: ReactNode };
+export type ActivityCount = {
+  label: string;
+  count: number;
+  /** Which kind of event this counts, so it takes that kind's colour. */
+  kind?: EventKind;
+  icon?: ReactNode;
+};
 
 /**
  * How much has been going on, at a glance.
@@ -128,21 +134,33 @@ export function ActivityStrip({ counts }: { counts: ActivityCount[] }) {
   // four kinds of contact became four boxes inside a fifth — five frames to
   // say "three calls". The numbers are the content; they only need to be
   // bigger than their labels to read as figures.
+  //
+  // What each figure does carry is its kind's glyph, in its kind's colour —
+  // the same two the timeline below uses. Without it the strip and the feed
+  // were two unrelated readings of one set of facts.
   return (
-    <dl className="flex flex-wrap gap-x-5 gap-y-1">
+    <dl className="flex flex-wrap gap-x-4 gap-y-1.5">
       {counts
         .filter((entry) => entry.count > 0)
-        .map((entry) => (
-          <div key={entry.label} className="flex items-baseline gap-1.5">
-            <dt className="sr-only">{entry.label}</dt>
-            <dd className="font-mono text-base tabular-nums text-[var(--text-strong)]">
-              {entry.count}
-            </dd>
-            <span aria-hidden="true" className="text-sm text-[var(--text-muted)]">
-              {entry.label}
-            </span>
-          </div>
-        ))}
+        .map((entry) => {
+          const { icon: KindIcon, accent } = eventKindStyle(entry.kind);
+          return (
+            <div key={entry.label} className="flex items-center gap-1.5">
+              <dt className="sr-only">{entry.label}</dt>
+              {entry.kind ? (
+                <span data-accent={accent} className="text-[var(--accent-fg)]">
+                  <KindIcon className="size-3.5" aria-hidden="true" />
+                </span>
+              ) : null}
+              <dd className="font-mono text-base tabular-nums text-[var(--text-strong)]">
+                {entry.count}
+              </dd>
+              <span aria-hidden="true" className="text-sm text-[var(--text-muted)]">
+                {entry.label}
+              </span>
+            </div>
+          );
+        })}
     </dl>
   );
 }
@@ -349,9 +367,11 @@ export function EmailPreview({
   );
 }
 
-export type PanelCall = {
+export type PanelContact = {
   id: string;
   at: string;
+  /** Call, email, meeting — what actually happened. */
+  kind: EventKind;
   actorName?: string | null;
   summary?: string | null;
   /** Somebody rang and nobody answered — worth showing differently. */
@@ -359,56 +379,65 @@ export type PanelCall = {
 };
 
 /**
- * Who has rung, and when.
+ * The last few times anybody dealt with these people, and how.
  *
  * Separated from the timeline because "when did we last actually speak to
  * them" is the question that decides whether to ring now, and answering it
- * from a mixed feed means scrolling past every note and stage change.
+ * from a mixed feed means scrolling past every stage change and raised
+ * document.
+ *
+ * It used to be calls only, under a strip counting four kinds — so a record
+ * whose last three contacts were emails read as "nobody has logged a call"
+ * beside a figure saying four emails. Every kind of contact belongs here; the
+ * glyph and its colour, shared with the timeline, are what keep them apart.
  */
-export function CallList({
-  calls,
-  emptyMessage = "Nobody has logged a call.",
+export function ContactList({
+  contacts,
+  emptyMessage = "Nobody has logged any contact.",
 }: {
-  calls: PanelCall[];
+  contacts: PanelContact[];
   emptyMessage?: string;
 }) {
-  if (calls.length === 0) {
+  if (contacts.length === 0) {
     return <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>;
   }
 
   return (
     <Stack as="ul" gap="xs">
-      {calls.map((call) => (
-        <li key={call.id} className="flex items-start gap-2">
-          <Phone
-            className={cn(
-              "mt-0.5 size-4 shrink-0",
-              call.missed ? "text-[var(--status-error-text)]" : "text-[var(--text-subtle)]",
-            )}
-            aria-hidden="true"
-          />
-          <span className="min-w-0 flex-1">
-            <span className="flex items-baseline justify-between gap-2">
-              <span className="truncate text-sm text-[var(--text-strong)]">
-                {call.actorName ?? "Someone"}
-                {call.missed ? " · no answer" : ""}
-              </span>
-              {/* The day, not the second. This is a three-line "when did we
-                  last speak" summary in a narrow column, and a full
-                  "8/4/2026, 9:06:53 PM" both wraps and answers a question
-                  nobody asked. The exact time is on the timeline. */}
-              <span className="shrink-0 text-sm text-[var(--text-muted)]">
-                <ClientDate value={call.at} mode="date" />
-              </span>
+      {contacts.map((contact) => {
+        const { icon: KindIcon, accent, label } = eventKindStyle(contact.kind);
+        return (
+          <li key={contact.id} className="flex items-start gap-2">
+            <span
+              data-accent={contact.missed ? "red" : accent}
+              title={label}
+              className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)]"
+            >
+              <KindIcon className="size-3" aria-hidden="true" />
             </span>
-            {call.summary ? (
-              <span className="block truncate text-sm text-[var(--text-muted)]">
-                {richTextToPlain(call.summary, 120)}
+            <span className="min-w-0 flex-1">
+              <span className="flex items-baseline justify-between gap-2">
+                <span className="truncate text-sm text-[var(--text-strong)]">
+                  {contact.actorName ?? "Someone"}
+                  {contact.missed ? " · no answer" : ""}
+                </span>
+                {/* The day, not the second. This is a three-line "when did we
+                    last speak" summary in a narrow column, and a full
+                    "8/4/2026, 9:06:53 PM" both wraps and answers a question
+                    nobody asked. The exact time is on the timeline. */}
+                <span className="shrink-0 text-sm tabular-nums text-[var(--text-muted)]">
+                  <ClientDate value={contact.at} mode="date" />
+                </span>
               </span>
-            ) : null}
-          </span>
-        </li>
-      ))}
+              {contact.summary ? (
+                <span className="block truncate text-sm text-[var(--text-muted)]">
+                  {richTextToPlain(contact.summary, 120)}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
     </Stack>
   );
 }

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -108,63 +108,6 @@ export function MeetingCard({
   );
 }
 
-export type ActivityCount = {
-  label: string;
-  count: number;
-  /** Which kind of event this counts, so it takes that kind's colour. */
-  kind?: EventKind;
-  icon?: ReactNode;
-};
-
-/**
- * How much has been going on, at a glance.
- *
- * A strip rather than a chart: the question is "has anybody spoken to these
- * people" and the answer is a handful of small numbers, which a chart would
- * spend two hundred pixels failing to say more clearly.
- */
-export function ActivityStrip({ counts }: { counts: ActivityCount[] }) {
-  const total = counts.reduce((sum, entry) => sum + entry.count, 0);
-
-  if (total === 0) {
-    return <p className="text-sm text-[var(--text-muted)]">Nothing logged yet.</p>;
-  }
-
-  // Figures, not chips. A chip draws a bordered box around each number, so
-  // four kinds of contact became four boxes inside a fifth — five frames to
-  // say "three calls". The numbers are the content; they only need to be
-  // bigger than their labels to read as figures.
-  //
-  // What each figure does carry is its kind's glyph, in its kind's colour —
-  // the same two the timeline below uses. Without it the strip and the feed
-  // were two unrelated readings of one set of facts.
-  return (
-    <dl className="flex flex-wrap gap-x-4 gap-y-1.5">
-      {counts
-        .filter((entry) => entry.count > 0)
-        .map((entry) => {
-          const { icon: KindIcon, accent } = eventKindStyle(entry.kind);
-          return (
-            <div key={entry.label} className="flex items-center gap-1.5">
-              <dt className="sr-only">{entry.label}</dt>
-              {entry.kind ? (
-                <span data-accent={accent} className="text-[var(--accent-fg)]">
-                  <KindIcon className="size-3.5" aria-hidden="true" />
-                </span>
-              ) : null}
-              <dd className="font-mono text-base tabular-nums text-[var(--text-strong)]">
-                {entry.count}
-              </dd>
-              <span aria-hidden="true" className="text-sm text-[var(--text-muted)]">
-                {entry.label}
-              </span>
-            </div>
-          );
-        })}
-    </dl>
-  );
-}
-
 export type PanelAttachment = {
   id: string;
   name: string;
@@ -390,6 +333,12 @@ export type PanelContact = {
  * whose last three contacts were emails read as "nobody has logged a call"
  * beside a figure saying four emails. Every kind of contact belongs here; the
  * glyph and its colour, shared with the timeline, are what keep them apart.
+ *
+ * And it is the list alone. The counts that sat above it — "2 calls · 4 emails
+ * · 2 notes" — were a second, coarser answer to the question the list below
+ * them was already answering better: five rows say how much has been going on
+ * *and* what was said, in the order it happened. Two readings of one set of
+ * facts, stacked, is how a narrow column runs out of room.
  */
 export function ContactList({
   contacts,
@@ -403,21 +352,24 @@ export function ContactList({
   }
 
   return (
-    <Stack as="ul" gap="xs">
+    // Each row is two lines of its own, so the gap between rows has to beat the
+    // gap inside one or the list reads as one paragraph with coloured dots in
+    // it. `xs` was tuned for single-line rows and did not.
+    <ul className="flex flex-col gap-3">
       {contacts.map((contact) => {
         const { icon: KindIcon, accent, label } = eventKindStyle(contact.kind);
         return (
-          <li key={contact.id} className="flex items-start gap-2">
+          <li key={contact.id} className="flex items-start gap-2.5">
             <span
               data-accent={contact.missed ? "red" : accent}
               title={label}
-              className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)]"
+              className="mt-px flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)]"
             >
               <KindIcon className="size-3" aria-hidden="true" />
             </span>
             <span className="min-w-0 flex-1">
               <span className="flex items-baseline justify-between gap-2">
-                <span className="truncate text-sm text-[var(--text-strong)]">
+                <span className="truncate text-sm font-medium text-[var(--text-strong)]">
                   {contact.actorName ?? "Someone"}
                   {contact.missed ? " · no answer" : ""}
                 </span>
@@ -430,7 +382,7 @@ export function ContactList({
                 </span>
               </span>
               {contact.summary ? (
-                <span className="block truncate text-sm text-[var(--text-muted)]">
+                <span className="mt-0.5 block truncate text-sm text-[var(--text-muted)]">
                   {richTextToPlain(contact.summary, 120)}
                 </span>
               ) : null}
@@ -438,6 +390,6 @@ export function ContactList({
           </li>
         );
       })}
-    </Stack>
+    </ul>
   );
 }

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -360,10 +360,13 @@ export function ContactList({
         const { icon: KindIcon, accent, label } = eventKindStyle(contact.kind);
         return (
           <li key={contact.id} className="flex items-start gap-2.5">
+            {/* Solid, like the chip on the timeline: this is the same coding
+                doing the same job, and at 20px a tint has nothing left to
+                spend. `--accent-on` carries the hue's own contrast. */}
             <span
               data-accent={contact.missed ? "red" : accent}
               title={label}
-              className="mt-px flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)]"
+              className="mt-px flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-solid)] text-[var(--accent-on)]"
             >
               <KindIcon className="size-3" aria-hidden="true" />
             </span>

--- a/components/crm/records/record-panels.tsx
+++ b/components/crm/records/record-panels.tsx
@@ -121,7 +121,8 @@ export type PanelAttachment = {
  *
  * The coloured mark is doing real work: a rail of eleven attachments is
  * searched for "the PDF" or "the photo", and colour answers that without
- * reading a single filename.
+ * reading a single filename. Solid, like every other mark in a record — a
+ * tint reads as a disabled or draft state next to a column of filled discs.
  */
 export function AttachmentsPanel({
   attachments,
@@ -150,7 +151,7 @@ export function AttachmentsPanel({
               <span
                 data-accent={mark.accent}
                 aria-hidden="true"
-                className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--accent-bg)] font-mono text-sm font-medium text-[var(--accent-fg)]"
+                className="solid-mark flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] font-mono text-sm font-semibold"
               >
                 {mark.label}
               </span>

--- a/components/crm/records/record-story.tsx
+++ b/components/crm/records/record-story.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
 
 import { Avatar } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
-import { ClientDate } from "@/components/ui/client-date";
 import {
   ArrowRight,
   Calendar,
@@ -23,6 +22,31 @@ import { RichTextRenderer } from "@/components/crm/collaboration/rich-text-rende
 import { cn } from "@/lib/utils";
 
 const PAGE_SIZE = 25;
+
+/**
+ * The time of day, and nothing else.
+ *
+ * Same hydration contract as `ClientDate`: the first paint is a slice of the
+ * raw ISO string, so the server bytes and the first client render are
+ * identical, and only afterwards does the reader's locale come into it.
+ * `ClientDate` has no time-only mode, hence the dozen lines.
+ */
+const NO_RESUBSCRIBE = () => () => {};
+
+function ClientTime({ value }: { value: string }) {
+  // useSyncExternalStore rather than a mount effect: the server snapshot and
+  // the client's first snapshot are both `false`, so hydration matches without
+  // a render-triggering setState.
+  const hydrated = useSyncExternalStore(
+    NO_RESUBSCRIBE,
+    () => true,
+    () => false,
+  );
+
+  const date = new Date(value);
+  if (!hydrated || Number.isNaN(date.getTime())) return <>{value.slice(11, 16)}</>;
+  return <>{date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}</>;
+}
 
 /**
  * One thing that happened, whatever kind of thing it was.
@@ -131,10 +155,10 @@ function StoryRow({ event }: { event: StoryEvent }) {
         ) : null}
         <span className={cn("text-sm", quiet && "text-[var(--text-muted)]")}>{event.title}</span>
         {/* The day is already the section heading, so the row only needs the
-            time — but ClientDate is what keeps the server and first client
-            render identical, so it stays rather than a bare toLocaleTimeString. */}
+            time of day — a full "8/4/2026, 9:06:53 PM" on every one of a
+            hundred rows repeats the heading and adds a second nobody reads. */}
         <span className="text-sm text-[var(--text-subtle)]">
-          <ClientDate value={event.occurredAt} mode="datetime" />
+          <ClientTime value={event.occurredAt} />
         </span>
       </div>
 

--- a/components/crm/records/record-story.tsx
+++ b/components/crm/records/record-story.tsx
@@ -101,11 +101,12 @@ function StoryRow({ event }: { event: StoryEvent }) {
     <>
       <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
         {event.actorName ? (
-          // Tinted by who wrote it, not by what kind of event it is — that
+          // Coloured by who wrote it, not by what kind of event it is — that
           // second channel is the chip on the rail. The design system hashes
           // the name for us, so two colleagues in one day's worth of rows come
-          // out as two colours rather than two identical discs.
-          <Avatar size="sm" name={event.actorName} />
+          // out as two colours rather than two identical discs. Solid, to match
+          // the chip beside it.
+          <Avatar size="sm" name={event.actorName} solid />
         ) : null}
         <span
           className={cn(
@@ -174,11 +175,18 @@ function StoryRow({ event }: { event: StoryEvent }) {
 
       {/* The kind, as a colour and a glyph. `data-accent` is how the design
           system swaps a hue — it rebinds `--accent-*` on this element, so the
-          classes below stay static and only the attribute changes. */}
+          classes below stay static and only the attribute changes.
+
+          Solid, not a tint inside a ring. A 24px disc has room for one thing,
+          and a pale wash behind a pale glyph inside a pale outline spends all
+          three on the same weak signal — at arm's length the whole rail read as
+          one grey column again. `--accent-on` is the hue's own guaranteed
+          contrast against `--accent-solid`, so it is white where white works
+          and near-black on amber and yellow where it does not. */}
       <span
         data-accent={accent}
         title={EVENT_KIND[event.kind]?.label}
-        className="relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)] ring-1 ring-inset ring-[var(--accent-bd)]"
+        className="relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--accent-solid)] text-[var(--accent-on)]"
       >
         <Icon className="size-3.5" />
       </span>
@@ -191,7 +199,7 @@ function StoryRow({ event }: { event: StoryEvent }) {
           // without reading a word of any of them.
           <div
             data-accent={accent}
-            className="rounded-[var(--card-radius)] border border-[var(--border)] border-l-2 border-l-[var(--accent-bd)] p-3"
+            className="rounded-[var(--card-radius)] border border-[var(--border)] border-l-2 border-l-[var(--accent-solid)] p-3"
           >
             {content}
           </div>

--- a/components/crm/records/record-story.tsx
+++ b/components/crm/records/record-story.tsx
@@ -180,13 +180,13 @@ function StoryRow({ event }: { event: StoryEvent }) {
           Solid, not a tint inside a ring. A 24px disc has room for one thing,
           and a pale wash behind a pale glyph inside a pale outline spends all
           three on the same weak signal — at arm's length the whole rail read as
-          one grey column again. `--accent-on` is the hue's own guaranteed
-          contrast against `--accent-solid`, so it is white where white works
-          and near-black on amber and yellow where it does not. */}
+          one grey column again. `.solid-mark` owns the fill-and-glyph pairing
+          for every mark in the product; see `globals.css` for why three of the
+          thirteen hues are darkened rather than reversed. */}
       <span
         data-accent={accent}
         title={EVENT_KIND[event.kind]?.label}
-        className="relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--accent-solid)] text-[var(--accent-on)]"
+        className="solid-mark relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
       >
         <Icon className="size-3.5" />
       </span>

--- a/components/crm/records/record-story.tsx
+++ b/components/crm/records/record-story.tsx
@@ -4,20 +4,13 @@ import { useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
 
 import { Avatar } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
+import { FileText } from "@/lib/icons";
 import {
-  ArrowRight,
-  Calendar,
-  Checklist,
-  ChatCircle,
-  FileText,
-  Mail,
-  MapPin,
-  NoteAdd,
-  Payments,
-  Phone,
-  Send,
-  User,
-} from "@/lib/icons";
+  EVENT_KIND,
+  QUIET_KINDS,
+  type EventKind,
+  eventKindStyle,
+} from "@/components/crm/records/event-kind";
 import { RichTextRenderer } from "@/components/crm/collaboration/rich-text-renderer";
 import { cn } from "@/lib/utils";
 
@@ -58,20 +51,7 @@ function ClientTime({ value }: { value: string }) {
  */
 export type StoryEvent = {
   id: string;
-  kind:
-    | "note"
-    | "call"
-    | "email"
-    | "whatsapp"
-    | "meeting"
-    | "stage"
-    | "document"
-    | "payment"
-    | "task"
-    | "visit"
-    | "comment"
-    | "intake"
-    | "system";
+  kind: EventKind;
   /** The sentence: "Nicolas Sharp created a task". */
   title: string;
   /** What was said, if anything was. */
@@ -87,38 +67,8 @@ export type StoryEvent = {
   href?: string;
 };
 
-const KIND_ICON: Record<StoryEvent["kind"], typeof NoteAdd> = {
-  note: NoteAdd,
-  call: Phone,
-  email: Mail,
-  whatsapp: Send,
-  meeting: Calendar,
-  stage: ArrowRight,
-  document: FileText,
-  payment: Payments,
-  task: Checklist,
-  visit: MapPin,
-  comment: ChatCircle,
-  intake: User,
-  system: ArrowRight,
-};
-
-/**
- * Which events are context and which are news.
- *
- * A stage change is worth knowing and worth passing over quickly; a note
- * somebody wrote is the thing you came to read. The quiet ones keep their
- * place in the order but not the reader's attention.
- */
-const QUIET: ReadonlySet<StoryEvent["kind"]> = new Set([
-  "stage",
-  "system",
-  "document",
-  "payment",
-]);
-
 /** Events that carry a body worth boxing rather than running as one line. */
-const BOXED: ReadonlySet<StoryEvent["kind"]> = new Set([
+const BOXED: ReadonlySet<EventKind> = new Set([
   "email",
   "note",
   "comment",
@@ -143,21 +93,32 @@ function dayLabel(iso: string, now: Date): string {
 }
 
 function StoryRow({ event }: { event: StoryEvent }) {
-  const Icon = KIND_ICON[event.kind];
-  const quiet = QUIET.has(event.kind);
+  const { icon: Icon, accent } = eventKindStyle(event.kind);
+  const quiet = QUIET_KINDS.has(event.kind);
   const boxed = BOXED.has(event.kind) && Boolean(event.body);
 
   const content = (
     <>
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
         {event.actorName ? (
-          <Avatar size="sm" name={event.actorName} className="translate-y-1" />
+          // Tinted by who wrote it, not by what kind of event it is — that
+          // second channel is the chip on the rail. The design system hashes
+          // the name for us, so two colleagues in one day's worth of rows come
+          // out as two colours rather than two identical discs.
+          <Avatar size="sm" name={event.actorName} />
         ) : null}
-        <span className={cn("text-sm", quiet && "text-[var(--text-muted)]")}>{event.title}</span>
+        <span
+          className={cn(
+            "text-sm",
+            quiet ? "text-[var(--text-muted)]" : "font-medium text-[var(--text-strong)]",
+          )}
+        >
+          {event.title}
+        </span>
         {/* The day is already the section heading, so the row only needs the
             time of day — a full "8/4/2026, 9:06:53 PM" on every one of a
             hundred rows repeats the heading and adds a second nobody reads. */}
-        <span className="text-sm text-[var(--text-subtle)]">
+        <span className="text-sm tabular-nums text-[var(--text-subtle)]">
           <ClientTime value={event.occurredAt} />
         </span>
       </div>
@@ -211,20 +172,27 @@ function StoryRow({ event }: { event: StoryEvent }) {
         className="absolute bottom-0 left-[11px] top-6 w-px bg-[var(--border-subtle)] last:hidden"
       />
 
+      {/* The kind, as a colour and a glyph. `data-accent` is how the design
+          system swaps a hue — it rebinds `--accent-*` on this element, so the
+          classes below stay static and only the attribute changes. */}
       <span
-        className={cn(
-          "relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full",
-          quiet
-            ? "bg-[var(--surface-muted)] text-[var(--text-muted)]"
-            : "bg-[var(--surface-subtle)] text-[var(--text)]",
-        )}
+        data-accent={accent}
+        title={EVENT_KIND[event.kind]?.label}
+        className="relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[var(--accent-bg)] text-[var(--accent-fg)] ring-1 ring-inset ring-[var(--accent-bd)]"
       >
         <Icon className="size-3.5" />
       </span>
 
       <div className="min-w-0 flex-1">
         {boxed ? (
-          <div className="rounded-[var(--card-radius)] border border-[var(--border)] p-3">
+          // What somebody actually wrote gets a box, and the box takes the
+          // event's colour on its leading edge — so a scrolled feed shows at a
+          // glance which paragraphs are the client's and which are ours,
+          // without reading a word of any of them.
+          <div
+            data-accent={accent}
+            className="rounded-[var(--card-radius)] border border-[var(--border)] border-l-2 border-l-[var(--accent-bd)] p-3"
+          >
             {content}
           </div>
         ) : (

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
-
 import { CommentThread } from "@/components/crm/collaboration/comment-thread";
 import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
 import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-detail/activity-composer";
@@ -12,6 +10,15 @@ import { FilesTab } from "./files-tab";
 import type { FileOwnerKind } from "@/lib/crm/record-files";
 import type { CollabEntity } from "@/lib/crm/collaboration";
 import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
+
+import {
+  At,
+  ChatCircle,
+  Checklist,
+  Clock,
+  FlowArrow,
+  Paperclip,
+} from "@/lib/icons";
 
 import type { RecordTab } from "@/components/records/record-page-shell";
 
@@ -89,7 +96,8 @@ export function timelineTab({
   const target = activityTarget(ref);
   return {
     value: "timeline",
-    label: "Timeline",
+    label: "Overview",
+    icon: Clock,
     content: (
       <div className="space-y-4">
         {target ? <ActivityComposer target={target} /> : null}
@@ -109,6 +117,7 @@ export function tasksTab({
   return {
     value: "tasks",
     label: "Tasks",
+    icon: Checklist,
     content: <RecordTasksTab record={taskRef(ref)} currentUserId={currentUserId} />,
   };
 }
@@ -123,6 +132,7 @@ export function commentsTab({
   return {
     value: "comments",
     label: "Comments",
+    icon: ChatCircle,
     content: (
       <CommentThread
         entity={COLLAB[ref.kind]}
@@ -142,6 +152,7 @@ export function mentionsTab({ ref }: { ref: RecordRef }): RecordTab {
   return {
     value: "mentions",
     label: "Mentions",
+    icon: At,
     content: <MentionsTab recordId={ref.id} />,
   };
 }
@@ -167,6 +178,7 @@ export function automationTab({ ref }: { ref: RecordRef }): RecordTab {
   return {
     value: "automation",
     label: "Workflows",
+    icon: FlowArrow,
     content: <AutomationTab entity={AUTOMATION_ENTITY[ref.kind]} recordId={ref.id} />,
   };
 }
@@ -183,6 +195,7 @@ export function filesTab({ ref }: { ref: RecordRef }): RecordTab {
   return {
     value: "files",
     label: "Files",
+    icon: Paperclip,
     content: <FilesTab owner={FILE_OWNER[ref.kind]} ownerId={ref.id} />,
   };
 }
@@ -197,11 +210,6 @@ const FILE_OWNER: Record<RecordKind, FileOwnerKind> = {
 };
 
 /** A tab a single record type adds to the shared set. */
-export function extraTab(tab: {
-  value: string;
-  label: string;
-  count?: number;
-  content: ReactNode;
-}): RecordTab {
+export function extraTab(tab: RecordTab): RecordTab {
   return tab;
 }

--- a/components/crm/records/record-tabs.tsx
+++ b/components/crm/records/record-tabs.tsx
@@ -1,24 +1,25 @@
 "use client";
 
-import { CommentThread } from "@/components/crm/collaboration/comment-thread";
+import { useMemo, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+
 import { RecordTasksTab } from "@/components/crm/tasks/record-tasks-tab";
-import { ActivityComposer, type ActivityTarget } from "@/components/crm/lead-detail/activity-composer";
+import {
+  ConversationComposer,
+  type ConversationTarget,
+} from "@/components/crm/collaboration/conversation-composer";
+import { SubSections } from "@/components/records/sub-sections";
 import { RecordStory, type StoryEvent } from "./record-story";
 import { MentionsTab } from "./mentions-tab";
 import { AutomationTab } from "./automation-tab";
+import { FieldHistoryTab } from "./field-history-tab";
 import { FilesTab } from "./files-tab";
+import { RecordHistoryTab } from "./record-history-tab";
 import type { FileOwnerKind } from "@/lib/crm/record-files";
 import type { CollabEntity } from "@/lib/crm/collaboration";
-import type { CrmTaskRecordRef } from "@/lib/crm/crm-v2";
+import { fetchCrmComments, type CrmTaskRecordRef } from "@/lib/crm/crm-v2";
 
-import {
-  At,
-  ChatCircle,
-  Checklist,
-  Clock,
-  FlowArrow,
-  Paperclip,
-} from "@/lib/icons";
+import { Checklist, Clock, FileText, FlowArrow, History } from "@/lib/icons";
 
 import type { RecordTab } from "@/components/records/record-page-shell";
 
@@ -64,27 +65,52 @@ export function taskRef(ref: RecordRef): CrmTaskRecordRef {
 }
 
 /**
- * Which records somebody can write an activity against. A site is a place,
- * not a correspondent — what happened there is logged on the visit or the
- * deal, so its timeline reads without a composer rather than offering one
- * that posts nowhere.
+ * Every record can be talked about, including a site — the composer decides
+ * for itself which kinds it can offer. A site is a place rather than a
+ * correspondent, so it takes comments and not logged calls.
  */
-function activityTarget(ref: RecordRef): ActivityTarget | null {
-  switch (ref.kind) {
-    case "lead":
-      return { kind: "lead", id: ref.id };
-    case "deal":
-      return { kind: "deal", id: ref.id };
-    case "person":
-      return { kind: "person", id: ref.id };
-    case "company":
-      return { kind: "company", id: ref.id };
-    case "site":
-      return null;
-  }
+function conversationTarget(ref: RecordRef): ConversationTarget {
+  return { kind: ref.kind, id: ref.id };
 }
 
-export function timelineTab({
+/**
+ * The record's one feed: what was said and what happened, in one order.
+ *
+ * Comments used to be a section of their own, seven rows along the rail, while
+ * notes and calls were at the top of the timeline — so a record's conversation
+ * was split across two screens by a distinction (internal or not) that the
+ * reader does not have in their head when they are looking for what somebody
+ * said. `buildStory` has always taken comments; nothing ever passed them.
+ */
+/**
+ * This record's comments, shaped for `buildStory`.
+ *
+ * A hook rather than something `conversationTab` does for itself, because the
+ * tab builders are plain functions called during a page's render and a hook
+ * hidden inside one is a rules-of-hooks bug waiting for the first conditional
+ * tab. The page calls this, then hands the result to `buildStory` alongside
+ * the activities.
+ */
+export function useRecordComments(ref: RecordRef) {
+  const entity = COLLAB[ref.kind];
+  const { data } = useQuery({
+    queryKey: ["crm-comments", entity, ref.id],
+    queryFn: () => fetchCrmComments(entity, ref.id),
+  });
+
+  return useMemo(
+    () =>
+      (data ?? []).map((comment) => ({
+        id: comment.id,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        author: { id: comment.createdBy.id, name: comment.createdBy.name },
+      })),
+    [data],
+  );
+}
+
+export function conversationTab({
   ref,
   events,
   emptyMessage,
@@ -93,14 +119,13 @@ export function timelineTab({
   events: StoryEvent[];
   emptyMessage?: string;
 }): RecordTab {
-  const target = activityTarget(ref);
   return {
     value: "timeline",
-    label: "Overview",
+    label: "Conversation",
     icon: Clock,
     content: (
       <div className="space-y-4">
-        {target ? <ActivityComposer target={target} /> : null}
+        <ConversationComposer target={conversationTarget(ref)} />
         <RecordStory events={events} emptyMessage={emptyMessage} />
       </div>
     ),
@@ -122,38 +147,57 @@ export function tasksTab({
   };
 }
 
-export function commentsTab({
+/**
+ * The audit trail, in one section.
+ *
+ * Three rows in the rail — History, Field history, Mentions — for one
+ * question: what has this record been through, and where else does it come up.
+ * They are genuinely different lists, which is why they were separate; they
+ * are not different *destinations*, which is why they no longer are.
+ */
+export function historyTab({
   ref,
-  currentUserId,
+  entity,
+  activities,
 }: {
   ref: RecordRef;
-  currentUserId?: string;
+  /** The field-history layer's name for this record. */
+  entity: string;
+  /** Omitted where the record has no activity feed of its own — a site. */
+  activities?: Parameters<typeof RecordHistoryTab>[0]["activities"];
 }): RecordTab {
   return {
-    value: "comments",
-    label: "Comments",
-    icon: ChatCircle,
+    value: "history",
+    label: "History",
+    icon: History,
     content: (
-      <CommentThread
-        entity={COLLAB[ref.kind]}
-        recordId={ref.id}
-        currentUserId={currentUserId}
+      <SubSections
+        label="History"
+        sections={[
+          ...(activities
+            ? [
+                {
+                  value: "activity",
+                  label: "Activity",
+                  content: <RecordHistoryTab activities={activities} />,
+                },
+              ]
+            : []),
+          {
+            value: "changes",
+            label: "Field changes",
+            content: <FieldHistoryTab entity={entity} recordId={ref.id} />,
+          },
+          {
+            // The other half of a link: a reference to this site in a note on
+            // a deal is exactly the connection that was invisible before.
+            value: "mentions",
+            label: "Mentions",
+            content: <MentionsTab recordId={ref.id} />,
+          },
+        ]}
       />
     ),
-  };
-}
-
-/**
- * Where this record has been written about elsewhere. Every kind gets it,
- * because a reference to a site in a note on a deal is exactly the connection
- * that was invisible before.
- */
-export function mentionsTab({ ref }: { ref: RecordRef }): RecordTab {
-  return {
-    value: "mentions",
-    label: "Mentions",
-    icon: At,
-    content: <MentionsTab recordId={ref.id} />,
   };
 }
 
@@ -184,19 +228,53 @@ export function automationTab({ ref }: { ref: RecordRef }): RecordTab {
 }
 
 /**
- * Files that arrived from outside, on every kind.
+ * All the paperwork on a record, in one section.
  *
- * Separate from Documents, which is what the system raised and numbered. A
- * signed contract and a quotation are both "a document" to a reader, but only
- * one of them has a total and a status, and mixing them makes the register
- * useless for either question.
+ * A quotation and an uploaded contract are not the same object — only one of
+ * them has a total, a status and a version chain — which is why the two lists
+ * stay separate. But "what paperwork is on this record" is one question, and
+ * it was two rows in the rail. The segmented control keeps the lists apart
+ * without keeping the destinations apart.
+ *
+ * `documents` is the register the system raised and numbered; pass it where
+ * the record has one. Files alone still render, without a control.
  */
-export function filesTab({ ref }: { ref: RecordRef }): RecordTab {
+export function paperworkTab({
+  ref,
+  documents,
+  documentCount,
+}: {
+  ref: RecordRef;
+  documents?: ReactNode;
+  documentCount?: number;
+}): RecordTab {
   return {
-    value: "files",
-    label: "Files",
-    icon: Paperclip,
-    content: <FilesTab owner={FILE_OWNER[ref.kind]} ownerId={ref.id} />,
+    value: "documents",
+    label: "Documents",
+    icon: FileText,
+    count: documentCount,
+    content: (
+      <SubSections
+        label="Paperwork"
+        sections={[
+          ...(documents
+            ? [
+                {
+                  value: "documents",
+                  label: "Issued",
+                  count: documentCount,
+                  content: documents,
+                },
+              ]
+            : []),
+          {
+            value: "files",
+            label: "Uploads",
+            content: <FilesTab owner={FILE_OWNER[ref.kind]} ownerId={ref.id} />,
+          },
+        ]}
+      />
+    ),
   };
 }
 

--- a/components/crm/records/relation-attribute.tsx
+++ b/components/crm/records/relation-attribute.tsx
@@ -7,6 +7,8 @@ import { ResponsivePopover } from "@/components/ui/responsive-popover";
 import { Pencil, X } from "@/lib/icons";
 
 import { EntityLink } from "@/components/records/entity-link";
+import { ATTRIBUTE_ROW } from "@/components/records/record-attributes";
+import { cn } from "@/lib/utils";
 import { RecordPicker, type PickableType, type PickedRecord } from "./record-picker";
 
 /**
@@ -110,7 +112,10 @@ export function RelationAttribute({
         ) : (
           <button
             type="button"
-            className="-mx-1.5 flex min-h-9 w-full min-w-0 items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] sm:min-h-0"
+            className={cn(
+              "-mx-1.5 flex w-full min-w-0 items-center rounded-[var(--radius-sm)] px-1.5 text-left text-[var(--text-muted)] hover:bg-[var(--surface-subtle)]",
+              ATTRIBUTE_ROW,
+            )}
           >
             {placeholder}
           </button>
@@ -124,8 +129,10 @@ export function RelationAttribute({
   if (!value) return editor;
 
   return (
-    <span className="flex min-w-0 items-center gap-1">
-      <EntityLink href={href} className="min-w-0 truncate text-sm">
+    // The same line box the rest of the property list uses, so a linked value
+    // sits on the label's baseline rather than a few pixels above it.
+    <span className={cn("flex min-w-0 items-center gap-1", ATTRIBUTE_ROW)}>
+      <EntityLink href={href} className="min-w-0 truncate">
         {value}
       </EntityLink>
       {editor}

--- a/components/crm/records/relation-attribute.tsx
+++ b/components/crm/records/relation-attribute.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { X } from "@/lib/icons";
+import { ResponsivePopover } from "@/components/ui/responsive-popover";
+import { Pencil, X } from "@/lib/icons";
 
 import { EntityLink } from "@/components/records/entity-link";
 import { RecordPicker, type PickableType, type PickedRecord } from "./record-picker";
@@ -18,8 +18,15 @@ import { RecordPicker, type PickableType, type PickedRecord } from "./record-pic
  * ring before turning up. Those were drawn as links and nothing else, so the
  * only way to correct one was to have got it right at creation.
  *
- * Reads as the link it is until you press it, because the common case is
- * following the reference, not changing it.
+ * Reads as the link it is, because the common case is following the reference,
+ * not changing it — so the link keeps the whole row and the way to repoint it
+ * is a pencil at the end. It used to be a "Change" button spelled out in
+ * words, which cost about 55px of a value column that is only 200px wide on a
+ * phone: on a lead, "Chitungwiza Medical Centre" and "Chang…" both ran off the
+ * right edge of the screen, and neither could be read.
+ *
+ * With nothing linked there is no link to protect, so the placeholder is the
+ * trigger — the same rule the other property editors follow.
  */
 export function RelationAttribute({
   value,
@@ -42,64 +49,86 @@ export function RelationAttribute({
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<PickedRecord | null>(null);
 
-  return (
-    <span className="flex min-w-0 items-center gap-1.5">
-      {value ? (
-        <EntityLink href={href} className="min-w-0 truncate text-sm">
-          {value}
-        </EntityLink>
-      ) : (
-        <span className="text-sm text-[var(--text-muted)]">{placeholder}</span>
-      )}
-
-      <Popover
-        open={open}
-        onOpenChange={(next) => {
-          setOpen(next);
-          if (!next) setDraft(null);
+  const picker = (
+    <>
+      <RecordPicker
+        value={draft}
+        onChange={(next) => {
+          setDraft(next);
+          if (next) {
+            onPick(next);
+            setOpen(false);
+            setDraft(null);
+          }
         }}
-      >
-        <PopoverTrigger asChild>
+        types={types}
+        placeholder={searchPlaceholder ?? "Search records"}
+      />
+      {value && onClear ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-1.5 text-[var(--text-muted)]"
+          onClick={() => {
+            onClear();
+            setOpen(false);
+          }}
+        >
+          <X className="size-3.5" />
+          Clear it
+        </Button>
+      ) : null}
+    </>
+  );
+
+  // A sheet on a phone, a popover on a desktop. This was a bare 320px Popover,
+  // which at 390px is a panel almost as wide as the screen with nothing to
+  // anchor to — the case `ResponsivePopover` exists for.
+  const editor = (
+    <ResponsivePopover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setDraft(null);
+      }}
+      title={value ? "Change link" : "Set link"}
+      align="start"
+      className="w-80 p-2"
+      contentClassName="space-y-2"
+      trigger={
+        value ? (
           <Button
             type="button"
             variant="ghost"
             size="sm"
-            className="h-6 px-1.5 text-sm text-[var(--text-muted)]"
+            aria-label="Change link"
+            className="size-7 shrink-0 p-0 text-[var(--text-muted)]"
           >
-            {value ? "Change" : "Set"}
+            <Pencil className="size-4" />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-80 space-y-2 p-2">
-          <RecordPicker
-            value={draft}
-            onChange={(next) => {
-              setDraft(next);
-              if (next) {
-                onPick(next);
-                setOpen(false);
-                setDraft(null);
-              }
-            }}
-            types={types}
-            placeholder={searchPlaceholder ?? "Search records"}
-          />
-          {value && onClear ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start gap-1.5 text-[var(--text-muted)]"
-              onClick={() => {
-                onClear();
-                setOpen(false);
-              }}
-            >
-              <X className="size-3.5" />
-              Clear it
-            </Button>
-          ) : null}
-        </PopoverContent>
-      </Popover>
+        ) : (
+          <button
+            type="button"
+            className="-mx-1.5 flex min-h-9 w-full min-w-0 items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] sm:min-h-0"
+          >
+            {placeholder}
+          </button>
+        )
+      }
+    >
+      {picker}
+    </ResponsivePopover>
+  );
+
+  if (!value) return editor;
+
+  return (
+    <span className="flex min-w-0 items-center gap-1">
+      <EntityLink href={href} className="min-w-0 truncate text-sm">
+        {value}
+      </EntityLink>
+      {editor}
     </span>
   );
 }

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -11,7 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StatusChip } from "@/components/ui/status-chip";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
-import { Building2, CalendarCheck, MapPin, UserRound } from "@/lib/icons";
+import { Building2, CalendarCheck, Funnel, History, MapPin, UserRound } from "@/lib/icons";
 import type { LeadFilterOwner } from "@/components/crm/leads/leads-filters";
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
@@ -276,9 +276,16 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
       onTabChange={setTab}
       tabs={[
         {
+          // A site's own story is its visits — it has no activity feed of its
+          // own, so this is the record's overview.
           value: "visits",
           label: "Visits",
+          icon: CalendarCheck,
           count: site.appointments.length,
+          attention: site.appointments.some(
+            (visit) =>
+              visit.status === "SCHEDULED" && new Date(visit.scheduledStart) < new Date(),
+          ),
           content:
             site.appointments.length === 0 ? (
               <p className="py-6 text-center text-sm text-[var(--text-muted)]">
@@ -312,9 +319,11 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               </Stack>
             ),
         },
+        commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
         {
           value: "deals",
           label: "Deals",
+          icon: Funnel,
           count: site.deals.length,
           content: (
             <RelatedList
@@ -330,9 +339,8 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           ),
         },
         tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
-        commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
-        mentionsTab({ ref: { kind: "site", id: siteId } }),
         filesTab({ ref: { kind: "site", id: siteId } }),
+        mentionsTab({ ref: { kind: "site", id: siteId } }),
         automationTab({ ref: { kind: "site", id: siteId } }),
         {
           // Was a History tab rendering an empty array, permanently: a site
@@ -342,6 +350,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           // history a site genuinely has — its edits are recorded.
           value: "changes",
           label: "Field history",
+          icon: History,
           content: <FieldHistoryTab entity="SITE" recordId={siteId} />,
         },
       ]}

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -11,7 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StatusChip } from "@/components/ui/status-chip";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
-import { Building2, CalendarCheck, Funnel, History, MapPin, UserRound } from "@/lib/icons";
+import { Building2, CalendarCheck, Clock, Funnel, MapPin, UserRound } from "@/lib/icons";
 import type { LeadFilterOwner } from "@/components/crm/leads/leads-filters";
 import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
@@ -21,13 +21,18 @@ import { formatMoney } from "@/components/crm/documents/document-types";
 import { customFieldAttributes } from "@/components/records/custom-field-attributes";
 import { CustomFieldDisplay } from "./custom-field-display";
 import { RecordMark } from "@/components/records/record-mark";
-import { automationTab, commentsTab, filesTab, mentionsTab, tasksTab } from "./record-tabs";
+import {
+  automationTab,
+  historyTab,
+  paperworkTab,
+  tasksTab,
+} from "./record-tabs";
 import { RecordAttributes } from "@/components/records/record-attributes";
 import { RelationAttribute } from "./relation-attribute";
 import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
-import { FieldHistoryTab } from "@/components/crm/records/field-history-tab";
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
+import { ConversationComposer } from "@/components/crm/collaboration/conversation-composer";
 import { SiteFormSheet } from "./site-form-sheet";
 
 import { Stack } from "@corelithzw/react";
@@ -319,7 +324,12 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               </Stack>
             ),
         },
-        commentsTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
+        {
+          value: "conversation",
+          label: "Conversation",
+          icon: Clock,
+          content: <ConversationComposer target={{ kind: "site", id: siteId }} />,
+        },
         {
           value: "deals",
           label: "Deals",
@@ -339,20 +349,11 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           ),
         },
         tasksTab({ ref: { kind: "site", id: siteId }, currentUserId: session?.user?.id }),
-        filesTab({ ref: { kind: "site", id: siteId } }),
-        mentionsTab({ ref: { kind: "site", id: siteId } }),
+        paperworkTab({ ref: { kind: "site", id: siteId } }),
         automationTab({ ref: { kind: "site", id: siteId } }),
-        {
-          // Was a History tab rendering an empty array, permanently: a site
-          // has no activity foreign key, so nothing could ever appear in it.
-          // A tab kept "for consistency" that can never answer its own
-          // question is worse than one that is absent. Field history is the
-          // history a site genuinely has — its edits are recorded.
-          value: "changes",
-          label: "Field history",
-          icon: History,
-          content: <FieldHistoryTab entity="SITE" recordId={siteId} />,
-        },
+        // No activity list: a site has no activity foreign key, so its history
+        // is the edits made to it and the places it gets referred to.
+        historyTab({ ref: { kind: "site", id: siteId }, entity: "SITE" }),
       ]}
       rail={rail}
       />

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -5,12 +5,15 @@ import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { ClientDate } from "@/components/ui/client-date";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusChip } from "@/components/ui/status-chip";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { fetchCrmFieldDefinitions, type CrmFieldDefinitionRecord } from "@/lib/crm/crm-v2";
-import { Building2, MapPin, UserRound } from "@/lib/icons";
+import { Building2, CalendarCheck, MapPin, UserRound } from "@/lib/icons";
+import type { LeadFilterOwner } from "@/components/crm/leads/leads-filters";
+import { VisitScheduleSheet } from "@/components/crm/visits/visit-schedule-sheet";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 
 import { formatMoney } from "@/components/crm/documents/document-types";
@@ -73,6 +76,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
   const { data: session } = useSession();
   const [tab, setTab] = useState("visits");
   const [editOpen, setEditOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
 
   const siteQuery = useQuery({
     queryKey: ["crm", "site", siteId],
@@ -86,7 +90,14 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
     queryKey: ["crm", "field-definitions", "SITE"],
     queryFn: () => fetchCrmFieldDefinitions("SITE"),
   });
+  // Who a visit can be given to. Shared cache key with the rest of the module,
+  // so opening the sheet costs nothing the page has not already paid.
+  const teamQuery = useQuery({
+    queryKey: ["crm", "team"],
+    queryFn: () => fetchJson<{ data: LeadFilterOwner[] }>("/api/v2/crm/team"),
+  });
 
+  const owners = teamQuery.data?.data ?? [];
   const definitions: CrmFieldDefinitionRecord[] = fieldsQuery.data?.data ?? [];
   const site = siteQuery.data;
 
@@ -129,11 +140,51 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
       ? `https://www.google.com/maps?q=${site.latitude},${site.longitude}`
       : null;
 
+  /**
+   * What the rail has left to say once the properties are at the top.
+   *
+   * It used to open with Address, Access and Primary contact — all three of
+   * which are property rows a few centimetres above it. On a phone that is
+   * the whole Overview tab spent repeating the screen you scrolled down from.
+   * What is genuinely not a property is kept: the map link, which comes out of
+   * the coordinates rather than being them, the site's own conditions, and the
+   * administrator's fields.
+   */
+  const railSections = [
+    mapsHref ? (
+      <RailSection key="directions" title="Getting there">
+        <a href={mapsHref} target="_blank" rel="noreferrer" className="text-sm hover:underline">
+          Open in maps
+        </a>
+      </RailSection>
+    ) : null,
+    site.siteConditions ? (
+      <RailSection key="conditions" title="Conditions">
+        <p className="whitespace-pre-wrap text-sm">{site.siteConditions}</p>
+      </RailSection>
+    ) : null,
+    definitions.length > 0 ? (
+      <CustomFieldDisplay key="custom" definitions={definitions} values={site.customFields} />
+    ) : null,
+  ].filter(Boolean);
+
+  const rail = railSections.length > 0 ? <>{railSections}</> : undefined;
+
   return (
     <>
       <RecordPageShell
       icon={MapPin}
       backHref="/crm/sites"
+      primaryAction={
+        // A site is a place somebody has to go to. Every other verb on this
+        // record — edit the address, repoint the company — is maintenance;
+        // arranging the visit is the work, which is why Visits is also the
+        // tab this page opens on.
+        <Button size="sm" className="gap-1.5" onClick={() => setScheduleOpen(true)}>
+          <CalendarCheck className="h-3.5 w-3.5" />
+          Schedule a visit
+        </Button>
+      }
       actions={[{ label: "Edit", onSelect: () => setEditOpen(true) }]}
       backLabel="All sites"
       leading={
@@ -294,55 +345,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           content: <FieldHistoryTab entity="SITE" recordId={siteId} />,
         },
       ]}
-      rail={
-        <>
-          <RailSection title="Address">
-            {site.addressLine ? <p className="text-sm">{site.addressLine}</p> : null}
-            <p className="text-sm text-[var(--text-muted)]">
-              {[site.city, site.country].filter(Boolean).join(", ") || "No address recorded"}
-            </p>
-            {mapsHref ? (
-              <a
-                href={mapsHref}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-1 inline-block text-sm hover:underline"
-              >
-                Open in maps
-              </a>
-            ) : null}
-          </RailSection>
-
-          <RailSection title="Access">
-            {site.accessInstructions ? (
-              <p className="whitespace-pre-wrap text-sm">{site.accessInstructions}</p>
-            ) : (
-              <p className="text-sm text-[var(--text-muted)]">No access notes yet.</p>
-            )}
-          </RailSection>
-
-          {site.siteConditions ? (
-            <RailSection title="Conditions">
-              <p className="whitespace-pre-wrap text-sm">{site.siteConditions}</p>
-            </RailSection>
-          ) : null}
-
-          <RailSection title="Primary contact">
-            {site.primaryContact ? (
-              <>
-                <p className="text-sm">{site.primaryContact.fullName}</p>
-                {site.primaryContact.phone ? (
-                  <p className="text-sm text-[var(--text-muted)]">{site.primaryContact.phone}</p>
-                ) : null}
-              </>
-            ) : (
-              <p className="text-sm text-[var(--text-muted)]">Nobody named yet.</p>
-            )}
-          </RailSection>
-
-          <CustomFieldDisplay definitions={definitions} values={site.customFields} />
-        </>
-      }
+      rail={rail}
       />
 
       <SiteFormSheet
@@ -366,6 +369,18 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
           siteConditions: site.siteConditions ?? "",
         }}
         onSaved={() => siteQuery.refetch()}
+      />
+
+      <VisitScheduleSheet
+        open={scheduleOpen}
+        onOpenChange={setScheduleOpen}
+        subject={{ siteId, clientId: site.client?.id ?? null }}
+        defaultLocation={
+          [site.addressLine, site.city].filter(Boolean).join(", ") || null
+        }
+        owners={owners}
+        currentUserId={session?.user?.id}
+        onScheduled={() => siteQuery.refetch()}
       />
     </>
   );

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -35,6 +35,11 @@ import { cn } from "@/lib/utils";
  * read six labels before they can look at anything. So below `sm` the whole
  * lot goes behind one button, and what stays on screen is what somebody came
  * for: the search box, and the records under it.
+ *
+ * Which means a phone toolbar with no `search` is one outline button on a band
+ * of its own — 60px of page spent on a control nobody came for. Every surface
+ * that uses this passes a search now; a caller that genuinely has nothing to
+ * search gets the button inline with whatever `end` holds rather than a band.
  */
 export function ViewToolbar({
   start,

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -92,11 +92,13 @@ export function ViewToolbar({
             {/* Stacked and full width — each control gets a line, which is
                 the only way a nine-option filter reads on a phone. Labels go
                 to the left edge: a button centres its label, which is right
-                for a button you press and wrong for a row you read down. */}
-            {/* `w-full` on each control is what tells the button it is a row:
-                the left-aligned label and far-right caret come from that, in
-                globals.css, rather than from a rule written here. */}
-            <div className="flex flex-col items-stretch gap-2 [&>*]:w-full [&_.btn]:w-full">
+                for a button you press and wrong for a row you read down.
+                `.stacked-controls` in globals.css is what says so; setting
+                the width from here only stretched the buttons and left every
+                label centred, because the rule that turns a stretched button
+                into a row keys off a class this sheet cannot put on controls
+                it was handed. */}
+            <div className="stacked-controls flex flex-col items-stretch gap-2">
               {start}
               {end}
             </div>

--- a/components/crm/reports/reports-content.tsx
+++ b/components/crm/reports/reports-content.tsx
@@ -278,7 +278,7 @@ function renderReportCard(type: string, context: CardContext) {
         title: "Headline figures",
         entity: "deal",
         children: (
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-2 gap-3 sm:gap-3 lg:grid-cols-4">
             <StatCard
               label="Win rate"
               value={formatRate(report.winRate)}

--- a/components/crm/reps/reps-content.tsx
+++ b/components/crm/reps/reps-content.tsx
@@ -68,7 +68,14 @@ export function RepsContent() {
           </Badge>
         ),
         facts: [
-          { label: "Open pipeline", value: formatMoney(pipeline, "USD"), mono: true },
+          {
+            label: "Open pipeline",
+            value: formatMoney(pipeline, "USD"),
+            mono: true,
+            // What a rep's row is about, and the one figure worth the width
+            // on a phone.
+            primary: true,
+          },
           // A dash, not a zero: "not shown to you" and "sold nothing" are
           // different facts and must not look the same.
           {

--- a/components/crm/settings/custom-fields-panel.tsx
+++ b/components/crm/settings/custom-fields-panel.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -154,14 +154,9 @@ export function CustomFieldsPanel() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-start justify-between gap-2">
-        <div>
-          <CardTitle>Custom fields</CardTitle>
-          <p className="text-sm text-[var(--text-muted)]">
-            Extra fields for your business. They show up on the form, the record page and the
-            filters as soon as you add them.
-          </p>
-        </div>
+      {/* The settings shell already names this section and describes it; see
+          the note in `pipelines-panel.tsx`. */}
+      <CardHeader className="flex flex-row items-center justify-end gap-2">
         <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
           <Plus className="h-4 w-4" />
           New field

--- a/components/crm/settings/pipelines-panel.tsx
+++ b/components/crm/settings/pipelines-panel.tsx
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -371,13 +371,11 @@ export function PipelinesPanel() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-2">
-        <div>
-          <CardTitle>Pipelines</CardTitle>
-          <p className="text-sm text-[var(--text-muted)]">
-            The stages a deal moves through. Different kinds of work can follow different paths.
-          </p>
-        </div>
+      {/* No title here. The settings shell draws "Pipelines" and its
+          description immediately above this card, and the panel repeating both
+          in slightly different words spent the whole first screen of a phone
+          saying the same thing twice before a single pipeline appeared. */}
+      <CardHeader className="flex flex-row items-center justify-end gap-2">
         <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
           <Plus className="h-4 w-4" />
           New pipeline

--- a/components/crm/tasks/task-list.tsx
+++ b/components/crm/tasks/task-list.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge, Button, EmptyState, Stack } from "@corelithzw/react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ClientDate } from "@/components/ui/client-date";
+import { dsConfirm } from "@/components/ui/ds-confirm";
 import { useToast } from "@/components/ui/use-toast";
 import { getApiErrorMessage } from "@/lib/api-client";
 import { deleteCrmTask, updateCrmTask, type CrmTaskRecord } from "@/lib/crm/crm-v2";
@@ -178,13 +179,24 @@ export function TaskList({
                 ) : null}
               </div>
 
+              {/* Asked first. This is a one-tap delete at the right edge of
+                  every row, which on a phone is exactly where a thumb lands
+                  while scrolling, and a deleted task has no undo. */}
               {task.assignedToId === currentUserId || !task.assignedToId ? (
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
                   aria-label={`Delete ${task.title}`}
-                  onClick={() => remove.mutate(task.id)}
+                  onClick={async () => {
+                    const confirmed = await dsConfirm({
+                      title: "Delete this task?",
+                      description: task.title,
+                      confirmLabel: "Delete",
+                      variant: "danger",
+                    });
+                    if (confirmed) remove.mutate(task.id);
+                  }}
                 >
                   <Trash2 className="size-4" />
                 </Button>

--- a/components/crm/templates/template-analytics.tsx
+++ b/components/crm/templates/template-analytics.tsx
@@ -71,7 +71,7 @@ export function TemplateAnalytics({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <Stat
           label="Opened"
           value={String(viewCount)}

--- a/components/crm/widgets/widget-grid.tsx
+++ b/components/crm/widgets/widget-grid.tsx
@@ -40,12 +40,22 @@ import {
 import { IconButton } from "@/components/ui/icon-button";
 import { cn } from "@/lib/utils";
 
-/** Tailwind cannot see a computed `col-span-${n}`, so the classes are spelled out. */
+/**
+ * Tailwind cannot see a computed `col-span-${n}`, so the classes are spelled
+ * out.
+ *
+ * A quarter and a third are two-up on a phone rather than stacked. Six metric
+ * widgets at full width were six screens of one number each, and you reached
+ * the bottom of the overview without ever seeing two figures at once — which
+ * is the entire point of an overview. Anything a caller chose to make half the
+ * page or wider stays full width: it was sized that way because its contents
+ * need the room.
+ */
 const SPAN_CLASS: Record<WidgetSpan, string> = {
-  3: "sm:col-span-6 lg:col-span-3",
-  4: "sm:col-span-6 lg:col-span-4",
-  6: "sm:col-span-6 lg:col-span-6",
-  8: "sm:col-span-12 lg:col-span-8",
+  3: "col-span-6 lg:col-span-3",
+  4: "col-span-6 lg:col-span-4",
+  6: "col-span-12 sm:col-span-6",
+  8: "col-span-12 lg:col-span-8",
   12: "col-span-12",
 };
 

--- a/components/crm/workflows/run-insights-panel.tsx
+++ b/components/crm/workflows/run-insights-panel.tsx
@@ -45,7 +45,7 @@ export function RunInsightsPanel({ range }: { range: ReportRange }) {
 
   if (query.isLoading) {
     return (
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4" aria-busy="true">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4" aria-busy="true">
         {[0, 1, 2, 3].map((index) => (
           <Skeleton key={index} height={96} />
         ))}
@@ -76,7 +76,7 @@ export function RunInsightsPanel({ range }: { range: ReportRange }) {
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
         <StatCard
           label="Runs"
           value={String(totals.runs)}

--- a/components/inventory/catalogue-panel.tsx
+++ b/components/inventory/catalogue-panel.tsx
@@ -19,6 +19,7 @@ import {
   TableRow,
 } from "@corelithzw/react";
 
+import { PageActions } from "@/components/layout/page-chrome";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -49,7 +50,19 @@ const KIND_FILTERS = [
  * stock beside price is the point: it is the same screen whether you are
  * pricing a service that is never held anywhere or a pump sitting in a yard.
  */
-export function CataloguePanel() {
+export function CataloguePanel({
+  /**
+   * Put "New item" in the top app bar instead of above the table.
+   *
+   * On its own page in Stock & Inventory that is where a primary action goes,
+   * the same as "New person" on the people list. The panel is also embedded in
+   * CRM settings, where the bar belongs to that page — so this is opt-in, and
+   * the button stays in the body by default.
+   */
+  actionInBar = false,
+}: {
+  actionInBar?: boolean;
+} = {}) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [search, setSearch] = useState("");
@@ -81,8 +94,21 @@ export function CataloguePanel() {
     onError: (err) => toast({ title: getApiErrorMessage(err), variant: "destructive" }),
   });
 
+  const newItem = (
+    <Button
+      variant="primary"
+      size="sm"
+      startIcon={<Plus className="size-4" />}
+      onClick={() => setCreating(true)}
+    >
+      New item
+    </Button>
+  );
+
   return (
     <div className="space-y-4">
+      {actionInBar ? <PageActions>{newItem}</PageActions> : null}
+
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-sm font-semibold">What the business sells</h2>
@@ -92,9 +118,7 @@ export function CataloguePanel() {
             {priceList ? ` Prices shown from the ${priceList.name} list.` : null}
           </p>
         </div>
-        <Button variant="primary" size="sm" startIcon={<Plus className="size-4" />} onClick={() => setCreating(true)}>
-          New item
-        </Button>
+        {actionInBar ? null : newItem}
       </div>
 
       <div className="flex flex-wrap items-center gap-2">

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -69,8 +69,8 @@ export function AppShell({
               isCctvRoute
                 ? "min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] py-0"
                 : isScrapRoute
-                  ? "content-shell min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] pt-4 pb-[max(1rem,env(safe-area-inset-bottom))] md:py-6"
-                  : "content-shell min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] md:py-6"
+                  ? "content-shell min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] pt-[var(--content-gutter-y)] pb-[max(1rem,env(safe-area-inset-bottom))] md:py-[var(--content-gutter-y)]"
+                  : "content-shell min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] pt-[var(--content-gutter-y)] pb-[max(1.5rem,env(safe-area-inset-bottom))] md:py-[var(--content-gutter-y)]"
             }
           >
             <OnboardingProvider>{children}</OnboardingProvider>

--- a/components/layout/command-bar/global-command-bar.tsx
+++ b/components/layout/command-bar/global-command-bar.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 
+import { IconButton } from "@/components/ui/icon-button";
 import { useSidebar } from "@/components/ui/sidebar";
 import { fetchJson } from "@/lib/api-client";
 import { navSections } from "@/lib/navigation";
@@ -547,25 +548,38 @@ export function GlobalCommandBar() {
   return (
     <>
       {/*
+        A phone gets the icon, everything else gets the box.
+        ===================================================
+        The comment here used to claim "on mobile the icon alone opens the bar",
+        but the input rendered at every width — 144px of it, plus a bell and a
+        primary action, on a 390px bar. What gave way was the page title, which
+        is the one thing in that bar nothing else on the screen says: every CRM
+        page with a "New …" button showed "C…" where its name should be.
+
+        So there are two triggers into one bar. Which is not the same as two
+        searches: both hand their text to the `CommandBar` below, so there is
+        one query, one result shape and one keyboard contract.
+      */}
+      <IconButton
+        aria-label="Search records and actions"
+        size="lg"
+        className="md:hidden"
+        onClick={() => changeOpen(true)}
+      >
+        <Search />
+      </IconButton>
+
+      {/*
         A real input, not a button dressed as one.
         =========================================
         It used to be a `<button>`, which meant the app bar advertised a search
         box and then asked you to open a dialog before you could type into it —
         two gestures for the thing people do most. Now the first keystroke lands
         where you aimed it.
-
-        What it is *not* is a second search. Typing hands the text straight to
-        the same `CommandBar` this file already renders, seeded with what you
-        typed, so there is one query, one result shape and one keyboard contract.
-        A separate suggestions dropdown here would have been a second engine to
-        keep in step with the first.
-
-        Kept narrow on purpose: on mobile the app bar has no room, so the icon
-        alone opens the bar.
       */}
-      <div className="relative flex items-center">
+      <div className="relative hidden items-center md:flex">
         <Search
-          className="pointer-events-none absolute left-2.5 size-4 text-[var(--text-subtle)] md:left-2.5"
+          className="pointer-events-none absolute left-2.5 size-4 text-[var(--text-subtle)]"
           aria-hidden="true"
         />
         <input

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -27,6 +27,7 @@ import { CrmMembers } from "@/components/crm/crm-members";
 import { NotificationCenter } from "@/components/notifications/notification-center";
 import { ArrowLeft, MoreHorizontal, type LucideIcon } from "@/lib/icons";
 import { navSections } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
 import { canAccessCapabilityWithToken } from "@/lib/platform/gating/token-check";
 
 /**
@@ -74,17 +75,22 @@ export function Navbar() {
   return (
     // Sticky, so it is genuinely floating over the scrolling content: a crisp
     // hairline plus a hard 1px shadow (no blur), not a soft glow.
-    <header className="sticky top-0 z-20 border-b border-[var(--chrome-edge)] bg-surface-base pt-[env(safe-area-inset-top)] shadow-[var(--chrome-shadow)]">
-      <div className="px-2 h-14 lg:pr-4">
+    <header className="sticky top-0 z-[var(--z-nav)] border-b border-[var(--chrome-edge)] bg-surface-base pt-[env(safe-area-inset-top)] shadow-[var(--chrome-shadow)]">
+      {/* The bar's own gutter is the content's, less the padding an icon
+          button carries inside itself — so the first glyph sits on the same
+          vertical line as the text below it rather than eight pixels inside
+          it. That misalignment is most of what read as "inconsistent
+          spacing": three different left edges down the top of every page. */}
+      <div className="h-14 px-[calc(var(--content-gutter-x)-0.5rem)] lg:pr-4">
         <>
-          <div className="flex h-14 items-center gap-1.5 md:hidden">
+          <div className="flex h-14 items-center gap-1 md:hidden">
             <SidebarTrigger />
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               {back ? (
                 <Link
                   href={back.href}
                   aria-label={`Back to ${back.label}`}
-                  className="-ml-1 flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
+                  className="-ml-1 flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-muted)] hover:bg-[var(--surface-muted)] hover:text-[var(--text)]"
                 >
                   <ArrowLeft className="size-4" />
                 </Link>
@@ -103,9 +109,16 @@ export function Navbar() {
                 : null}
               <h1 className="truncate text-sm font-semibold text-foreground">{title}</h1>
             </div>
-            <GlobalCommandBar />
-            {showNotificationCenter ? <NotificationCenter /> : null}
-            <MobileNavbarActions actions={actions} />
+
+            {/* Two clusters, not five loose controls. The quiet icons sit
+                tight together so they read as one group of tools, and the
+                page's own action is set apart from them by a wider gap —
+                which is the only spacing in the row that means anything. */}
+            <div className="flex shrink-0 items-center gap-0.5">
+              <GlobalCommandBar />
+              {showNotificationCenter ? <NotificationCenter /> : null}
+            </div>
+            <MobileNavbarActions actions={actions} className="ml-1.5" />
           </div>
 
           <div className="hidden h-14 items-center gap-3 md:flex justify-between">
@@ -146,7 +159,13 @@ export function Navbar() {
   );
 }
 
-function MobileNavbarActions({ actions }: { actions: ReactNode }) {
+function MobileNavbarActions({
+  actions,
+  className,
+}: {
+  actions: ReactNode;
+  className?: string;
+}) {
   const flattenedActions = flattenNavbarActions(actions);
 
   if (flattenedActions.length === 0) {
@@ -154,13 +173,13 @@ function MobileNavbarActions({ actions }: { actions: ReactNode }) {
   }
 
   if (flattenedActions.length === 1) {
-    return <div className="flex items-center">{flattenedActions[0]}</div>;
+    return <div className={cn("flex items-center", className)}>{flattenedActions[0]}</div>;
   }
 
   const [primaryAction, ...overflowActions] = flattenedActions;
 
   return (
-    <ButtonGroup className="shrink-0">
+    <ButtonGroup className={cn("shrink-0", className)}>
       {primaryAction}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -80,9 +80,9 @@ export function Navbar() {
           vertical line as the text below it rather than eight pixels inside
           it. That misalignment is most of what read as "inconsistent
           spacing": three different left edges down the top of every page. */}
-      <div className="h-14 px-[calc(var(--content-gutter-x)-0.5rem)] lg:pr-4">
+      <div className="h-[var(--app-bar-h)] px-[calc(var(--content-gutter-x)-0.5rem)] lg:pr-4">
         <>
-          <div className="flex h-14 items-center gap-1 md:hidden">
+          <div className="flex h-[var(--app-bar-h)] items-center gap-1 md:hidden">
             <SidebarTrigger />
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               {back ? (
@@ -120,7 +120,7 @@ export function Navbar() {
             <MobileNavbarActions actions={actions} className="ml-1.5" />
           </div>
 
-          <div className="hidden h-14 items-center gap-3 md:flex justify-between">
+          <div className="hidden h-[var(--app-bar-h)] items-center gap-3 md:flex justify-between">
             <div className="flex min-w-0 items-center gap-2">
               <SidebarTrigger />
               {back ? (

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -89,7 +89,13 @@ export function Navbar() {
                   <ArrowLeft className="size-4" />
                 </Link>
               ) : null}
-              {pageIcon
+              {/* The icon gives way to the back arrow on a phone. A record
+                  page carries both plus a primary action, and at 390px what
+                  gave way instead was the record's own name — "Tena…" where
+                  "Tenant billing portal" should be. The arrow says where you
+                  are; the icon only repeats the type the identity strip
+                  below already shows. */}
+              {pageIcon && !back
                 ? createElement(pageIcon, {
                     className: "h-4 w-4 shrink-0 text-[var(--text-muted)]",
                     "aria-hidden": true,

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -13,7 +13,6 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 
 import { getCurrentPageTitle } from "@/components/layout/breadcrumbs";
-import { ButtonGroup } from "@/components/ui/button-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -179,7 +178,18 @@ function MobileNavbarActions({
   const [primaryAction, ...overflowActions] = flattenedActions;
 
   return (
-    <ButtonGroup className={cn("shrink-0", className)}>
+    // Two controls side by side, not a segmented group.
+    // =================================================
+    // `ButtonGroup` fences its children in a bordered, clipped box with a
+    // divider between them — the right shape for a set of alternatives, and
+    // the wrong one for "do the thing" plus "everything else". It put a solid
+    // brand button and a bare icon button inside one outline, so the overflow
+    // appeared to have a second border of its own and the pair read as one
+    // control painted two colours.
+    //
+    // Loose, with the same gap the desktop bar uses, so the action row is one
+    // shape at every width.
+    <div className={cn("flex shrink-0 items-center gap-1.5", className)}>
       {primaryAction}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -200,7 +210,7 @@ function MobileNavbarActions({
           </div>
         </DropdownMenuContent>
       </DropdownMenu>
-    </ButtonGroup>
+    </div>
   );
 }
 

--- a/components/layout/offline-runtime-banner.tsx
+++ b/components/layout/offline-runtime-banner.tsx
@@ -59,43 +59,43 @@ export function OfflineRuntimeBanner() {
   return (
     <div className="border-b border-[color-mix(in_srgb,var(--edge-subtle)_78%,transparent)] bg-[color-mix(in_srgb,var(--surface-base)_95%,white)] px-4 py-3 md:px-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        {/* The chip and the step label share a line rather than stacking. This
+            band sits above the app bar on every page in the product while a
+            background download runs, and stacked it was four blocks and ~130px
+            — a third of a phone's first screen spent on something nobody is
+            waiting for. */}
         <div className="min-w-0 flex-1">
-          <div
-            style={{ "--status-chip": `var(${bannerTone.colorVar})` } as CSSProperties}
-            className="inline-flex items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--status-chip)_12%,transparent)] bg-[color-mix(in_srgb,var(--surface-muted)_82%,white)] px-3 py-1 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]"
-          >
-            <BannerIcon className={["size-3", bannerTone.iconClassName].join(" ")} />
-            {bannerTone.text}
-          </div>
-          <div className="mt-1 text-sm font-medium text-foreground">
-            {showUpdatePrompt
-              ? "A newer version is ready for this device."
-              : updateState === "activating"
-                ? "Applying the downloaded update."
-                : bootstrapProgress?.currentStepLabel ??
-                  "Preparing offline workspace."}
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <div
+              style={{ "--status-chip": `var(${bannerTone.colorVar})` } as CSSProperties}
+              className="inline-flex flex-none items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--status-chip)_12%,transparent)] bg-[color-mix(in_srgb,var(--surface-muted)_82%,white)] px-3 py-1 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]"
+            >
+              <BannerIcon className={["size-3", bannerTone.iconClassName].join(" ")} />
+              {bannerTone.text}
+            </div>
+            <div className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {showUpdatePrompt
+                ? "A newer version is ready for this device."
+                : updateState === "activating"
+                  ? "Applying the downloaded update."
+                  : bootstrapProgress?.currentStepLabel ??
+                    "Preparing offline workspace."}
+            </div>
           </div>
           {isPreparing ? (
-            <div className="mt-3 max-w-xl">
-              <div className="flex items-center gap-3">
-                <Progress
-                  value={progressValue}
-                  max={progressMax}
-                  className="h-2 flex-1 border-0 bg-[color-mix(in_srgb,var(--surface-muted)_78%,white)] shadow-none"
-                />
-                <span className="text-sm font-mono tabular-nums text-[var(--text-muted)]">
-                  {bootstrapProgress?.completedSteps ?? 0}/
-                  {bootstrapProgress?.totalSteps ?? 0}
-                </span>
-              </div>
-              <div className="mt-2 text-sm text-[var(--text-muted)]">
-                {(bootstrapProgress?.completedSteps ?? 0) ===
-                (bootstrapProgress?.totalSteps ?? 0)
-                  ? "Core offline setup is ready."
-                  : `${bootstrapProgress?.completedSteps ?? 0} of ${
-                      bootstrapProgress?.totalSteps ?? 0
-                    } setup steps ready.`}
-              </div>
+            // The fraction is the whole progress report. "12 of 45 setup steps
+            // ready" underneath it said the same thing again, in words, on a
+            // second line.
+            <div className="mt-2 flex max-w-xl items-center gap-3">
+              <Progress
+                value={progressValue}
+                max={progressMax}
+                className="h-2 flex-1 border-0 bg-[color-mix(in_srgb,var(--surface-muted)_78%,white)] shadow-none"
+              />
+              <span className="flex-none font-mono text-sm tabular-nums text-[var(--text-muted)]">
+                {bootstrapProgress?.completedSteps ?? 0}/
+                {bootstrapProgress?.totalSteps ?? 0}
+              </span>
             </div>
           ) : (
             <div className="mt-1 text-sm text-[var(--text-muted)]">

--- a/components/people/employee-wizard.tsx
+++ b/components/people/employee-wizard.tsx
@@ -1643,13 +1643,19 @@ export function EmployeeWizard({
         size="full"
         tabletBehavior="fullscreen"
         inset={false}
+        // The header below draws the close, so the popup's own is off. Both
+        // rendered before this, one on top of the other.
+        showClose={false}
         className="flex h-[100dvh] max-h-[100dvh] flex-col !rounded-none"
       >
         <div className="flex shrink-0 items-center justify-between gap-4 border-b border-[var(--edge-subtle)] px-5 py-3 sm:px-6">
           <DialogHeader className="min-w-0 flex-1">
             <DialogTitle className="text-[15px]">New employee</DialogTitle>
           </DialogHeader>
-          <DialogClose className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-muted-foreground transition-colors hover:bg-[var(--surface-soft)] hover:text-foreground">
+          <DialogClose
+            aria-label="Close"
+            className="inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-[var(--surface-subtle)] text-muted-foreground transition-colors hover:bg-[var(--surface-soft)] hover:text-foreground"
+          >
             <X className="h-4 w-4" />
           </DialogClose>
         </div>

--- a/components/preferences/organization/departments-preferences.tsx
+++ b/components/preferences/organization/departments-preferences.tsx
@@ -13,6 +13,7 @@ import {
 } from "@corelithzw/react";
 
 import { DsDataTable } from "@/components/corelith/ds-data-table";
+import { PageActions } from "@/components/layout/page-chrome";
 import { useToast } from "@/components/ui/use-toast";
 import { useReservedId } from "@/hooks/use-reserved-id";
 import {
@@ -263,6 +264,23 @@ export function DepartmentsPreferences() {
 
   return (
     <>
+      {/* The page's one verb, in the app bar — where "New person" and "New
+          item" are in the other modules. Parked in the table's controls row it
+          sat under the title, the description and the search box, about four
+          hundred pixels down a 390px screen, while the bar beside the bell was
+          empty. */}
+      <PageActions>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          startIcon={<Plus className="size-4" aria-hidden="true" />}
+          onClick={openCreateForm}
+        >
+          New department
+        </Button>
+      </PageActions>
+
       <DsDataTable
         ariaLabel="Departments"
         rows={pageRows}
@@ -272,17 +290,6 @@ export function DepartmentsPreferences() {
         searchPlaceholder="Search departments"
         onSearchChange={setSearch}
         onSearchSubmit={() => setSubmittedSearch(search)}
-        actions={
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            startIcon={<Plus className="size-4" aria-hidden="true" />}
-            onClick={openCreateForm}
-          >
-            New department
-          </Button>
-        }
         isLoading={departmentsQuery.isLoading}
         loadingLabel="Fetching departments"
         error={loadErrorMessage}

--- a/components/preferences/organization/sites-preferences.tsx
+++ b/components/preferences/organization/sites-preferences.tsx
@@ -14,6 +14,7 @@ import {
 } from "@corelithzw/react";
 
 import { DsDataTable } from "@/components/corelith/ds-data-table";
+import { PageActions } from "@/components/layout/page-chrome";
 import { useToast } from "@/components/ui/use-toast";
 import { useReservedId } from "@/hooks/use-reserved-id";
 import {
@@ -289,6 +290,21 @@ export function SitesPreferences() {
 
   return (
     <>
+      {/* The page's one verb, in the app bar — where every other module puts
+          it. In the table's controls row it sat below the title, the
+          description and the search box. */}
+      <PageActions>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          startIcon={<Plus className="size-4" aria-hidden="true" />}
+          onClick={openCreateForm}
+        >
+          New site
+        </Button>
+      </PageActions>
+
       <DsDataTable
         ariaLabel="Sites"
         rows={pageRows}
@@ -298,17 +314,6 @@ export function SitesPreferences() {
         searchPlaceholder="Search sites"
         onSearchChange={setSearch}
         onSearchSubmit={() => setSubmittedSearch(search)}
-        actions={
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            startIcon={<Plus className="size-4" aria-hidden="true" />}
-            onClick={openCreateForm}
-          >
-            New site
-          </Button>
-        }
         isLoading={sitesQuery.isLoading}
         loadingLabel="Fetching sites"
         error={loadErrorMessage}

--- a/components/preferences/organization/users-preferences.tsx
+++ b/components/preferences/organization/users-preferences.tsx
@@ -16,6 +16,7 @@ import {
 } from "@corelithzw/react";
 
 import { DsDataTable } from "@/components/corelith/ds-data-table";
+import { PageActions } from "@/components/layout/page-chrome";
 import { useToast } from "@/components/ui/use-toast";
 import { getApiErrorMessage } from "@/lib/api-client";
 import { getAllowedUserRoleOptionsForWorkspace } from "@/lib/platform/vertical-roles";
@@ -373,6 +374,23 @@ export function UsersPreferences() {
         </Alert>
       ) : null}
 
+      {/* Only for somebody who can actually create one: a manager browsing a
+          read-only directory gets a bar with nothing in it rather than a
+          button that refuses. */}
+      {canMutate ? (
+        <PageActions>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            startIcon={<Plus className="size-4" aria-hidden="true" />}
+            onClick={() => setCreateOpen(true)}
+          >
+            New user
+          </Button>
+        </PageActions>
+      ) : null}
+
       <DsDataTable
         ariaLabel="Users"
         rows={users}
@@ -406,19 +424,6 @@ export function UsersPreferences() {
               <option value="INACTIVE">Inactive</option>
             </Select>
           </div>
-        }
-        actions={
-          canMutate ? (
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              startIcon={<Plus className="size-4" aria-hidden="true" />}
-              onClick={() => setCreateOpen(true)}
-            >
-              New user
-            </Button>
-          ) : null
         }
         isLoading={usersQuery.isLoading}
         loadingLabel="Fetching users"

--- a/components/preferences/preferences-shell.tsx
+++ b/components/preferences/preferences-shell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { PageHeader } from "@corelithzw/react";
 
+import { NavRail } from "@/components/ui/nav-rail";
 import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 
 import {
@@ -88,7 +89,13 @@ export function PreferencesShell({
 
   return (
     <div className="settings-layout container mx-auto w-full">
-      <aside className="settings-rail" aria-label="Preferences navigation">
+      {/* Same trade as the management shell: a rail beside the content on a
+          desktop, a scrolling strip above it on a phone. */}
+      <NavRail
+        className="settings-rail"
+        label="Preferences navigation"
+        orientation="responsive"
+      >
         <NavGroup label="Account">
           {renderNavItems(accountItems, pathname)}
         </NavGroup>
@@ -97,7 +104,7 @@ export function PreferencesShell({
             {renderNavItems(organizationItems, pathname)}
           </NavGroup>
         ) : null}
-      </aside>
+      </NavRail>
 
       <main className="settings-content">
         <PageHeader title={title} primaryAction={actions} />

--- a/components/preferences/preferences-shell.tsx
+++ b/components/preferences/preferences-shell.tsx
@@ -3,8 +3,7 @@
 import * as React from "react";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { PageHeader } from "@corelithzw/react";
-
+import { PageChrome } from "@/components/layout/page-chrome";
 import { NavRail } from "@/components/ui/nav-rail";
 import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 
@@ -106,8 +105,13 @@ export function PreferencesShell({
         ) : null}
       </NavRail>
 
+      {/* Title and actions to the app bar, the same as the management shell
+          and every module beside it. Drawn in the page, the title was the
+          second copy of a word the bar was already showing, and it cost about
+          a hundred and ten pixels of a 844px screen to say it again. */}
+      <PageChrome title={title}>{actions}</PageChrome>
+
       <main className="settings-content">
-        <PageHeader title={title} primaryAction={actions} />
         {description ? (
           <p className="t-body t-muted max-w-[var(--content-max)]">
             {description}

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -164,7 +164,13 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
         type="button"
         onClick={() => setDraft(attribute.value ?? "")}
         className={cn(
-          "-mx-1.5 flex min-h-9 w-full items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)] sm:min-h-0",
+          // `block` and `break-words`, not `flex items-center`. A flex child
+          // will not wrap, so an email address longer than the value column —
+          // which at 390px is about 200px — ran off the right edge of the
+          // screen with no ellipsis and no way to read the rest of it. A
+          // property that cannot be read is worse than one that takes two
+          // lines.
+          "-mx-1.5 block min-h-9 w-full rounded-[var(--radius-sm)] px-1.5 py-1 text-left text-sm break-words hover:bg-[var(--surface-subtle)] sm:min-h-0",
           attribute.mono && "font-mono",
           !attribute.value && "text-[var(--text-muted)]",
         )}
@@ -179,7 +185,10 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
       autoFocus
       value={draft}
       aria-label={attribute.label}
-      className="h-7"
+      // Full width of the value column and no wider: the input inherited a
+      // default width that overflowed the row on a phone, so the field you
+      // were typing into was cut off by the edge of the screen.
+      className="h-8 w-full"
       onChange={(event) => setDraft(event.target.value)}
       onBlur={() => {
         if (draft !== (attribute.value ?? "")) attribute.onCommit?.(draft);
@@ -219,10 +228,21 @@ export function RecordAttributes({
         {shown.map((attribute) => {
           const Icon = attribute.icon;
           return (
-            <div key={attribute.id} className="flex items-center gap-3 py-0.5">
-              <dt className="flex w-36 shrink-0 items-center gap-1.5 text-sm text-[var(--text-muted)]">
-                {Icon ? <Icon className="size-4" aria-hidden="true" /> : null}
-                <span className="truncate">{attribute.label}</span>
+            // `items-start`, not `items-center`: a value that wraps to two
+            // lines should hang off its label, not push the label into the
+            // middle of it.
+            <div key={attribute.id} className="flex items-start gap-3 py-0.5">
+              {/* Narrower on a phone. A 144px label column out of the ~358px a
+                  390px screen has left barely 200px for the value, which is
+                  what pushed emails, company names and the pickers beside them
+                  off the right edge. */}
+              <dt className="flex w-28 shrink-0 items-start gap-1.5 py-1 text-sm text-[var(--text-muted)] sm:w-36">
+                {Icon ? <Icon className="mt-0.5 size-4 shrink-0" aria-hidden="true" /> : null}
+                {/* Wraps rather than truncates. In a 112px column "Primary
+                    contact" became "Primary cont…", which is a label somebody
+                    has to guess at — and a label is the half of the row that
+                    has to be readable for the other half to mean anything. */}
+                <span className="min-w-0">{attribute.label}</span>
               </dt>
               <dd className="min-w-0 flex-1">
                 {/* Which editor a row gets is decided here, from the shape of

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -42,6 +42,12 @@ export type RecordAttribute = {
   display?: ReactNode;
   /** For a plain value somebody can retype in place. */
   value?: string | null;
+  /**
+   * What the closed row reads as, when the stored value is not what a reader
+   * wants to see: "USD 9,800" over a bare `9800`. Editing still opens on
+   * `value`, so what you type is what gets stored.
+   */
+  formatted?: string | null;
   onCommit?: (value: string) => void;
   /**
    * The row is a choice rather than free text: an owner, a status, a stage,
@@ -133,6 +139,7 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
 
 function EditableValue({ attribute }: { attribute: RecordAttribute }) {
   const [draft, setDraft] = useState<string | null>(null);
+  const shown = attribute.formatted ?? attribute.value;
 
   if (!attribute.onCommit) {
     return (
@@ -143,7 +150,7 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
           !attribute.value && "text-[var(--text-muted)]",
         )}
       >
-        {attribute.value || attribute.placeholder || "—"}
+        {shown || attribute.placeholder || "—"}
       </span>
     );
   }
@@ -159,7 +166,7 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
           !attribute.value && "text-[var(--text-muted)]",
         )}
       >
-        {attribute.value || attribute.placeholder || "Empty"}
+        {shown || attribute.placeholder || "Empty"}
       </button>
     );
   }

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -241,8 +241,12 @@ export function RecordAttributes({
   const hidden = attributes.length - shown.length;
 
   return (
-    <div className={cn("space-y-0.5", className)}>
-      <dl className="grid gap-x-6 gap-y-0.5 sm:grid-cols-2">
+    // Sized to the column it is in, not to the window. This list renders full
+    // width under the identity strip on a phone and inside a 320px standing
+    // column on a desktop; keyed to the viewport, the desktop case put two
+    // columns inside 320px and "USD 9,100.00" came out one character per line.
+    <div className={cn("@container space-y-0.5", className)}>
+      <dl className="grid gap-x-6 gap-y-0.5 @md:grid-cols-2">
         {shown.map((attribute) => {
           const Icon = attribute.icon;
           return (
@@ -256,7 +260,7 @@ export function RecordAttributes({
                   off the right edge. */}
               <dt
                 className={cn(
-                  "flex w-28 shrink-0 items-start gap-2 text-[var(--text-muted)] sm:w-36",
+                  "flex w-28 shrink-0 items-start gap-2 text-[var(--text-muted)] @md:w-36",
                   ATTRIBUTE_ROW,
                 )}
               >

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -23,6 +23,23 @@ import { cn } from "@/lib/utils";
  * else either.
  */
 
+/**
+ * The line box every half of a property row sits in.
+ *
+ * The label carried `py-1`, the value control carried `py-1` *and* `min-h-9`,
+ * and the icon carried a `mt-0.5` picked to look right against neither. So the
+ * three parts of a row each started at a different height and the row read as
+ * crooked — most visible where a label wrapped to two lines and its value
+ * floated somewhere near the middle.
+ *
+ * One constant, used by the label, by all three value renderers and by
+ * `RelationAttribute` next door, so they cannot drift apart again. The padding
+ * is what makes the touch target on a phone (20px line + 16px = 36px); it is
+ * not a `min-height`, because a min-height centres text in a box the label does
+ * not share and puts the two sides back out of line.
+ */
+export const ATTRIBUTE_ROW = "py-2 text-sm leading-5 sm:py-1";
+
 export type RecordAttributeOption = {
   value: string;
   label: string;
@@ -88,9 +105,8 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
         <button
           type="button"
           className={cn(
-            // `min-h-9` on a phone: this is the control you press to change
-            // the property, and a 20px line of text is not a touch target.
-            "-mx-1.5 flex min-h-9 w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)] sm:min-h-0",
+            "-mx-1.5 flex w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-1.5 text-left hover:bg-[var(--surface-subtle)]",
+            ATTRIBUTE_ROW,
             !current && "text-[var(--text-muted)]",
           )}
         >
@@ -148,7 +164,8 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
     return (
       <span
         className={cn(
-          "text-sm",
+          "block break-words",
+          ATTRIBUTE_ROW,
           attribute.mono && "font-mono",
           !attribute.value && "text-[var(--text-muted)]",
         )}
@@ -170,7 +187,8 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
           // screen with no ellipsis and no way to read the rest of it. A
           // property that cannot be read is worse than one that takes two
           // lines.
-          "-mx-1.5 block min-h-9 w-full rounded-[var(--radius-sm)] px-1.5 py-1 text-left text-sm break-words hover:bg-[var(--surface-subtle)] sm:min-h-0",
+          "-mx-1.5 block w-full rounded-[var(--radius-sm)] px-1.5 text-left break-words hover:bg-[var(--surface-subtle)]",
+          ATTRIBUTE_ROW,
           attribute.mono && "font-mono",
           !attribute.value && "text-[var(--text-muted)]",
         )}
@@ -231,13 +249,21 @@ export function RecordAttributes({
             // `items-start`, not `items-center`: a value that wraps to two
             // lines should hang off its label, not push the label into the
             // middle of it.
-            <div key={attribute.id} className="flex items-start gap-3 py-0.5">
+            <div key={attribute.id} className="flex items-start gap-3">
               {/* Narrower on a phone. A 144px label column out of the ~358px a
                   390px screen has left barely 200px for the value, which is
                   what pushed emails, company names and the pickers beside them
                   off the right edge. */}
-              <dt className="flex w-28 shrink-0 items-start gap-1.5 py-1 text-sm text-[var(--text-muted)] sm:w-36">
-                {Icon ? <Icon className="mt-0.5 size-4 shrink-0" aria-hidden="true" /> : null}
+              <dt
+                className={cn(
+                  "flex w-28 shrink-0 items-start gap-2 text-[var(--text-muted)] sm:w-36",
+                  ATTRIBUTE_ROW,
+                )}
+              >
+                {/* `mt-px` against a 20px line box, which is where the optical
+                    centre of a 16px glyph actually falls — the old `mt-0.5`
+                    was tuned against a line box the value no longer uses. */}
+                {Icon ? <Icon className="mt-px size-4 shrink-0" aria-hidden="true" /> : null}
                 {/* Wraps rather than truncates. In a 112px column "Primary
                     contact" became "Primary cont…", which is a label somebody
                     has to guess at — and a label is the half of the row that

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -4,7 +4,7 @@ import { useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ResponsivePopover } from "@/components/ui/responsive-popover";
 import { Check, ChevronDown, ChevronRight, type LucideIcon } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
@@ -74,12 +74,23 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
   const current = options.find((option) => option.value === (attribute.value ?? ""));
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    // A popover beside the value on a desktop; on a phone the same options
+    // come up from the bottom edge under the property's own name. The trigger
+    // sits in the right-hand column of a two-column list, so a panel anchored
+    // to it at 390px had nowhere to go but over the properties above it.
+    <ResponsivePopover
+      open={open}
+      onOpenChange={setOpen}
+      title={attribute.label}
+      align="start"
+      className="w-[min(15rem,calc(100vw-2rem))] p-1"
+      trigger={
         <button
           type="button"
           className={cn(
-            "-mx-1.5 flex w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)]",
+            // `min-h-9` on a phone: this is the control you press to change
+            // the property, and a 20px line of text is not a touch target.
+            "-mx-1.5 flex min-h-9 w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)] sm:min-h-0",
             !current && "text-[var(--text-muted)]",
           )}
         >
@@ -89,16 +100,9 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
             </span>
           )}
         </button>
-      </PopoverTrigger>
-      {/* The trigger sits in the right-hand column of the property list, so a
-          fixed 240px panel aligned to its start runs off a 390px screen.
-          Bounded by the viewport, and told to keep clear of the edges. */}
-      <PopoverContent
-        align="start"
-        collisionPadding={12}
-        className="w-[min(15rem,calc(100vw-2rem))] p-1"
-      >
-        <div className="max-h-72 overflow-y-auto">
+      }
+    >
+        <div className="overflow-y-auto sm:max-h-72">
           {options.map((option) => (
             <button
               key={option.value}
@@ -108,7 +112,7 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
                 setOpen(false);
               }}
               className={cn(
-                "flex min-h-9 w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 text-left text-sm hover:bg-[var(--surface-hover)]",
+                "flex min-h-11 w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 text-left text-sm hover:bg-[var(--surface-hover)] sm:min-h-9",
                 option.value === attribute.value && "font-medium",
               )}
             >
@@ -126,14 +130,13 @@ function ChoiceValue({ attribute }: { attribute: RecordAttribute }) {
                 attribute.onCommit?.("");
                 setOpen(false);
               }}
-              className="flex min-h-9 w-full items-center rounded-[var(--radius-sm)] px-2 text-left text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)]"
+              className="flex min-h-11 w-full items-center rounded-[var(--radius-sm)] px-2 text-left text-sm text-[var(--text-muted)] hover:bg-[var(--surface-hover)] sm:min-h-9"
             >
               {attribute.clearLabel}
             </button>
           ) : null}
         </div>
-      </PopoverContent>
-    </Popover>
+    </ResponsivePopover>
   );
 }
 
@@ -161,7 +164,7 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
         type="button"
         onClick={() => setDraft(attribute.value ?? "")}
         className={cn(
-          "-mx-1.5 w-full rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)]",
+          "-mx-1.5 flex min-h-9 w-full items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-left text-sm hover:bg-[var(--surface-subtle)] sm:min-h-0",
           attribute.mono && "font-mono",
           !attribute.value && "text-[var(--text-muted)]",
         )}

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -7,7 +7,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 
 import { Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
-import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
+import { NavRail, NavRailItem } from "@/components/ui/nav-rail";
 import { StatusChip } from "@/components/ui/status-chip";
 import {
   DropdownMenu,
@@ -18,7 +18,7 @@ import {
 import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { ChevronRight, DotsThree, type LucideIcon } from "@/lib/icons";
+import { DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { cn } from "@/lib/utils";
 
@@ -29,7 +29,7 @@ export type RecordTab = {
   value: string;
   label: string;
   count?: number;
-  /** The section's mark, shown in the strip and in the phone's section list. */
+  /** The section's mark, shown in the rail at every width. */
   icon?: LucideIcon;
   /**
    * Something in here wants looking at — an unread comment, an overdue task,
@@ -69,13 +69,13 @@ export type RecordAction = {
  * paint is correct — the alternative is `matchMedia`, which has no answer
  * before hydration and paints the desktop shape on a phone for a frame.
  *
- * ## A phone drills in; a desktop switches tabs
+ * ## The sections are a rail, and a phone drills into one
  *
- * Nine sections is not a tab strip at 390px; it is a strip you scroll sideways
- * hunting for a word. So the phone gets what the sections actually are — a
- * list, with the mark, the count and whether anything needs attention — and
- * opening one fills the page. The strip is still a strip where there is room
- * for it. Both read the same URL, so neither is a separate mode.
+ * Thirteen sections is not a tab strip: it wrapped onto two rows at 1440px and
+ * had to be scrolled sideways at 390px. They are a vertical rail — the one the
+ * back office already uses — beside the section on a desktop, and the same rail
+ * at the foot of the landing view on a phone, where tapping a row opens that
+ * section full-width. Both read the same URL, so neither is a separate mode.
  */
 export function RecordPageShell({
   backHref,
@@ -177,6 +177,61 @@ export function RecordPageShell({
   const currentTab = openSection
     ? visibleTabs.find((tab) => tab.value === openSection)
     : landingTab;
+
+  /**
+   * The sections, as one vertical rail at every width.
+   *
+   * They were a horizontal strip, which is the wrong shape for this many:
+   * thirteen sections wrapped onto two rows on a 1440px desktop and had to be
+   * scrolled sideways on a phone. A segmented control — the grammar the
+   * activity composer uses for Note / Call / Email — is right for three or
+   * four peers in a fixed track and cannot hold thirteen; its columns are
+   * equal-width by construction.
+   *
+   * So the rail the back office already uses for exactly this problem: a
+   * column of 36px rows with the mark, the name and the count. On a desktop it
+   * sits to the left of the section. On a phone it is the same rail at the
+   * foot of the landing view, and tapping a row opens that section full-width.
+   * One component, one grammar, two placements.
+   */
+  const sectionRail = (
+    <NavRail label={`${title} sections`}>
+      {visibleTabs.map((tab) => {
+        const Icon = tab.icon;
+        return (
+          <NavRailItem
+            key={tab.value}
+            to={tab.value === landingTab?.value ? recordHref : sectionHref(tab.value)}
+            active={tab.value === currentTab?.value}
+            icon={Icon ? <Icon className="size-4" aria-hidden="true" /> : undefined}
+            // A zero is not a count — it is a column of grey noise. Only a
+            // section with something in it says how much.
+            count={tab.count && tab.count > 0 ? tab.count : undefined}
+            trailing={
+              tab.attention ? (
+                <span
+                  aria-label="Needs attention"
+                  className="size-1.5 rounded-full bg-[var(--action-primary-bg)]"
+                />
+              ) : undefined
+            }
+          >
+            {tab.label}
+          </NavRailItem>
+        );
+      })}
+    </NavRail>
+  );
+
+  // One column on a phone; rail plus section from `md`; and the summary takes
+  // a third from `lg`, which is where `.detail-grid` already stopped crushing
+  // the content column.
+  const sectionGrid = cn(
+    "min-w-0 md:grid md:gap-6",
+    visibleTabs.length > 1 ? "md:grid-cols-[13rem_minmax(0,1fr)]" : "md:grid-cols-1",
+    rail && visibleTabs.length > 1 && "lg:grid-cols-[13rem_minmax(0,1fr)_20rem]",
+    rail && visibleTabs.length <= 1 && "lg:grid-cols-[minmax(0,1fr)_20rem]",
+  );
 
   // And the other direction: the URL is the source of truth, so a page holding
   // its own `tab` state — the lead's billing panel jumps to Documents, the
@@ -315,42 +370,13 @@ export function RecordPageShell({
 
           {beforeTabs}
 
-          <div className={rail ? "detail-grid" : "min-w-0"}>
-            <div className="min-w-0 space-y-4">
-              {/* The strip, where there is room for one. Below `md` the same
-                  sections are a list further down the page, so this is hidden
-                  in CSS rather than by a media query hook — a hook has no
-                  answer before hydration and would paint a nine-item strip on
-                  a phone for a frame. */}
-              {visibleTabs.length > 1 ? (
-                // `.section-tabs` scrolls sideways on its own; wrapping it in
-                // another scroller made it wrap onto a second row instead.
-                <div className="hidden max-w-full md:block">
-                  <SectionTabs label={`${title} sections`}>
-                    {visibleTabs.map((tab) => (
-                      <SectionTab
-                        key={tab.value}
-                        to={tab.value === landingTab?.value ? recordHref : sectionHref(tab.value)}
-                        active={tab.value === currentTab?.value}
-                        icon={tab.icon ? <tab.icon aria-hidden="true" /> : undefined}
-                        // A zero is not a count, it is nine grey pills saying
-                        // nothing. Only a section with something in it says
-                        // how much.
-                        count={tab.count && tab.count > 0 ? tab.count : undefined}
-                      >
-                        {tab.label}
-                        {tab.attention ? (
-                          <span
-                            aria-label="Needs attention"
-                            className="ml-1 inline-block size-1.5 rounded-full bg-[var(--action-primary-bg)] align-middle"
-                          />
-                        ) : null}
-                      </SectionTab>
-                    ))}
-                  </SectionTabs>
-                </div>
-              ) : null}
+          <div className={sectionGrid}>
+            {/* The sections, on the left, where the back office puts them. */}
+            {visibleTabs.length > 1 ? (
+              <aside className="hidden md:block">{sectionRail}</aside>
+            ) : null}
 
+            <div className="min-w-0 space-y-4">
               {/* The summary, above the story, in one view.
                   ==========================================
                   The rail used to become a tab of its own called "Overview",
@@ -362,48 +388,13 @@ export function RecordPageShell({
 
               <div className="min-w-0">{landingTab?.content}</div>
 
-              {/* Every other section, as a list. */}
+              {/* The same rail, at the foot of the landing view, where a phone
+                  has no column to put it in. One component either way, so a
+                  section reads the same whichever width you meet it at. */}
               {visibleTabs.length > 1 ? (
-                <nav aria-label="Record sections" className="md:hidden">
-                  <ul className="divide-y divide-[var(--border-subtle)] border-y border-[var(--border-subtle)]">
-                    {visibleTabs.slice(1).map((tab) => {
-                      const Icon = tab.icon;
-                      return (
-                        <li key={tab.value}>
-                          <Link
-                            href={sectionHref(tab.value)}
-                            className="flex min-h-12 items-center gap-3 py-2.5 text-sm hover:bg-[var(--surface-hover)]"
-                          >
-                            {Icon ? (
-                              <Icon
-                                className="size-4 shrink-0 text-[var(--text-subtle)]"
-                                aria-hidden="true"
-                              />
-                            ) : null}
-                            <span className="min-w-0 flex-1 truncate text-[var(--text-strong)]">
-                              {tab.label}
-                            </span>
-                            {tab.attention ? (
-                              <span
-                                aria-label="Needs attention"
-                                className="size-1.5 shrink-0 rounded-full bg-[var(--action-primary-bg)]"
-                              />
-                            ) : null}
-                            {tab.count && tab.count > 0 ? (
-                              <span className="shrink-0 font-mono text-sm text-[var(--text-muted)]">
-                                {tab.count}
-                              </span>
-                            ) : null}
-                            <ChevronRight
-                              className="size-4 shrink-0 text-[var(--text-subtle)]"
-                              aria-hidden="true"
-                            />
-                          </Link>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </nav>
+                <div className="border-t border-[var(--border-subtle)] pt-4 md:hidden">
+                  {sectionRail}
+                </div>
               ) : null}
             </div>
 

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -18,12 +18,15 @@ import {
 import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { DotsThree, type LucideIcon } from "@/lib/icons";
+import { ChevronLeftIcon, ChevronRight, DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { cn } from "@/lib/utils";
 
 /** The query parameter that says which section of a record is open. */
 const SECTION_PARAM = "section";
+
+/** Where the standing column's open state is remembered. */
+const INFO_COLUMN_KEY = "record-info-column";
 
 export type RecordTab = {
   value: string;
@@ -130,6 +133,25 @@ export function RecordPageShell({
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  /**
+   * Whether the standing column is open, remembered across records.
+   *
+   * Read in an effect rather than during render: `localStorage` does not exist
+   * on the server, and seeding state from it directly is a hydration mismatch.
+   * Open is the honest default — a reader who has never collapsed it should see
+   * what the record is.
+   */
+  const [infoOpen, setInfoOpen] = useState(true);
+  useEffect(() => {
+    setInfoOpen(window.localStorage.getItem(INFO_COLUMN_KEY) !== "closed");
+  }, []);
+  const toggleInfo = () => {
+    setInfoOpen((open) => {
+      window.localStorage.setItem(INFO_COLUMN_KEY, open ? "closed" : "open");
+      return !open;
+    });
+  };
   // The width at which the app bar switches to its phone row and stops having
   // room for the record's name. Only ever used for chrome the bar itself owns.
   const narrow = useIsMobile();
@@ -178,6 +200,16 @@ export function RecordPageShell({
     ? visibleTabs.find((tab) => tab.value === openSection)
     : landingTab;
 
+  // The URL is the source of truth, so a page holding its own `tab` state — the
+  // lead's billing panel jumps to Documents, the deal's stage bar reads which
+  // section is open — is told when it changes. The push effect above bails when
+  // the two already agree, so this cannot ping-pong with it.
+  const currentValue = currentTab?.value;
+  useEffect(() => {
+    if (currentValue && currentValue !== activeTab) onTabChange(currentValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentValue]);
+
   /**
    * The sections, as one vertical rail at every width.
    *
@@ -223,31 +255,76 @@ export function RecordPageShell({
     </NavRail>
   );
 
-  // The right column carries the properties and the summary, so it is worth a
-  // column whenever there is either.
-  const hasRightColumn = Boolean(rail || attributes);
-  const hasSectionRail = visibleTabs.length > 1;
+  /**
+   * Everything the record *is*, in one column.
+   *
+   * The mark, the name, the reference, the status, the one line that says what
+   * this is, the properties, and whatever summary the page supplies. All of it
+   * used to be a band stretched across the top of the page, between the app bar
+   * and the columns — which meant the identity of the record scrolled away the
+   * moment you started reading a section, and the widest thing on the page was
+   * a status chip with three centimetres of nothing beside it.
+   *
+   * Gathered into the standing column it is in view the whole time, and the
+   * band is gone, so a section starts where the page starts.
+   */
+  // Held lowercase and rendered through the binding, the way the sidebar does
+  // it: a capitalised name assigned from a prop reads to the lint rule as a
+  // component defined during render.
+  const RecordIcon = icon;
 
-  // One column on a phone; sections plus content from `md`; and the standing
-  // column from `lg`, which is where `.detail-grid` already stopped crushing
-  // the middle.
-  const sectionGrid = cn(
-    "min-w-0 md:grid md:gap-6",
-    hasSectionRail ? "md:grid-cols-[13rem_minmax(0,1fr)]" : "md:grid-cols-1",
-    hasRightColumn && hasSectionRail && "lg:grid-cols-[13rem_minmax(0,1fr)_20rem]",
-    hasRightColumn && !hasSectionRail && "lg:grid-cols-[minmax(0,1fr)_20rem]",
+  const infoColumn = (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <div className="flex items-start gap-2.5">
+          {leading ? (
+            <span className="flex-none">{leading}</span>
+          ) : RecordIcon ? (
+            <span className="mt-0.5 flex size-8 flex-none items-center justify-center rounded-[var(--radius-sm)] bg-[var(--surface-muted)] text-[var(--text-muted)]">
+              <RecordIcon className="size-4" aria-hidden="true" />
+            </span>
+          ) : null}
+
+          <div className="min-w-0 flex-1">
+            <h2 className="text-base font-semibold leading-snug text-[var(--text-strong)]">
+              {title}
+            </h2>
+            {reference ? (
+              <p className="font-mono text-sm text-[var(--text-muted)]">{reference}</p>
+            ) : null}
+          </div>
+        </div>
+
+        {status ? <StatusChip status={status.status} label={status.label} /> : null}
+
+        {subtitle ? (
+          <p className="text-sm text-[var(--text-muted)]">{subtitle}</p>
+        ) : null}
+      </div>
+
+      {attributes ? (
+        <div className="border-t border-[var(--border-subtle)] pt-4">{attributes}</div>
+      ) : null}
+
+      {beforeTabs ? (
+        <div className="border-t border-[var(--border-subtle)] pt-4">{beforeTabs}</div>
+      ) : null}
+
+      {rail ? <div className="space-y-7 border-t border-[var(--border-subtle)] pt-4">{rail}</div> : null}
+    </div>
   );
 
-  // And the other direction: the URL is the source of truth, so a page holding
-  // its own `tab` state — the lead's billing panel jumps to Documents, the
-  // deal's stage bar reads which section is open — is told when it changes.
-  // The push effect above bails when the two already agree, so this cannot
-  // ping-pong with it.
-  const currentValue = currentTab?.value;
-  useEffect(() => {
-    if (currentValue && currentValue !== activeTab) onTabChange(currentValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentValue]);
+  const hasSectionRail = visibleTabs.length > 1;
+
+  // Columns, and the dividers between them. No gap: the rule *is* the gap, and
+  // the padding either side of it is what keeps the columns off it.
+  const sectionGrid = cn(
+    "min-w-0 md:grid",
+    hasSectionRail && !infoOpen && "md:grid-cols-[13rem_minmax(0,1fr)_auto]",
+    hasSectionRail && infoOpen && "md:grid-cols-[13rem_minmax(0,1fr)] lg:grid-cols-[13rem_minmax(0,1fr)_22rem]",
+    !hasSectionRail && !infoOpen && "md:grid-cols-[minmax(0,1fr)_auto]",
+    !hasSectionRail && infoOpen && "md:grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem]",
+  );
 
   /**
    * The record's actions, in the top app bar.
@@ -319,74 +396,49 @@ export function RecordPageShell({
 
   return (
     <div className="space-y-4">
-      {/* Drilled into a section, "up" is the record — not the list it came
-          from. Getting that wrong is what makes a phone drilldown feel like a
-          trapdoor: you open Documents, press back, and you are in the leads
-          list with the record gone. */}
-      {/* The bar keeps saying which *record* you are in, at every depth —
-          losing that is how a drilldown stops feeling like part of the record
-          and starts feeling like a separate page. The section names itself on
-          the page below. */}
+      {/* Drilled into a section on a phone, "up" is the record — not the list
+          it came from. Getting that wrong is what makes a drilldown feel like
+          a trapdoor: you open Documents, press back, and you are in the leads
+          list with the record gone.
+
+          Only on a phone, though. A desktop never leaves the record — the
+          rail and the section sit side by side — so "up" stays the list, and
+          pointing it at the record would put the record's name in the bar
+          twice, once as the back link and once as the title. */}
       <PageChrome
         title={title}
         icon={icon}
-        backHref={openSection ? recordHref : backHref}
-        backLabel={openSection ? title : backLabel}
+        backHref={openSection && narrow ? recordHref : backHref}
+        backLabel={openSection && narrow ? title : backLabel}
       >
         {barActions}
       </PageChrome>
 
-      {/* The record's frame, at every depth.
-          =====================================
-          Opening a section used to replace the whole page — right for a phone,
-          where a drilldown *is* the page, and wrong for a desktop, which lost
-          its section rail and its properties the moment you clicked one of
-          them. The frame is always rendered now and the phone hides the parts
-          it does not want, in CSS, so the first paint is right at both widths.
-          Only the middle column changes. */}
-      <div className={openSection ? "hidden space-y-4 md:block" : "space-y-4"}>
-        {/* The record's name, on a phone.
-            ================================
-            It lives in the top app bar, which on a 390px screen is holding a
-            back arrow, a search icon, a bell and a primary action as well —
-            so the name truncated to "Tenant b…" and appeared nowhere else on
-            the page. The strip below carries the reference and the status;
-            on a phone it carries the name too, at the size a page title
-            reads. */}
-        {narrow ? (
-          <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
-        ) : null}
-
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          {leading ? <span className="flex-none">{leading}</span> : null}
-
-          {reference ? (
-            <span className="font-mono text-sm text-[var(--text-muted)]">{reference}</span>
-          ) : null}
-          {status ? <StatusChip status={status.status} label={status.label} /> : null}
-          {subtitle ? (
-            <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
-          ) : null}
-        </div>
-
-        {/* Properties are the right column's job from `lg` up, where they can
-            stay in view while you read a section. Below that there is no third
-            column, so they sit here, full width, the way Notion puts them at
-            the top of a page. */}
-        {attributes ? (
-          <div className="border-y border-[var(--border-subtle)] py-3 lg:hidden">{attributes}</div>
-        ) : null}
-
-        {beforeTabs}
-      </div>
-
+      {/* Everything about the record lives in the standing column now, so
+          there is no band between the app bar and the columns to render — a
+          section starts where the page starts. On a phone there is no third
+          column, so the same content leads the landing view. */}
       <div className={sectionGrid}>
-        {/* The sections, on the left, where the back office puts them. */}
-        {visibleTabs.length > 1 ? (
-          <aside className="hidden md:block">{sectionRail}</aside>
+        {/* The sections. Sticky, because a rail you have to scroll back up to
+            reach is a rail you stop using on a long timeline. */}
+        {hasSectionRail ? (
+          <aside className="hidden md:block">
+            <div className="sticky top-0 pr-5">{sectionRail}</div>
+          </aside>
         ) : null}
 
-        <div className="min-w-0 space-y-4">
+        <div
+          className={cn(
+            "min-w-0 space-y-4",
+            // The rule between columns, and the room either side of it.
+            hasSectionRail && "md:border-l md:border-[var(--border-subtle)] md:pl-5",
+            infoOpen && "lg:pr-5",
+          )}
+        >
+          {/* The record, at the head of the landing view, where a phone has no
+              column to stand it in. */}
+          {!openSection ? <div className="lg:hidden">{infoColumn}</div> : null}
+
           {/* Drilled in on a phone, the section names itself — the bar is
               still carrying the record's name. */}
           {openSection ? (
@@ -395,35 +447,42 @@ export function RecordPageShell({
             </h2>
           ) : null}
 
-          {/* The summary, above the story, in one view.
-              ==========================================
-              The rail used to become a tab of its own called "Overview",
-              which a phone landed on — so a record opened on a summary and
-              the thing that had actually happened to it was one tap away,
-              behind a word. They are one reading now: what this record is
-              worth and what is next, then what has happened. */}
-          {rail && !openSection ? <div className="space-y-7 lg:hidden">{rail}</div> : null}
-
           <div className="min-w-0">{currentTab?.content}</div>
 
           {/* The same rail, at the foot of the landing view, where a phone
               has no column to put it in. One component either way, so a
               section reads the same whichever width you meet it at. */}
-          {visibleTabs.length > 1 && !openSection ? (
+          {hasSectionRail && !openSection ? (
             <div className="border-t border-[var(--border-subtle)] pt-4 md:hidden">
               {sectionRail}
             </div>
           ) : null}
         </div>
 
-        {/* The column that never changes: what this record *is*, and what it
-            is worth, beside whichever section is being read. */}
-        {hasRightColumn ? (
-          <aside className="hidden space-y-7 lg:block">
-            {attributes ? <div>{attributes}</div> : null}
-            {rail}
+        {/* The standing column: what this record is, and what it is worth,
+            beside whichever section is being read. Collapsible, because a
+            reader working through a long document list wants the width — and
+            sticky, so it is still there when they scroll back to the top. */}
+        {infoOpen ? (
+          <aside className="hidden border-l border-[var(--border-subtle)] pl-5 lg:block">
+            <div className="sticky top-0 space-y-4">
+              <div className="flex justify-end">
+                <IconButton aria-label="Hide record details" onClick={toggleInfo}>
+                  <ChevronRight />
+                </IconButton>
+              </div>
+              {infoColumn}
+            </div>
           </aside>
-        ) : null}
+        ) : (
+          <aside className="hidden border-l border-[var(--border-subtle)] pl-2 lg:block">
+            <div className="sticky top-0">
+              <IconButton aria-label="Show record details" onClick={toggleInfo}>
+                <ChevronLeftIcon />
+              </IconButton>
+            </div>
+          </aside>
+        )}
       </div>
 
       {children}

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 
-import { useIsBelow, useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger, Stack } from "@corelithzw/react";
+import { Stack } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
+import { SectionTab, SectionTabs } from "@/components/ui/section-tabs";
 import { StatusChip } from "@/components/ui/status-chip";
 import {
   DropdownMenu,
@@ -16,17 +17,26 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
-import { DotsThree, type LucideIcon } from "@/lib/icons";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { ChevronRight, DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { cn } from "@/lib/utils";
 
-/** The synthetic tab the rail becomes when there is no room beside the content. */
-const OVERVIEW_TAB = "overview";
+/** The query parameter that says which section of a record is open. */
+const SECTION_PARAM = "section";
 
 export type RecordTab = {
   value: string;
   label: string;
   count?: number;
+  /** The section's mark, shown in the strip and in the phone's section list. */
+  icon?: LucideIcon;
+  /**
+   * Something in here wants looking at — an unread comment, an overdue task,
+   * a quote waiting on a customer. Drawn as a dot, because a count already
+   * says how much and this says whether it matters.
+   */
+  attention?: boolean;
   content: ReactNode;
 };
 
@@ -49,6 +59,23 @@ export type RecordAction = {
  * Tabs with no content are dropped rather than shown empty: a company with no
  * site visits shouldn't advertise a Visits tab, and a page that only shows
  * what exists is faster to read than one padded with blanks.
+ *
+ * ## Which section is open lives in the URL
+ *
+ * `?section=documents`, not component state. Three things fall out of that and
+ * none of them work without it: the phone's back arrow and the browser's back
+ * button both return to the record rather than to the list two levels up, a
+ * link to a record's documents is a link somebody can send, and the first
+ * paint is correct — the alternative is `matchMedia`, which has no answer
+ * before hydration and paints the desktop shape on a phone for a frame.
+ *
+ * ## A phone drills in; a desktop switches tabs
+ *
+ * Nine sections is not a tab strip at 390px; it is a strip you scroll sideways
+ * hunting for a word. So the phone gets what the sections actually are — a
+ * list, with the mark, the count and whether anything needs attention — and
+ * opening one fills the page. The strip is still a strip where there is room
+ * for it. Both read the same URL, so neither is a separate mode.
  */
 export function RecordPageShell({
   backHref,
@@ -101,48 +128,66 @@ export function RecordPageShell({
    */
   attributes?: ReactNode;
 }) {
-  // Below `lg` there is no room for a rail beside the content, and stacking it
-  // above the tabs pushed the record itself under the fold — you scrolled past
-  // a summary to reach the thing you opened. So the summary becomes a tab, and
-  // it is the one you land on: the same content, in a place with a name.
-  const compact = useIsBelow(1024);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   // The width at which the app bar switches to its phone row and stops having
-  // room for the record's name. Not the same question as `compact`, which is
-  // about whether a rail fits beside the content.
+  // room for the record's name. Only ever used for chrome the bar itself owns.
   const narrow = useIsMobile();
 
-  const visibleTabs = useMemo(() => {
-    const real = tabs.filter((tab) => tab.content !== null && tab.content !== undefined);
-    if (!rail || !compact) return real;
-    return [{ value: OVERVIEW_TAB, label: "Overview", content: rail }, ...real];
-  }, [tabs, rail, compact]);
+  const visibleTabs = useMemo(
+    () => tabs.filter((tab) => tab.content !== null && tab.content !== undefined),
+    [tabs],
+  );
 
-  // Compact, the landing tab is Overview: it is what the rail used to show
-  // before anything else, and a record that opens on its timeline makes you
-  // hunt for the summary you came for. The parent still owns which *real* tab
-  // is showing, so "add a task" jumping to Tasks works from here too.
-  const [compactTab, setCompactTab] = useState<string | null>(null);
-  // Adjusting state during render rather than in an effect: this is the
-  // sanctioned way to follow a prop, and it lands before paint instead of
-  // showing the old tab for a frame.
-  const [lastActive, setLastActive] = useState(activeTab);
-  if (activeTab !== lastActive) {
-    setLastActive(activeTab);
-    setCompactTab(activeTab);
-  }
+  const landingTab = visibleTabs[0];
+  const requested = searchParams.get(SECTION_PARAM);
+  // A stale or hand-typed section name falls back to the landing view rather
+  // than rendering a page with nothing on it.
+  const openSection = visibleTabs.some((tab) => tab.value === requested) ? requested : null;
 
-  const preferred = compact && rail ? (compactTab ?? OVERVIEW_TAB) : activeTab;
-
-  // Widening the window takes the Overview tab away with the rail. Falling back
-  // to the first real tab beats rendering a pane that no trigger points at.
-  const currentTab = visibleTabs.some((tab) => tab.value === preferred)
-    ? preferred
-    : (visibleTabs[0]?.value ?? activeTab);
-
-  const handleTabChange = (value: string) => {
-    setCompactTab(value);
-    if (value !== OVERVIEW_TAB) onTabChange(value);
+  const sectionHref = (value: string) => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.set(SECTION_PARAM, value);
+    return `${pathname}?${next.toString()}`;
   };
+
+  /** The record with no section open — where the phone's back arrow returns to. */
+  const recordHref = (() => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete(SECTION_PARAM);
+    const query = next.toString();
+    return query ? `${pathname}?${query}` : pathname;
+  })();
+
+  // The parent still owns `activeTab`, because buttons inside the page jump
+  // sections — "add a task" from an empty Up next, "open documents" from the
+  // billing panel. Those set the parent's state; this carries the change into
+  // the URL, which is where everything else reads it from.
+  useEffect(() => {
+    if (!activeTab || activeTab === openSection) return;
+    if (!visibleTabs.some((tab) => tab.value === activeTab)) return;
+    // The landing tab is the record's own page, not a section of it.
+    if (activeTab === landingTab?.value) return;
+    window.history.pushState(null, "", sectionHref(activeTab));
+    // `sectionHref` closes over this render's params; re-running on every
+    // render is what a dependency array would buy, and it is not wanted here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
+
+  const currentTab = openSection
+    ? visibleTabs.find((tab) => tab.value === openSection)
+    : landingTab;
+
+  // And the other direction: the URL is the source of truth, so a page holding
+  // its own `tab` state — the lead's billing panel jumps to Documents, the
+  // deal's stage bar reads which section is open — is told when it changes.
+  // The push effect above bails when the two already agree, so this cannot
+  // ping-pong with it.
+  const currentValue = currentTab?.value;
+  useEffect(() => {
+    if (currentValue && currentValue !== activeTab) onTabChange(currentValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentValue]);
 
   /**
    * The record's actions, in the top app bar.
@@ -214,66 +259,158 @@ export function RecordPageShell({
 
   return (
     <div className="space-y-4">
-      <PageChrome title={title} icon={icon} backHref={backHref} backLabel={backLabel}>
+      {/* Drilled into a section, "up" is the record — not the list it came
+          from. Getting that wrong is what makes a phone drilldown feel like a
+          trapdoor: you open Documents, press back, and you are in the leads
+          list with the record gone. */}
+      {/* The bar keeps saying which *record* you are in, at every depth —
+          losing that is how a drilldown stops feeling like part of the record
+          and starts feeling like a separate page. The section names itself on
+          the page below. */}
+      <PageChrome
+        title={title}
+        icon={icon}
+        backHref={openSection ? recordHref : backHref}
+        backLabel={openSection ? title : backLabel}
+      >
         {barActions}
       </PageChrome>
 
-      {/* The record's name, on a phone.
-          ================================
-          It lives in the top app bar, which on a 390px screen is holding a
-          back arrow, a search icon, a bell and a primary action as well — so
-          the name truncated to "Tenant b…" and appeared nowhere else on the
-          page. The strip below carries the reference and the status; on a
-          phone it carries the name too, at the size a page title reads. */}
-      {narrow ? (
-        <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
-      ) : null}
+      {openSection ? (
+        <>
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">
+            {currentTab?.label}
+          </h2>
+          <div className="min-w-0">{currentTab?.content}</div>
+        </>
+      ) : (
+        <>
+          {/* The record's name, on a phone.
+              ================================
+              It lives in the top app bar, which on a 390px screen is holding a
+              back arrow, a search icon, a bell and a primary action as well —
+              so the name truncated to "Tenant b…" and appeared nowhere else on
+              the page. The strip below carries the reference and the status;
+              on a phone it carries the name too, at the size a page title
+              reads. */}
+          {narrow ? (
+            <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
+          ) : null}
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        {leading ? <span className="flex-none">{leading}</span> : null}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            {leading ? <span className="flex-none">{leading}</span> : null}
 
-        {reference ? (
-          <span className="font-mono text-sm text-[var(--text-muted)]">{reference}</span>
-        ) : null}
-        {status ? <StatusChip status={status.status} label={status.label} /> : null}
-        {subtitle ? (
-          <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
-        ) : null}
-      </div>
+            {reference ? (
+              <span className="font-mono text-sm text-[var(--text-muted)]">{reference}</span>
+            ) : null}
+            {status ? <StatusChip status={status.status} label={status.label} /> : null}
+            {subtitle ? (
+              <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
+            ) : null}
+          </div>
 
-      {attributes ? (
-        <div className="border-y border-[var(--border-subtle)] py-3">{attributes}</div>
-      ) : null}
+          {attributes ? (
+            <div className="border-y border-[var(--border-subtle)] py-3">{attributes}</div>
+          ) : null}
 
-      {beforeTabs}
+          {beforeTabs}
 
-      <div className={rail ? "detail-grid" : "min-w-0"}>
-        <div className="min-w-0 space-y-4">
-          <Tabs value={currentTab} onValueChange={handleTabChange}>
-            <div className="scroll-rail max-w-full">
-              <TabsList>
-                {visibleTabs.map((tab) => (
-                  <TabsTrigger key={tab.value} value={tab.value}>
-                    {tab.label}
-                    {tab.count && tab.count > 0 ? ` (${tab.count})` : ""}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+          <div className={rail ? "detail-grid" : "min-w-0"}>
+            <div className="min-w-0 space-y-4">
+              {/* The strip, where there is room for one. Below `md` the same
+                  sections are a list further down the page, so this is hidden
+                  in CSS rather than by a media query hook — a hook has no
+                  answer before hydration and would paint a nine-item strip on
+                  a phone for a frame. */}
+              {visibleTabs.length > 1 ? (
+                // `.section-tabs` scrolls sideways on its own; wrapping it in
+                // another scroller made it wrap onto a second row instead.
+                <div className="hidden max-w-full md:block">
+                  <SectionTabs label={`${title} sections`}>
+                    {visibleTabs.map((tab) => (
+                      <SectionTab
+                        key={tab.value}
+                        to={tab.value === landingTab?.value ? recordHref : sectionHref(tab.value)}
+                        active={tab.value === currentTab?.value}
+                        icon={tab.icon ? <tab.icon aria-hidden="true" /> : undefined}
+                        // A zero is not a count, it is nine grey pills saying
+                        // nothing. Only a section with something in it says
+                        // how much.
+                        count={tab.count && tab.count > 0 ? tab.count : undefined}
+                      >
+                        {tab.label}
+                        {tab.attention ? (
+                          <span
+                            aria-label="Needs attention"
+                            className="ml-1 inline-block size-1.5 rounded-full bg-[var(--action-primary-bg)] align-middle"
+                          />
+                        ) : null}
+                      </SectionTab>
+                    ))}
+                  </SectionTabs>
+                </div>
+              ) : null}
+
+              {/* The summary, above the story, in one view.
+                  ==========================================
+                  The rail used to become a tab of its own called "Overview",
+                  which a phone landed on — so a record opened on a summary and
+                  the thing that had actually happened to it was one tap away,
+                  behind a word. They are one reading now: what this record is
+                  worth and what is next, then what has happened. */}
+              {rail ? <div className="space-y-7 lg:hidden">{rail}</div> : null}
+
+              <div className="min-w-0">{landingTab?.content}</div>
+
+              {/* Every other section, as a list. */}
+              {visibleTabs.length > 1 ? (
+                <nav aria-label="Record sections" className="md:hidden">
+                  <ul className="divide-y divide-[var(--border-subtle)] border-y border-[var(--border-subtle)]">
+                    {visibleTabs.slice(1).map((tab) => {
+                      const Icon = tab.icon;
+                      return (
+                        <li key={tab.value}>
+                          <Link
+                            href={sectionHref(tab.value)}
+                            className="flex min-h-12 items-center gap-3 py-2.5 text-sm hover:bg-[var(--surface-hover)]"
+                          >
+                            {Icon ? (
+                              <Icon
+                                className="size-4 shrink-0 text-[var(--text-subtle)]"
+                                aria-hidden="true"
+                              />
+                            ) : null}
+                            <span className="min-w-0 flex-1 truncate text-[var(--text-strong)]">
+                              {tab.label}
+                            </span>
+                            {tab.attention ? (
+                              <span
+                                aria-label="Needs attention"
+                                className="size-1.5 shrink-0 rounded-full bg-[var(--action-primary-bg)]"
+                              />
+                            ) : null}
+                            {tab.count && tab.count > 0 ? (
+                              <span className="shrink-0 font-mono text-sm text-[var(--text-muted)]">
+                                {tab.count}
+                              </span>
+                            ) : null}
+                            <ChevronRight
+                              className="size-4 shrink-0 text-[var(--text-subtle)]"
+                              aria-hidden="true"
+                            />
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </nav>
+              ) : null}
             </div>
-            {visibleTabs.map((tab) => (
-              <TabsContent
-                key={tab.value}
-                value={tab.value}
-                className={tab.value === OVERVIEW_TAB ? "space-y-7 pt-5" : "pt-4"}
-              >
-                {tab.content}
-              </TabsContent>
-            ))}
-          </Tabs>
-        </div>
 
-        {rail ? <aside className="hidden space-y-7 lg:block">{rail}</aside> : null}
-      </div>
+            {rail ? <aside className="hidden space-y-7 lg:block">{rail}</aside> : null}
+          </div>
+        </>
+      )}
 
       {children}
     </div>

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -318,8 +318,16 @@ export function RecordPageShell({
 
   // Columns, and the dividers between them. No gap: the rule *is* the gap, and
   // the padding either side of it is what keeps the columns off it.
+  //
+  // `min-h` because grid tracks are only as tall as their tallest child, and
+  // the rules are drawn on the columns. A section with little in it — an empty
+  // Documents list, a record with four tasks — left two vertical lines that
+  // stopped a third of the way down the screen and a page that looked cropped.
+  // The columns fill whatever the viewport has left after the app bar and
+  // `main`'s padding, which is what `--content-viewport` is; longer content
+  // still grows past it, since this is a floor and not a height.
   const sectionGrid = cn(
-    "min-w-0 md:grid",
+    "min-w-0 md:grid md:min-h-[var(--content-viewport)]",
     hasSectionRail && !infoOpen && "md:grid-cols-[13rem_minmax(0,1fr)_auto]",
     hasSectionRail && infoOpen && "md:grid-cols-[13rem_minmax(0,1fr)] lg:grid-cols-[13rem_minmax(0,1fr)_22rem]",
     !hasSectionRail && !infoOpen && "md:grid-cols-[minmax(0,1fr)_auto]",

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -223,14 +223,19 @@ export function RecordPageShell({
     </NavRail>
   );
 
-  // One column on a phone; rail plus section from `md`; and the summary takes
-  // a third from `lg`, which is where `.detail-grid` already stopped crushing
-  // the content column.
+  // The right column carries the properties and the summary, so it is worth a
+  // column whenever there is either.
+  const hasRightColumn = Boolean(rail || attributes);
+  const hasSectionRail = visibleTabs.length > 1;
+
+  // One column on a phone; sections plus content from `md`; and the standing
+  // column from `lg`, which is where `.detail-grid` already stopped crushing
+  // the middle.
   const sectionGrid = cn(
     "min-w-0 md:grid md:gap-6",
-    visibleTabs.length > 1 ? "md:grid-cols-[13rem_minmax(0,1fr)]" : "md:grid-cols-1",
-    rail && visibleTabs.length > 1 && "lg:grid-cols-[13rem_minmax(0,1fr)_20rem]",
-    rail && visibleTabs.length <= 1 && "lg:grid-cols-[minmax(0,1fr)_20rem]",
+    hasSectionRail ? "md:grid-cols-[13rem_minmax(0,1fr)]" : "md:grid-cols-1",
+    hasRightColumn && hasSectionRail && "lg:grid-cols-[13rem_minmax(0,1fr)_20rem]",
+    hasRightColumn && !hasSectionRail && "lg:grid-cols-[minmax(0,1fr)_20rem]",
   );
 
   // And the other direction: the URL is the source of truth, so a page holding
@@ -331,77 +336,95 @@ export function RecordPageShell({
         {barActions}
       </PageChrome>
 
-      {openSection ? (
-        <>
-          <h2 className="text-base font-semibold text-[var(--text-strong)]">
-            {currentTab?.label}
-          </h2>
+      {/* The record's frame, at every depth.
+          =====================================
+          Opening a section used to replace the whole page — right for a phone,
+          where a drilldown *is* the page, and wrong for a desktop, which lost
+          its section rail and its properties the moment you clicked one of
+          them. The frame is always rendered now and the phone hides the parts
+          it does not want, in CSS, so the first paint is right at both widths.
+          Only the middle column changes. */}
+      <div className={openSection ? "hidden space-y-4 md:block" : "space-y-4"}>
+        {/* The record's name, on a phone.
+            ================================
+            It lives in the top app bar, which on a 390px screen is holding a
+            back arrow, a search icon, a bell and a primary action as well —
+            so the name truncated to "Tenant b…" and appeared nowhere else on
+            the page. The strip below carries the reference and the status;
+            on a phone it carries the name too, at the size a page title
+            reads. */}
+        {narrow ? (
+          <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          {leading ? <span className="flex-none">{leading}</span> : null}
+
+          {reference ? (
+            <span className="font-mono text-sm text-[var(--text-muted)]">{reference}</span>
+          ) : null}
+          {status ? <StatusChip status={status.status} label={status.label} /> : null}
+          {subtitle ? (
+            <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
+          ) : null}
+        </div>
+
+        {/* Properties are the right column's job from `lg` up, where they can
+            stay in view while you read a section. Below that there is no third
+            column, so they sit here, full width, the way Notion puts them at
+            the top of a page. */}
+        {attributes ? (
+          <div className="border-y border-[var(--border-subtle)] py-3 lg:hidden">{attributes}</div>
+        ) : null}
+
+        {beforeTabs}
+      </div>
+
+      <div className={sectionGrid}>
+        {/* The sections, on the left, where the back office puts them. */}
+        {visibleTabs.length > 1 ? (
+          <aside className="hidden md:block">{sectionRail}</aside>
+        ) : null}
+
+        <div className="min-w-0 space-y-4">
+          {/* Drilled in on a phone, the section names itself — the bar is
+              still carrying the record's name. */}
+          {openSection ? (
+            <h2 className="text-base font-semibold text-[var(--text-strong)] md:hidden">
+              {currentTab?.label}
+            </h2>
+          ) : null}
+
+          {/* The summary, above the story, in one view.
+              ==========================================
+              The rail used to become a tab of its own called "Overview",
+              which a phone landed on — so a record opened on a summary and
+              the thing that had actually happened to it was one tap away,
+              behind a word. They are one reading now: what this record is
+              worth and what is next, then what has happened. */}
+          {rail && !openSection ? <div className="space-y-7 lg:hidden">{rail}</div> : null}
+
           <div className="min-w-0">{currentTab?.content}</div>
-        </>
-      ) : (
-        <>
-          {/* The record's name, on a phone.
-              ================================
-              It lives in the top app bar, which on a 390px screen is holding a
-              back arrow, a search icon, a bell and a primary action as well —
-              so the name truncated to "Tenant b…" and appeared nowhere else on
-              the page. The strip below carries the reference and the status;
-              on a phone it carries the name too, at the size a page title
-              reads. */}
-          {narrow ? (
-            <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
-          ) : null}
 
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-            {leading ? <span className="flex-none">{leading}</span> : null}
-
-            {reference ? (
-              <span className="font-mono text-sm text-[var(--text-muted)]">{reference}</span>
-            ) : null}
-            {status ? <StatusChip status={status.status} label={status.label} /> : null}
-            {subtitle ? (
-              <span className="min-w-0 truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
-            ) : null}
-          </div>
-
-          {attributes ? (
-            <div className="border-y border-[var(--border-subtle)] py-3">{attributes}</div>
-          ) : null}
-
-          {beforeTabs}
-
-          <div className={sectionGrid}>
-            {/* The sections, on the left, where the back office puts them. */}
-            {visibleTabs.length > 1 ? (
-              <aside className="hidden md:block">{sectionRail}</aside>
-            ) : null}
-
-            <div className="min-w-0 space-y-4">
-              {/* The summary, above the story, in one view.
-                  ==========================================
-                  The rail used to become a tab of its own called "Overview",
-                  which a phone landed on — so a record opened on a summary and
-                  the thing that had actually happened to it was one tap away,
-                  behind a word. They are one reading now: what this record is
-                  worth and what is next, then what has happened. */}
-              {rail ? <div className="space-y-7 lg:hidden">{rail}</div> : null}
-
-              <div className="min-w-0">{landingTab?.content}</div>
-
-              {/* The same rail, at the foot of the landing view, where a phone
-                  has no column to put it in. One component either way, so a
-                  section reads the same whichever width you meet it at. */}
-              {visibleTabs.length > 1 ? (
-                <div className="border-t border-[var(--border-subtle)] pt-4 md:hidden">
-                  {sectionRail}
-                </div>
-              ) : null}
+          {/* The same rail, at the foot of the landing view, where a phone
+              has no column to put it in. One component either way, so a
+              section reads the same whichever width you meet it at. */}
+          {visibleTabs.length > 1 && !openSection ? (
+            <div className="border-t border-[var(--border-subtle)] pt-4 md:hidden">
+              {sectionRail}
             </div>
+          ) : null}
+        </div>
 
-            {rail ? <aside className="hidden space-y-7 lg:block">{rail}</aside> : null}
-          </div>
-        </>
-      )}
+        {/* The column that never changes: what this record *is*, and what it
+            is worth, beside whichever section is being read. */}
+        {hasRightColumn ? (
+          <aside className="hidden space-y-7 lg:block">
+            {attributes ? <div>{attributes}</div> : null}
+            {rail}
+          </aside>
+        ) : null}
+      </div>
 
       {children}
     </div>

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -6,6 +6,7 @@ import { useIsBelow, useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger, Stack } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
 import { StatusChip } from "@/components/ui/status-chip";
 import {
   DropdownMenu,
@@ -17,6 +18,7 @@ import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
 import { DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
+import { cn } from "@/lib/utils";
 
 /** The synthetic tab the rail becomes when there is no room beside the content. */
 const OVERVIEW_TAB = "overview";
@@ -142,35 +144,73 @@ export function RecordPageShell({
     if (value !== OVERVIEW_TAB) onTabChange(value);
   };
 
-  const barActions = useMemo(
-    () => (
+  /**
+   * The record's actions, in the top app bar.
+   *
+   * Two shapes, because the bar has two.
+   *
+   * On a desktop the bar renders whatever it is given, side by side, so the
+   * secondary actions are collected into a menu here — a row of five buttons
+   * beside the record's name is not a bar, it is a toolbar.
+   *
+   * On a phone the bar does its own collecting: it shows the first action and
+   * folds the rest behind a "More actions" button of its own. Handing it a
+   * menu, as this used to, meant the phone put a menu inside a menu — you
+   * pressed `···` and got a panel containing a single unlabelled `···` to
+   * press again, with two controls on screen both called "More actions". So
+   * the phone gets the actions flat and the bar folds them once.
+   */
+  const barActions = useMemo(() => {
+    if (!actions || actions.length === 0) return primaryAction;
+
+    if (narrow) {
+      return (
+        <>
+          {primaryAction}
+          {actions.map((action) => (
+            <Button
+              key={action.label}
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "justify-start gap-2",
+                action.destructive && "text-[var(--status-error-text)]",
+              )}
+              onClick={action.onSelect}
+            >
+              {action.icon}
+              {action.label}
+            </Button>
+          ))}
+        </>
+      );
+    }
+
+    return (
       <>
         {primaryAction}
-        {actions && actions.length > 0 ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <IconButton aria-label="More actions">
-                <DotsThree />
-              </IconButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {actions.map((action) => (
-                <DropdownMenuItem
-                  key={action.label}
-                  onClick={action.onSelect}
-                  className={action.destructive ? "text-[var(--status-error-text)]" : undefined}
-                >
-                  {action.icon}
-                  {action.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : null}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton aria-label="More actions">
+              <DotsThree />
+            </IconButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {actions.map((action) => (
+              <DropdownMenuItem
+                key={action.label}
+                onClick={action.onSelect}
+                className={action.destructive ? "text-[var(--status-error-text)]" : undefined}
+              >
+                {action.icon}
+                {action.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </>
-    ),
-    [actions, primaryAction],
-  );
+    );
+  }, [actions, narrow, primaryAction]);
 
   return (
     <div className="space-y-4">

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -305,7 +305,7 @@ export function RecordPageShell({
               <DropdownMenuItem
                 key={action.label}
                 onClick={action.onSelect}
-                className={action.destructive ? "text-[var(--status-error-text)]" : undefined}
+                variant={action.destructive ? "destructive" : "default"}
               >
                 {action.icon}
                 {action.label}

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, type ReactNode } from "react";
 
-import { useIsBelow } from "@/hooks/use-mobile";
+import { useIsBelow, useIsMobile } from "@/hooks/use-mobile";
 import Link from "next/link";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger, Stack } from "@corelithzw/react";
@@ -104,6 +104,10 @@ export function RecordPageShell({
   // a summary to reach the thing you opened. So the summary becomes a tab, and
   // it is the one you land on: the same content, in a place with a name.
   const compact = useIsBelow(1024);
+  // The width at which the app bar switches to its phone row and stops having
+  // room for the record's name. Not the same question as `compact`, which is
+  // about whether a rail fits beside the content.
+  const narrow = useIsMobile();
 
   const visibleTabs = useMemo(() => {
     const real = tabs.filter((tab) => tab.content !== null && tab.content !== undefined);
@@ -173,6 +177,17 @@ export function RecordPageShell({
       <PageChrome title={title} icon={icon} backHref={backHref} backLabel={backLabel}>
         {barActions}
       </PageChrome>
+
+      {/* The record's name, on a phone.
+          ================================
+          It lives in the top app bar, which on a 390px screen is holding a
+          back arrow, a search icon, a bell and a primary action as well — so
+          the name truncated to "Tenant b…" and appeared nowhere else on the
+          page. The strip below carries the reference and the status; on a
+          phone it carries the name too, at the size a page title reads. */}
+      {narrow ? (
+        <h2 className="text-base font-semibold text-[var(--text-strong)]">{title}</h2>
+      ) : null}
 
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
         {leading ? <span className="flex-none">{leading}</span> : null}

--- a/components/records/sub-sections.tsx
+++ b/components/records/sub-sections.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+import { SegmentedControl } from "@/components/ui/segmented-control";
+
+export type SubSection = {
+  value: string;
+  label: string;
+  count?: number;
+  content: ReactNode;
+};
+
+/**
+ * Two or three views of one idea, inside a single section.
+ *
+ * Documents and Files were separate sections, and so were History and Field
+ * history — four rows in the rail for two questions. They are not the same
+ * thing (a quotation has a total and a status; an uploaded contract does not),
+ * which is why they were split in the first place, but "what paperwork is on
+ * this record" is one question and it should be one place to go and ask it.
+ *
+ * The segmented control is the right grammar for this and the wrong one for
+ * the rail: a fixed track of equal-width columns holds three peers of one kind
+ * beautifully and thirteen sections not at all. So it lives here, one level
+ * down, where the choices are few — the same control the composer uses to pick
+ * between a comment and a logged call.
+ */
+export function SubSections({
+  label,
+  sections,
+}: {
+  /** Accessible name for the control, e.g. "Paperwork". */
+  label: string;
+  sections: SubSection[];
+}) {
+  const [value, setValue] = useState(sections[0]?.value ?? "");
+  const current = sections.find((section) => section.value === value) ?? sections[0];
+
+  if (sections.length === 0) return null;
+  if (sections.length === 1) return <>{sections[0].content}</>;
+
+  return (
+    <div className="space-y-4">
+      <SegmentedControl
+        value={current?.value ?? ""}
+        onValueChange={setValue}
+        options={sections.map((section) => ({
+          value: section.value,
+          label: section.label,
+          // The DS renders this right-aligned inside the segment. A zero is
+          // not a count anywhere else in the product and is not one here.
+          count: section.count && section.count > 0 ? section.count : undefined,
+        }))}
+        size="sm"
+        ariaLabel={label}
+      />
+      <div className="min-w-0">{current?.content}</div>
+    </div>
+  );
+}

--- a/components/settings/management-shell.tsx
+++ b/components/settings/management-shell.tsx
@@ -3,8 +3,8 @@
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { PageHeader } from "@corelithzw/react";
 
+import { PageChrome } from "@/components/layout/page-chrome";
 import { NavRail } from "@/components/ui/nav-rail";
 import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 import {
@@ -23,9 +23,9 @@ type ManagementShellProps = {
   description?: string;
   actions?: React.ReactNode;
   /**
-   * Skip the shell's own PageHeader. For content that draws its own — the DS
-   * `MasterData` assembly composes one — where two headers would say the same
-   * thing twice.
+   * Skip the in-page description block. For content that draws its own header —
+   * the DS `MasterData` assembly composes one — where two would say the same
+   * thing twice. The app bar still gets the title and the actions either way.
    */
   hideHeader?: boolean;
   children: React.ReactNode;
@@ -112,14 +112,24 @@ export function ManagementShell({
         </NavGroup>
       </NavRail>
 
+      {/* The back office's actions belong in the app bar, the same as every
+          other module's.
+          ==================================================================
+          This shell drew its own `PageHeader` inside the page instead, which
+          on a 390px screen put "New department" about four hundred pixels
+          down — under a title the bar was already showing, under the
+          description, and under the whole search-and-pagination row — while
+          the bar itself sat empty next to the bell. The one verb on the page
+          was the last thing you could reach.
+
+          The title goes to the bar too, so it is stated once. What stays on
+          the page is the description, which is the only part of the old
+          header that said something the bar cannot. */}
+      <PageChrome title={title || modulePresentation.title}>{actions}</PageChrome>
+
       <section className="settings-content">
-        {hideHeader ? null : (
-          <>
-            <PageHeader title={title || modulePresentation.title} primaryAction={actions} />
-            {description ? (
-              <p className="t-body t-muted max-w-[var(--content-max)]">{description}</p>
-            ) : null}
-          </>
+        {hideHeader || !description ? null : (
+          <p className="t-body t-muted max-w-[var(--content-max)]">{description}</p>
         )}
         <div className="w-full max-w-[96rem] space-y-6">{children}</div>
       </section>

--- a/components/settings/management-shell.tsx
+++ b/components/settings/management-shell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { PageHeader } from "@corelithzw/react";
 
+import { NavRail } from "@/components/ui/nav-rail";
 import { NavGroup, NavItem } from "@/components/ui/settings-rail";
 import {
   getAreaLabel,
@@ -67,7 +68,17 @@ export function ManagementShell({
 
   return (
     <div className="settings-layout container mx-auto w-full">
-      <aside className="settings-rail" aria-label="Management navigation">
+      {/* A rail on a desktop, a scrolling strip on a phone. Stacked, these
+          thirteen sections were five hundred pixels of navigation above the
+          page they navigate to — you scrolled past the whole of Settings to
+          reach Master Data's own content. `orientation="responsive"` is what
+          CRM settings already uses; this is the same rail, drawn the same
+          way. */}
+      <NavRail
+        className="settings-rail"
+        label="Management navigation"
+        orientation="responsive"
+      >
         <NavGroup label="Settings">
           {visibleModules.map((module) => {
             const ModuleIcon = module.icon;
@@ -99,7 +110,7 @@ export function ManagementShell({
             );
           })}
         </NavGroup>
-      </aside>
+      </NavRail>
 
       <section className="settings-content">
         {hideHeader ? null : (

--- a/components/stores/stores-shell.tsx
+++ b/components/stores/stores-shell.tsx
@@ -126,10 +126,18 @@ export function StoresShell({
     return `${href}?${params.toString()}`;
   };
 
+  // Issuing and receiving move stock, so they belong on the views about stock
+  // — which is the same split the sidebar already draws between "Stock" and
+  // "What we sell". On the catalogue they were the wrong verbs in the loudest
+  // place on the screen: at 390px the bar showed "Receive" and pushed "Issue"
+  // into an overflow menu, while the page's actual primary action, "New item",
+  // sat down in the body under a heading and a paragraph.
+  const movesStock = activeTab !== "catalogue" && activeTab !== "price-lists";
+
   // Not memoised: the compiler infers a different dependency set than any
   // hand-written one here, and a fresh element per render costs nothing —
   // `PageChrome` only re-renders the bar, not the page.
-  const barActions = (
+  const barActions = movesStock ? (
       <>
         {actions}
         <Button
@@ -146,6 +154,11 @@ export function StoresShell({
           Issue
         </Button>
       </>
+  ) : (
+    // Left undefined rather than empty when the page has nothing of its own:
+    // that is how `PageChrome` is told to claim only the title, so the panel
+    // inside can register the bar's action itself.
+    actions
   );
 
   const activeLabel =

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -63,9 +63,9 @@ function AlertDialogOverlay({
       className={cn(
         // `fixed inset-0` restates what `.modal-scrim` already does, so the
         // overlay does not depend on which of the package's two `.modal-scrim`
-        // rules lands last; `z-50` pins it to the app's overlay layer rather
-        // than the DS's own `z-index: 1100`.
-        "modal-scrim fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        // rules lands last. The z-index comes from the app's one overlay scale
+        // (see `globals.css`) rather than the DS's own 1100.
+        "modal-scrim fixed inset-0 z-[var(--z-overlay)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -87,7 +87,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "modal-card group/alert-dialog-content fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 overflow-y-auto p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[size=sm]:max-w-sm data-[size=default]:sm:max-w-lg",
+          "modal-card group/alert-dialog-content fixed left-[50%] top-[50%] z-[var(--z-overlay)] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 overflow-y-auto p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[size=sm]:max-w-sm data-[size=default]:sm:max-w-lg",
           className
         )}
         {...props}

--- a/components/ui/client-date.tsx
+++ b/components/ui/client-date.tsx
@@ -1,31 +1,69 @@
 "use client";
 
-import { ClientDate, type ClientDateProps } from "@corelithzw/react";
+import { useSyncExternalStore, type ReactNode } from "react";
+
+export type ClientDateMode = "datetime" | "date";
+
+export type ClientDateProps = {
+  /** ISO 8601 timestamp. `null`/`undefined`/unparseable renders `fallback`. */
+  value: string | null | undefined;
+  /** `date` renders the day only, `datetime` adds the time. @default 'datetime' */
+  mode?: ClientDateMode;
+  /** Rendered when there is no usable value. @default '—' */
+  fallback?: ReactNode;
+};
+
+const NO_RESUBSCRIBE = () => () => {};
 
 /**
- * ClientDate — the design system's, re-exported under this repo's name.
+ * A timestamp in the reader's locale, without breaking hydration.
  *
- * 39 files drop this inline inside table cells and text runs, so the migration
- * was gated on the DS version preserving both invariants the local copy had:
+ * Two invariants, because 39 files drop this inline inside table cells and
+ * text runs:
  *
  *   1. It returns a **bare fragment**, never a wrapper element — no `<span>`,
- *      no class hook — so it never disturbs the layout of the cell or sentence
- *      it sits in.
+ *      no class hook — so it never disturbs the layout of the cell or the
+ *      sentence it sits in.
  *   2. Before mount it emits a **string slice of the raw ISO input**
- *      (`value.slice(0, 10)` for `date`, `value.slice(0, 16).replace('T', ' ')`
- *      for `datetime`). Nothing derived from `new Date()` reaches the first
- *      paint, so the server bytes and the first client render match and React
- *      hydration error #418 stays away. Only after the mount effect does it
- *      swap to `toLocaleDateString()` / `toLocaleString()`.
+ *      (`slice(0, 10)` for `date`, `slice(0, 16)` with the `T` swapped for
+ *      `datetime`). Nothing derived from `new Date()` reaches the first paint,
+ *      so the server bytes and the first client render match and React
+ *      hydration error #418 stays away.
  *
- * `@corelithzw/react` ships both, byte for byte, so this is a straight
- * re-export rather than a reimplementation. The only widening is `fallback`,
- * which is `ReactNode` in the DS where it was `string` here.
+ * This began as a straight re-export of `@corelithzw/react`'s `ClientDate`,
+ * which holds both invariants — but its `datetime` renders through
+ * `toLocaleString()`, and that carries **seconds**. On a record page that
+ * means "8/4/2026, 9:06:53 PM" beside every quote, comment and logged call: a
+ * precision nobody asked for, in a column narrow enough that it wraps to buy
+ * it. So the formatting is spelled out here and the seconds are dropped.
+ * Anything needing them should format explicitly at the call site rather than
+ * putting them back for every reader of every table.
  *
- * `"use client"` is load-bearing: the published DS bundle carries no client
- * directive of its own, so this module is what marks `ClientDate` — which uses
- * `useState`/`useEffect` — as a client reference for the server components that
- * import it.
+ * `"use client"` is load-bearing: this module is what marks the hook use as a
+ * client reference for the server components that import it.
  */
-export { ClientDate };
-export type { ClientDateProps };
+export function ClientDate({ value, mode = "datetime", fallback = "—" }: ClientDateProps) {
+  const hydrated = useSyncExternalStore(
+    NO_RESUBSCRIBE,
+    () => true,
+    () => false,
+  );
+
+  if (!value) return <>{fallback}</>;
+
+  if (!hydrated) {
+    return <>{mode === "date" ? value.slice(0, 10) : value.slice(0, 16).replace("T", " ")}</>;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return <>{fallback}</>;
+
+  if (mode === "date") return <>{date.toLocaleDateString()}</>;
+
+  return (
+    <>
+      {date.toLocaleDateString()},{" "}
+      {date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+    </>
+  );
+}

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -7,7 +7,7 @@ import { Calendar } from "@corelithzw/react";
 import { CalendarIcon, ChevronDown, Clock3 } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ResponsivePopover } from "@/components/ui/responsive-popover";
 import { Separator } from "@/components/ui/separator";
 import {
   Select,
@@ -42,7 +42,7 @@ type CommonProps = {
   contentClassName?: string;
   placeholder?: string;
   disabled?: boolean;
-  align?: React.ComponentProps<typeof PopoverContent>["align"];
+  align?: React.ComponentProps<typeof ResponsivePopover>["align"];
   sideOffset?: number;
   label?: string;
 };
@@ -168,19 +168,25 @@ export function DatePicker(props: DatePickerProps) {
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       {label ? <Label>{label}</Label> : null}
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild disabled={disabled}>
+      {/* A calendar is 280px wide and its trigger is usually near the bottom
+          of a form, so on a phone the popover had to open *over* the fields
+          above it. Below `sm` it comes up from the bottom edge instead. */}
+      <ResponsivePopover
+        open={open}
+        onOpenChange={setOpen}
+        title={isDateTime ? "Select date and time" : "Select date"}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn("w-auto p-0", contentClassName)}
+        trigger={
           <DatePickerTrigger
             className={triggerClassName}
             value={triggerValue}
             placeholder={placeholder}
+            disabled={disabled}
           />
-        </PopoverTrigger>
-        <PopoverContent
-          align={align}
-          sideOffset={sideOffset}
-          className={cn("w-auto p-0", contentClassName)}
-        >
+        }
+      >
           {/* `.popover` scopes `.pop-h` / `.ti` / `.pop-actions`; its own
               surface is cleared because PopoverContent already draws one. */}
           <div className="popover max-w-none overflow-hidden rounded-[var(--card-radius)] border-0 p-0 shadow-none">
@@ -279,8 +285,7 @@ export function DatePicker(props: DatePickerProps) {
               </>
             ) : null}
           </div>
-        </PopoverContent>
-      </Popover>
+      </ResponsivePopover>
     </div>
   );
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -99,12 +99,12 @@ const DialogContent = React.forwardRef<
   <DialogPortal>
     {/* `fixed inset-0` restates what `.modal-scrim` already does, so the
         backdrop does not depend on which of the package's two `.modal-scrim`
-        rules lands last; `z-50` pins it to the app's overlay layer rather than
-        the DS's own `z-index: 1100`. */}
-    <DialogPrimitive.Backdrop className="modal-scrim fixed inset-0 z-50 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-200" />
+        rules lands last. The z-index comes from the app's one overlay scale
+        (see `globals.css`) rather than the DS's own 1100. */}
+    <DialogPrimitive.Backdrop className="modal-scrim fixed inset-0 z-[var(--z-overlay)] motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-200" />
     <DialogPrimitive.Viewport
       className={cn(
-        "fixed inset-0 z-50 flex justify-center overflow-y-auto overscroll-contain",
+        "fixed inset-0 z-[var(--z-overlay)] flex justify-center overflow-y-auto overscroll-contain",
         DIALOG_TABLET_VIEWPORT_CLASSNAMES[tabletBehavior],
         DIALOG_INSET_VIEWPORT_CLASSNAMES[inset ? "true" : "false"]
       )}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -81,12 +81,21 @@ type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.
   size?: ResponsiveSurfaceSize
   tabletBehavior?: DialogTabletBehavior
   inset?: boolean
+  /**
+   * Off for a surface that draws its own close.
+   *
+   * The built-in one is absolutely positioned at the popup's top-right corner
+   * and knows nothing about what the caller put there. The employee wizard has
+   * a close in its own header bar, so both rendered — two X glyphs overlapping
+   * in one 32px circle, which is what a phone screenshot of the wizard showed.
+   */
+  showClose?: boolean
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Popup>,
   DialogContentProps
->(({ className, children, size = "md", tabletBehavior = "adaptive", inset = true, ...props }, ref) => (
+>(({ className, children, size = "md", tabletBehavior = "adaptive", inset = true, showClose = true, ...props }, ref) => (
   <DialogPortal>
     {/* `fixed inset-0` restates what `.modal-scrim` already does, so the
         backdrop does not depend on which of the package's two `.modal-scrim`
@@ -113,13 +122,15 @@ const DialogContent = React.forwardRef<
         {/* `.modal-card .x` styles this; it only binds because the button is
             inside the popup. Placement stays absolute — the DS puts its close
             in the header, which this compound API cannot guarantee exists. */}
-        <DialogClose
-          data-slot="dialog-close"
-          className="x absolute right-3 top-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)] disabled:pointer-events-none"
-        >
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogClose>
+        {showClose ? (
+          <DialogClose
+            data-slot="dialog-close"
+            className="x absolute right-3 top-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)] disabled:pointer-events-none"
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        ) : null}
       </DialogPrimitive.Popup>
     </DialogPrimitive.Viewport>
   </DialogPortal>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -87,7 +87,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     data-slot="dropdown-menu-sub-content"
     className={cn(
-      "menu z-50 data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "menu z-[var(--z-overlay)] data-[state=open]:animate-in data-[state=closed]:animate-out",
       className,
     )}
     {...props}
@@ -105,7 +105,7 @@ const DropdownMenuContent = React.forwardRef<
       data-slot="dropdown-menu-content"
       sideOffset={sideOffset}
       className={cn(
-        "menu z-50 data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "menu z-[var(--z-overlay)] data-[state=open]:animate-in data-[state=closed]:animate-out",
         className,
       )}
       {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -44,9 +44,31 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
-/** Shared by every row: the DS item, unpicked from its grid. See the note above. */
+/**
+ * Shared by every row: the DS item, unpicked from its grid. See the note above.
+ *
+ * The icon rules are here rather than at each call site because they were at
+ * each call site, and drifted: `h-4 w-4` in one menu, `size-4` in another,
+ * inherited black in a third and muted grey in a fourth, with the gap between
+ * mark and label set independently every time. A menu is a column of rows that
+ * have to scan as one thing. Any icon a caller passes is now sized, spaced and
+ * muted the same, and a toned item tints its own mark to match its label —
+ * which is what makes a destructive row read as destructive at a glance rather
+ * than after reading the verb.
+ */
 const MENU_ITEM_BASE =
-  "menu-item flex w-full min-w-0 select-none items-center outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+  "menu-item flex w-full min-w-0 select-none items-center gap-2 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg:not([class*='text-'])]:text-[var(--text-subtle)]"
+
+/** What a row means, drawn on the label and its mark together. */
+const MENU_ITEM_TONE = {
+  default: "",
+  /** Removes something, or cannot be undone. */
+  destructive: "danger [&_svg]:text-[var(--status-error-text)]",
+  /** Completes something — settling an invoice, accepting a quote. */
+  positive: "text-[var(--status-success-text)] [&_svg]:text-[var(--status-success-text)]",
+  /** The one thing this menu is mostly opened to do. */
+  primary: "[&_svg]:text-[var(--action-primary-bg)]",
+} as const
 
 const DropdownMenuGroup = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Group>,
@@ -118,8 +140,8 @@ type DropdownMenuItemProps = React.ComponentPropsWithoutRef<
   typeof DropdownMenuPrimitive.Item
 > & {
   inset?: boolean
-  /** Additive; maps onto the DS's `.danger` item treatment. */
-  variant?: "default" | "destructive"
+  /** Additive; `destructive` maps onto the DS's `.danger` item treatment. */
+  variant?: keyof typeof MENU_ITEM_TONE
 }
 
 const DropdownMenuItem = React.forwardRef<
@@ -132,7 +154,7 @@ const DropdownMenuItem = React.forwardRef<
     data-variant={variant}
     className={cn(
       MENU_ITEM_BASE,
-      variant === "destructive" && "danger",
+      MENU_ITEM_TONE[variant],
       inset && "pl-8",
       className,
     )}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -15,7 +15,9 @@ import { cn } from "@/lib/utils";
  *
  * Two local utilities survive on purpose:
  *
- *   - `z-50`. `.popover` sets no stacking context of its own.
+ *   - The popover rung of the app's overlay scale. `.popover` sets no
+ *     stacking context of its own, and a popover opened from inside a sheet or
+ *     a dialog has to paint above it — see the scale in `globals.css`.
  *   - `max-w-none`. `.popover` caps itself at 320px, but five call sites are
  *     wider than that — four pass `w-[var(--radix-popover-trigger-width)]` to
  *     match a full-width trigger and one asks for `w-[min(23rem,…)]`. Those set
@@ -54,7 +56,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "popover z-50 w-72 max-w-none outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "popover z-[var(--z-overlay)] w-72 max-w-none outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}

--- a/components/ui/responsive-popover.tsx
+++ b/components/ui/responsive-popover.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import * as React from "react";
+
+import { useIsBelow } from "@/hooks/use-mobile";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+/**
+ * A transient surface that is a popover on a desktop and a sheet on a phone.
+ *
+ * A popover is anchored to the control that opened it, which is what makes it
+ * readable: the list of owners appears beside the word "Owner". At 390px there
+ * is nothing to anchor to. A 358px-wide panel opened from a control near the
+ * bottom of a form has nowhere to go but *over* the form — a screenshot of the
+ * client picker in "New lead" showed it covering the four fields above its own
+ * trigger, with the trigger itself still visible underneath, so the thing you
+ * pressed and the thing that opened had no visible relationship at all.
+ *
+ * Below `sm` the same content comes up from the bottom edge instead, with the
+ * property's name at the top of it. Which is both the platform convention and
+ * the thing this product's record pages were asked for: Notion edits a
+ * property by opening a labelled sheet, not by floating a menu over the page.
+ *
+ * The trigger is the caller's own element either way, so keyboard and pointer
+ * behaviour on a desktop is exactly the Radix popover it was before.
+ */
+export function ResponsivePopover({
+  open,
+  onOpenChange,
+  trigger,
+  /** Names the sheet on a phone. The property's label, usually. */
+  title,
+  children,
+  align = "start",
+  sideOffset,
+  /** Classes for the popover surface only — a sheet is always full width. */
+  className,
+  /** Classes for the region that holds `children` in both shapes. */
+  contentClassName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: React.ReactNode;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  align?: React.ComponentProps<typeof PopoverContent>["align"];
+  sideOffset?: number;
+  className?: string;
+  contentClassName?: string;
+}) {
+  const compact = useIsBelow(640);
+
+  /**
+   * Escape closes this sheet and nothing behind it.
+   *
+   * The sheet is a Radix dialog; the form it is usually opened from is a Base
+   * UI one. Neither library knows about the other's layer stack, so both
+   * answered the same Escape: the client picker closed *and* the "New lead"
+   * form under it closed with it, losing everything typed. That is the
+   * "clicking a popover and then outside it closes the modal" this fixes.
+   *
+   * A native capture-phase listener on the document, registered while this
+   * sheet is open, so it runs before either library's own document listener
+   * and can stop the event dead. Registering last means the innermost open
+   * sheet wins, which is the right one.
+   */
+  React.useEffect(() => {
+    if (!compact || !open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      onOpenChange(false);
+    };
+    document.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => document.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [compact, open, onOpenChange]);
+
+  if (compact) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetTrigger asChild>{trigger}</SheetTrigger>
+        {/* `size="lg"` is a cap, not a height — the sheet is as tall as what
+            is in it. A picker with three options should not open a panel with
+            room for twenty. */}
+        <SheetContent side="bottom" size="lg" className="p-0">
+          <SheetHeader className="px-4 pb-2 pt-1 text-left">
+            <SheetTitle className="text-base">{title}</SheetTitle>
+          </SheetHeader>
+          <div className={cn("min-h-0 overflow-y-auto px-2 pb-2", contentClassName)}>
+            {children}
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align={align} sideOffset={sideOffset} className={className}>
+        <div className={contentClassName}>{children}</div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -13,7 +13,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ResponsivePopover } from "@/components/ui/responsive-popover";
 import { CheckIcon, ChevronDown, Plus } from "@/lib/icons";
 
 /**
@@ -80,7 +80,7 @@ export function SearchableSelect({
   return (
     <div className="field">
       {label ? <label className="field-label">{label}</label> : null}
-      <Popover
+      <ResponsivePopover
         open={open}
         onOpenChange={(next) => {
           setOpen(next);
@@ -88,8 +88,9 @@ export function SearchableSelect({
             setQuery("");
           }
         }}
-      >
-        <PopoverTrigger asChild>
+        title={label ?? placeholder}
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        trigger={
           <Button
             type="button"
             variant="outline"
@@ -107,8 +108,8 @@ export function SearchableSelect({
             </span>
             <ChevronDown className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        }
+      >
           <Command shouldFilter={false}>
             <CommandInput
               value={query}
@@ -193,8 +194,7 @@ export function SearchableSelect({
               ) : null}
             </CommandList>
           </Command>
-        </PopoverContent>
-      </Popover>
+      </ResponsivePopover>
     </div>
   );
 }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -104,7 +104,7 @@ function SelectContent({
         className={cn(
           // DS popover surface: background, border, radius, shadow, padding.
           "menu",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[var(--z-overlay)] max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -51,9 +51,9 @@ const SheetOverlay = React.forwardRef<
     className={cn(
       // `fixed inset-0` restates what `.modal-scrim` already does, so the
       // overlay does not depend on which of the package's two `.modal-scrim`
-      // rules lands last; `z-50` pins it to the app's overlay layer rather than
-      // the DS's own `z-index: 1100`.
-      "modal-scrim fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-150 data-[state=open]:duration-200",
+      // rules lands last. The z-index comes from the app's one overlay scale
+      // (see `globals.css`) rather than the DS's own 1100.
+      "modal-scrim fixed inset-0 z-[var(--z-overlay)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-150 data-[state=open]:duration-200",
       className
     )}
     {...props}
@@ -76,7 +76,7 @@ const SHEET_SURFACE_SIZE: Record<ResponsiveSurfaceSize, string> = {
 }
 
 const sheetVariants = cva(
-  "drawer fixed z-50 max-h-[100dvh] overflow-y-auto overscroll-contain transition ease-[var(--motion-ease-standard)] focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=open]:duration-200",
+  "drawer fixed z-[var(--z-overlay)] max-h-[100dvh] overflow-y-auto overscroll-contain transition ease-[var(--motion-ease-standard)] focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=open]:duration-200",
   {
     variants: {
       side: {

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -174,6 +174,30 @@ apply them to any module.
   a trailing caret at the right. Use `.stacked-controls`.
 - A destructive action at the right edge of a row is under the thumb of anyone
   scrolling. It confirms first.
+- The magnifier is an outline. Search is the quietest control in a toolbar.
+
+### Overlays
+- **One rung, `--z-overlay`, for every dismissable surface** — sheet, dialog,
+  popover, menu, select. Open order decides what is on top, which is the only
+  rule that survives nesting in both directions. Chrome sits below it
+  (`--z-sidebar`, `--z-nav`), toasts above (`--z-toast`). Never write a bare
+  `z-50` on an overlay.
+- **A picker is a sheet on a phone, a popover on a desktop.** Use
+  `ResponsivePopover`. A 358px panel anchored to a control near the bottom of a
+  form has nowhere to go but over the form.
+- **A bottom sheet is as tall as its content**, capped — never a fixed height.
+  Rounded top, grabber, safe-area padding.
+- **Dismissing a layer dismisses that layer only.** Escape in a picker must not
+  close the form behind it. Mixing overlay libraries makes this a live risk:
+  cover it with a test, not with hope.
+
+### Navigation
+- A section rail is a **scrolling strip** on a phone, never a stacked column.
+  Thirteen items in a column is five hundred pixels of navigation above the
+  page it navigates to.
+- **No chrome that a phone will never use, not even for one frame.** Anything
+  that picks a layout with `matchMedia` has no answer before hydration; give
+  the phone the right answer in CSS so the first paint is not the desktop.
 
 ## Compliance Checklist
 A screen is compliant only when:

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -235,6 +235,43 @@ rules bite hardest.
   record that looks exactly like a working one is how somebody spends ten
   minutes on business nobody is pursuing.
 
+### Record sections
+- **Which section is open lives in the URL**, not in component state. That is
+  what makes the back arrow return to the record rather than to the list two
+  levels up, makes a link to a record's documents sendable, and makes the first
+  paint correct — `matchMedia` has no answer before hydration.
+- **A phone drills in; a desktop switches tabs.** Nine sections is not a strip
+  at 390px, it is a strip you scroll sideways hunting for a word. Below `md`
+  the sections are a list — mark, label, count, attention dot, chevron — and
+  opening one fills the page. Both shapes read the same URL, so neither is a
+  separate mode.
+- **The bar keeps naming the record at every depth.** Losing it is how a
+  drilldown stops feeling like part of the record. The section names itself on
+  the page below.
+- **A record's own tab strip is the platform's `SectionTabs`**, not a second
+  opinion about what a tab looks like: neutral active indicator, count pill,
+  icon slot. Brand colour is for primary actions.
+- **A zero is not a count.** Nine grey pills reading `0` say nothing; only a
+  section with something in it says how much.
+- Section order follows what a record is opened for: the summary and the story
+  first and in **one** view, then talking about it, then the records hanging
+  off it, and only then the audit tabs.
+
+### Scanning a summary
+- One figure leads. The rest is evidence and is **muted** — a summary drawn at
+  one weight throughout is a wall of numbers with nothing in front.
+- Colour marks what to stop on: lateness, a shortfall, a signal counting
+  against the record. Not every number.
+- A number carries the colour of the thing it is judging, not just the word
+  beside it.
+
+### Action rows
+- A primary action and an overflow menu are **two controls side by side**, not
+  a segmented group. `ButtonGroup` fences its children in one bordered box with
+  a divider — the right shape for a set of alternatives, and the wrong one for
+  "do the thing" plus "everything else". Grouped, a solid brand button and a
+  bare icon button read as one control painted two colours.
+
 ### Navigation
 - A section rail is a **scrolling strip** on a phone, never a stacked column.
   Thirteen items in a column is five hundred pixels of navigation above the

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -267,6 +267,18 @@ rules bite hardest.
 - A number carries the colour of the thing it is judging, not just the word
   beside it.
 
+### Menus
+- **Every row carries a mark**, and the mark is sized, spaced and muted by the
+  primitive rather than by each call site — that is where `h-4 w-4` in one menu
+  and `size-4` in another came from.
+- **Tone is a prop, not a colour class.** `destructive` for what removes or
+  cannot be undone, `positive` for what completes something, `primary` for the
+  one thing the menu is mostly opened to do. A toned row tints its own mark to
+  match its label, which is what makes it read at a glance rather than after
+  reading the verb.
+- Group with separators and name the group when the menu acts on a specific
+  thing — a document number, a record's name.
+
 ### Action rows
 - A primary action and an overflow menu are **two controls side by side**, not
   a segmented group. `ButtonGroup` fences its children in one bordered box with

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -240,19 +240,21 @@ rules bite hardest.
   what makes the back arrow return to the record rather than to the list two
   levels up, makes a link to a record's documents sendable, and makes the first
   paint correct — `matchMedia` has no answer before hydration.
-- **A phone drills in; a desktop switches tabs.** Nine sections is not a strip
-  at 390px, it is a strip you scroll sideways hunting for a word. Below `md`
-  the sections are a list — mark, label, count, attention dot, chevron — and
-  opening one fills the page. Both shapes read the same URL, so neither is a
-  separate mode.
+- **A record's sections are a vertical rail, not a horizontal strip.** Thirteen
+  of them wrapped onto two rows at 1440px and had to be scrolled sideways at
+  390px. Use `NavRail` — the one the back office already uses — beside the
+  section on a desktop, and the same rail at the foot of the landing view on a
+  phone, where tapping a row opens that section full-width. One component, one
+  grammar, two placements.
+- **A segmented control is for three or four peers, not for sections.** Its
+  columns are equal-width by construction, so it is right for Note / Call /
+  Email in the activity composer and cannot hold a record's section set. Reach
+  for it when the choices are few and of one kind.
 - **The bar keeps naming the record at every depth.** Losing it is how a
   drilldown stops feeling like part of the record. The section names itself on
   the page below.
-- **A record's own tab strip is the platform's `SectionTabs`**, not a second
-  opinion about what a tab looks like: neutral active indicator, count pill,
-  icon slot. Brand colour is for primary actions.
-- **A zero is not a count.** Nine grey pills reading `0` say nothing; only a
-  section with something in it says how much.
+- **A zero is not a count.** A column of grey `0`s says nothing; only a section
+  with something in it says how much.
 - Section order follows what a record is opened for: the summary and the story
   first and in **one** view, then talking about it, then the records hanging
   off it, and only then the audit tabs.

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -66,6 +66,18 @@ When any UX guidance conflicts with other docs, this playbook wins.
 
 ## Shell Patterns
 
+### Where the title and the primary action go
+- **The top app bar, always.** A shell that draws its own `PageHeader` in the
+  page states the title twice — the bar is already showing it — and spends
+  about 110px of an 844px screen doing it, while the bar sits empty beside the
+  bell. Register both with `PageChrome`.
+- A page's primary action belongs in the bar even when the page's table has a
+  controls row of its own: parked there it lands under the title, the
+  description and the search box, which on a phone is four hundred pixels down.
+- A shell that offers module-wide verbs (Issue, Receive) offers them only on
+  the views they are the verb for. On the others the bar carries the page's
+  own action instead.
+
 ### List Shell
 - Header row with title and primary action.
 - Optional context tabs/segments directly above the DataTable.
@@ -190,6 +202,38 @@ apply them to any module.
 - **Dismissing a layer dismisses that layer only.** Escape in a picker must not
   close the form behind it. Mixing overlay libraries makes this a live risk:
   cover it with a test, not with hope.
+
+### Record pages
+Written from a screenshot audit of every CRM record at 390px. A record page
+carries more per screen than anything else in the product, so it is where these
+rules bite hardest.
+
+- **Properties live at the top of the page, and they have to be readable
+  there.** The label column is narrow on a phone (`w-28`), labels wrap rather
+  than truncate — "Primary cont…" is a label somebody has to guess at — and a
+  value that will not fit on one line wraps too. Nothing about a property may
+  run off the right edge of the screen.
+- **A property's editor is opened by pressing the value**, not by a verb parked
+  beside it. Where the value is a link worth following, the affordance is an
+  icon at the end of the row, not a word: "Change" spelled out costs about a
+  quarter of the value column at phone width.
+- **A rail section that repeats a property is deleted, not moved.** Once
+  properties are at the top, an Overview tab that restates the address and the
+  primary contact is a screen spent on what you just scrolled past.
+- **A summary with nothing in it is not a tab.** Pass no rail rather than an
+  empty one; the record then opens on its first real tab instead of on a blank
+  screen with a name.
+- **The record's actions are flat on a phone.** The app bar does its own
+  collecting — first action shown, rest behind one `···`. Hand it a menu and
+  the phone nests a menu inside a menu, with two controls on screen both
+  called "More actions".
+- Every record type has **one primary action**, and it is the thing that record
+  exists for: convert a lead, schedule a visit on a site, start a deal on a
+  company or a person. A record page whose bar holds only a back arrow and an
+  overflow menu has not been designed, it has been rendered.
+- A record that is no longer live **says so in its status chip**. An archived
+  record that looks exactly like a working one is how somebody spends ten
+  minutes on business nobody is pursuing.
 
 ### Navigation
 - A section rail is a **scrolling strip** on a phone, never a stacked column.

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -130,6 +130,51 @@ Use these labels exactly across tables, filters, legends, exports, and chips:
 - Must include selected count, allowed bulk actions, and a clear selection action.
 - Bulk actions must honor the same valid-action rule as row actions.
 
+## Phone Rules
+Written from a screenshot audit of every CRM screen at 390px. They generalise;
+apply them to any module.
+
+### The app bar
+- The page's name is the one thing the bar says that nothing else on screen
+  does. Nothing in the bar may crowd it out — search is an icon below `md`, and
+  the route icon gives way when a back arrow is present.
+- A record's name is too long for the bar at phone width. Repeat it on the page,
+  above the identity strip, whenever the bar is in its phone row.
+
+### Vertical budget
+- The first screen belongs to the records, not to the chrome above them.
+- Stat tiles are **two-up** on a phone (three only for a set of bare counts).
+  A column of full-width tiles spends a screen per number.
+- A dashboard widget narrower than half the grid is two-up on a phone.
+- Never state the same fact twice in the same band — a progress fraction and a
+  sentence saying the same thing, a section title in the shell and again in the
+  panel inside it.
+
+### Rails and strips
+- Anything that scrolls sideways — stage chips, section tabs — runs to the edges
+  of the screen and snaps. A strip cut short of the gutter reads as clipping;
+  cut by the screen edge it reads as "there is more".
+- A segment label never wraps. A strip that cannot fit scrolls rather than
+  squashing its labels.
+
+### Rows
+- Two lines per row, and one fact on the right — the value, the balance, the
+  figure the row is about. **Facts that need their label to make sense do not
+  appear on a phone**: an unlabelled "0" after somebody's name says nothing.
+- Sort before grouping. A letter heading over rows in `updatedAt` order is
+  worse than no heading.
+- Money carries its currency everywhere it appears, including inside an
+  editable property.
+
+### Controls
+- A search box's placeholder is written for the width it renders at. Clipped
+  hint text reads as a broken control; keep the long form as the accessible
+  name.
+- A column of controls in a sheet is a column of rows: labels at the left edge,
+  a trailing caret at the right. Use `.stacked-controls`.
+- A destructive action at the right edge of a row is under the thumb of anyone
+  scrolling. It confirms first.
+
 ## Compliance Checklist
 A screen is compliant only when:
 1. Warm paper tokens are applied with semantic variables.
@@ -140,3 +185,4 @@ A screen is compliant only when:
 6. Canonical statuses are used exactly, with `Ignored` chart-only.
 7. Charts use dashed grid, muted labels, status mapping, and hatch for ignored.
 8. List to detail navigation preserves context and bulk bar behavior follows this standard.
+9. It has been looked at on a 390px screen against the phone rules above.

--- a/e2e/crm-overlays.spec.ts
+++ b/e2e/crm-overlays.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Overlay behaviour at phone width — the part screenshots cannot see.
+ *
+ * Three defects this pins down, all of them reported from a real phone and all
+ * of them invisible to a static shot:
+ *
+ *   1. A menu opened inside the expanded sidebar painted *behind* it, because
+ *      the design system's drawer carries an inline `z-index: 1100` and every
+ *      overlay in this repo carried `z-50`.
+ *   2. A picker opened from inside a form dialog opened behind the dialog, for
+ *      the same reason in the other direction.
+ *   3. Escape in that picker closed the form under it and lost everything
+ *      typed — the sheet is a Radix dialog, the form is a Base UI one, and
+ *      both answered the same key.
+ *
+ * Run against the CRM demo tenant; see `crm-shots.spec.ts` for the seed.
+ */
+
+const BASE = process.env.E2E_BASE_URL ?? "http://crmdemo.apps.pagka.local:3000";
+const EMAIL = process.env.SHOT_EMAIL ?? "crm@demo.test";
+const PASSWORD = process.env.SHOT_PASSWORD ?? "Password123!";
+
+test.use({
+  baseURL: BASE,
+  viewport: { width: 390, height: 844 },
+  launchOptions: { executablePath: "/opt/pw-browsers/chromium" },
+});
+
+async function signIn(page: Page) {
+  await page.goto("/login");
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(2000);
+  await page.fill("#login-email", EMAIL);
+  await page.fill("#login-password", PASSWORD);
+  await page.click('button[type="submit"]');
+  await expect
+    .poll(
+      async () =>
+        (await page.context().cookies()).some((cookie) =>
+          cookie.name.includes("session-token"),
+        ),
+      { timeout: 45000 },
+    )
+    .toBe(true);
+  await page.goto("/", { waitUntil: "commit" }).catch(() => {});
+  await page.waitForTimeout(800);
+}
+
+async function openLeads(page: Page) {
+  await page.goto("/crm/leads");
+  await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(5000);
+}
+
+test("a menu opened inside the sidebar paints above it", async ({ page }) => {
+  test.setTimeout(180_000);
+  await signIn(page);
+  await openLeads(page);
+
+  await page.locator('[data-slot="sidebar-trigger"], [data-sidebar="trigger"]').first().click();
+  await page.waitForTimeout(1200);
+  await page.getByRole("button", { name: /Scrap & Recycling/i }).first().click();
+  await page.waitForTimeout(1500);
+
+  // Hit-testing rather than z-index arithmetic: what is actually on top at the
+  // menu's own coordinates?
+  const verdict = await page.evaluate(() => {
+    const menu = document.querySelector<HTMLElement>(".menu");
+    if (!menu) return "no menu rendered";
+    const box = menu.getBoundingClientRect();
+    const top = document.elementFromPoint(box.x + box.width / 2, box.y + 20);
+    return top && menu.contains(top) ? "on top" : `covered by .${top?.className}`;
+  });
+  expect(verdict).toBe("on top");
+});
+
+test("a picker opened from a form dialog stays in front of it, and Escape closes only the picker", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await signIn(page);
+  await openLeads(page);
+
+  await page.getByRole("button", { name: /New lead/i }).first().click();
+  await page.waitForTimeout(2000);
+  const dialog = page.locator('[data-slot="dialog-content"]').first();
+  await expect(dialog).toBeVisible();
+
+  await page.getByRole("button", { name: /Search clients/i }).first().click();
+  await page.waitForTimeout(1500);
+
+  // On a phone the picker is a sheet, not a popover floating over the form.
+  const picker = page.locator(".drawer.drawer-bottom").first();
+  await expect(picker).toBeVisible();
+  const onTop = await page.evaluate(() => {
+    const sheet = document.querySelector<HTMLElement>(".drawer.drawer-bottom");
+    if (!sheet) return "no sheet";
+    const box = sheet.getBoundingClientRect();
+    const top = document.elementFromPoint(box.x + box.width / 2, box.y + 30);
+    return top && sheet.contains(top) ? "on top" : `covered by .${top?.className}`;
+  });
+  expect(onTop).toBe("on top");
+
+  // Choosing keeps the form.
+  const option = page
+    .locator('[cmdk-item], [role="option"]')
+    .filter({ hasText: "Zambezi Mining Supplies" })
+    .first();
+  await option.click();
+  await page.waitForTimeout(1200);
+  await expect(dialog).toBeVisible();
+
+  // And so does dismissing without choosing. This is the regression: both
+  // libraries used to answer the same Escape and the form went with it.
+  await page.getByRole("button", { name: /Zambezi|Search clients/i }).first().click();
+  await page.waitForTimeout(1200);
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(1200);
+  await expect(picker).toBeHidden();
+  await expect(dialog).toBeVisible();
+});

--- a/e2e/crm-shots.spec.ts
+++ b/e2e/crm-shots.spec.ts
@@ -50,6 +50,27 @@ const SCREENS: Screen[] = [
   { name: "crm-import", path: "/crm/import" },
   { name: "crm-settings", path: "/crm/settings" },
   { name: "crm-reps", path: "/crm/reps" },
+  // The create flow, which on a phone is a sheet over the list it was opened
+  // from — worth photographing because it is where most typing happens.
+  {
+    name: "crm-new-lead-sheet",
+    path: "/crm/leads",
+    prepare: async (page) => {
+      await page.getByRole("button", { name: /New lead/i }).first().click();
+      await page.waitForTimeout(1500);
+    },
+  },
+  {
+    name: "crm-view-sheet",
+    path: "/crm/leads",
+    prepare: async (page) => {
+      const trigger = page.getByRole("button", { name: /View and filters/i }).first();
+      if (!(await trigger.isVisible().catch(() => false))) return;
+      await trigger.click();
+      await page.waitForTimeout(1500);
+    },
+  },
+
   // Record pages, reached by opening the first row of their list — the ids are
   // uuids, so there is no path to hardcode, and naming a record by its title
   // fails the moment the board opens on a stage that record is not in.
@@ -69,9 +90,19 @@ function openFirstRecord(prefix: string) {
       console.error(`[shots] no record row to open under ${prefix}`);
       return;
     }
+    const href = await link.getAttribute("href");
     await link.click();
-    await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
-    await page.waitForTimeout(4000);
+    // Wait on the URL, not on the network: the record route compiles on first
+    // hit against a dev server, and `networkidle` settles on the list long
+    // before the record has painted — which produced three pictures of the
+    // list with one row hovered.
+    if (href) {
+      await page.waitForURL(`**${href}`, { timeout: 30000 }).catch(() => {
+        console.error(`[shots] never landed on ${href}`);
+      });
+    }
+    await page.waitForLoadState("networkidle", { timeout: 20000 }).catch(() => {});
+    await page.waitForTimeout(6000);
   };
 }
 

--- a/e2e/crm-shots.spec.ts
+++ b/e2e/crm-shots.spec.ts
@@ -50,6 +50,23 @@ const SCREENS: Screen[] = [
   { name: "crm-import", path: "/crm/import" },
   { name: "crm-settings", path: "/crm/settings" },
   { name: "crm-reps", path: "/crm/reps" },
+  { name: "crm-clients", path: "/crm/clients" },
+  { name: "crm-receipts", path: "/crm/receipts" },
+  { name: "crm-workflow-runs", path: "/crm/workflows/runs" },
+  { name: "crm-workflow-new", path: "/crm/workflows/new" },
+
+  // Management — the same vertical's back office, held to the same rules.
+  { name: "mgmt-master-data", path: "/management/master-data" },
+  { name: "mgmt-departments", path: "/management/master-data/hr/departments" },
+  { name: "mgmt-job-grades", path: "/management/master-data/hr/job-grades" },
+  { name: "mgmt-sites", path: "/management/master-data/operations/sites" },
+  { name: "mgmt-sections", path: "/management/master-data/operations/sections" },
+  { name: "mgmt-downtime-codes", path: "/management/master-data/operations/downtime-codes" },
+  { name: "mgmt-users", path: "/management/users" },
+  { name: "mgmt-users-create", path: "/management/users/create" },
+  { name: "mgmt-users-status", path: "/management/users/status" },
+  { name: "mgmt-users-role-change", path: "/management/users/role-change" },
+  { name: "mgmt-users-password-reset", path: "/management/users/password-reset" },
   // The create flow, which on a phone is a sheet over the list it was opened
   // from — worth photographing because it is where most typing happens.
   {
@@ -170,6 +187,13 @@ for (const [label, width, height] of VIEWPORTS) {
       await page.waitForTimeout(1000);
 
       for (const { name, path, prepare } of SELECTED) {
+        // Close whatever the last screen left open. A screen whose `prepare`
+        // opens a sheet or the sidebar used to leave it open across the next
+        // `goto`, which is how a picture of the clients list came back showing
+        // the sidebar over it.
+        await page.keyboard.press("Escape").catch(() => {});
+        await page.waitForTimeout(300);
+
         // One retry: an aborted navigation is a race, not a broken route.
         try {
           await page.goto(path);

--- a/e2e/crm-shots.spec.ts
+++ b/e2e/crm-shots.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Screenshots of the CRM surface, at every width it has to work at.
+ *
+ * The module is judged on a phone as often as on a desktop, and a board, a
+ * record page or a filter row can only be judged with records in it — so this
+ * runs against the CRM demo tenant, not an empty one:
+ *
+ *   npx tsx scripts/seed-staging-tenant.ts --slug crmdemo \
+ *     --email crm@demo.test --password 'Password123!' --name 'Corelith Demo'
+ *   npx tsx scripts/seed-crm-demo.ts --slug crmdemo
+ *   E2E_BASE_URL=http://localhost:3000 npx playwright test e2e/crm-shots.spec.ts
+ *
+ * `SHOT_ONLY=crm-leads,crm-deals SHOT_VIEWPORTS=phone` reshoots one screen at
+ * one width, which is the loop you want while changing it.
+ */
+
+const OUT = process.env.SHOT_DIR ?? "/tmp/shots";
+const BASE = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+const EMAIL = process.env.SHOT_EMAIL ?? "crm@demo.test";
+const PASSWORD = process.env.SHOT_PASSWORD ?? "Password123!";
+
+type Screen = {
+  name: string;
+  path: string;
+  prepare?: (page: Page) => Promise<void>;
+};
+
+const SCREENS: Screen[] = [
+  { name: "crm-overview", path: "/crm" },
+  { name: "crm-leads", path: "/crm/leads" },
+  { name: "crm-leads-list", path: "/crm/leads?layout=table" },
+  { name: "crm-deals", path: "/crm/deals" },
+  { name: "crm-people", path: "/crm/people" },
+  { name: "crm-companies", path: "/crm/companies" },
+  { name: "crm-sites", path: "/crm/sites" },
+  { name: "crm-tasks", path: "/crm/tasks" },
+  { name: "crm-follow-ups", path: "/crm/follow-ups" },
+  { name: "crm-quotes", path: "/crm/quotes" },
+  { name: "crm-invoices", path: "/crm/invoices" },
+  { name: "crm-collections", path: "/crm/collections" },
+  { name: "crm-appointments", path: "/crm/appointments" },
+  { name: "crm-work-orders", path: "/crm/work-orders" },
+  { name: "crm-insights", path: "/crm/insights" },
+  { name: "crm-reports", path: "/crm/reports" },
+  { name: "crm-workflows", path: "/crm/workflows" },
+  { name: "crm-templates", path: "/crm/templates" },
+  { name: "crm-forms", path: "/crm/forms" },
+  { name: "crm-import", path: "/crm/import" },
+  { name: "crm-settings", path: "/crm/settings" },
+  { name: "crm-reps", path: "/crm/reps" },
+  // Record pages, reached by opening the first row of their list — the ids are
+  // uuids, so there is no path to hardcode, and naming a record by its title
+  // fails the moment the board opens on a stage that record is not in.
+  { name: "crm-deal-record", path: "/crm/deals", prepare: openFirstRecord("/crm/deals/") },
+  {
+    name: "crm-company-record",
+    path: "/crm/companies",
+    prepare: openFirstRecord("/crm/companies/"),
+  },
+  { name: "crm-person-record", path: "/crm/people", prepare: openFirstRecord("/crm/people/") },
+];
+
+function openFirstRecord(prefix: string) {
+  return async (page: Page) => {
+    const link = page.locator(`a[href^="${prefix}"]`).first();
+    if (!(await link.isVisible().catch(() => false))) {
+      console.error(`[shots] no record row to open under ${prefix}`);
+      return;
+    }
+    await link.click();
+    await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+    await page.waitForTimeout(4000);
+  };
+}
+
+// The environment ships a chromium this Playwright did not download, so point
+// at the installed binary rather than fetching one.
+test.use({
+  baseURL: BASE,
+  launchOptions: { executablePath: "/opt/pw-browsers/chromium" },
+});
+
+const ALL_VIEWPORTS: Array<[label: string, width: number, height: number]> = [
+  ["desktop", 1440, 900],
+  ["tablet", 768, 1024],
+  ["phone", 390, 844],
+];
+
+function only(value: string | undefined) {
+  const names = (value ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  return names.length > 0 ? new Set(names) : null;
+}
+
+const screenFilter = only(process.env.SHOT_ONLY);
+const viewportFilter = only(process.env.SHOT_VIEWPORTS);
+const SELECTED = screenFilter
+  ? SCREENS.filter((screen) => screenFilter.has(screen.name))
+  : SCREENS;
+const VIEWPORTS = viewportFilter
+  ? ALL_VIEWPORTS.filter(([label]) => viewportFilter.has(label))
+  : ALL_VIEWPORTS;
+
+for (const [label, width, height] of VIEWPORTS) {
+  test.describe(`${label}`, () => {
+    test.use({ viewport: { width, height } });
+
+    test(`crm screens at ${width}x${height}`, async ({ page }) => {
+      // The config's 60s global timeout cannot fit a pass: sign-in alone is
+      // ~30s against a dev server, and each screen waits for compile-on-first-
+      // hit. Sized to the work, so an overrun fails rather than half-writing a
+      // directory of images that looks like a complete run.
+      test.setTimeout(90_000 + SELECTED.length * 25_000);
+
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(2500);
+      await page.fill("#login-email", EMAIL);
+      await page.fill("#login-password", PASSWORD);
+      await page.click('button[type="submit"]');
+      // Wait on the cookie rather than the URL: NEXTAUTH_URL pins the
+      // post-login redirect to whichever host it names, while the session is
+      // issued for the host the form posted to.
+      await expect
+        .poll(
+          async () => {
+            const cookies = await page.context().cookies();
+            return cookies.some((cookie) => cookie.name.includes("session-token"));
+          },
+          { timeout: 45000 },
+        )
+        .toBe(true);
+
+      await page.goto("/", { waitUntil: "commit" }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      for (const { name, path, prepare } of SELECTED) {
+        // One retry: an aborted navigation is a race, not a broken route.
+        try {
+          await page.goto(path);
+        } catch {
+          await page.waitForTimeout(1000);
+          await page.goto(path);
+        }
+        await page.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+        // Compile-on-first-hit takes seconds against a dev server; a shot taken
+        // during it is a picture of a skeleton.
+        await page.waitForTimeout(6000);
+        const banner = page.getByText(/Unable to load|Failed to (fetch|load)/i).first();
+        if (await banner.isVisible().catch(() => false)) {
+          console.error(`[shots] ${name} at ${label} rendered an error banner`);
+        }
+        if (prepare) {
+          await prepare(page);
+          await page.waitForTimeout(1500);
+        }
+        await page.screenshot({ path: `${OUT}/${name}-${label}.png`, fullPage: true });
+      }
+    });
+  });
+}

--- a/e2e/record-shots.spec.ts
+++ b/e2e/record-shots.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Every record page, at the width it is hardest at.
+ *
+ * The list screens were audited first; records are where the work is, because
+ * a record page carries more per screen than anything else in the product —
+ * a name, a status, a dozen properties, a stage bar, nine tabs and a rail.
+ * Phone comes first in the viewport list for that reason: it is the width
+ * that decides whether the page is readable, and the one people actually open
+ * a lead on while standing on a site.
+ *
+ *   npx playwright test e2e/record-shots.spec.ts
+ *   SHOT_ONLY=lead SHOT_VIEWPORTS=phone npx playwright test e2e/record-shots.spec.ts
+ *
+ * Runs against the CRM demo tenant; see e2e/crm-shots.spec.ts for the seed.
+ */
+
+const OUT = process.env.SHOT_DIR ?? "/tmp/shots";
+const BASE = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+const EMAIL = process.env.SHOT_EMAIL ?? "crm@demo.test";
+const PASSWORD = process.env.SHOT_PASSWORD ?? "Password123!";
+
+type Record_ = {
+  name: string;
+  /** The list to open the record from — record ids are uuids, so there is no path to hardcode. */
+  list: string;
+  /** The record route's prefix, which is what a row's link starts with. */
+  prefix: string;
+  /** A tab to open once the record has loaded, for the shot that shows tab content. */
+  tab?: string;
+};
+
+const RECORDS: Record_[] = [
+  { name: "lead", list: "/crm/leads?layout=table", prefix: "/crm/leads/" },
+  { name: "deal", list: "/crm/deals", prefix: "/crm/deals/" },
+  { name: "company", list: "/crm/companies", prefix: "/crm/companies/" },
+  { name: "person", list: "/crm/people", prefix: "/crm/people/" },
+  { name: "site", list: "/crm/sites", prefix: "/crm/sites/" },
+  { name: "rep", list: "/crm/reps", prefix: "/crm/reps/" },
+];
+
+async function openFirstRecord(page: Page, list: string, prefix: string) {
+  try {
+    await page.goto(list);
+  } catch {
+    await page.waitForTimeout(1000);
+    await page.goto(list);
+  }
+  await page.waitForLoadState("networkidle", { timeout: 20000 }).catch(() => {});
+  await page.waitForTimeout(6000);
+
+  const link = page.locator(`a[href^="${prefix}"]`).first();
+  if (!(await link.isVisible().catch(() => false))) {
+    console.error(`[shots] no record row under ${prefix}`);
+    return false;
+  }
+  const href = await link.getAttribute("href");
+  await link.click();
+  // Wait on the URL rather than the network: the record route compiles on
+  // first hit, and `networkidle` settles on the list long before the record
+  // has painted.
+  if (href) {
+    await page.waitForURL(`**${href}`, { timeout: 30000 }).catch(() => {
+      console.error(`[shots] never landed on ${href}`);
+    });
+  }
+  await page.waitForLoadState("networkidle", { timeout: 20000 }).catch(() => {});
+  await page.waitForTimeout(6000);
+  return true;
+}
+
+test.use({
+  baseURL: BASE,
+  launchOptions: { executablePath: "/opt/pw-browsers/chromium" },
+});
+
+const ALL_VIEWPORTS: Array<[label: string, width: number, height: number]> = [
+  ["phone", 390, 844],
+  ["desktop", 1440, 900],
+];
+
+function only(value: string | undefined) {
+  const names = (value ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  return names.length > 0 ? new Set(names) : null;
+}
+
+const recordFilter = only(process.env.SHOT_ONLY);
+const viewportFilter = only(process.env.SHOT_VIEWPORTS);
+const SELECTED = recordFilter ? RECORDS.filter((r) => recordFilter.has(r.name)) : RECORDS;
+const VIEWPORTS = viewportFilter
+  ? ALL_VIEWPORTS.filter(([label]) => viewportFilter.has(label))
+  : ALL_VIEWPORTS;
+
+for (const [label, width, height] of VIEWPORTS) {
+  test.describe(`${label}`, () => {
+    test.use({ viewport: { width, height } });
+
+    test(`record pages at ${width}x${height}`, async ({ page }) => {
+      test.setTimeout(90_000 + SELECTED.length * 40_000);
+
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(2500);
+      await page.fill("#login-email", EMAIL);
+      await page.fill("#login-password", PASSWORD);
+      await page.click('button[type="submit"]');
+      // Poll the session endpoint rather than the cookie jar or the URL. The
+      // cookie's name depends on how the deployment is configured, and
+      // NEXTAUTH_URL pins the post-login redirect to whichever host it names —
+      // which need not be the host the form posted to. Whether the session
+      // exists is the thing actually being waited on.
+      await expect
+        .poll(
+          async () =>
+            page.request
+              .get(BASE + "/api/auth/session")
+              .then((response) => response.json())
+              .then((body: { user?: unknown }) => Boolean(body?.user))
+              .catch(() => false),
+          { timeout: 45000 },
+        )
+        .toBe(true);
+
+      await page.goto("/", { waitUntil: "commit" }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      for (const { name, list, prefix } of SELECTED) {
+        await page.keyboard.press("Escape").catch(() => {});
+        await page.waitForTimeout(300);
+
+        const opened = await openFirstRecord(page, list, prefix);
+        if (!opened) continue;
+
+        // The whole page, which is what shows how much scrolling a record
+        // costs, and the first screen, which is what somebody actually gets.
+        await page.screenshot({ path: `${OUT}/record-${name}-${label}.png`, fullPage: true });
+        await page.screenshot({ path: `${OUT}/record-${name}-${label}-fold.png` });
+      }
+    });
+  });
+}

--- a/lib/crm/auto-assign.ts
+++ b/lib/crm/auto-assign.ts
@@ -30,7 +30,10 @@ export async function autoAssignLead(
     where: {
       companyId,
       assignedToId: { in: users.map((user) => user.id) },
-      convertedAt: null,
+      // Archived, not merely unconverted: a lead somebody put away by hand is
+      // as much off their plate as one that became a deal, and counting it as
+      // load sends the next enquiry to whoever tidied up least.
+      archivedAt: null,
       stage: { notIn: ["WON", "LOST"] },
     },
     _count: { _all: true },

--- a/lib/crm/conversion.ts
+++ b/lib/crm/conversion.ts
@@ -257,6 +257,14 @@ export async function convertLead(
       convertedClientId: clientId,
       clientId: clientId ?? undefined,
       stage: "QUALIFIED",
+      // Archived in the same breath. Marking a lead converted was never
+      // enough on its own: it stayed in the leads list and on the board, so
+      // the same opportunity sat in the pipeline twice — once as a lead in
+      // Qualified and once as the deal it had just become — and every count
+      // that spanned both was wrong. The record is kept, as history always
+      // was; it is only out of the working set.
+      archivedAt: now,
+      archivedById: userId,
     },
   });
 

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -15,6 +15,7 @@ import type { CollabEntity } from "@/lib/crm/collaboration";
 import type { TaskQueue } from "@/lib/crm/tasks";
 import type { ImportEntity, ImportPlan } from "@/lib/crm/import";
 import type { FieldChoice, MergeFieldPlan } from "@/lib/crm/merge";
+import type { RecordSort } from "@/lib/crm/records";
 import type { LeadSort, LeadViewFilters } from "@/lib/crm/views";
 import type { SiteVisitItemInput, SiteVisitReportInput } from "@/lib/crm/site-visits";
 
@@ -648,7 +649,7 @@ export function recordFiltersToParams(
 }
 
 export function fetchCrmPeople(
-  params: { filters?: Record<string, unknown>; sort?: LeadSort; page?: number; limit?: number } = {},
+  params: { filters?: Record<string, unknown>; sort?: RecordSort; page?: number; limit?: number } = {},
 ) {
   return fetchJson<ListResponse<CrmPersonRecord>>(
     `/api/v2/crm/people${qs({
@@ -662,7 +663,7 @@ export function fetchCrmPeople(
 }
 
 export function fetchCrmCompanies(
-  params: { filters?: Record<string, unknown>; sort?: LeadSort; page?: number; limit?: number } = {},
+  params: { filters?: Record<string, unknown>; sort?: RecordSort; page?: number; limit?: number } = {},
 ) {
   return fetchJson<ListResponse<CrmCompanyRecord>>(
     `/api/v2/crm/companies${qs({
@@ -676,7 +677,7 @@ export function fetchCrmCompanies(
 }
 
 export function fetchCrmDeals(
-  params: { filters?: Record<string, unknown>; sort?: LeadSort; page?: number; limit?: number } = {},
+  params: { filters?: Record<string, unknown>; sort?: RecordSort; page?: number; limit?: number } = {},
 ) {
   return fetchJson<ListResponse<CrmDealRecord>>(
     `/api/v2/crm/deals${qs({
@@ -690,7 +691,7 @@ export function fetchCrmDeals(
 }
 
 export function fetchCrmSites(
-  params: { filters?: Record<string, unknown>; sort?: LeadSort; page?: number; limit?: number } = {},
+  params: { filters?: Record<string, unknown>; sort?: RecordSort; page?: number; limit?: number } = {},
 ) {
   return fetchJson<ListResponse<CrmSiteRecord>>(
     `/api/v2/crm/sites${qs({

--- a/lib/crm/crm-v2.ts
+++ b/lib/crm/crm-v2.ts
@@ -219,6 +219,7 @@ export function leadFiltersToParams(
     createdFrom: filters.createdFrom,
     createdTo: filters.createdTo,
     overdueOnly: filters.overdueOnly ? "1" : undefined,
+    archived: filters.archived ? "1" : undefined,
   };
 }
 
@@ -345,7 +346,8 @@ export function createCrmList(body: {
 
 export type CrmBulkLeadAction =
   | { action: "assign"; ids: string[]; assignedToId: string | null }
-  | { action: "stage"; ids: string[]; stage: CrmLeadStage; lostReason?: string };
+  | { action: "stage"; ids: string[]; stage: CrmLeadStage; lostReason?: string }
+  | { action: "archive"; ids: string[]; archived: boolean };
 
 export function bulkUpdateCrmLeads(body: CrmBulkLeadAction) {
   return fetchJson<

--- a/lib/crm/search.ts
+++ b/lib/crm/search.ts
@@ -120,7 +120,10 @@ export async function searchCrm(
       db.crmLead.findMany({
         where: {
           companyId,
-          convertedAt: null,
+          // Archived, not merely unconverted. Search offers things to go and
+          // work on; a lead that has been put away is not one of them, and
+          // hiding only the converted ones let every archived lead back in.
+          archivedAt: null,
           OR: [
             { leadNo: contains },
             { title: contains },

--- a/lib/crm/story.ts
+++ b/lib/crm/story.ts
@@ -1,4 +1,7 @@
 import type { StoryEvent } from "@/components/crm/records/record-story";
+// The wire-type → kind map lives beside the table that says what each kind
+// looks like, so a new activity type is one edit and not two.
+import { ACTIVITY_KIND } from "@/components/crm/records/event-kind";
 
 /**
  * Turning a record's several tables into one story.
@@ -58,22 +61,6 @@ type CommentLike = {
   author?: { id: string; name: string | null } | null;
 };
 
-/** Activity types map onto the story's kinds; anything unknown reads as system. */
-const ACTIVITY_KIND: Record<string, StoryEvent["kind"]> = {
-  NOTE: "note",
-  CALL: "call",
-  EMAIL: "email",
-  WHATSAPP: "whatsapp",
-  MEETING: "meeting",
-  STAGE_CHANGE: "stage",
-  INTAKE_SUBMISSION: "intake",
-  DOCUMENT_CREATED: "document",
-  DOCUMENT_SENT: "document",
-  DOCUMENT_APPROVED: "document",
-  DOCUMENT_DECLINED: "document",
-  PAYMENT_RECORDED: "payment",
-  SYSTEM: "system",
-};
 
 /**
  * The types somebody writes prose into. Their content is written in the CRM's

--- a/lib/crm/views.test.ts
+++ b/lib/crm/views.test.ts
@@ -7,20 +7,32 @@ import {
   hasActiveLeadFilters,
   leadViewFiltersSchema,
   parseLeadFiltersFromParams,
+  type LeadViewFilters,
 } from "./views";
 
 const COMPANY = "company-1";
 const USER = "user-1";
 
+/**
+ * The clauses a query carries beyond the archive one, which is always first
+ * and is asserted on its own below. Written as a helper so a test about owner
+ * filtering says something about owner filtering.
+ */
+function filterClauses(where: ReturnType<typeof buildLeadWhere>) {
+  return (where.AND as unknown[]).slice(1);
+}
+
 describe("buildLeadWhere", () => {
   it("always scopes to the company, even with no filters", () => {
-    expect(buildLeadWhere(COMPANY, {}, USER)).toEqual({ companyId: COMPANY });
+    const where = buildLeadWhere(COMPANY, {}, USER);
+    expect(where.companyId).toBe(COMPANY);
+    expect(filterClauses(where)).toEqual([]);
   });
 
   it("keeps the company scope alongside every filter", () => {
     const where = buildLeadWhere(COMPANY, { stages: ["NEW"], q: "roof" }, USER);
     expect(where.companyId).toBe(COMPANY);
-    expect(where.AND).toHaveLength(2);
+    expect(filterClauses(where)).toHaveLength(2);
   });
 
   it("treats explicit owners and unassigned as alternatives", () => {
@@ -29,41 +41,69 @@ describe("buildLeadWhere", () => {
       { assignedToIds: ["user-2"], unassigned: true },
       USER,
     );
-    expect(where.AND).toEqual([
+    expect(filterClauses(where)).toEqual([
       { OR: [{ assignedToId: { in: ["user-2"] } }, { assignedToId: null }] },
     ]);
   });
 
   it("applies a single owner clause directly rather than wrapping it in OR", () => {
     const where = buildLeadWhere(COMPANY, { assignedToIds: ["user-2"] }, USER);
-    expect(where.AND).toEqual([{ assignedToId: { in: ["user-2"] } }]);
+    expect(filterClauses(where)).toEqual([{ assignedToId: { in: ["user-2"] } }]);
   });
 
   it("resolves mineOnly against the calling user", () => {
     const where = buildLeadWhere(COMPANY, { mineOnly: true }, USER);
-    expect(where.AND).toEqual([{ assignedToId: USER }]);
+    expect(filterClauses(where)).toEqual([{ assignedToId: USER }]);
   });
 
   it("builds a bounded value range", () => {
     const where = buildLeadWhere(COMPANY, { valueMin: 100, valueMax: 500 }, USER);
-    expect(where.AND).toEqual([{ estimatedValue: { gte: 100, lte: 500 } }]);
+    expect(filterClauses(where)).toEqual([{ estimatedValue: { gte: 100, lte: 500 } }]);
   });
 
   it("builds an open-ended value range", () => {
     const where = buildLeadWhere(COMPANY, { valueMin: 100 }, USER);
-    expect(where.AND).toEqual([{ estimatedValue: { gte: 100 } }]);
+    expect(filterClauses(where)).toEqual([{ estimatedValue: { gte: 100 } }]);
   });
 
   it("searches across lead number, title, contact and client name", () => {
     const where = buildLeadWhere(COMPANY, { q: "acme" }, USER);
-    const or = (where.AND as Array<{ OR?: unknown[] }>)[0].OR;
+    const or = (filterClauses(where) as Array<{ OR?: unknown[] }>)[0].OR;
     expect(or).toHaveLength(5);
   });
 
   it("filters to leads carrying an overdue follow-up", () => {
     const where = buildLeadWhere(COMPANY, { overdueOnly: true }, USER);
-    const clause = (where.AND as Array<{ followUps?: { some?: { status?: string } } }>)[0];
+    const clause = (filterClauses(where) as Array<{ followUps?: { some?: { status?: string } } }>)[0];
     expect(clause.followUps?.some?.status).toBe("PENDING");
+  });
+
+  // The double-count this whole thing exists to stop: a converted lead is
+  // archived, so if archived rows leaked into a default query the deal and the
+  // lead it came from would both be counted as live business.
+  it("leaves archived leads out of every query by default", () => {
+    const cases: LeadViewFilters[] = [{}, { stages: ["NEW"] }, { mineOnly: true }];
+    for (const filters of cases) {
+      const where = buildLeadWhere(COMPANY, filters, USER);
+      expect((where.AND as unknown[])[0]).toEqual({ archivedAt: null });
+    }
+  });
+
+  it("swaps the set rather than narrowing it when the archive is asked for", () => {
+    const where = buildLeadWhere(COMPANY, { archived: true }, USER);
+    expect((where.AND as unknown[])[0]).toEqual({ archivedAt: { not: null } });
+    expect(filterClauses(where)).toEqual([]);
+  });
+
+  it("still narrows the archive by the other filters", () => {
+    const where = buildLeadWhere(COMPANY, { archived: true, mineOnly: true }, USER);
+    expect((where.AND as unknown[])[0]).toEqual({ archivedAt: { not: null } });
+    expect(filterClauses(where)).toEqual([{ assignedToId: USER }]);
+  });
+
+  it("reads the archive flag off a query string", () => {
+    expect(parseLeadFiltersFromParams(new URLSearchParams("archived=1")).archived).toBe(true);
+    expect(parseLeadFiltersFromParams(new URLSearchParams("")).archived).toBeUndefined();
   });
 });
 

--- a/lib/crm/views.ts
+++ b/lib/crm/views.ts
@@ -36,6 +36,12 @@ export const leadViewFiltersSchema = z.object({
   createdTo: z.string().datetime().optional(),
   /** Only leads with a pending follow-up already past due. */
   overdueOnly: z.boolean().optional(),
+  /**
+   * Show archived leads instead of live ones. Archiving is not a filter people
+   * combine with others — it is a different question ("what did we put away")
+   * — so it swaps the set rather than narrowing it.
+   */
+  archived: z.boolean().optional(),
 });
 
 export type LeadViewFilters = z.infer<typeof leadViewFiltersSchema>;
@@ -89,6 +95,7 @@ export function parseLeadFiltersFromParams(searchParams: URLSearchParams): LeadV
     createdFrom: searchParams.get("createdFrom") || undefined,
     createdTo: searchParams.get("createdTo") || undefined,
     overdueOnly: bool("overdueOnly"),
+    archived: bool("archived"),
   };
 
   const parsed = leadViewFiltersSchema.safeParse(candidate);
@@ -105,6 +112,12 @@ export function buildLeadWhere(
   userId: string,
 ): Prisma.CrmLeadWhereInput {
   const and: Prisma.CrmLeadWhereInput[] = [];
+
+  // Archived leads are out of every list, board and count unless they are what
+  // was asked for. This is also what stops a converted lead and the deal it
+  // became appearing as two live opportunities: conversion archives the lead,
+  // so the pipeline stops counting the same piece of business twice.
+  and.push(filters.archived ? { archivedAt: { not: null } } : { archivedAt: null });
 
   if (filters.stages?.length) {
     and.push({ stage: { in: filters.stages } });

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -448,3 +448,4 @@ export const Upload = createPhosphorIcon("UploadSimple", "Upload");
 export const Paperclip = createPhosphorIcon("Paperclip", "Paperclip");
 export const At = createPhosphorIcon("At", "At");
 export const FlowArrow = createPhosphorIcon("FlowArrow", "FlowArrow");
+export const Archive = createPhosphorIcon("Archive", "Archive");

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -42,12 +42,27 @@ function getIconComponent(iconName: string) {
 const STROKE_WEIGHT_PREFIX = /^Caret/;
 const STROKE_WEIGHT_EXACT = new Set(["X", "Plus", "Minus", "Check", "Checks", "Equals"]);
 
+/**
+ * Marks drawn as outlines rather than solids.
+ *
+ * A filled magnifier is a black lollipop: the lens, which is the part that
+ * says "search", is exactly the part the fill removes. It reads as heavier
+ * than everything around it in a toolbar of quiet controls — and search is
+ * the quietest thing in a toolbar, not the loudest.
+ *
+ * `regular` rather than `bold`: these are shapes with an interior, so they
+ * want an outline weight, not a thickened stroke.
+ */
+const OUTLINE_WEIGHT_EXACT = new Set(["MagnifyingGlass"]);
+
 function createPhosphorIcon(iconName: string, displayName: string): LucideIcon {
   const IconComponent = getIconComponent(iconName);
   const defaultWeight: PhosphorIconProps["weight"] =
     STROKE_WEIGHT_PREFIX.test(iconName) || STROKE_WEIGHT_EXACT.has(iconName)
       ? "bold"
-      : "fill";
+      : OUTLINE_WEIGHT_EXACT.has(iconName)
+        ? "regular"
+        : "fill";
 
   const Icon = ({
     className,

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -443,3 +443,8 @@ export const ChatCircle = createPhosphorIcon("ChatCircle", "ChatCircle");
 export const PushPin = createPhosphorIcon("PushPin", "PushPin");
 export const Repeat = createPhosphorIcon("Repeat", "Repeat");
 export const Upload = createPhosphorIcon("UploadSimple", "Upload");
+
+/** Marks for a record's sections — the tab strip and the phone's section list. */
+export const Paperclip = createPhosphorIcon("Paperclip", "Paperclip");
+export const At = createPhosphorIcon("At", "At");
+export const FlowArrow = createPhosphorIcon("FlowArrow", "FlowArrow");

--- a/prisma/migrations/20260815090000_crm_lead_archive/migration.sql
+++ b/prisma/migrations/20260815090000_crm_lead_archive/migration.sql
@@ -1,0 +1,41 @@
+-- A lead can be put away.
+--
+-- `CrmLead` had no ending short of the LOST stage, which is a claim about the
+-- business — somebody looked at the enquiry and said no. A duplicate typed
+-- twice, a test row or a wrong number is not that, and there was nothing else
+-- to do with one: leads could be neither archived nor deleted, so they stayed
+-- in the pipeline for good.
+--
+-- It also had no way to stop counting a converted lead. `convertedAt` was set
+-- when a lead became a deal, but nothing read it in a list query, so the same
+-- opportunity sat in the pipeline twice — once as a lead in Qualified, once as
+-- the deal it had just become — and every figure spanning both was wrong.
+--
+--   CrmLead.archivedAt     when it left the working set; NULL means live
+--   CrmLead.archivedById   who put it away
+--
+-- Conversion now sets both, alongside the `convertedAt` it already wrote, and
+-- every lead query excludes archived rows unless they are what was asked for.
+-- The record itself is kept either way: source reporting reads it to answer
+-- "where did this business come from".
+--
+-- No index. Every lead query is already scoped by `companyId` through one of
+-- the composite indexes on this table, and `archivedAt IS NULL` matches almost
+-- every row in it — a column that selective earns nothing as an index and
+-- costs a write on every update.
+
+ALTER TABLE "CrmLead" ADD COLUMN "archivedAt" TIMESTAMP(3);
+ALTER TABLE "CrmLead" ADD COLUMN "archivedById" TEXT;
+
+ALTER TABLE "CrmLead"
+  ADD CONSTRAINT "CrmLead_archivedById_fkey"
+  FOREIGN KEY ("archivedById") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Leads converted before this migration are the double-count it exists to fix,
+-- so they are archived where they stand, credited to whoever converted them.
+UPDATE "CrmLead"
+   SET "archivedAt" = "convertedAt",
+       "archivedById" = "convertedById"
+ WHERE "convertedAt" IS NOT NULL
+   AND "archivedAt" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1053,6 +1053,7 @@ model User {
   crmPipelinesCreated               CrmPipeline[]                  @relation("CrmPipelineCreatedBy")
   crmFieldDefinitionsCreated        CrmFieldDefinition[]           @relation("CrmFieldDefinitionCreatedBy")
   crmLeadsConverted                 CrmLead[]                      @relation("CrmLeadConvertedBy")
+  crmLeadsArchived                  CrmLead[]                      @relation("CrmLeadArchivedBy")
   crmListsCreated                   CrmList[]                      @relation("CrmListCreatedBy")
   crmOverviewLayouts                CrmOverviewLayout[]            @relation("CrmOverviewLayoutUser")
   crmCustomWidgetsCreated           CrmCustomWidget[]              @relation("CrmCustomWidgetCreatedBy")
@@ -8938,6 +8939,13 @@ model CrmLead {
   convertedDealId   String?
   convertedPersonId String?
   convertedClientId String?
+  /// Out of the working set, but not gone. Archiving is how a lead stops
+  /// appearing in lists, boards and counts without destroying the record of
+  /// where the enquiry came from — which is what source reporting is built on.
+  /// Conversion sets this too: a converted lead and the deal it became are the
+  /// same opportunity, and showing both is how a pipeline gets counted twice.
+  archivedAt        DateTime?
+  archivedById      String?
   createdAt         DateTime       @default(now())
   updatedAt         DateTime       @updatedAt
 
@@ -8954,6 +8962,7 @@ model CrmLead {
   convertedDeal     CrmDeal?              @relation("CrmLeadConvertedDeal", fields: [convertedDealId], references: [id], onDelete: SetNull)
   convertedPerson   CrmPerson?            @relation("CrmLeadConvertedPerson", fields: [convertedPersonId], references: [id], onDelete: SetNull)
   convertedBy       User?                 @relation("CrmLeadConvertedBy", fields: [convertedById], references: [id])
+  archivedBy        User?                 @relation("CrmLeadArchivedBy", fields: [archivedById], references: [id])
   tasks             CrmTask[]
   comments          CrmComment[]
   files             CrmRecordFile[]

--- a/scripts/seed-crm-demo.ts
+++ b/scripts/seed-crm-demo.ts
@@ -1,0 +1,320 @@
+/**
+ * Seed a CRM workspace with enough of everything to look at.
+ *
+ * `seed-staging-tenant.ts` grants the features but leaves the module empty, so
+ * every CRM screen renders its empty state and none of them can be judged —
+ * which is no use when the thing being changed is how a board, a list or a
+ * record page behaves once it has records in it. This fills the module with a
+ * small, realistic book of business: companies, the people at them, sites,
+ * leads across every stage, a pipeline with deals in it, and the tasks that
+ * hang off them.
+ *
+ * Idempotent by record number — re-running updates rather than duplicating.
+ * Never point it at production.
+ *
+ *   npx tsx scripts/seed-crm-demo.ts --slug crmdemo
+ */
+import { type CrmLeadStage } from "@prisma/client";
+
+import { disconnectPrisma, prisma } from "./platform/prisma";
+
+function readArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const argument = process.argv[index];
+    if (argument === `--${name}`) return process.argv[index + 1];
+    if (argument.startsWith(prefix)) return argument.slice(prefix.length);
+  }
+  return undefined;
+}
+
+const days = (count: number) => new Date(Date.now() + count * 24 * 60 * 60 * 1000);
+
+const COMPANIES = [
+  { no: "CRMC-0001", name: "Lux Liqour", industry: "Retail", city: "Harare" },
+  { no: "CRMC-0002", name: "Zambezi Mining Supplies", industry: "Mining", city: "Kwekwe" },
+  { no: "CRMC-0003", name: "Highveld Logistics", industry: "Transport", city: "Bulawayo" },
+  { no: "CRMC-0004", name: "Msasa Property Group", industry: "Property", city: "Harare" },
+  { no: "CRMC-0005", name: "Nyanga Coffee Estate", industry: "Agriculture", city: "Nyanga" },
+  { no: "CRMC-0006", name: "Chitungwiza Medical Centre", industry: "Healthcare", city: "Chitungwiza" },
+];
+
+const PEOPLE = [
+  { no: "CRMP-0001", first: "Tendai", last: "Moyo", title: "Operations Director", company: 0 },
+  { no: "CRMP-0002", first: "Rutendo", last: "Chikafu", title: "Finance Manager", company: 0 },
+  { no: "CRMP-0003", first: "Blessing", last: "Ncube", title: "Procurement Lead", company: 1 },
+  { no: "CRMP-0004", first: "Farai", last: "Dube", title: "Site Manager", company: 2 },
+  { no: "CRMP-0005", first: "Nyasha", last: "Mutsvangwa", title: "Managing Director", company: 3 },
+  { no: "CRMP-0006", first: "Chipo", last: "Marange", title: "Estate Manager", company: 4 },
+  { no: "CRMP-0007", first: "Simba", last: "Nyathi", title: "IT Lead", company: 5 },
+  { no: "CRMP-0008", first: "Anesu", last: "Gwena", title: "Head of Retail", company: 0 },
+];
+
+const SITES = [
+  { no: "CRMS-0001", name: "Lux Liqour — Borrowdale", company: 0, city: "Harare" },
+  { no: "CRMS-0002", name: "Lux Liqour — Avondale", company: 0, city: "Harare" },
+  { no: "CRMS-0003", name: "Zambezi Yard 2", company: 1, city: "Kwekwe" },
+  { no: "CRMS-0004", name: "Highveld Depot", company: 2, city: "Bulawayo" },
+  { no: "CRMS-0005", name: "Msasa Park Block C", company: 3, city: "Harare" },
+];
+
+const LEADS: Array<{
+  no: string;
+  title: string;
+  stage: CrmLeadStage;
+  value: number;
+  company: number;
+  source: string;
+}> = [
+  { no: "CRMD-0001", title: "Deploy Corelith Retail for Lux Liqour", stage: "QUALIFIED", value: 3900, company: 0, source: "Referral" },
+  { no: "CRMD-0002", title: "Stock control for Avondale branch", stage: "NEW", value: 1250, company: 0, source: "Website" },
+  { no: "CRMD-0003", title: "Weighbridge integration", stage: "CONTACTED", value: 8400, company: 1, source: "Trade show" },
+  { no: "CRMD-0004", title: "Fleet tracking rollout", stage: "QUOTED", value: 15600, company: 2, source: "Cold call" },
+  { no: "CRMD-0005", title: "Tenant billing portal", stage: "SITE_VISIT", value: 22000, company: 3, source: "Referral" },
+  { no: "CRMD-0006", title: "Estate payroll migration", stage: "QUALIFIED", value: 6400, company: 4, source: "Website" },
+  { no: "CRMD-0007", title: "Clinic scheduling pilot", stage: "NEW", value: 2800, company: 5, source: "Inbound email" },
+  { no: "CRMD-0008", title: "Second-yard stock take", stage: "WON", value: 4700, company: 1, source: "Referral" },
+  { no: "CRMD-0009", title: "Depot CCTV expansion", stage: "LOST", value: 9100, company: 2, source: "Cold call" },
+  { no: "CRMD-0010", title: "Point-of-sale refresh", stage: "CONTACTED", value: 3300, company: 0, source: "Website" },
+];
+
+const STAGES = [
+  { name: "Discovery", position: 0, probability: 10, inactivityDays: 7 },
+  { name: "Site visit", position: 1, probability: 30, inactivityDays: 10 },
+  { name: "Quoted", position: 2, probability: 55, inactivityDays: 14 },
+  { name: "Negotiation", position: 3, probability: 75, inactivityDays: 10 },
+  { name: "Won", position: 4, probability: 100, inactivityDays: null },
+  { name: "Lost", position: 5, probability: 0, inactivityDays: null },
+];
+
+const DEALS = [
+  { no: "DEAL-0001", title: "Corelith Retail — 4 branches", stage: 2, value: 18400, company: 0, site: 0, contact: 0, close: 12 },
+  { no: "DEAL-0002", title: "Weighbridge + stock integration", stage: 1, value: 26500, company: 1, site: 2, contact: 2, close: 26 },
+  { no: "DEAL-0003", title: "Fleet telemetry, phase one", stage: 3, value: 41200, company: 2, site: 3, contact: 3, close: 6 },
+  { no: "DEAL-0004", title: "Tenant billing portal", stage: 0, value: 9800, company: 3, site: 4, contact: 4, close: 40 },
+  { no: "DEAL-0005", title: "Estate payroll and leave", stage: 2, value: 12600, company: 4, site: null, contact: 5, close: 18 },
+  { no: "DEAL-0006", title: "Clinic scheduling", stage: 4, value: 7400, company: 5, site: null, contact: 6, close: -3 },
+  { no: "DEAL-0007", title: "Avondale expansion", stage: 5, value: 5200, company: 0, site: 1, contact: 7, close: -20 },
+];
+
+async function main() {
+  const slug = (readArg("slug") ?? "crmdemo").trim().toLowerCase();
+
+  if (/\bprod(uction)?\b/.test(process.env.DATABASE_URL ?? "")) {
+    throw new Error("DATABASE_URL looks like production. Refusing to seed.");
+  }
+
+  const company = await prisma.company.findUnique({
+    where: { slug },
+    select: { id: true, name: true },
+  });
+  if (!company) throw new Error(`No tenant with slug ${slug}. Seed one first.`);
+
+  const owner = await prisma.user.findFirst({
+    where: { companyId: company.id, isActive: true },
+    select: { id: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const assignedToId = owner?.id ?? null;
+
+  const clients = [];
+  for (const entry of COMPANIES) {
+    clients.push(
+      await prisma.crmClient.upsert({
+        where: { companyId_clientNo: { companyId: company.id, clientNo: entry.no } },
+        update: { name: entry.name, industry: entry.industry, city: entry.city },
+        create: {
+          companyId: company.id,
+          clientNo: entry.no,
+          name: entry.name,
+          industry: entry.industry,
+          city: entry.city,
+          country: "Zimbabwe",
+          email: `hello@${entry.name.toLowerCase().replace(/[^a-z]+/g, "")}.co.zw`,
+          phone: "+263 77 000 0000",
+          assignedToId,
+        },
+        select: { id: true },
+      }),
+    );
+  }
+
+  const people = [];
+  for (const entry of PEOPLE) {
+    const fullName = `${entry.first} ${entry.last}`;
+    people.push(
+      await prisma.crmPerson.upsert({
+        where: { companyId_personNo: { companyId: company.id, personNo: entry.no } },
+        update: { fullName, jobTitle: entry.title },
+        create: {
+          companyId: company.id,
+          personNo: entry.no,
+          firstName: entry.first,
+          lastName: entry.last,
+          fullName,
+          jobTitle: entry.title,
+          email: `${entry.first.toLowerCase()}.${entry.last.toLowerCase()}@example.co.zw`,
+          emailNormalized: `${entry.first.toLowerCase()}.${entry.last.toLowerCase()}@example.co.zw`,
+          phone: "+263 71 000 0000",
+          clientId: clients[entry.company].id,
+          assignedToId,
+        },
+        select: { id: true },
+      }),
+    );
+  }
+
+  const sites = [];
+  for (const entry of SITES) {
+    sites.push(
+      await prisma.crmSite.upsert({
+        where: { companyId_siteNo: { companyId: company.id, siteNo: entry.no } },
+        update: { name: entry.name },
+        create: {
+          companyId: company.id,
+          siteNo: entry.no,
+          name: entry.name,
+          clientId: clients[entry.company].id,
+          addressLine: "12 Sam Nujoma Street",
+          city: entry.city,
+          country: "Zimbabwe",
+        },
+        select: { id: true },
+      }),
+    );
+  }
+
+  for (const entry of LEADS) {
+    await prisma.crmLead.upsert({
+      where: { companyId_leadNo: { companyId: company.id, leadNo: entry.no } },
+      update: { title: entry.title, stage: entry.stage, estimatedValue: entry.value },
+      create: {
+        companyId: company.id,
+        leadNo: entry.no,
+        title: entry.title,
+        stage: entry.stage,
+        estimatedValue: entry.value,
+        currency: "USD",
+        clientId: clients[entry.company].id,
+        contactName: `${PEOPLE[entry.company].first} ${PEOPLE[entry.company].last}`,
+        contactEmail: "buyer@example.co.zw",
+        contactPhone: "+263 77 123 4567",
+        source: entry.source,
+        assignedToId,
+        firstContactAt: entry.stage === "NEW" ? null : days(-4),
+      },
+    });
+  }
+
+  const pipeline = await prisma.crmPipeline.upsert({
+    where: { companyId_name: { companyId: company.id, name: "Sales" } },
+    update: { isDefault: true, isActive: true },
+    create: { companyId: company.id, name: "Sales", isDefault: true, position: 0 },
+    select: { id: true },
+  });
+
+  const stages = [];
+  for (const stage of STAGES) {
+    stages.push(
+      await prisma.crmPipelineStage.upsert({
+        where: { pipelineId_name: { pipelineId: pipeline.id, name: stage.name } },
+        update: { position: stage.position, probability: stage.probability },
+        create: {
+          companyId: company.id,
+          pipelineId: pipeline.id,
+          name: stage.name,
+          position: stage.position,
+          probability: stage.probability,
+          inactivityDays: stage.inactivityDays,
+          status: stage.name === "Won" ? "WON" : stage.name === "Lost" ? "LOST" : "OPEN",
+        },
+        select: { id: true, status: true },
+      }),
+    );
+  }
+
+  const deals = [];
+  for (const entry of DEALS) {
+    const stage = stages[entry.stage];
+    deals.push(
+      await prisma.crmDeal.upsert({
+        where: { companyId_dealNo: { companyId: company.id, dealNo: entry.no } },
+        update: { title: entry.title, stageId: stage.id, value: entry.value, status: stage.status },
+        create: {
+          companyId: company.id,
+          dealNo: entry.no,
+          title: entry.title,
+          pipelineId: pipeline.id,
+          stageId: stage.id,
+          status: stage.status,
+          value: entry.value,
+          currency: "USD",
+          clientId: clients[entry.company].id,
+          primaryContactId: people[entry.contact].id,
+          siteId: entry.site === null ? null : sites[entry.site].id,
+          expectedCloseDate: days(entry.close),
+          assignedToId,
+          stageEnteredAt: days(-9),
+          wonAt: stage.status === "WON" ? days(-3) : null,
+          lostAt: stage.status === "LOST" ? days(-20) : null,
+          lostReason: stage.status === "LOST" ? "Went with an incumbent supplier" : null,
+        },
+        select: { id: true },
+      }),
+    );
+  }
+
+  const taskSpecs = [
+    { title: "Call Tendai about the branch count", due: -2, deal: 0 },
+    { title: "Send the revised quote", due: 0, deal: 1 },
+    { title: "Book the site visit at the depot", due: 1, deal: 2 },
+    { title: "Chase the signed order", due: -5, deal: 3 },
+    { title: "Confirm go-live date", due: 4, deal: 4 },
+    { title: "Write the handover note", due: 7, deal: 5 },
+  ];
+  const existingTasks = await prisma.crmTask.findMany({
+    where: { companyId: company.id, title: { in: taskSpecs.map((task) => task.title) } },
+    select: { id: true, title: true },
+  });
+  for (const spec of taskSpecs) {
+    const existing = existingTasks.find((task) => task.title === spec.title);
+    const data = {
+      companyId: company.id,
+      title: spec.title,
+      dueAt: days(spec.due),
+      dealId: deals[spec.deal].id,
+      subjectType: "DEAL" as const,
+      subjectId: deals[spec.deal].id,
+      assignedToId,
+      priority: spec.due < 0 ? ("HIGH" as const) : ("NORMAL" as const),
+    };
+    if (existing) {
+      await prisma.crmTask.update({ where: { id: existing.id }, data });
+    } else {
+      await prisma.crmTask.create({ data });
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        tenant: slug,
+        companies: clients.length,
+        people: people.length,
+        sites: sites.length,
+        leads: LEADS.length,
+        deals: deals.length,
+        tasks: taskSpecs.length,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(disconnectPrisma);

--- a/scripts/seed-crm-year.ts
+++ b/scripts/seed-crm-year.ts
@@ -1,0 +1,850 @@
+/**
+ * A CRM that has been running for a year.
+ *
+ * `seed-crm-demo.ts` gives the module six companies and ten leads, which is
+ * enough to see that a board draws and not enough to judge anything else: a
+ * timeline with two entries does not scroll, a list of six rows never paginates,
+ * an approval that nobody ever answered cannot show you what a declined quote
+ * looks like. Screens are judged on how they behave when they are full.
+ *
+ * So this lays down twelve months of trading on top of that: companies and the
+ * people at them, leads that arrived and were worked and were won or lost or
+ * quietly archived, deals moving through a pipeline, and — the part that
+ * matters most for the record pages — several thousand activities, tasks,
+ * visits, comments and documents spread across the year rather than all dated
+ * today.
+ *
+ * Deterministic. The generator is a seeded LCG, so two runs produce the same
+ * book of business and a screenshot diff means a code change rather than fresh
+ * random data. Idempotent by record number.
+ *
+ * Never point it at production.
+ *
+ *   npx tsx scripts/seed-crm-year.ts --slug crmdemo
+ *   npx tsx scripts/seed-crm-year.ts --slug crmdemo --months 12 --leads 180
+ */
+import type { CrmActivityType, CrmLeadStage, Prisma } from "@prisma/client";
+
+import { disconnectPrisma, prisma } from "./platform/prisma";
+
+function readArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < process.argv.length; index += 1) {
+    const argument = process.argv[index];
+    if (argument === `--${name}`) return process.argv[index + 1];
+    if (argument.startsWith(prefix)) return argument.slice(prefix.length);
+  }
+  return undefined;
+}
+
+/**
+ * A seeded generator, so the book of business is the same every run.
+ *
+ * `Math.random` would mean every screenshot pass produced different figures,
+ * and a visual diff could never distinguish "the layout changed" from "the
+ * data changed".
+ */
+function makeRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+const random = makeRandom(20260815);
+const pick = <T,>(items: readonly T[]): T => items[Math.floor(random() * items.length)];
+const between = (min: number, max: number) => min + Math.floor(random() * (max - min + 1));
+const chance = (probability: number) => random() < probability;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * N days back, at a plausible hour of that working day.
+ *
+ * Subtracting whole days from `Date.now()` gives every row in the year the
+ * same time of day — the minute the seed happened to run — and a timeline
+ * where forty consecutive events all say "9:06 PM" reads as fake at a glance
+ * and hides any bug in how the UI groups by time.
+ */
+const daysAgo = (count: number) => {
+  const date = new Date(Date.now() - count * DAY);
+  date.setHours(between(8, 17), between(0, 59), between(0, 59), 0);
+  return date;
+};
+const daysAhead = (count: number) => new Date(Date.now() + count * DAY);
+
+const TRADING_NAMES = [
+  "Lux Liqour", "Zambezi Mining Supplies", "Highveld Logistics", "Msasa Property Group",
+  "Nyanga Coffee Estate", "Chitungwiza Medical Centre", "Borrowdale Hardware",
+  "Kariba Fisheries", "Mutare Timber Works", "Gweru Steel", "Victoria Falls Safaris",
+  "Chinhoyi Agrichem", "Bulawayo Bottling", "Ruwa Plastics", "Norton Grain Millers",
+  "Marondera Dairy", "Hwange Colliery Services", "Kadoma Textiles", "Bindura Fertiliser",
+  "Rusape Transport", "Chegutu Poultry", "Zvishavane Quarry", "Beitbridge Clearing",
+  "Kwekwe Engineering", "Shurugwi Platinum Supply", "Masvingo Motors", "Gokwe Cotton Co-op",
+  "Banket Irrigation", "Karoi Tobacco Floors", "Mvurwi Seed House", "Chiredzi Sugar Services",
+  "Plumtree Freight", "Redcliff Foundry", "Chipinge Tea Estates", "Murewa Builders",
+];
+
+const INDUSTRIES = [
+  "Retail", "Mining", "Transport", "Property", "Agriculture", "Healthcare",
+  "Manufacturing", "Hospitality", "Construction", "Education",
+];
+
+const CITIES = [
+  "Harare", "Bulawayo", "Mutare", "Gweru", "Kwekwe", "Masvingo", "Chinhoyi",
+  "Marondera", "Kadoma", "Bindura", "Victoria Falls", "Chiredzi",
+];
+
+const FIRST_NAMES = [
+  "Tendai", "Rutendo", "Blessing", "Farai", "Nyasha", "Chipo", "Simba", "Anesu",
+  "Tafara", "Rumbidzai", "Takudzwa", "Vimbai", "Tapiwa", "Shamiso", "Munashe",
+  "Kudzai", "Panashe", "Tinashe", "Rufaro", "Nokutenda", "Batsirai", "Chiedza",
+];
+
+const LAST_NAMES = [
+  "Moyo", "Chikafu", "Ncube", "Dube", "Mutsvangwa", "Marange", "Nyathi", "Gwena",
+  "Sibanda", "Mhlanga", "Chirwa", "Makoni", "Zhou", "Mangwiro", "Chinamasa",
+  "Muponda", "Ziyambi", "Nyoni", "Mabhena", "Chademana",
+];
+
+const JOB_TITLES = [
+  "Operations Director", "Finance Manager", "Procurement Lead", "Site Manager",
+  "Managing Director", "Estate Manager", "IT Lead", "Head of Retail",
+  "General Manager", "Financial Controller", "Stores Supervisor", "Plant Manager",
+];
+
+const SOURCES = [
+  "Referral", "Website", "Trade show", "Cold call", "Inbound email",
+  "LinkedIn", "Existing customer", "Partner", "Walk-in",
+];
+
+const LEAD_STAGES: CrmLeadStage[] = [
+  "NEW", "CONTACTED", "QUALIFIED", "SITE_VISIT", "QUOTED", "INVOICED", "WON", "LOST",
+];
+
+const WORK = [
+  "stock control rollout", "weighbridge integration", "fleet tracking", "payroll migration",
+  "point-of-sale refresh", "CCTV expansion", "site survey", "inventory count",
+  "billing portal", "workshop scheduling", "fuel monitoring", "asset register",
+  "compliance pack", "reporting dashboard", "second-site rollout", "handheld scanners",
+];
+
+const NOTE_BODIES = [
+  "Rang to confirm the scope. They want the second branch included from the start.",
+  "Left a voicemail — will try again on Thursday.",
+  "Sent the revised pricing across. Waiting on their finance sign-off.",
+  "Met on site. The yard is bigger than the drawing suggested, so add a second reader.",
+  "They asked whether we can phase the payment over two quarters.",
+  "Procurement have gone quiet since the budget freeze.",
+  "Good call — they are ready to move once the new depot opens.",
+  "Asked for references from another mining client before they commit.",
+  "Follow-up after the demo: the reporting is what sold it.",
+  "They are comparing us against an incumbent supplier on price alone.",
+  "Confirmed the go-live date. Training booked for the week before.",
+  "Chased the signed order. Their MD is travelling until the 14th.",
+  "Walked their ops lead through the handheld workflow. No objections.",
+  "They want a trial at one branch before committing the group.",
+  "Their IT will not open the firewall for the sync — needs a call with us.",
+  "Quote resent with the training line itemised, as they asked.",
+  "Site is further out than we priced. Travel needs adding.",
+  "Spoke to the FD directly. The number is fine, the timing is not.",
+  "They have had a bad experience with a similar rollout. Go carefully.",
+  "Warehouse manager is the real decision maker here, not procurement.",
+  "Agreed a deposit of 40% and the balance on commissioning.",
+  "Deferred to next quarter — capex is frozen until the audit closes.",
+  "Wants the scanners bundled rather than billed separately.",
+  "Introduced to their second site. Same setup, same problems.",
+  "Sent the reference pack. Two of the names are on their board.",
+  "They pushed back on the licence term. Offered 24 months instead of 36.",
+  "Delivery slipped a week; told them before they noticed.",
+  "Everything signed. Kickoff booked for the first Monday of the month.",
+];
+
+const COMMENT_BODIES = [
+  "Worth pushing on this one — they have budget this quarter.",
+  "@team heads up, their finance manager wants the quote in USD not ZWL.",
+  "I have seen this pattern before. They will ask for a discount at the last minute.",
+  "Handing this over while I am on leave. Everything is in the timeline.",
+  "Careful with the pricing here, we underquoted the last job at this site.",
+  "Nice work getting the site visit booked so quickly.",
+];
+
+const TASK_TITLES = [
+  "Call about the branch count", "Send the revised quote", "Book the site visit",
+  "Chase the signed order", "Confirm the go-live date", "Write the handover note",
+  "Check the delivery address", "Follow up on the demo", "Prepare the reference pack",
+  "Re-quote with the phased option", "Confirm the training dates", "Close the loop with finance",
+];
+
+const ACTIVITY_TYPES: CrmActivityType[] = ["NOTE", "CALL", "EMAIL", "WHATSAPP", "MEETING"];
+
+const STAGES = [
+  { name: "Discovery", position: 0, probability: 10, inactivityDays: 7 },
+  { name: "Site visit", position: 1, probability: 30, inactivityDays: 10 },
+  { name: "Quoted", position: 2, probability: 55, inactivityDays: 14 },
+  { name: "Negotiation", position: 3, probability: 75, inactivityDays: 10 },
+  { name: "Won", position: 4, probability: 100, inactivityDays: null },
+  { name: "Lost", position: 5, probability: 0, inactivityDays: null },
+];
+
+async function main() {
+  const slug = (readArg("slug") ?? "crmdemo").trim().toLowerCase();
+  const months = Number(readArg("months") ?? 12);
+  const leadCount = Number(readArg("leads") ?? 180);
+  const window = Math.round(months * 30);
+
+  if (/\bprod(uction)?\b/.test(process.env.DATABASE_URL ?? "")) {
+    throw new Error("DATABASE_URL looks like production. Refusing to seed.");
+  }
+
+  const company = await prisma.company.findUnique({
+    where: { slug },
+    select: { id: true, name: true },
+  });
+  if (!company) throw new Error(`No tenant with slug ${slug}. Seed one first.`);
+  const companyId = company.id;
+
+  const users = await prisma.user.findMany({
+    where: { companyId, isActive: true },
+    select: { id: true, name: true },
+    orderBy: { createdAt: "asc" },
+  });
+  if (users.length === 0) throw new Error("The tenant has no active users to own records.");
+  const userIds = users.map((user) => user.id);
+  const owner = () => pick(userIds);
+
+  // ---- Companies ---------------------------------------------------------
+  const clients: string[] = [];
+  for (let index = 0; index < TRADING_NAMES.length; index += 1) {
+    const name = TRADING_NAMES[index];
+    const clientNo = `CRMC-${String(index + 1).padStart(4, "0")}`;
+    const city = pick(CITIES);
+    const slugged = name.toLowerCase().replace(/[^a-z]+/g, "");
+    const client = await prisma.crmClient.upsert({
+      where: { companyId_clientNo: { companyId, clientNo } },
+      update: { name },
+      create: {
+        companyId,
+        clientNo,
+        name,
+        industry: pick(INDUSTRIES),
+        city,
+        country: "Zimbabwe",
+        email: `accounts@${slugged}.co.zw`,
+        emailNormalized: `accounts@${slugged}.co.zw`,
+        phone: `+263 77 ${between(100, 999)} ${between(1000, 9999)}`,
+        website: `https://${slugged}.co.zw`,
+        addressLine: `${between(1, 240)} ${pick(["Samora Machel", "Sam Nujoma", "Robert Mugabe", "Leopold Takawira"])} Avenue`,
+        assignedToId: owner(),
+        createdAt: daysAgo(between(window - 30, window)),
+      },
+      select: { id: true },
+    });
+    clients.push(client.id);
+  }
+
+  // ---- People ------------------------------------------------------------
+  const people: Array<{ id: string; clientIndex: number; fullName: string }> = [];
+  let personSeq = 0;
+  for (let clientIndex = 0; clientIndex < clients.length; clientIndex += 1) {
+    for (let n = 0; n < between(2, 5); n += 1) {
+      personSeq += 1;
+      const first = pick(FIRST_NAMES);
+      const last = pick(LAST_NAMES);
+      const fullName = `${first} ${last}`;
+      const personNo = `CRMP-${String(personSeq).padStart(4, "0")}`;
+      const email = `${first.toLowerCase()}.${last.toLowerCase()}${personSeq}@example.co.zw`;
+      const person = await prisma.crmPerson.upsert({
+        where: { companyId_personNo: { companyId, personNo } },
+        update: { fullName },
+        create: {
+          companyId,
+          personNo,
+          firstName: first,
+          lastName: last,
+          fullName,
+          jobTitle: pick(JOB_TITLES),
+          email,
+          emailNormalized: email,
+          phone: `+263 71 ${between(100, 999)} ${between(1000, 9999)}`,
+          clientId: clients[clientIndex],
+          assignedToId: owner(),
+          createdAt: daysAgo(between(1, window)),
+        },
+        select: { id: true },
+      });
+      people.push({ id: person.id, clientIndex, fullName });
+    }
+  }
+
+  // ---- Sites -------------------------------------------------------------
+  const sites: Array<{ id: string; clientIndex: number }> = [];
+  let siteSeq = 0;
+  for (let clientIndex = 0; clientIndex < clients.length; clientIndex += 1) {
+    if (!chance(0.6)) continue;
+    for (let n = 0; n < between(1, 3); n += 1) {
+      siteSeq += 1;
+      const siteNo = `CRMS-${String(siteSeq).padStart(4, "0")}`;
+      const city = pick(CITIES);
+      const site = await prisma.crmSite.upsert({
+        where: { companyId_siteNo: { companyId, siteNo } },
+        update: {},
+        create: {
+          companyId,
+          siteNo,
+          name: `${TRADING_NAMES[clientIndex]} — ${pick(["Depot", "Yard", "Branch", "Warehouse", "Plant"])} ${n + 1}`,
+          clientId: clients[clientIndex],
+          addressLine: `${between(1, 90)} ${pick(["Industrial", "Airport", "Mutare", "Bulawayo"])} Road`,
+          city,
+          country: "Zimbabwe",
+          accessInstructions: chance(0.5)
+            ? "Report to the gatehouse. Hard hat and hi-vis required beyond the weighbridge."
+            : null,
+          createdAt: daysAgo(between(1, window)),
+        },
+        select: { id: true },
+      });
+      sites.push({ id: site.id, clientIndex });
+    }
+  }
+
+  // ---- Pipeline ----------------------------------------------------------
+  const pipeline = await prisma.crmPipeline.upsert({
+    where: { companyId_name: { companyId, name: "Sales" } },
+    update: { isDefault: true, isActive: true },
+    create: { companyId, name: "Sales", isDefault: true, position: 0 },
+    select: { id: true },
+  });
+
+  const stages = [];
+  for (const stage of STAGES) {
+    stages.push(
+      await prisma.crmPipelineStage.upsert({
+        where: { pipelineId_name: { pipelineId: pipeline.id, name: stage.name } },
+        update: { position: stage.position, probability: stage.probability },
+        create: {
+          companyId,
+          pipelineId: pipeline.id,
+          name: stage.name,
+          position: stage.position,
+          probability: stage.probability,
+          inactivityDays: stage.inactivityDays,
+          status: stage.name === "Won" ? "WON" : stage.name === "Lost" ? "LOST" : "OPEN",
+        },
+        select: { id: true, status: true, name: true },
+      }),
+    );
+  }
+
+  // ---- Leads -------------------------------------------------------------
+  //
+  // Spread across the year rather than dated today, and weighted the way a real
+  // book is: most of the old ones are finished, most of the recent ones are
+  // still moving. A third of the finished ones are archived, which is what
+  // makes the Archived view worth looking at.
+  const leads: Array<{ id: string; clientIndex: number; createdAt: Date; archived: boolean }> = [];
+  for (let index = 0; index < leadCount; index += 1) {
+    const leadNo = `CRMD-${String(index + 1).padStart(4, "0")}`;
+    const age = between(0, window);
+    const createdAt = daysAgo(age);
+    const clientIndex = between(0, clients.length - 1);
+    const contact = people.filter((person) => person.clientIndex === clientIndex)[0];
+    // Older leads have had time to finish; recent ones are still in play.
+    const settled = age > 60 ? chance(0.8) : chance(0.2);
+    const stage: CrmLeadStage = settled
+      ? pick(["WON", "LOST"] as CrmLeadStage[])
+      : pick(LEAD_STAGES.slice(0, 6));
+    const archived = settled && chance(0.4);
+
+    const lead = await prisma.crmLead.upsert({
+      where: { companyId_leadNo: { companyId, leadNo } },
+      update: { stage, archivedAt: archived ? daysAgo(between(1, age || 1)) : null },
+      create: {
+        companyId,
+        leadNo,
+        title: `${TRADING_NAMES[clientIndex]} ${pick(WORK)}`,
+        stage,
+        estimatedValue: between(8, 460) * 100,
+        currency: "USD",
+        probability: between(5, 95),
+        clientId: clients[clientIndex],
+        contactName: contact?.fullName ?? null,
+        contactEmail: "buyer@example.co.zw",
+        contactPhone: `+263 77 ${between(100, 999)} ${between(1000, 9999)}`,
+        source: pick(SOURCES),
+        assignedToId: owner(),
+        createdById: owner(),
+        createdAt,
+        firstContactAt: stage === "NEW" ? null : daysAgo(Math.max(0, age - between(1, 4))),
+        wonAt: stage === "WON" ? daysAgo(Math.max(0, age - between(5, 30))) : null,
+        lostAt: stage === "LOST" ? daysAgo(Math.max(0, age - between(5, 30))) : null,
+        lostReason: stage === "LOST" ? pick([
+          "Went with an incumbent supplier",
+          "Budget pulled for the quarter",
+          "Price — we were 20% over",
+          "Project shelved after a restructure",
+        ]) : null,
+        archivedAt: archived ? daysAgo(between(1, Math.max(1, age))) : null,
+        archivedById: archived ? owner() : null,
+      },
+      select: { id: true },
+    });
+    leads.push({ id: lead.id, clientIndex, createdAt, archived });
+  }
+
+  // ---- Deals -------------------------------------------------------------
+  const deals: Array<{ id: string; clientIndex: number; createdAt: Date }> = [];
+  const dealCount = Math.round(leadCount / 2);
+  for (let index = 0; index < dealCount; index += 1) {
+    const dealNo = `DEAL-${String(index + 1).padStart(4, "0")}`;
+    const age = between(0, window);
+    const clientIndex = between(0, clients.length - 1);
+    const stage = age > 70 ? pick([stages[4], stages[5]]) : pick(stages.slice(0, 4));
+    const contact = people.filter((person) => person.clientIndex === clientIndex)[0];
+    const site = sites.filter((entry) => entry.clientIndex === clientIndex)[0];
+
+    const deal = await prisma.crmDeal.upsert({
+      where: { companyId_dealNo: { companyId, dealNo } },
+      update: { stageId: stage.id, status: stage.status },
+      create: {
+        companyId,
+        dealNo,
+        title: `${TRADING_NAMES[clientIndex]} ${pick(WORK)}`,
+        pipelineId: pipeline.id,
+        stageId: stage.id,
+        status: stage.status,
+        value: between(20, 900) * 100,
+        currency: "USD",
+        probability: stage.status === "WON" ? 100 : between(10, 90),
+        clientId: clients[clientIndex],
+        primaryContactId: contact?.id ?? null,
+        siteId: site?.id ?? null,
+        expectedCloseDate: stage.status === "OPEN" ? daysAhead(between(-10, 60)) : daysAgo(between(1, age || 1)),
+        assignedToId: owner(),
+        createdById: owner(),
+        createdAt: daysAgo(age),
+        stageEnteredAt: daysAgo(between(0, Math.min(age, 30))),
+        wonAt: stage.status === "WON" ? daysAgo(between(1, Math.max(1, age))) : null,
+        lostAt: stage.status === "LOST" ? daysAgo(between(1, Math.max(1, age))) : null,
+        lostReason: stage.status === "LOST" ? "Went with an incumbent supplier" : null,
+      },
+      select: { id: true },
+    });
+    deals.push({ id: deal.id, clientIndex, createdAt: daysAgo(age) });
+
+    if (contact) {
+      const existing = await prisma.crmDealContact.findFirst({
+        where: { companyId, dealId: deal.id, personId: contact.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        await prisma.crmDealContact.create({
+          data: { companyId, dealId: deal.id, personId: contact.id, role: "PRIMARY" },
+        });
+      }
+    }
+  }
+
+  // ---- Activity ----------------------------------------------------------
+  //
+  // The bulk of it, and the reason this script exists: a record page with two
+  // timeline entries tells you nothing about how it reads with eighty.
+  const existingActivity = await prisma.crmActivity.count({ where: { companyId } });
+  const activityRows: Prisma.CrmActivityCreateManyInput[] = [];
+  if (existingActivity < 500) {
+    for (const lead of leads) {
+      const ageDays = Math.round((Date.now() - lead.createdAt.getTime()) / DAY);
+      for (let n = 0; n < between(0, 14); n += 1) {
+        const type = pick(ACTIVITY_TYPES);
+        const body = pick(NOTE_BODIES);
+        activityRows.push({
+          companyId,
+          type,
+          leadId: lead.id,
+          clientId: clients[lead.clientIndex],
+          subject: body.slice(0, 120),
+          body,
+          occurredAt: daysAgo(between(0, Math.max(1, ageDays))),
+          createdById: owner(),
+        });
+      }
+    }
+    for (const deal of deals) {
+      const ageDays = Math.round((Date.now() - deal.createdAt.getTime()) / DAY);
+      for (let n = 0; n < between(2, 20); n += 1) {
+        const body = pick(NOTE_BODIES);
+        activityRows.push({
+          companyId,
+          type: pick(ACTIVITY_TYPES),
+          dealId: deal.id,
+          clientId: clients[deal.clientIndex],
+          subject: body.slice(0, 120),
+          body,
+          occurredAt: daysAgo(between(0, Math.max(1, ageDays))),
+          createdById: owner(),
+        });
+      }
+    }
+    // `createMany` in chunks: one statement with twenty thousand rows in it is
+    // how a seed script runs out of parameters.
+    for (let index = 0; index < activityRows.length; index += 1000) {
+      await prisma.crmActivity.createMany({ data: activityRows.slice(index, index + 1000) });
+    }
+  }
+
+  // ---- Tasks and follow-ups ---------------------------------------------
+  const existingTasks = await prisma.crmTask.count({ where: { companyId } });
+  if (existingTasks < 100) {
+    const taskRows: Prisma.CrmTaskCreateManyInput[] = [];
+    for (const deal of deals) {
+      for (let n = 0; n < between(0, 4); n += 1) {
+        const done = chance(0.55);
+        taskRows.push({
+          companyId,
+          title: pick(TASK_TITLES),
+          dueAt: done ? daysAgo(between(1, 120)) : daysAhead(between(-14, 21)),
+          dealId: deal.id,
+          subjectType: "DEAL" as const,
+          subjectId: deal.id,
+          assignedToId: owner(),
+          status: done ? ("COMPLETED" as const) : ("OPEN" as const),
+          completedAt: done ? daysAgo(between(1, 120)) : null,
+          priority: chance(0.25) ? ("HIGH" as const) : ("NORMAL" as const),
+        });
+      }
+    }
+    for (let index = 0; index < taskRows.length; index += 500) {
+      await prisma.crmTask.createMany({ data: taskRows.slice(index, index + 500) });
+    }
+
+    const followUpRows: Prisma.CrmFollowUpCreateManyInput[] = [];
+    for (const lead of leads) {
+      if (!chance(0.4)) continue;
+      const done = chance(0.5);
+      followUpRows.push({
+        companyId,
+        title: pick(TASK_TITLES),
+        dueAt: done ? daysAgo(between(1, 90)) : daysAhead(between(-10, 20)),
+        leadId: lead.id,
+        clientId: clients[lead.clientIndex],
+        assignedToId: owner(),
+        status: done ? ("COMPLETED" as const) : ("PENDING" as const),
+        completedAt: done ? daysAgo(between(1, 90)) : null,
+      });
+    }
+    for (let index = 0; index < followUpRows.length; index += 500) {
+      await prisma.crmFollowUp.createMany({ data: followUpRows.slice(index, index + 500) });
+    }
+  }
+
+  // ---- Comments ----------------------------------------------------------
+  const existingComments = await prisma.crmComment.count({ where: { companyId } });
+  if (existingComments < 50) {
+    const commentRows: Prisma.CrmCommentCreateManyInput[] = [];
+    for (const deal of deals) {
+      for (let n = 0; n < between(0, 3); n += 1) {
+        commentRows.push({
+          companyId,
+          dealId: deal.id,
+          body: pick(COMMENT_BODIES),
+          createdById: owner(),
+          createdAt: daysAgo(between(1, 200)),
+        });
+      }
+    }
+    for (const lead of leads.slice(0, 60)) {
+      if (!chance(0.5)) continue;
+      commentRows.push({
+        companyId,
+        leadId: lead.id,
+        body: pick(COMMENT_BODIES),
+        createdById: owner(),
+        createdAt: daysAgo(between(1, 200)),
+      });
+    }
+    for (let index = 0; index < commentRows.length; index += 500) {
+      await prisma.crmComment.createMany({ data: commentRows.slice(index, index + 500) });
+    }
+  }
+
+  // ---- Visits ------------------------------------------------------------
+  const existingVisits = await prisma.crmAppointment.count({ where: { companyId } });
+  if (existingVisits < 40) {
+    let visitSeq = existingVisits;
+    for (const deal of deals.slice(0, 60)) {
+      if (!chance(0.5)) continue;
+      visitSeq += 1;
+      const past = chance(0.6);
+      const site = sites.filter((entry) => entry.clientIndex === deal.clientIndex)[0];
+      await prisma.crmAppointment.create({
+        data: {
+          companyId,
+          appointmentNo: `CRMA-${String(visitSeq).padStart(4, "0")}`,
+          title: pick(["Site visit", "Scoping visit", "Install survey", "Handover walkthrough"]),
+          dealId: deal.id,
+          clientId: clients[deal.clientIndex],
+          siteId: site?.id ?? null,
+          scheduledStart: past ? daysAgo(between(1, 180)) : daysAhead(between(1, 21)),
+          // Past and still "scheduled" is the state a record page should be
+          // shouting about: somebody went and never wrote it up.
+          status: past
+            ? chance(0.75)
+              ? ("COMPLETED" as const)
+              : ("SCHEDULED" as const)
+            : ("SCHEDULED" as const),
+          location: `${between(1, 90)} Industrial Road`,
+          assignedToId: owner(),
+        },
+      });
+    }
+  }
+
+  // ---- Paperwork ---------------------------------------------------------
+  //
+  // A year of trading with no quotes or invoices is not a year of trading, and
+  // it leaves the Documents section — approval feedback, deposits, part
+  // payments — with nothing to show. Each deal old enough to have been quoted
+  // gets a quote; some of those become an invoice; some of those get paid, in
+  // full or in part.
+  const existingDocs = await prisma.crmLeadDocument.count({ where: { companyId } });
+  if (existingDocs < 30) {
+    // Sales lives against `Customer`, the CRM against `CrmClient`. The link
+    // between them is what lets a quote raised here be recognised over there.
+    const customerIds: string[] = [];
+    for (let index = 0; index < clients.length; index += 1) {
+      const existing = await prisma.crmClient.findUnique({
+        where: { id: clients[index] },
+        select: { customerId: true, name: true, email: true, phone: true },
+      });
+      if (existing?.customerId) {
+        customerIds.push(existing.customerId);
+        continue;
+      }
+      const customer = await prisma.customer.create({
+        data: {
+          companyId,
+          name: existing?.name ?? TRADING_NAMES[index],
+          email: existing?.email ?? null,
+          phone: existing?.phone ?? null,
+        },
+        select: { id: true },
+      });
+      await prisma.crmClient.update({
+        where: { id: clients[index] },
+        data: { customerId: customer.id },
+      });
+      customerIds.push(customer.id);
+    }
+
+    let quoteSeq = 0;
+    let invoiceSeq = 0;
+    let receiptSeq = 0;
+
+    for (const deal of deals) {
+      const ageDays = Math.round((Date.now() - deal.createdAt.getTime()) / DAY);
+      if (ageDays < 14 || !chance(0.7)) continue;
+
+      const customerId = customerIds[deal.clientIndex];
+      const quotedAt = daysAgo(between(Math.max(1, ageDays - 10), ageDays));
+      const subTotal = between(15, 780) * 100;
+      const taxTotal = Math.round(subTotal * 0.15);
+      const total = subTotal + taxTotal;
+
+      quoteSeq += 1;
+      const quotation = await prisma.salesQuotation.create({
+        data: {
+          companyId,
+          customerId,
+          quotationNumber: `QT-${String(quoteSeq).padStart(5, "0")}`,
+          quotationDate: quotedAt,
+          validUntil: new Date(quotedAt.getTime() + 30 * DAY),
+          status: "SENT",
+          currency: "USD",
+          subTotal,
+          taxTotal,
+          total,
+          issuedAt: quotedAt,
+          issuedById: owner(),
+          createdById: owner(),
+          createdAt: quotedAt,
+          lines: {
+            create: [
+              {
+                description: `${pick(WORK)} — supply and commissioning`,
+                quantity: 1,
+                unitPrice: subTotal,
+                taxRate: 15,
+                taxAmount: taxTotal,
+                lineTotal: total,
+              },
+            ],
+          },
+        },
+        select: { id: true },
+      });
+
+      const quoteDoc = await prisma.crmLeadDocument.create({
+        data: {
+          companyId,
+          dealId: deal.id,
+          type: "QUOTATION",
+          quotationId: quotation.id,
+          amount: total,
+          currency: "USD",
+          createdById: owner(),
+          createdAt: quotedAt,
+        },
+        select: { id: true },
+      });
+
+      // What the client did with it. Four outcomes, because "sent" and
+      // "opened and ignored" are different facts and the panel draws them
+      // differently.
+      const roll = random();
+      const sentAt = new Date(quotedAt.getTime() + between(1, 6) * 3600_000);
+      await prisma.crmDocumentApproval.create({
+        data: {
+          companyId,
+          leadDocumentId: quoteDoc.id,
+          token: `seed-${quoteDoc.id}`,
+          status: roll < 0.45 ? "APPROVED" : roll < 0.6 ? "DECLINED" : "PENDING",
+          createdAt: sentAt,
+          firstViewedAt: roll < 0.8 ? new Date(sentAt.getTime() + between(1, 72) * 3600_000) : null,
+          respondedAt: roll < 0.6 ? new Date(sentAt.getTime() + between(24, 240) * 3600_000) : null,
+          responderName: roll < 0.6 ? pick(FIRST_NAMES) + " " + pick(LAST_NAMES) : null,
+          responseNote:
+            roll < 0.45
+              ? pick([
+                  "Approved. Please invoice against PO 44821.",
+                  "Happy with this — go ahead.",
+                  "Approved subject to the training being included.",
+                ])
+              : roll < 0.6
+                ? pick([
+                    "Too high against the other bid. Can you revisit the licence line?",
+                    "Not this quarter — budget is closed.",
+                  ])
+                : null,
+        },
+      });
+
+      // Only approved quotes become invoices, which is what makes the
+      // Documents section legible: the money follows the answer.
+      if (roll >= 0.45 || !chance(0.8)) continue;
+
+      const invoicedAt = daysAgo(between(0, Math.max(1, ageDays - 12)));
+      const deposit = chance(0.4);
+      const invoiceTotal = deposit ? Math.round(total * 0.4) : total;
+      const paidRoll = random();
+      const amountPaid =
+        paidRoll < 0.4 ? invoiceTotal : paidRoll < 0.75 ? Math.round(invoiceTotal * 0.5) : 0;
+
+      invoiceSeq += 1;
+      const invoice = await prisma.salesInvoice.create({
+        data: {
+          companyId,
+          customerId,
+          quotationId: quotation.id,
+          invoiceNumber: `INV-${String(invoiceSeq).padStart(5, "0")}`,
+          invoiceDate: invoicedAt,
+          dueDate: new Date(invoicedAt.getTime() + 30 * DAY),
+          status: amountPaid >= invoiceTotal ? "PAID" : "ISSUED",
+          currency: "USD",
+          subTotal: Math.round(invoiceTotal / 1.15),
+          taxTotal: invoiceTotal - Math.round(invoiceTotal / 1.15),
+          total: invoiceTotal,
+          amountPaid,
+          issuedAt: invoicedAt,
+          issuedById: owner(),
+          createdById: owner(),
+          createdAt: invoicedAt,
+          lines: {
+            create: [
+              {
+                description: deposit ? "Deposit — 40% on order" : "Supply and commissioning",
+                quantity: 1,
+                unitPrice: Math.round(invoiceTotal / 1.15),
+                taxRate: 15,
+                taxAmount: invoiceTotal - Math.round(invoiceTotal / 1.15),
+                lineTotal: invoiceTotal,
+              },
+            ],
+          },
+        },
+        select: { id: true },
+      });
+
+      await prisma.crmLeadDocument.create({
+        data: {
+          companyId,
+          dealId: deal.id,
+          type: "INVOICE",
+          invoiceId: invoice.id,
+          amount: invoiceTotal,
+          currency: "USD",
+          isDeposit: deposit,
+          createdById: owner(),
+          createdAt: invoicedAt,
+        },
+      });
+
+      if (amountPaid <= 0) continue;
+
+      receiptSeq += 1;
+      const receivedAt = new Date(invoicedAt.getTime() + between(2, 40) * DAY);
+      const receipt = await prisma.salesReceipt.create({
+        data: {
+          companyId,
+          invoiceId: invoice.id,
+          receiptNumber: `RCT-${String(receiptSeq).padStart(5, "0")}`,
+          receivedAt: receivedAt > new Date() ? new Date() : receivedAt,
+          amount: amountPaid,
+          method: pick(["EFT", "Cash", "Card", "Mobile money"]),
+          reference: `REF${between(100000, 999999)}`,
+          createdById: owner(),
+        },
+        select: { id: true },
+      });
+
+      await prisma.crmLeadDocument.create({
+        data: {
+          companyId,
+          dealId: deal.id,
+          type: "RECEIPT",
+          receiptId: receipt.id,
+          amount: amountPaid,
+          currency: "USD",
+          createdById: owner(),
+          createdAt: receivedAt > new Date() ? new Date() : receivedAt,
+        },
+      });
+    }
+  }
+
+  const counts = {
+    tenant: slug,
+    companies: clients.length,
+    people: people.length,
+    sites: sites.length,
+    leads: leads.length,
+    archivedLeads: leads.filter((lead) => lead.archived).length,
+    deals: deals.length,
+    activities: await prisma.crmActivity.count({ where: { companyId } }),
+    tasks: await prisma.crmTask.count({ where: { companyId } }),
+    followUps: await prisma.crmFollowUp.count({ where: { companyId } }),
+    comments: await prisma.crmComment.count({ where: { companyId } }),
+    visits: await prisma.crmAppointment.count({ where: { companyId } }),
+    quotations: await prisma.crmLeadDocument.count({ where: { companyId, type: "QUOTATION" } }),
+    invoices: await prisma.crmLeadDocument.count({ where: { companyId, type: "INVOICE" } }),
+    receipts: await prisma.crmLeadDocument.count({ where: { companyId, type: "RECEIPT" } }),
+  };
+  console.log(JSON.stringify(counts, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(disconnectPrisma);


### PR DESCRIPTION
## What this is

A screenshot-driven pass over the CRM vertical and the management module at
390px, plus the shared shell, overlay and record primitives the rest of the
product uses. The shape it moves toward is Notion's: the page says what it is,
properties sit at the top of a record in a list you read on the way in, rows are
two lines with one figure on the right, and anything that scrolls sideways is cut
by the edge of the screen rather than by a gutter eight pixels inside it.

Nothing here was inferred from reading the code. A CRM screen with nothing in it
cannot be judged, so the first commit adds what made the audit possible:
`scripts/seed-crm-demo.ts` (a small book of business — companies, the people at
them, sites, leads across every stage, a pipeline with deals, tasks) and
`e2e/crm-shots.spec.ts` (every screen at desktop, tablet and phone, with
`SHOT_ONLY` / `SHOT_VIEWPORTS` for a tight loop). 42 screens shot, no error
banners.

---

## Round 1 — what the screenshots showed

**The app bar.** The global command bar rendered a 144px search input at every
width, so any page with a primary action showed `C…` where its name should be.
A phone gets the icon; the box returns at `md`. On a record page the bar also
holds a back arrow and a primary action, so the record's name is now repeated
above the identity strip, where it can be read in full.

**Vertical budget.** Collections stacked six full-width tiles — six screens of
`USD 0.00` before the chase list. Follow-ups stacked three. The CRM overview
rendered every widget full width, so six metrics were six screens. Tiles are
two-up now (three for a set of bare counts), with tile and KPI numerals sized to
fit what is left. The offline banner was four stacked blocks and ~130px above the
bar on every page, and reported its progress twice.

**Toolbars.** Boards spent a whole band on a lone "View" button, because leads
had no record search at all. Leads searches like every other record page now, and
a shared `ListSearch` shortens its placeholder to the noun on a phone instead of
clipping `Search deals by title, number or c…`. The filter sheet stacked six
controls and centred every label; that grammar is now named `.stacked-controls`.

**Lists.** The people and company directories grouped by first letter over rows
the API returned in `updatedAt` order, so the headings came out A, S, C, N, F.
Both sort by name before grouping. A row's leading fact was kept on a phone
whatever it was, which put an unlabelled `0` after a person's name — callers now
name the one fact worth keeping without its label.

**Rails.** The board's stage rail was cut short of the gutter, which reads as
clipping rather than as scrolling; it is full-bleed and snaps, and the bare
`USD 4,050` under it now says what it counts (`2 leads in New · USD 4,050`).
Six segments on a 390px strip wrapped "On site" inside its own pill and ran off
the page; labels never wrap and a strip that cannot fit scrolls.

**Correctness found on the way.** Two close buttons overlapped in the employee
wizard's corner. A deal's value read `9800` with no currency in a workspace that
bills in two. `:last-child` counts elements only, so the rule meant for a
trailing caret was shoving icon-and-label against the right edge of every
full-width button in the app. CRM settings drew each section's title and
description twice. Deleting a task was a one-tap destructive action at thumb
height with no undo; it asks first.

---

## Round 2 — overlays, and the Notion property pattern

Four defects reported from a real phone. All were reproduced in a browser before
being fixed, and all are now covered by `e2e/crm-overlays.spec.ts`.

**Menus painted behind the sidebar.** Every overlay in `components/ui` carried a
bare `z-50` while the design system's drawer sets `zIndex: 1100` as an *inline
style*, so opening the sidebar and tapping the workspace switcher put the menu
underneath it.

**A picker opened from a form dialog opened behind the dialog** — the same fault
in the other direction, and the reason a fixed rung cannot work here. This
product nests overlays both ways: a filter sheet made of popovers and a form
dialog whose client picker is a sheet want popover-and-drawer over modal, while a
"discard these changes?" dialog raised from inside a form sheet wants the
opposite. So every dismissable overlay shares one rung (`--z-overlay`) and open
order decides, which is the only rule right in both directions. Chrome sits below
(`--z-sidebar`, `--z-nav`), toasts above (`--z-toast`).

**Escape in a picker closed the form under it**, losing everything typed: the
sheet is a Radix dialog, the form is a Base UI one, and both answered the same
key. A capture-phase listener now stops the event at the innermost sheet.

**Bottom sheets opened at exactly half the screen** whatever was in them, because
`.drawer-bottom` takes a fixed height from `--drawer-size`. They size to their
content now, capped, with a rounded top, a grabber and safe-area padding.

**The property pattern.** The worst of it was the picker itself: a 358px popover
anchored to a control near the bottom of a form had nowhere to go but *over* the
form — a screenshot showed the client picker covering the four fields above its
own trigger. `ResponsivePopover` keeps the anchored popover on a desktop and
brings the same content up from the bottom edge on a phone, under the property's
own name.

Also in this round: the magnifier is drawn as an outline rather than a solid, and
the app bar's gutter lines up with the content below it instead of sitting eight
pixels inside it.

---

## Round 3 — the rest of the vertical

- **Management and Preferences** drew their section rail as a full-width column:
  thirteen items, ~500px of navigation above the page it navigates to. Both now
  use the responsive rail CRM settings already used.
- **Every cold load on a phone painted the desktop sidebar for a frame**, with
  the page squeezed beside it, because the design system picks between rail and
  drawer with a media query that has no answer before hydration.
- Intake forms offered "New form" and "Build the first form" at once, in the same
  blue, on the same empty screen.
- A rep's row lost its figure when facts became opt-in; open pipeline is what
  that row is about, so it is marked.

`docs/ux/platform-ux-playbook.md` gained a **Phone Rules** section covering the
app bar, vertical budget, rails, rows, controls, overlays and navigation — the
playbook had no mobile section, which is how the module reached this state:
every rule it broke was a rule nobody had written down.

---

## Round 4 — record pages, primary actions, and giving a lead an ending

Rounds 1–3 audited list screens. This one shoots the **records**.
`e2e/record-shots.spec.ts` opens the first row of each list and photographs
lead, deal, company, person, site and rep, phone first. Most of what the
pictures showed is fixed in the **shell**, so it lands on all fourteen record
pages at once rather than six.

**Properties could not be read.** The label column took 144px of the ~358px a
390px screen has, and neither labels nor values wrapped or truncated — a
company's email ran off the edge as `hello@chitungwizamedicalcentre.co`, a
lead's company read `Chitungwiza Medical Centre  Chang`, `Primary contact`
became `Primary cont…`, and the input you were typing into was cut by the edge
of the screen.

**The relation picker broke two rules already written down.** A bare 320px
`Popover` at 390px — the case `ResponsivePopover` was added in round 2 to fix —
with a **"Change"** button spelled out in words beside the value, costing about
a quarter of the value column. It is a sheet with a pencil now.

**A menu inside a menu.** On a phone the bar collects its own actions. The
record shell handed it a `DropdownMenu`, so the phone put a menu inside a menu:
you pressed the dots and got a panel containing a single unlabelled dots button
to press again, with two controls on screen both called "More actions".

**Records with nothing to do on them.** Company, person and site had no primary
action at all. They start a deal and schedule a visit now. The person record's
edit form had no way of ever opening: the state was declared and
`PersonFormSheet` was mounted, but nothing set it.

**Primary actions in management, preferences and stores.** `ManagementShell`
and `PreferencesShell` each drew their own `PageHeader` inside the page: the
title stated twice, ~110px spent saying it again, and the app bar empty beside
the bell. Both register with `PageChrome` now. `StoresShell` put **Issue** and
**Receive** on every tab, including the catalogue where neither is the verb and
the page's real action, "New item", sat in the body under a paragraph.

**A lead can end.** There was no way to archive or delete one — the only exit
was the LOST stage, and Lost is a claim about the business, not a tidy-up.

- `POST /api/v2/crm/leads/[id]/archive` — archive and restore
- `DELETE /api/v2/crm/leads/[id]` — permanent, gated on `records.delete`
- `action: "archive"` on the bulk endpoint
- An **Archived** filter on the leads list, and a Restore control on the bulk bar

**Conversion archives the lead it converts.** This is the "two copies of the
same thing" in the request. `convertedAt` was already set — but nothing read it
in a list query, so the same opportunity sat in the pipeline twice, once as a
lead in Qualified and once as the deal it had just become. `buildLeadWhere` now
excludes archived leads everywhere unless the archive is what was asked for.
Four other places were counting the husk and are fixed with it: rep workload on
the list and the detail page, the unanswered-enquiry tile, round-robin
auto-assignment, and global search. Source reporting and insights deliberately
still read archived leads.

Verified end to end against a running app: archive removes the lead from the
list (10 → 9) and the board; restore returns it; conversion archives it;
restoring or deleting a converted lead is refused with a 409; deleting an
ordinary one works.

**Database change.** `CrmLead.archivedAt` and `archivedById`, with
`prisma/migrations/20260815090000_crm_lead_archive`, which also backfills
already-converted leads. No new index: every lead query is already scoped by
`companyId` through a composite index, and `archivedAt IS NULL` matches almost
every row.

---

## Round 5 — the record's own grammar

**The action row was a segmented group.** A solid brand button and a bare icon
button fenced inside one `ButtonGroup`, which draws a border, clips its children
and puts a divider between them — so the overflow appeared to carry a second
outline and the pair read as one control painted two colours. Two controls side
by side now.

**A property row sat on three different baselines.** The label carried `py-1`,
the value carried `py-1` *and* a `min-h-9`, and the icon a `mt-0.5` tuned
against neither. One shared line box, exported and used by the label, all three
value renderers and the relation attribute.

**Overview and the timeline were two places to look at one thing** — worse on a
phone, where the summary was a tab named Overview that the page landed on, so
what had happened to the record was one tap away behind a word. One view.

**The sections became a vertical rail.** Thirteen wrapped onto two rows at
1440px and had to be scrolled sideways at 390px. A segmented control cannot take
them — `.segmented` is a fixed track of equal-width columns — so it stays where
it belongs, on a few peers of one kind. `NavRail` beside the section on a
desktop, the same rail at the foot of the landing view on a phone.

**Which section is open lives in the URL** (`?section=documents`). That is what
makes the back arrow and the browser's back button return to the record rather
than the list two levels up, makes a link to a record's documents sendable, and
makes the first paint correct — `matchMedia` has no answer before hydration.

**The summary scans.** Score signals were drawn as darkly as the figure above
them, so nothing led. Muted; the total takes the band's colour, and only a
signal counting against the lead keeps a red one.

---

## Round 6 — merging, a standing column, and what the client said

**Ten sections to six.** Comments folded into the timeline as one
**Conversation**: they were split across two screens by a distinction (internal
or not) that nobody has in their head when looking for what somebody said.
`buildStory` has always accepted comments and nothing ever passed them, so the
merge was mostly a deletion. One composer, with the segmented control choosing
between a comment and a logged call. Documents absorbed Files; History absorbed
Field history and Mentions. Those lists stay distinct — a quotation has a total
and a version chain, an uploaded contract has neither — but they are not
distinct *destinations*, and the segmented control carries the split one level
down.

This supersedes Round 5's "Comments follows immediately": there is no Comments
section any more.

**Two active rows in the rail.** `.rail-item:hover` and `.rail-item.active`
both painted `--surface-muted`, so pointing at the rail put a second row in
exactly the selected state and there was no telling which one you were on.
Hover is the lighter tint; selection carries a brand bar down the leading edge,
which hovering never produces.

**A standing column.** Round 5 introduced a bug: opening a section replaced the
whole page — right for a phone, where a drilldown *is* the page, and wrong for a
desktop, which lost its rail and its properties the moment you clicked one of
them. The frame is always rendered and the phone hides what it does not want in
CSS, so only the middle column changes. From `lg` the record has three columns:
sections, the section, and one that keeps the properties and the summary in view
whichever section is open. The property list is keyed to its container rather
than the viewport — keyed to the viewport it put two columns inside 320px and
`USD 9,100.00` came out one character per line.

**What the client did with a quote.** `CrmDocumentApproval` has stored
`firstViewedAt`, `respondedAt`, `responderName` and `responseNote` since
approval links shipped; the record page selected none of them and showed none of
them, so "have they even opened it?" and "why did they turn it down?" were
questions the system knew the answers to and would not tell anybody — the chip
said "Declined" and stopped. Four states now, because each is a different next
move: not sent, sent and unopened, opened and silent, or answered with the
reason quoted. Covered by `components/crm/documents/approval-feedback.test.tsx`.

**Email to the client.** There is no outbound mail in this platform — no
provider, no key, nowhere to queue a retry — so this mints the approval link and
hands a composed draft to whatever the reader sends mail with, rather than being
a button that appears to send and does not. `emailToClient` is the one call site
to change when server-side mail arrives. Flagging it explicitly because it is
the one item in the request that is not implemented as asked.

Part payments and deposits already worked; the menu now says so plainly —
"Settle in full" beside "Record a part payment", so the two read as the same
decision at different amounts.

**Menus.** Icon rules moved into the primitive because they were at each call
site and had drifted — `h-4 w-4` here, `size-4` there, inherited black in one
menu and muted grey in the next. Tone became a prop: `destructive`, `positive`,
`primary`. A toned row tints its own mark to match its label.

---

## Round 7 — one place for the record, one box for what you write, and a year of data

**Everything about the record now lives in one standing column.** It had been in
three places: name, icon, status and reference in a band under the app bar;
properties in the middle; the section rail below both. None of the three
survived a scroll, and the band cost a screen of height before a section
started. The right column carries the lot — icon, title, reference, status chip,
subtitle, properties and the summary panels — sticky, ruled off from the section
with a vertical divider, and collapsible for anyone who wants the width back
(the choice is remembered). The rail is sticky too, so both edges stay put and
only the section scrolls. On a phone, where there is no third column, that same
content leads the landing view.

**The composer is rebuilt around the mistake it can cause.** Round 6 merged the
activity logger and the comment box, which is right — both are somebody typing a
paragraph about this record — but the merge creates a hazard, and it is the
serious one: an internal remark filed as a record of what we told the client.
*"Careful, we underquoted this site last time"* is a sentence you do not want in
the customer-facing history, and six equal chips in a row do not stop it
happening: the difference that matters is carried by nothing more than the
position of the first chip, and the consequence is never stated.

So the choice is made twice, at two sizes:

1. **A binary, first and largest** — *Note to the team* or *Record of contact*.
   Two options cannot be misread the way six can.
2. **The kind of contact**, only once the first is answered, and only because a
   call and an email are genuinely different facts.

The panel is tinted per mode, so an internal note never *looks* like a customer
record even at a glance across a room. The consequence is written in a sentence
beside the button that commits it — *"Only your team sees this."* against
*"Goes on this record's history as a call."* — and the button names the act:
**Post comment** or **Log the call**, which are hard to press by accident when
you meant the other.

**A year of trading to look at.** `scripts/seed-crm-year.ts` writes what a year
of running this CRM would leave behind: 35 companies, 108 people, 47 sites, 180
leads (49 of them archived), 90 deals, 1,240 logged activities, 128 tasks, 76
follow-ups, 143 comments, 64 visits, and the paperwork — 56 quotes, each with
the client's answer to it (approved, declined with the reason, opened and
silent, or never opened), 20 invoices including deposits, and 16 receipts, some
settling the invoice and some paying half of it. Deterministic, seeded from a
fixed number, so a screenshot diff means the code changed and not the data. A
record page with two timeline entries tells you nothing about how it reads with
eighty.

**Four things the year of data exposed:**

- The timeline stamped every row `8/4/2026, 9:06:53 PM` — under a heading that
  already gave the day, and to the second. Rows carry the time of day only.
- Recent calls in the summary were all attributed to *"Someone"*. The API had
  always sent who logged it; the panel had never asked.
- On a desktop the app bar showed the record's name twice, once as the back link
  and once as the title, because the phone's drilldown rule ("up is the record")
  was being applied at every width. A desktop never leaves the record, so up
  stays the list.
- And one that was not specific to the CRM: `ClientDate` was a straight
  re-export of the design system's, whose `datetime` mode formats through
  `toLocaleString()` — which carries **seconds**. Every timestamp in the
  product, across 39 files, was reporting a precision nobody asked for in
  columns narrow enough that buying it cost a wrapped line. The formatting is
  spelled out locally now and the seconds are gone; both invariants the call
  sites depend on (a bare fragment, and an ISO slice before mount so hydration
  matches) are kept.

Every CRM screen was then shot at 1440×900 and 390×844 against the seeded year —
lists, boards, directories, money, analysis, setup, and each section of a lead,
a deal, a company, a person, a site and a rep. 78 exposures, no error banners.

---

## Round 8 — the columns fill the screen, and events say what they are

**A record's rules ran out halfway down.** Grid tracks are only as tall as their
tallest child, and the rules between a record's columns are drawn on the
columns — so a section with little in it (two people on a deal, an empty
document list) left two vertical lines stopping a third of the way down and a
page that read as cropped. The columns now take a floor of whatever the viewport
has left below the app bar. It is a `min-height`, not a height: a long timeline
still grows past it and scrolls as before. Sticky started behaving properly as a
side effect — a track exactly as tall as its content gave `top-0` nothing to
travel in.

The floor is `--content-viewport`, and the two numbers it subtracts are now read
from the same place they are set: `Navbar` takes its height from `--app-bar-h`
and `main` its vertical padding from `--content-gutter-y`, instead of three
files each spelling out `3.5rem` and `1.5rem` and drifting the next time the bar
changes. Same rendered values as before.

**Every event looked the same.** The timeline drew eleven kinds of thing —
a call, a quote raised, a site visit, an internal remark — with one grey disc,
told apart by a glyph 14 pixels across and a word. `event-kind.tsx` is now the
one table saying what each kind looks like (its word, its glyph, its hue), and
the timeline and the recent-contact list both read from it. Colour only becomes
a shortcut once it is the same shortcut everywhere.

The hues are assigned by what the event *is*. Talking to the client takes the
cool half of the wheel, so call/email/meeting/WhatsApp read as one family with
four members. A site visit takes orange — the one kind that costs a morning. An
internal comment takes pink, the one hue no client-facing event uses, so a
remark meant for the team is never mistaken for a record of contact at a glance:
the same mistake the composer is shaped to prevent, carried through to how it
reads afterwards. Paperwork and money take brown and green; what the system did
to the record takes gray, which is the point. Colour is never the only channel —
every kind keeps its own glyph and its own word.

Three more out of the same pass:

- **The summary was lying.** It counted four kinds of contact and then listed
  *calls*, so a record whose last month was all email read as silent under a
  figure saying four emails. `ContactList` shows every kind, and is named for
  what it is.
- **Bodies carry the edge.** An email, note, comment or visit write-up takes the
  event's colour on its leading border, so a scrolled feed shows which
  paragraphs are the client's without reading any of them.
- **The wire-type → kind map had two copies drifting apart.** Now one, plus a
  deliberately narrower `CONTACT_ACTIVITY_KIND`: a stage move is not contact
  with anybody, and counting it under "contact so far" answers "have we spoken
  to them" with paperwork.

**Avatars across the whole product get their colour back.** The design system
hashes a name onto one of thirteen hues, stamps it on the element as
`data-accent` and paints it with `.avatar-accent` — then emits its plain
`.avatar` rule, `background: var(--surface-sunken)`, twenty thousand characters
later in the same bundle. Two single-class selectors of equal specificity in one
layer: the last one wins, so every avatar in the app came out the same grey and
four colleagues in a thread were four identical discs. Corrected from
`@layer app`, which outranks the package's layer; verified by reading the
computed style in a browser rather than by eye.

---

## Round 9 — the contact panel, and marks that hold up at 20px

**"Contact so far" is a list and nothing else.** It opened with a strip of
counts — "2 calls · 4 emails · 2 notes · 4 meetings · 2 messages" — above the
last few contacts. Two readings of one set of facts, stacked in a 22rem column:
the rows below already say how much has been going on *and* what was said, in
the order it happened, which is the coarser answer plus the one the reader
actually wants. The strip also wrapped to two lines at that width, so it cost
more room than the rows it was summarising. Six rows now instead of four, and
`ActivityStrip` is deleted rather than left as an unused export.

Spacing with it: each row is two lines of its own, so the gap between rows has
to beat the gap inside one or the list reads as a single paragraph with coloured
dots scattered through it. `Stack gap="xs"` was tuned for single-line rows and
did not.

**Every mark is a white glyph on a solid fill.** Tint-inside-a-ring was the
wrong call in Round 8: a 24px disc has room for one thing, and a pale wash
behind a pale glyph inside a pale outline spends all three on the same weak
signal — at arm's length the rail read as one grey column again, which is what
the colour coding existed to prevent.

The contrast needed working out rather than guessing. `--accent-solid` reverses
white on ten of the thirteen hues; on orange, amber and yellow white lands at
3.4, 2.9 and 2.5 to one, which is why the package pairs those three with a
near-black `--accent-on` instead. That pairing passes as a *number* and fails as
a *mark*: a 14px stroked glyph in `#3D2800` on `#D08A05` is mud, and two avatar
initials in it are worse, because thin strokes need far more separation than the
body text those ratios were derived for. So those three take `--accent-fg` — the
same hue, darkened to the value the package already uses for text on a light
ground — and reverse white at 5.5 to one, better than the teal (4.5) and red
(4.5) solids already in service. No hue had to be dropped to get there.

One class, `.solid-mark`, owns the fill-and-glyph pairing for the timeline
chips, the contact marks, solid avatars and the PDF/XLS file marks, rather than
five call sites each spelling out a fill and a foreground.

All six record types were then re-shot at both widths — 36 exposures, deal and
lead with every section, plus company, person, site and rep.

---

## Checks

- `npx tsc --noEmit` clean.
- `npx eslint .` reports **the same errors with and without this branch's
  changes** (verified by stashing) — none new.
- `npx vitest run components/ lib/crm` — 52 files, 680 tests, all pass. The
  `lib/schools/**` and `app/api/v2/schools/**` failures elsewhere are
  pre-existing and unchanged: they assert DB-level CHECK constraints that exist
  only in migration SQL, and this environment's database was built with
  `db push`, so it has no `_prisma_migrations` table and never had them.
  Confirmed by stashing.
- `docs/ux/platform-ux-playbook.md` gains **Record pages**, **Record sections**,
  **Scanning a summary**, **Menus** and **Action rows**, plus **Where the title
  and the primary action go** under shell patterns.

## Decisions left open

- **Selection checkboxes still render on phone list rows.** Notion has none;
  removing them would take bulk actions off mobile entirely.
- **The primary action lives in the app bar**, everywhere. Round 3 left this
  open; Round 4 closed it by moving management, preferences and stores *into*
  the bar rather than out of it.
- **Rep records still have no primary action.** A colleague is not a customer
  and there is no obvious verb; left deliberately rather than inventing one.
- **Outbound email is not built.** See Round 6 — the menu item hands off to a
  mail client. Server-side sending needs a provider decision and secrets.
- **Inline reference chips keep their tint.** An `@mention` or a linked record
  sits *inside* a sentence rather than beside one, and a solid fill running
  through a paragraph reads as highlighter rather than as a link. The only
  deliberate exception to Round 9's solid marks.
- **`app/styles/components.css` is imported by nothing.** Found while chasing
  the avatar bug — a dead file whose rules mirror the package's. Left alone
  rather than deleted in a UI pass, but it should go.
- **Graph navigation is half done.** Related records sit directly after the
  summary, everything is a real link, and drilling into a section no longer
  costs you the record. What is *not* done is moving between records without
  losing your place — a back-stack that remembers where you came from, and a way
  to look at a related record without leaving the one you are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu