### PR TITLE
feat(crm): move through the record graph without losing your place

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,8 @@
       "Bash(npx vitest *)",
       "Bash(pnpm install *)",
       "mcp__Claude_Code_Remote__send_later",
-      "mcp__Claude_Code_Remote__list_triggers"
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__delete_trigger"
     ]
   }
 }

--- a/app/api/v2/crm/records/[entity]/[id]/summary/route.ts
+++ b/app/api/v2/crm/records/[entity]/[id]/summary/route.ts
@@ -1,0 +1,310 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorResponse, successResponse, validateSession } from "@/lib/api-utils";
+import { prisma } from "@/lib/prisma";
+import { RECORD_ENTITIES, type RecordEntity } from "@/lib/crm/record-ref";
+
+/**
+ * One record, small enough to look at without going there.
+ *
+ * The peek needs the same handful of facts about any of six different tables —
+ * what it is called, its reference, where it stands, and four or five
+ * properties — and each of those tables already has a detail endpoint that
+ * returns everything: a deal's `GET` carries its activities, its documents,
+ * its contacts and its visits. Fetching all of that to draw a card with five
+ * rows on it would make hovering a link cost more than opening the page.
+ *
+ * So: a summary of its own, normalised, so the peek has one shape to render
+ * rather than six, and one place to change when a record gains a fact worth
+ * previewing.
+ *
+ * The properties come back as `{ label, value }` in the order they should be
+ * read. Deliberately strings — this is a preview, and a peek that renders a
+ * live editor for six entity types is a second record page, not a peek.
+ */
+
+export type PeekTone = "neutral" | "info" | "success" | "warn" | "danger";
+
+export type PeekSummary = {
+  entity: RecordEntity;
+  id: string;
+  href: string;
+  title: string;
+  /** CRMD-0142, DEAL-0039 — the thing people quote at each other. */
+  reference: string | null;
+  /** Where it stands, when that means anything for this entity. */
+  status: { label: string; tone: PeekTone } | null;
+  /** The line under the title: a company, a job title, a town. */
+  subtitle: string | null;
+  properties: Array<{ label: string; value: string }>;
+  /** Archived records are still reachable by link, and should say so. */
+  archived: boolean;
+};
+
+const money = (value: number | null | undefined, currency: string | null | undefined) =>
+  value == null
+    ? null
+    : `${currency ?? "USD"} ${value.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+
+const day = (value: Date | null | undefined) => (value ? value.toISOString().slice(0, 10) : null);
+
+/** Drop the properties that have no answer rather than printing "—" five times. */
+const kept = (rows: Array<{ label: string; value: string | null | undefined }>) =>
+  rows.filter((row): row is { label: string; value: string } => Boolean(row.value));
+
+const LEAD_TONE: Record<string, PeekTone> = {
+  NEW: "info",
+  CONTACTED: "info",
+  QUALIFIED: "info",
+  SITE_VISIT: "info",
+  QUOTED: "warn",
+  INVOICED: "warn",
+  WON: "success",
+  LOST: "danger",
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ entity: string; id: string }> },
+) {
+  try {
+    const sessionResult = await validateSession(request);
+    if (sessionResult instanceof NextResponse) return sessionResult;
+    const { session } = sessionResult;
+    const { entity, id } = await params;
+
+    if (!RECORD_ENTITIES.includes(entity as RecordEntity)) {
+      return errorResponse("Unknown record type", 400);
+    }
+    const companyId = session.user.companyId;
+    const kind = entity as RecordEntity;
+
+    if (kind === "deal") {
+      const deal = await prisma.crmDeal.findFirst({
+        where: { id, companyId },
+        select: {
+          id: true,
+          dealNo: true,
+          title: true,
+          value: true,
+          currency: true,
+          expectedCloseDate: true,
+          archivedAt: true,
+          stage: { select: { name: true, status: true } },
+          client: { select: { name: true } },
+          primaryContact: { select: { fullName: true } },
+          site: { select: { name: true } },
+          assignedTo: { select: { name: true } },
+        },
+      });
+      if (!deal) return errorResponse("Deal not found", 404);
+      return successResponse<PeekSummary>({
+        entity: kind,
+        id: deal.id,
+        href: `/crm/deals/${deal.id}`,
+        title: deal.title,
+        reference: deal.dealNo,
+        status: deal.stage
+          ? {
+              label: deal.stage.name,
+              tone:
+                deal.stage.status === "WON"
+                  ? "success"
+                  : deal.stage.status === "LOST"
+                    ? "danger"
+                    : "info",
+            }
+          : null,
+        subtitle: deal.client?.name ?? null,
+        properties: kept([
+          { label: "Value", value: money(deal.value, deal.currency) },
+          { label: "Owner", value: deal.assignedTo?.name },
+          { label: "Contact", value: deal.primaryContact?.fullName },
+          { label: "Site", value: deal.site?.name },
+          { label: "Expected close", value: day(deal.expectedCloseDate) },
+        ]),
+        archived: Boolean(deal.archivedAt),
+      });
+    }
+
+    if (kind === "lead") {
+      const lead = await prisma.crmLead.findFirst({
+        where: { id, companyId },
+        select: {
+          id: true,
+          leadNo: true,
+          title: true,
+          contactName: true,
+          stage: true,
+          estimatedValue: true,
+          currency: true,
+          source: true,
+          archivedAt: true,
+          client: { select: { name: true } },
+          assignedTo: { select: { name: true } },
+        },
+      });
+      if (!lead) return errorResponse("Lead not found", 404);
+      return successResponse<PeekSummary>({
+        entity: kind,
+        id: lead.id,
+        href: `/crm/leads/${lead.id}`,
+        title: lead.title ?? lead.contactName ?? lead.leadNo,
+        reference: lead.leadNo,
+        status: {
+          label: lead.stage.replace(/_/g, " ").toLowerCase(),
+          tone: LEAD_TONE[lead.stage] ?? "neutral",
+        },
+        subtitle: lead.client?.name ?? lead.contactName ?? null,
+        properties: kept([
+          { label: "Value", value: money(lead.estimatedValue, lead.currency) },
+          { label: "Owner", value: lead.assignedTo?.name },
+          { label: "Source", value: lead.source },
+        ]),
+        archived: Boolean(lead.archivedAt),
+      });
+    }
+
+    if (kind === "company") {
+      const client = await prisma.crmClient.findFirst({
+        where: { id, companyId },
+        select: {
+          id: true,
+          clientNo: true,
+          name: true,
+          industry: true,
+          city: true,
+          country: true,
+          email: true,
+          phone: true,
+          archivedAt: true,
+          assignedTo: { select: { name: true } },
+          _count: { select: { deals: true, people: true, sites: true } },
+        },
+      });
+      if (!client) return errorResponse("Company not found", 404);
+      return successResponse<PeekSummary>({
+        entity: kind,
+        id: client.id,
+        href: `/crm/companies/${client.id}`,
+        title: client.name,
+        reference: client.clientNo,
+        status: null,
+        subtitle: [client.industry, client.city].filter(Boolean).join(" · ") || null,
+        properties: kept([
+          { label: "Owner", value: client.assignedTo?.name },
+          { label: "Email", value: client.email },
+          { label: "Phone", value: client.phone },
+          {
+            label: "On the books",
+            value:
+              client._count.deals || client._count.people || client._count.sites
+                ? [
+                    client._count.deals ? `${client._count.deals} deals` : null,
+                    client._count.people ? `${client._count.people} people` : null,
+                    client._count.sites ? `${client._count.sites} sites` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")
+                : null,
+          },
+        ]),
+        archived: Boolean(client.archivedAt),
+      });
+    }
+
+    if (kind === "person") {
+      const person = await prisma.crmPerson.findFirst({
+        where: { id, companyId },
+        select: {
+          id: true,
+          personNo: true,
+          fullName: true,
+          jobTitle: true,
+          email: true,
+          phone: true,
+          city: true,
+          archivedAt: true,
+          client: { select: { name: true } },
+        },
+      });
+      if (!person) return errorResponse("Person not found", 404);
+      return successResponse<PeekSummary>({
+        entity: kind,
+        id: person.id,
+        href: `/crm/people/${person.id}`,
+        title: person.fullName,
+        reference: person.personNo,
+        status: null,
+        subtitle: [person.jobTitle, person.client?.name].filter(Boolean).join(" · ") || null,
+        properties: kept([
+          { label: "Email", value: person.email },
+          { label: "Phone", value: person.phone },
+          { label: "Town", value: person.city },
+        ]),
+        archived: Boolean(person.archivedAt),
+      });
+    }
+
+    if (kind === "site") {
+      const site = await prisma.crmSite.findFirst({
+        where: { id, companyId },
+        select: {
+          id: true,
+          siteNo: true,
+          name: true,
+          addressLine: true,
+          city: true,
+          archivedAt: true,
+          client: { select: { name: true } },
+          primaryContact: { select: { fullName: true } },
+          _count: { select: { deals: true, appointments: true } },
+        },
+      });
+      if (!site) return errorResponse("Site not found", 404);
+      return successResponse<PeekSummary>({
+        entity: kind,
+        id: site.id,
+        href: `/crm/sites/${site.id}`,
+        title: site.name,
+        reference: site.siteNo,
+        status: null,
+        subtitle: site.client?.name ?? null,
+        properties: kept([
+          { label: "Address", value: [site.addressLine, site.city].filter(Boolean).join(", ") },
+          { label: "Contact", value: site.primaryContact?.fullName },
+          { label: "Deals", value: site._count.deals ? String(site._count.deals) : null },
+          {
+            label: "Visits",
+            value: site._count.appointments ? String(site._count.appointments) : null,
+          },
+        ]),
+        archived: Boolean(site.archivedAt),
+      });
+    }
+
+    // A rep is a colleague, and lives in `User` rather than in a CRM table.
+    const rep = await prisma.user.findFirst({
+      where: { id, companyId },
+      select: { id: true, name: true, email: true, role: true, isActive: true },
+    });
+    if (!rep) return errorResponse("Rep not found", 404);
+    return successResponse<PeekSummary>({
+      entity: "rep",
+      id: rep.id,
+      href: `/crm/reps/${rep.id}`,
+      title: rep.name ?? rep.email ?? "Colleague",
+      reference: null,
+      status: rep.isActive ? null : { label: "Inactive", tone: "neutral" },
+      subtitle: rep.role ? rep.role.replace(/_/g, " ").toLowerCase() : null,
+      properties: kept([{ label: "Email", value: rep.email }]),
+      archived: false,
+    });
+  } catch (error) {
+    console.error("[API] GET /api/v2/crm/records/[entity]/[id]/summary error:", error);
+    return errorResponse("Failed to load record", 500);
+  }
+}

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -9,6 +9,8 @@ import { PageChromeProvider } from "@/components/layout/page-chrome";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { OnboardingProvider } from "@/components/onboarding/onboarding-provider";
 import { isPublicPath } from "@/lib/public-routes";
+import { RecordPeekProvider } from "@/components/records/record-peek";
+import { RecordTrailProvider } from "@/components/records/record-trail";
 
 export function AppShell({
   children,
@@ -73,7 +75,14 @@ export function AppShell({
                   : "content-shell min-w-0 min-h-0 flex-1 overflow-y-auto overscroll-contain [touch-action:pan-y] pt-[var(--content-gutter-y)] pb-[max(1.5rem,env(safe-area-inset-bottom))] md:py-[var(--content-gutter-y)]"
             }
           >
-            <OnboardingProvider>{children}</OnboardingProvider>
+            {/* Both live above `main` rather than inside a page: the trail has
+                to survive the navigation it is recording, and the peek has to
+                render over the page it was opened from. */}
+            <RecordTrailProvider>
+              <RecordPeekProvider>
+                <OnboardingProvider>{children}</OnboardingProvider>
+              </RecordPeekProvider>
+            </RecordTrailProvider>
           </main>
         </SidebarInset>
       </SidebarProvider>

--- a/components/records/entity-link.tsx
+++ b/components/records/entity-link.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
+import { useRecordPeek } from "@/components/records/record-peek";
+import { useRecordTrail } from "@/components/records/record-trail";
+import { parseRecordHref } from "@/lib/crm/record-ref";
 import { cn } from "@/lib/utils";
 
 /**
@@ -17,12 +20,34 @@ import { cn } from "@/lib/utils";
  * a page of near-black text, and on a screen in daylight on a site it is
  * invisible; the underline is the part that says "this goes somewhere" without
  * relying on anyone noticing a hue.
+ *
+ * ## What a click does
+ *
+ * Two different questions get asked of the same link, and they want different
+ * answers:
+ *
+ *   - *what is this?* — which company, has that site got an address, is that
+ *     the person we spoke to. A journey is the wrong price for a glance, so a
+ *     plain click **peeks**: the record opens beside the page and the page
+ *     does not move.
+ *   - *take me there* — which is what the modifier keys have always meant.
+ *     ⌘/ctrl-click, shift-click and middle-click are left entirely alone, so
+ *     "open in a new tab" works the way it does everywhere else.
+ *
+ * And when navigation does happen — from the peek's own **Open full page**, or
+ * from a link that points somewhere the peek cannot summarise — the record
+ * being left is pushed onto the trail, so the next page's back arrow names it
+ * instead of a list nobody has been near.
+ *
+ * `peek={false}` opts a call site out, for a reference that is the point of
+ * the row rather than an aside.
  */
 export function EntityLink({
   href,
   children,
   className,
   muted,
+  peek = true,
 }: {
   /** Where the record lives. Pass null for a reference with no page yet. */
   href: string | null | undefined;
@@ -30,14 +55,45 @@ export function EntityLink({
   className?: string;
   /** For references in supporting text, which should not shout. */
   muted?: boolean;
+  /** Set false where a click should go straight there. */
+  peek?: boolean;
 }) {
+  const { open } = useRecordPeek();
+  const { current, follow } = useRecordTrail();
+
   if (!href) {
     return <span className={className}>{children}</span>;
   }
 
+  const target = parseRecordHref(href);
+  const peekable = peek && Boolean(target);
+
+  const onClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    // Everything the browser already does for a link, it keeps doing. A new
+    // tab is a deliberate act and none of our business.
+    if (event.defaultPrevented) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    if (event.button !== 0) return;
+
+    // A reference to the record you are already reading is not a journey and
+    // not worth a panel either.
+    if (current && current.href === href) {
+      event.preventDefault();
+      return;
+    }
+
+    if (peekable && open(href)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (current) follow(current);
+  };
+
   return (
     <Link
       href={href}
+      onClick={onClick}
       className={cn(
         "underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text)]",
         muted ? "text-[var(--text-muted)] hover:text-[var(--text)]" : "hover:text-[var(--text)]",

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -18,6 +18,7 @@ import {
 import { PageChrome } from "@/components/layout/page-chrome";
 import { IconButton } from "@/components/ui/icon-button";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useRecordTrail } from "@/components/records/record-trail";
 import { ChevronLeftIcon, ChevronRight, DotsThree, type LucideIcon } from "@/lib/icons";
 import type { CanonicalUiStatus } from "@/lib/ui/status-map";
 import { cn } from "@/lib/utils";
@@ -180,6 +181,16 @@ export function RecordPageShell({
     const query = next.toString();
     return query ? `${pathname}?${query}` : pathname;
   })();
+
+  // The trail is what makes "back" mean the record you came from rather than
+  // the list you have not seen for three hops. Registering also pops the trail
+  // when this record is already on it, which is how the bar's arrow and the
+  // browser's own back button end up agreeing.
+  const { register, back: trailBack } = useRecordTrail();
+  useEffect(() => {
+    register({ href: pathname, label: title });
+    return () => register(null);
+  }, [register, pathname, title]);
 
   // The parent still owns `activeTab`, because buttons inside the page jump
   // sections — "add a task" from an empty Up next, "open documents" from the
@@ -412,12 +423,22 @@ export function RecordPageShell({
           Only on a phone, though. A desktop never leaves the record — the
           rail and the section sit side by side — so "up" stays the list, and
           pointing it at the record would put the record's name in the bar
-          twice, once as the back link and once as the title. */}
+          twice, once as the back link and once as the title.
+
+          Otherwise "up" is wherever the reader actually came from. Three hops
+          into a graph — a deal, its company, another deal there — the list
+          this record belongs to is not up, it is sideways, and an arrow
+          pointing at it throws away the path. The trail knows the path; the
+          list is what it falls back to when there isn't one. */}
       <PageChrome
         title={title}
         icon={icon}
-        backHref={openSection && narrow ? recordHref : backHref}
-        backLabel={openSection && narrow ? title : backLabel}
+        backHref={
+          openSection && narrow ? recordHref : (trailBack?.href ?? backHref)
+        }
+        backLabel={
+          openSection && narrow ? title : (trailBack?.label ?? backLabel)
+        }
       >
         {barActions}
       </PageChrome>

--- a/components/records/record-peek.tsx
+++ b/components/records/record-peek.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge, type Accent } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { fetchJson } from "@/lib/api-client";
+import { useRecordTrail } from "@/components/records/record-trail";
+import {
+  ENTITY_LABEL,
+  parseRecordHref,
+  type RecordEntity,
+  type RecordRef,
+} from "@/lib/crm/record-ref";
+import { ArrowRight, Building2, Funnel, MapPin, User, Users } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * A look at a related record without leaving the one you are on.
+ *
+ * Half the references on a record page are answering a question, not starting
+ * a journey: *which* company is this, is that the site we quoted last year,
+ * has that person got a phone number on file. Following the link to find out
+ * costs the page you were reading, the section you had open and the place in
+ * the timeline you had scrolled to — and then costs them again coming back.
+ *
+ * So a plain click opens the record beside the one you are reading and the
+ * page underneath does not move. The URL does not change either, which is the
+ * point: nothing about where you are has been spent on a glance.
+ *
+ * What is deliberately *not* here is editing. A peek that can change six kinds
+ * of record is a second record page with a worse layout, and two places to
+ * edit the same thing is how they drift. The peek shows, and hands over.
+ *
+ * Escape hatches, because a preview that traps you is worse than no preview:
+ * **Open full page** sits at the bottom where a commit belongs, and back in
+ * `EntityLink` the modifier clicks are left entirely alone — ⌘-click and
+ * middle-click are how people already say "I want this properly", and
+ * intercepting them would be rude.
+ */
+
+/**
+ * The glyph and hue for each kind of record.
+ *
+ * Same job the event table does on a timeline, one level up: a peek that
+ * opens the same grey disc for a company and a site makes the reader read
+ * the eyebrow to find out which arrived. Site keeps the orange it has as an
+ * event, since "a place" means the same thing in both.
+ */
+const ENTITY_MARK: Record<RecordEntity, { icon: typeof Funnel; accent: Accent }> = {
+  lead: { icon: Funnel, accent: "cyan" },
+  deal: { icon: Funnel, accent: "blue" },
+  company: { icon: Building2, accent: "indigo" },
+  person: { icon: Users, accent: "violet" },
+  site: { icon: MapPin, accent: "orange" },
+  rep: { icon: User, accent: "green" },
+};
+
+type PeekSummary = {
+  entity: RecordEntity;
+  id: string;
+  href: string;
+  title: string;
+  reference: string | null;
+  status: { label: string; tone: "neutral" | "info" | "success" | "warn" | "danger" } | null;
+  subtitle: string | null;
+  properties: Array<{ label: string; value: string }>;
+  archived: boolean;
+};
+
+type PeekValue = {
+  /** Open the peek on a record. Returns false when the href is not one. */
+  open: (href: string) => boolean;
+  close: () => void;
+  peeking: RecordRef | null;
+};
+
+const RecordPeekContext = createContext<PeekValue | null>(null);
+
+export function useRecordPeek(): PeekValue {
+  return useContext(RecordPeekContext) ?? DEAD_PEEK;
+}
+
+const DEAD_PEEK: PeekValue = { open: () => false, close: () => {}, peeking: null };
+
+export function RecordPeekProvider({ children }: { children: ReactNode }) {
+  const [peeking, setPeeking] = useState<RecordRef | null>(null);
+
+  const open = useCallback((href: string) => {
+    const ref = parseRecordHref(href);
+    if (!ref) return false;
+    setPeeking(ref);
+    return true;
+  }, []);
+
+  const close = useCallback(() => setPeeking(null), []);
+
+  const value = useMemo<PeekValue>(() => ({ open, close, peeking }), [open, close, peeking]);
+
+  return (
+    <RecordPeekContext.Provider value={value}>
+      {children}
+      <PeekSheet peeking={peeking} onClose={close} />
+    </RecordPeekContext.Provider>
+  );
+}
+
+function PeekSheet({ peeking, onClose }: { peeking: RecordRef | null; onClose: () => void }) {
+  const router = useRouter();
+  const { current, follow } = useRecordTrail();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["crm-peek", peeking?.entity, peeking?.id],
+    enabled: Boolean(peeking),
+    // `successResponse` returns the record itself, not a `{ data }` envelope.
+    queryFn: () =>
+      fetchJson<PeekSummary>(`/api/v2/crm/records/${peeking!.entity}/${peeking!.id}/summary`),
+    // A peek is a glance, and the same record gets glanced at repeatedly on
+    // one page. Keeping it a minute means the second look is instant.
+    staleTime: 60_000,
+  });
+
+  const mark = peeking ? ENTITY_MARK[peeking.entity] : ENTITY_MARK.deal;
+  const Icon = mark.icon;
+
+  return (
+    <Sheet open={Boolean(peeking)} onOpenChange={(next) => (next ? null : onClose())}>
+      <SheetContent side="right" size="md" className="flex flex-col gap-0 p-0">
+        <SheetHeader className="border-b border-[var(--border-subtle)] p-4">
+          <p className="text-sm uppercase tracking-[0.08em] text-[var(--text-subtle)]">
+            {peeking ? ENTITY_LABEL[peeking.entity] : "Record"}
+          </p>
+          <SheetTitle className="flex items-start gap-2 text-left">
+            <span
+              data-accent={mark.accent}
+              className="solid-mark mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
+            >
+              <Icon className="size-3.5" aria-hidden="true" />
+            </span>
+            <span className="min-w-0 flex-1">
+              {isLoading ? "Loading…" : (data?.title ?? "Not found")}
+            </span>
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          {isError ? (
+            <p className="text-sm text-[var(--text-muted)]">
+              This record could not be loaded. It may have been deleted.
+            </p>
+          ) : isLoading ? (
+            <PeekSkeleton />
+          ) : data ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                {data.reference ? (
+                  <span className="font-mono text-sm text-[var(--text-subtle)]">
+                    {data.reference}
+                  </span>
+                ) : null}
+                {data.status ? <Badge tone={data.status.tone}>{data.status.label}</Badge> : null}
+                {data.archived ? <Badge tone="neutral">Archived</Badge> : null}
+              </div>
+
+              {data.subtitle ? (
+                <p className="text-sm text-[var(--text-muted)]">{data.subtitle}</p>
+              ) : null}
+
+              {data.properties.length > 0 ? (
+                <dl className="grid gap-x-4 gap-y-2 border-t border-[var(--border-subtle)] pt-4 sm:grid-cols-[9rem_minmax(0,1fr)]">
+                  {data.properties.map((property) => (
+                    <div key={property.label} className="contents">
+                      <dt className="text-sm text-[var(--text-muted)]">{property.label}</dt>
+                      <dd className="min-w-0 break-words text-sm text-[var(--text-strong)]">
+                        {property.value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="border-t border-[var(--border-subtle)] p-4">
+          {/* Routed by hand rather than by a `<Link onClick={close}>`: closing
+              a Radix dialog unmounts its own subtree, and the anchor's default
+              navigation goes with it. Pushing the trail first is what makes
+              the next page's back arrow name the record this peek was opened
+              from rather than that record's list. */}
+          <Button
+            variant="primary"
+            className="w-full justify-center"
+            disabled={!data}
+            onClick={() => {
+              if (!data) return;
+              if (current) follow(current);
+              onClose();
+              router.push(data.href);
+            }}
+          >
+            Open full page
+            <ArrowRight className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function PeekSkeleton() {
+  return (
+    <div className="space-y-3" aria-hidden="true">
+      {[0, 1, 2, 3].map((row) => (
+        <div
+          key={row}
+          className={cn(
+            "h-4 animate-pulse rounded-[var(--radius-sm)] bg-[var(--surface-muted)]",
+            row === 0 ? "w-1/3" : row === 3 ? "w-1/2" : "w-3/4",
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/records/record-trail.tsx
+++ b/components/records/record-trail.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * Where you came from, so going back means what it says.
+ *
+ * A CRM is a graph, and the way people actually work it is a path through that
+ * graph: a deal, the company on it, another deal at that company, the person
+ * who owns it. Every one of those hops is a real link and every one of them
+ * used to arrive at a page whose back arrow said "All deals" — pointing at a
+ * list nobody had been near, three hops ago.
+ *
+ * The trail is the path. Following a reference pushes the record you are
+ * leaving; arriving at a record that is already on the trail pops back to it,
+ * which is what makes the browser's own back button and the bar's back arrow
+ * agree without either of them knowing about the other.
+ *
+ * ## Why in memory rather than the URL or storage
+ *
+ * The URL is tempting and wrong: a trail in the query string makes every link
+ * to a record non-canonical, so a link somebody pastes into WhatsApp carries a
+ * stranger's browsing history in it, and two paths to the same record stop
+ * being the same page for caching.
+ *
+ * `sessionStorage` survives a reload, which sounds like a feature until a
+ * reload restores a trail whose pages are no longer behind the browser's back
+ * button — the arrow and the button then disagree, which is worse than a
+ * back arrow that has forgotten. Held in React state under the app shell, the
+ * trail survives every client navigation (which is all of them) and resets on
+ * a hard load, which is exactly when the reader has no history either.
+ */
+
+export type TrailEntry = {
+  href: string;
+  label: string;
+};
+
+type TrailValue = {
+  trail: TrailEntry[];
+  /** The record being looked at, if the current page is one. */
+  current: TrailEntry | null;
+  /** Called by a record page as it renders. */
+  register: (entry: TrailEntry | null) => void;
+  /** Called by a reference as it is followed. */
+  follow: (from: TrailEntry) => void;
+  /** Where the back arrow should go, or null to fall back to the list. */
+  back: TrailEntry | null;
+};
+
+const RecordTrailContext = createContext<TrailValue | null>(null);
+
+export function RecordTrailProvider({ children }: { children: ReactNode }) {
+  const [trail, setTrail] = useState<TrailEntry[]>([]);
+  const [current, setCurrent] = useState<TrailEntry | null>(null);
+
+  // Registration happens in an effect on every record render; without this the
+  // provider would re-render the whole app shell each time a record re-fetched
+  // and re-registered the same href.
+  const currentRef = useRef<TrailEntry | null>(null);
+
+  const register = useCallback((entry: TrailEntry | null) => {
+    const previous = currentRef.current;
+    if (previous?.href === entry?.href && previous?.label === entry?.label) return;
+    currentRef.current = entry;
+    setCurrent(entry);
+
+    if (!entry) return;
+
+    // Arriving somewhere already on the trail means we went back — by the bar's
+    // arrow, by the browser's, or by following a reference in a circle. Either
+    // way the path ends here, so everything after it is gone.
+    setTrail((existing) => {
+      const index = existing.findIndex((item) => item.href === entry.href);
+      return index === -1 ? existing : existing.slice(0, index);
+    });
+  }, []);
+
+  const follow = useCallback((from: TrailEntry) => {
+    setTrail((existing) => {
+      if (existing.at(-1)?.href === from.href) return existing;
+      // A path long enough to need scrolling is a path nobody is retracing by
+      // hand. Keep the last ten hops and let the older ones go.
+      return [...existing, from].slice(-10);
+    });
+  }, []);
+
+  const value = useMemo<TrailValue>(
+    () => ({ trail, current, register, follow, back: trail.at(-1) ?? null }),
+    [trail, current, register, follow],
+  );
+
+  return <RecordTrailContext.Provider value={value}>{children}</RecordTrailContext.Provider>;
+}
+
+/**
+ * The trail, or a dead one.
+ *
+ * Returns a no-op value rather than throwing when there is no provider: this
+ * is read by `EntityLink`, which renders in sheets, previews and tests that
+ * have no app shell around them, and a reference that throws because nothing
+ * is tracking where you have been is a worse bug than one that does not know.
+ */
+export function useRecordTrail(): TrailValue {
+  return useContext(RecordTrailContext) ?? DEAD_TRAIL;
+}
+
+const DEAD_TRAIL: TrailValue = {
+  trail: [],
+  current: null,
+  register: () => {},
+  follow: () => {},
+  back: null,
+};

--- a/docs/ux/platform-ux-playbook.md
+++ b/docs/ux/platform-ux-playbook.md
@@ -294,6 +294,28 @@ rules bite hardest.
   that picks a layout with `matchMedia` has no answer before hydration; give
   the phone the right answer in CSS so the first paint is not the desktop.
 
+### Moving through the graph
+Records point at records — a deal names a company, a site, the people on it —
+and the way people work is a path through those edges, not a series of visits
+to lists.
+
+- **A plain click on a reference peeks; it does not travel.** Half of them are
+  answering *which company is this*, and a journey is the wrong price for a
+  glance. `EntityLink` opens `RecordPeek` beside the page, the page underneath
+  does not move, and the URL does not change.
+- **The peek shows and hands over. It never edits.** A preview that can change
+  six kinds of record is a second record page with a worse layout, and two
+  places to edit one thing is how they drift.
+- **Modifier clicks are never intercepted.** ⌘/ctrl-click, shift-click and
+  middle-click are how people already say "properly, in a new tab".
+- **Back means where you came from.** Three hops in, the list a record belongs
+  to is not up, it is sideways. `RecordTrail` records the path; the app bar's
+  arrow names the last record on it and falls back to the list only when there
+  is no path.
+- **The trail is not in the URL.** A link somebody pastes into WhatsApp must
+  not carry a stranger's browsing history, and two ways of reaching one record
+  have to be the same page.
+
 ## Compliance Checklist
 A screen is compliant only when:
 1. Warm paper tokens are applied with semantic variables.

--- a/lib/crm/record-ref.test.ts
+++ b/lib/crm/record-ref.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRecordHref, recordHref, sameRecord } from "@/lib/crm/record-ref";
+
+describe("parseRecordHref", () => {
+  it("reads each entity out of its own path segment", () => {
+    expect(parseRecordHref("/crm/leads/a")).toEqual({ entity: "lead", id: "a" });
+    expect(parseRecordHref("/crm/deals/b")).toEqual({ entity: "deal", id: "b" });
+    expect(parseRecordHref("/crm/companies/c")).toEqual({ entity: "company", id: "c" });
+    expect(parseRecordHref("/crm/people/d")).toEqual({ entity: "person", id: "d" });
+    expect(parseRecordHref("/crm/sites/e")).toEqual({ entity: "site", id: "e" });
+    expect(parseRecordHref("/crm/reps/f")).toEqual({ entity: "rep", id: "f" });
+  });
+
+  it("ignores which section of the record the link opens", () => {
+    // The peek summarises the record, and `?section=` chooses a tab on the
+    // full page — the same record either way.
+    expect(parseRecordHref("/crm/deals/b?section=documents")).toEqual({
+      entity: "deal",
+      id: "b",
+    });
+    expect(parseRecordHref("/crm/deals/b#notes")).toEqual({ entity: "deal", id: "b" });
+  });
+
+  it("refuses anything that is not exactly one record", () => {
+    // A list, a nested page, another module, an absolute URL, a bare anchor.
+    // Each of these has to stay an ordinary link.
+    expect(parseRecordHref("/crm/deals")).toBeNull();
+    expect(parseRecordHref("/crm/deals/b/edit")).toBeNull();
+    expect(parseRecordHref("/crm/quotes/b")).toBeNull();
+    expect(parseRecordHref("/stores/items/b")).toBeNull();
+    expect(parseRecordHref("https://example.com/crm/deals/b")).toBeNull();
+    expect(parseRecordHref("#top")).toBeNull();
+    expect(parseRecordHref("")).toBeNull();
+    expect(parseRecordHref(null)).toBeNull();
+    expect(parseRecordHref(undefined)).toBeNull();
+  });
+
+  it("decodes an id that arrived encoded", () => {
+    expect(parseRecordHref("/crm/people/a%20b")).toEqual({ entity: "person", id: "a b" });
+  });
+});
+
+describe("recordHref", () => {
+  it("round-trips", () => {
+    const ref = { entity: "company", id: "abc" } as const;
+    expect(parseRecordHref(recordHref(ref))).toEqual(ref);
+  });
+
+  it("drops the section, so 'open in full' lands on the record itself", () => {
+    const ref = parseRecordHref("/crm/deals/b?section=history")!;
+    expect(recordHref(ref)).toBe("/crm/deals/b");
+  });
+});
+
+describe("sameRecord", () => {
+  it("is true only for the same entity and id", () => {
+    const deal = { entity: "deal", id: "a" } as const;
+    expect(sameRecord(deal, { entity: "deal", id: "a" })).toBe(true);
+    expect(sameRecord(deal, { entity: "deal", id: "b" })).toBe(false);
+    // Ids are uuids in practice, but nothing guarantees two tables cannot
+    // share one — the entity has to be part of the comparison.
+    expect(sameRecord(deal, { entity: "lead", id: "a" })).toBe(false);
+    expect(sameRecord(deal, null)).toBe(false);
+    expect(sameRecord(null, null)).toBe(false);
+  });
+});

--- a/lib/crm/record-ref.ts
+++ b/lib/crm/record-ref.ts
@@ -1,0 +1,89 @@
+/**
+ * Turning a link back into the record it points at.
+ *
+ * Every reference on a record page is already a real href — that was the easy
+ * half of "records are a graph". The half that needs this is looking at the
+ * other end of an edge *without* travelling down it: a peek has to know that
+ * `/crm/companies/abc` means the company `abc` before it can fetch anything,
+ * and the only thing it is ever handed is the href the link already carries.
+ *
+ * Pure, and separate from the components, because "which hrefs are records"
+ * is a fact about the routing table rather than about any one panel — and
+ * because the peek's whole behaviour turns on it, so it is worth testing on
+ * its own.
+ */
+
+export const RECORD_ENTITIES = [
+  "lead",
+  "deal",
+  "company",
+  "person",
+  "site",
+  "rep",
+] as const;
+
+export type RecordEntity = (typeof RECORD_ENTITIES)[number];
+
+/** The path segment each entity lives under. */
+const SEGMENT: Record<RecordEntity, string> = {
+  lead: "leads",
+  deal: "deals",
+  company: "companies",
+  person: "people",
+  site: "sites",
+  rep: "reps",
+};
+
+const BY_SEGMENT = new Map<string, RecordEntity>(
+  RECORD_ENTITIES.map((entity) => [SEGMENT[entity], entity]),
+);
+
+export type RecordRef = { entity: RecordEntity; id: string };
+
+/**
+ * `/crm/deals/abc?section=documents` → `{ entity: "deal", id: "abc" }`.
+ *
+ * Anything else — a list page, a link off to another module, an external URL,
+ * a deeper path like `/crm/deals/abc/edit` — returns null, and the caller
+ * treats the link as an ordinary link. Being strict here is what keeps the
+ * peek from opening on things it cannot summarise.
+ */
+export function parseRecordHref(href: string | null | undefined): RecordRef | null {
+  if (!href || !href.startsWith("/crm/")) return null;
+
+  // Drop the query and hash: `?section=` and `#anchor` say where to look
+  // *inside* a record, which does not change which record it is.
+  const path = href.split(/[?#]/)[0];
+  const parts = path.split("/").filter(Boolean);
+
+  // ["crm", <segment>, <id>] and nothing after it.
+  if (parts.length !== 3) return null;
+
+  const entity = BY_SEGMENT.get(parts[1]);
+  if (!entity) return null;
+
+  const id = decodeURIComponent(parts[2]);
+  if (!id) return null;
+
+  return { entity, id };
+}
+
+/** The canonical page for a record, which is where "open in full" goes. */
+export function recordHref(ref: RecordRef): string {
+  return `/crm/${SEGMENT[ref.entity]}/${ref.id}`;
+}
+
+/** Two refs pointing at the same record. */
+export function sameRecord(a: RecordRef | null, b: RecordRef | null): boolean {
+  return Boolean(a && b && a.entity === b.entity && a.id === b.id);
+}
+
+/** The word for an entity, for a heading or a fallback label. */
+export const ENTITY_LABEL: Record<RecordEntity, string> = {
+  lead: "Lead",
+  deal: "Deal",
+  company: "Company",
+  person: "Person",
+  site: "Site",
+  rep: "Rep",
+};


### PR DESCRIPTION
## What this is

The half of graph navigation #143 left open. Its own "Decisions left open"
named it:

> Related records sit directly after the summary, everything is a real link,
> and drilling into a section no longer costs you the record. What is *not*
> done is moving between records without losing your place — a back-stack that
> remembers where you came from, and a way to look at a related record without
> leaving the one you are on.

Both, now.

---

## A reference you can look at without going there

Half the links on a record are answering a question, not starting a journey:
*which* company is this, has that person got a phone number on file, is that
the site we quoted last year. Following one to find out cost the page being
read, the section that was open and the place in the timeline it had been
scrolled to — and cost them again coming back.

A plain click now **peeks**. `RecordPeek` opens the record beside the one being
read, the page underneath does not move, and the URL does not change: nothing
about where you are has been spent on a glance.

Three deliberate limits:

- **It shows and hands over; it never edits.** A preview that can change six
  kinds of record is a second record page with a worse layout, and two places
  to edit one thing is how they drift. **Open full page** is the only commit
  in it.
- **Modifier clicks are left entirely alone.** ⌘/ctrl-click, shift-click and
  middle-click already mean "properly, in a new tab". Intercepting them would
  be rude.
- **It only opens on things it can summarise.** A list, a nested page, another
  module's link, an external URL — all stay ordinary links.

`peek={false}` opts a call site out, for a reference that is the point of the
row rather than an aside.

## Back means where you came from

Three hops in — a deal, its company, another deal at that company — the list a
record belongs to is not up, it is *sideways*, and an arrow pointing at it
throws the path away. Every one of those hops used to arrive at a page whose
back arrow read "All deals".

`RecordTrail` holds the path. Following a reference pushes the record being
left; arriving at a record already on the trail pops back to it, which is what
makes the bar's arrow and the browser's own back button agree without either
knowing about the other. The list is what it falls back to when there is no
path. Ten hops are kept — a path longer than that is not one anybody is
retracing by hand.

**Deliberately not in the URL, and not in `sessionStorage`.** In the URL it
would make every link to a record non-canonical: a link pasted into WhatsApp
would carry a stranger's browsing history, and two ways of reaching one record
would stop being the same page for caching. In storage it would survive a
reload that the browser's own history did not, leaving the arrow and the button
pointing different ways — worse than a back arrow that has forgotten. In React
state under the app shell it survives every client navigation, which is all of
them, and resets on a hard load, which is exactly when the reader has no
history either.

## Supporting pieces

- **`lib/crm/record-ref.ts`** — which hrefs are records and which are not.
  Pure, and tested on its own, because the peek's whole behaviour turns on
  being strict about it. `?section=` and `#anchor` are ignored: they choose
  where to look *inside* a record, which does not change which record it is.
- **`GET /api/v2/crm/records/[entity]/[id]/summary`** — one normalised summary
  for all six types, so the peek has one shape to render rather than six. The
  existing detail endpoints return everything a page needs — a deal's carries
  its activities, its documents, its contacts and its visits — and fetching all
  of that to draw a card with five rows would make a glance cost more than the
  journey.
- Each entity gets its own glyph and hue in the peek, the same job the event
  table does one level down: a preview that opens the same grey disc for a
  company and a site makes the reader read the eyebrow to find out which
  arrived.

## Checks

- `npx tsc --noEmit` clean.
- `npx eslint components/ lib/crm app/api/v2/crm` reports **14 errors with and
  without this branch** — verified by stashing. None new.
- `npx vitest run components/ lib/crm` — 53 files, 687 tests, all pass (7 new,
  covering `parseRecordHref`).
- Verified end to end in a browser at 1440px and 390px: the peek opens with the
  URL unchanged, **Open full page** navigates, the company's app bar then reads
  `← Plumtree Freight second-site rollout` rather than "All companies", and
  pressing it returns to the deal.
- `docs/ux/platform-ux-playbook.md` gains **Moving through the graph** under
  Phone Rules → Navigation.

## Decisions left open

- **The peek is read-only, and stays that way.** The nearest thing to editing
  that belongs in it is a single primary action per entity ("log a call",
  "start a deal"); left out until somebody asks, rather than guessed at.
- **No peek-from-a-peek.** A reference inside the peek would open a second
  panel over the first, and a stack of panels is the thing the trail exists to
  avoid. Those links navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu

---
_Generated by [Claude Code](https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu)_