### PR TITLE
feat(crm): rename a record, and edit every property in place

### DIFF
--- a/components/crm/lead-detail/lead-detail-page.tsx
+++ b/components/crm/lead-detail/lead-detail-page.tsx
@@ -283,6 +283,7 @@ export function LeadDetailPage({ leadId }: { leadId: string }) {
       backHref="/crm/leads"
       backLabel="All leads"
       title={lead.title ?? lead.leadNo}
+      onTitleCommit={(next) => edit.save.mutate({ title: next })}
       reference={lead.leadNo}
       // An archived lead that looks exactly like a live one is how somebody
       // spends ten minutes working a record that is not in anybody's pipeline.

--- a/components/crm/records/company-detail-page.tsx
+++ b/components/crm/records/company-detail-page.tsx
@@ -234,6 +234,7 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
         />
       }
       title={company.name}
+      onTitleCommit={(next) => edit.save.mutate({ name: next })}
       reference={company.clientNo}
       status={ACCOUNT_STATUS_PRESENTATION[company.accountStatus] ?? null}
       subtitle={subtitle}
@@ -276,12 +277,27 @@ export function CompanyDetailPage({ companyId }: { companyId: string }) {
               placeholder: "Not recorded",
               ...edit.text("website", company.website),
             },
+            // Was one read-only "Location" reading "Healthcare · Chiredzi".
+            // Three columns behind it, so three rows: joined, there was no way
+            // to say which part of an address you were correcting.
             {
-              id: "location",
-              label: "Location",
+              id: "address",
+              label: "Address",
               icon: MapPin,
-              value: [company.city, company.country].filter(Boolean).join(", ") || null,
               placeholder: "Not recorded",
+              ...edit.text("addressLine", company.addressLine),
+            },
+            {
+              id: "city",
+              label: "City",
+              placeholder: "Not recorded",
+              ...edit.text("city", company.city),
+            },
+            {
+              id: "country",
+              label: "Country",
+              placeholder: "Not recorded",
+              ...edit.text("country", company.country),
             },
             {
               id: "industry",

--- a/components/crm/records/deal-detail-page.tsx
+++ b/components/crm/records/deal-detail-page.tsx
@@ -8,7 +8,6 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ClientDate } from "@/components/ui/client-date";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import {
@@ -302,6 +301,7 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
           />
         }
         title={deal.title}
+      onTitleCommit={(next) => edit.save.mutate({ title: next })}
         reference={deal.dealNo}
         status={{
           label: deal.stage.name,
@@ -348,20 +348,12 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 formatted:
                   deal.value == null ? null : formatMoney(deal.value, deal.currency),
               },
-              {
-                id: "stage",
-                label: "Stage",
-                icon: Funnel,
-                display: (
-                  <span className="text-sm">
-                    {deal.stage.name}
-                    <span className="text-[var(--text-muted)]">
-                      {" · "}
-                      {deal.pipeline.name}
-                    </span>
-                  </span>
-                ),
-              },
+              // Stage is deliberately not a property row. `DealStageBar` in
+              // the rail below is the control for it, and it is the richer one
+              // — it gates on the stage's checklist and asks for a reason on
+              // the way to Lost. A second, plainer editor up here would route
+              // around both, and two ways to move a deal is how a pipeline
+              // stops meaning anything.
               {
                 id: "owner",
                 label: "Owner",
@@ -399,13 +391,17 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
                 id: "close",
                 label: "Expected close",
                 icon: Calendar,
-                display: deal.expectedCloseDate ? (
-                  <span className="text-sm">
-                    <ClientDate value={deal.expectedCloseDate} mode="date" />
-                  </span>
-                ) : undefined,
-                value: null,
+                kind: "date" as const,
                 placeholder: "No date set",
+                // The stored value is an ISO instant and the editor wants a
+                // calendar day, so the row opens on the day and reads back as
+                // the reader's own format.
+                value: deal.expectedCloseDate ? deal.expectedCloseDate.slice(0, 10) : null,
+                formatted: deal.expectedCloseDate
+                  ? new Date(deal.expectedCloseDate).toLocaleDateString()
+                  : null,
+                onCommit: (next: string) =>
+                  edit.save.mutate({ expectedCloseDate: next.trim() === "" ? null : next }),
               },
               {
                 id: "probability",
@@ -418,22 +414,29 @@ export function DealDetailPage({ dealId }: { dealId: string }) {
               {
                 id: "forecast",
                 label: "Forecast",
-                value: deal.forecastCategory.toLowerCase().replace("_", " "),
+                ...edit.choice("forecastCategory", deal.forecastCategory, [
+                  { value: "PIPELINE", label: "Pipeline" },
+                  { value: "BEST_CASE", label: "Best case" },
+                  { value: "COMMIT", label: "Commit" },
+                  { value: "CLOSED", label: "Closed" },
+                ]),
               },
-              ...(deal.site
-                ? [
-                    {
-                      id: "site",
-                      label: "Site",
-                      icon: MapPin,
-                      display: (
-                        <EntityLink href={`/crm/sites/${deal.site.id}`} className="text-sm">
-                          {deal.site.name}
-                        </EntityLink>
-                      ),
-                    },
-                  ]
-                : []),
+              {
+                id: "site",
+                label: "Site",
+                icon: MapPin,
+                display: (
+                  <RelationAttribute
+                    value={deal.site?.name ?? null}
+                    href={deal.site ? `/crm/sites/${deal.site.id}` : null}
+                    types={["SITE"]}
+                    placeholder="No site"
+                    searchPlaceholder="Search sites"
+                    onPick={(record) => edit.save.mutate({ siteId: record.id })}
+                    onClear={() => edit.save.mutate({ siteId: null })}
+                  />
+                ),
+              },
               ...customFieldAttributes({
                 definitions,
                 values: deal.customFields,

--- a/components/crm/records/person-detail-page.tsx
+++ b/components/crm/records/person-detail-page.tsx
@@ -27,6 +27,7 @@ import {
   useRecordComments,
 } from "./record-tabs";
 import { RecordAttributes } from "@/components/records/record-attributes";
+import { RelationAttribute } from "@/components/crm/records/relation-attribute";
 import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
 import {
@@ -275,6 +276,17 @@ export function PersonDetailPage({ personId }: { personId: string }) {
         />
       }
       title={person.fullName}
+      // `fullName` is derived; the columns are first and last. A typed name
+      // splits on the final space, so "Tendai" sets a first name and clears
+      // nothing, and "Tendai N Mhlanga" keeps the middle with the first.
+      onTitleCommit={(next) => {
+        const cut = next.trim().lastIndexOf(" ");
+        edit.save.mutate(
+          cut === -1
+            ? { firstName: next.trim(), lastName: "" }
+            : { firstName: next.trim().slice(0, cut), lastName: next.trim().slice(cut + 1) },
+        );
+      }}
       reference={person.personNo}
       subtitle={subtitle}
       activeTab={tab}
@@ -300,16 +312,17 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               id: "company",
               label: "Company",
               icon: Building2,
-              display: person.client ? (
-                <EntityLink
-                  href={`/crm/companies/${person.client.id}`}
-                  className="text-sm"
-                >
-                  {person.client.name}
-                </EntityLink>
-              ) : undefined,
-              value: null,
-              placeholder: "No company",
+              display: (
+                <RelationAttribute
+                  value={person.client?.name ?? null}
+                  href={person.client ? `/crm/companies/${person.client.id}` : null}
+                  types={["COMPANY"]}
+                  placeholder="No company"
+                  searchPlaceholder="Search companies"
+                  onPick={(record) => edit.save.mutate({ clientId: record.id })}
+                  onClear={() => edit.save.mutate({ clientId: null })}
+                />
+              ),
             },
             {
               id: "owner",
@@ -329,7 +342,13 @@ export function PersonDetailPage({ personId }: { personId: string }) {
               id: "contactType",
               label: "Contact type",
               icon: AddressBook,
-              value: CONTACT_TYPE_LABELS[person.contactType] ?? person.contactType,
+              // Straight off the enum, so a type added to the schema shows up
+              // here without a second list to remember to update.
+              ...edit.choice(
+                "contactType",
+                person.contactType,
+                Object.entries(CONTACT_TYPE_LABELS).map(([value, label]) => ({ value, label })),
+              ),
             },
             {
               id: "role",
@@ -340,10 +359,13 @@ export function PersonDetailPage({ personId }: { personId: string }) {
             {
               id: "prefers",
               label: "Prefers",
-              value: person.preferredChannel
-                ? CHANNEL_LABELS[person.preferredChannel] ?? person.preferredChannel
-                : null,
               placeholder: "No preference",
+              ...edit.choice(
+                "preferredChannel",
+                person.preferredChannel,
+                Object.entries(CHANNEL_LABELS).map(([value, label]) => ({ value, label })),
+                "No preference",
+              ),
             },
             {
               id: "city",

--- a/components/crm/records/site-detail-page.tsx
+++ b/components/crm/records/site-detail-page.tsx
@@ -29,6 +29,7 @@ import {
 } from "./record-tabs";
 import { RecordAttributes } from "@/components/records/record-attributes";
 import { RelationAttribute } from "./relation-attribute";
+import { useToast } from "@/components/ui/use-toast";
 import { useAttributeEditor } from "@/components/records/use-attribute-editor";
 import { EntityLink } from "@/components/records/entity-link";
 import { RailSection, RecordPageShell, RelatedList } from "@/components/records/record-page-shell";
@@ -87,6 +88,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
     queryKey: ["crm", "site", siteId],
     queryFn: () => fetchJson<SiteDetail>(`/api/v2/crm/sites/${siteId}`),
   });
+  const { toast } = useToast();
   const edit = useAttributeEditor({
     path: `/api/v2/crm/sites/${siteId}`,
     invalidate: [["crm", "site", siteId], ["crm", "sites"]],
@@ -202,6 +204,7 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
         />
       }
       title={site.name}
+      onTitleCommit={(next) => edit.save.mutate({ name: next })}
       reference={site.siteNo}
       subtitle={subtitle}
       activeTab={tab}
@@ -247,27 +250,61 @@ export function SiteDetailPage({ siteId }: { siteId: string }) {
               placeholder: "Not recorded",
               ...edit.text("addressLine", site.addressLine),
             },
+            // City and country were one read-only row reading "Chiredzi,
+            // Zimbabwe". They are two columns, so they are two rows: joined,
+            // there was no way to say which half you were correcting.
             {
-              id: "location",
+              id: "city",
               label: "City",
-              value: [site.city, site.country].filter(Boolean).join(", ") || null,
               placeholder: "Not recorded",
+              ...edit.text("city", site.city),
+            },
+            {
+              id: "country",
+              label: "Country",
+              placeholder: "Not recorded",
+              ...edit.text("country", site.country),
             },
             {
               id: "coordinates",
               label: "Coordinates",
+              placeholder: "Not pinned",
+              mono: true,
+              // One row, because a pin is one fact and nobody holds a latitude
+              // in their head without the longitude next to it. Typed as the
+              // pair it is copied as — out of Maps, off a handset — and split
+              // here rather than made into two boxes.
               value:
+                site.latitude !== null && site.longitude !== null
+                  ? `${site.latitude}, ${site.longitude}`
+                  : null,
+              formatted:
                 site.latitude !== null && site.longitude !== null
                   ? `${site.latitude.toFixed(5)}, ${site.longitude.toFixed(5)}`
                   : null,
-              placeholder: "Not pinned",
-              mono: true,
+              onCommit: (next) => {
+                const trimmed = next.trim();
+                if (trimmed === "") {
+                  edit.save.mutate({ latitude: null, longitude: null });
+                  return;
+                }
+                const [lat, lng] = trimmed.split(/[,\s]+/).map(Number);
+                if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+                  toast({
+                    title: "That is not a pin",
+                    description: "Two numbers, latitude first — for example -20.19, 30.93.",
+                    variant: "destructive",
+                  });
+                  return;
+                }
+                edit.save.mutate({ latitude: lat, longitude: lng });
+              },
             },
             {
               id: "access",
               label: "Access",
-              value: site.accessInstructions,
               placeholder: "No instructions",
+              ...edit.text("accessInstructions", site.accessInstructions),
             },
             ...customFieldAttributes({
               definitions,

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -76,6 +76,13 @@ export type RecordAttribute = {
   clearLabel?: string;
   placeholder?: string;
   mono?: boolean;
+  /**
+   * What sort of value this is, where a plain text box is the wrong tool.
+   * `date` opens a date field and commits `YYYY-MM-DD`; the closed row still
+   * shows whatever `formatted` says, so a reader sees "8/11/2026" and an
+   * editor gets a picker rather than a string to retype in the right order.
+   */
+  kind?: "text" | "date";
 };
 
 /**
@@ -201,6 +208,7 @@ function EditableValue({ attribute }: { attribute: RecordAttribute }) {
   return (
     <Input
       autoFocus
+      type={attribute.kind === "date" ? "date" : "text"}
       value={draft}
       aria-label={attribute.label}
       // Full width of the value column and no wider: the input inherited a

--- a/components/records/record-page-shell.tsx
+++ b/components/records/record-page-shell.tsx
@@ -86,6 +86,7 @@ export function RecordPageShell({
   backLabel,
   icon,
   title,
+  onTitleCommit,
   reference,
   status,
   subtitle,
@@ -105,6 +106,13 @@ export function RecordPageShell({
   /** The entity's mark, shown beside the record name in the top bar. */
   icon?: LucideIcon;
   title: string;
+  /**
+   * Commit a new name for the record. Given one, the title in the standing
+   * column becomes an editor; without one it stays a heading, which is right
+   * for the records that have no name of their own — a rep is a colleague,
+   * and their name lives in the directory rather than here.
+   */
+  onTitleCommit?: (value: string) => void;
   reference?: string | null;
   status?: { label: string; status: CanonicalUiStatus } | null;
   subtitle?: ReactNode;
@@ -297,9 +305,18 @@ export function RecordPageShell({
           ) : null}
 
           <div className="min-w-0 flex-1">
-            <h2 className="text-base font-semibold leading-snug text-[var(--text-strong)]">
-              {title}
-            </h2>
+            {/* The name, editable in place like every other property. It was
+                the one fact on a record with no way to correct it: a lead
+                typed in wrong stayed wrong, and "rename" existed nowhere in
+                the module. Same grammar as the property list — press the thing
+                you are looking at, Enter or blur commits, Escape abandons. */}
+            {onTitleCommit ? (
+              <RecordTitleEditor title={title} onCommit={onTitleCommit} />
+            ) : (
+              <h2 className="text-base font-semibold leading-snug text-[var(--text-strong)]">
+                {title}
+              </h2>
+            )}
             {reference ? (
               <p className="font-mono text-sm text-[var(--text-muted)]">{reference}</p>
             ) : null}
@@ -516,6 +533,64 @@ export function RecordPageShell({
 
       {children}
     </div>
+  );
+}
+
+
+/**
+ * The record's name, edited where it is read.
+ *
+ * A textarea rather than an input: a deal is called "Plumtree Freight
+ * second-site rollout" and a single-line field in a 22rem column shows about
+ * a third of that, scrolling the rest out of sight while you try to fix a typo
+ * in the middle of it. It grows to the text and commits on Enter, so it still
+ * behaves like a name and not like a note.
+ */
+function RecordTitleEditor({
+  title,
+  onCommit,
+}: {
+  title: string;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  if (draft === null) {
+    return (
+      <button
+        type="button"
+        onClick={() => setDraft(title)}
+        title="Rename"
+        className="-mx-1.5 block w-full rounded-[var(--radius-sm)] px-1.5 text-left text-base font-semibold leading-snug text-[var(--text-strong)] hover:bg-[var(--surface-subtle)]"
+      >
+        {title}
+      </button>
+    );
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== title) onCommit(trimmed);
+    setDraft(null);
+  };
+
+  return (
+    <textarea
+      autoFocus
+      rows={Math.min(4, Math.max(1, Math.ceil(draft.length / 28)))}
+      value={draft}
+      aria-label="Record name"
+      className="-mx-1.5 block w-full resize-none rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-base)] px-1.5 py-0.5 text-base font-semibold leading-snug text-[var(--text-strong)] outline-none focus:border-[var(--action-primary-bg)]"
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          commit();
+        }
+        if (event.key === "Escape") setDraft(null);
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
## What this is

Two reported gaps — *"I am unable to change record names. Not all attributes of
a record are editable."* Both turned out to be the same shape: the machinery to
edit a property already existed, and the pages did not use it.

## A record could not be renamed

The name was the one fact on the page with no way to change it. A deal typed in
wrong stayed wrong, and "rename" existed nowhere in the module.

The standing column's heading is an editor now, on the same grammar as the
property list below it: press what you are looking at, Enter or blur commits,
Escape abandons. A **textarea** rather than an input — a deal is called
"Plumtree Freight second-site rollout", and a single-line field in a 22rem
column shows about a third of that while scrolling the rest out of sight as you
try to fix a typo in the middle.

It is opt-in per page (`onTitleCommit`), so a rep keeps a plain heading: a
colleague's name belongs to the directory, not to this page.

Person is the awkward one — `fullName` is derived and the columns are
`firstName`/`lastName`, so a typed name splits on its final space. "Tendai N
Mhlanga" keeps the middle name with the first.

## Twelve properties were read-only

`RecordAttribute` has taken an `onCommit` since it was written, and
`useAttributeEditor` has produced them since the round that added it. These rows
just passed a `display` and nothing else, which renders as text nobody can
press:

| Record | Now editable |
| --- | --- |
| Deal | expected close, forecast, site |
| Person | company, contact type, preferred channel |
| Company | address, city, country |
| Site | city, country, access, coordinates |

**Four of those were one row spanning several columns.** "Chiredzi, Zimbabwe"
joined city and country into a single read-only line, so even with an editor
there was no way to say which half you were correcting. They are separate rows
now, one per column — except coordinates, which stays one row on purpose: a pin
is one fact, nobody holds a latitude in their head without the longitude beside
it, and it gets copied out of Maps as a pair. That row takes the pair, splits
it, and refuses anything that is not two numbers rather than storing a silent
zero.

## Two supporting changes

- **`RecordAttribute` gained `kind: "date"`.** Expected close opens a date field
  and commits `YYYY-MM-DD`, while the closed row still reads in the viewer's own
  format. A date is not a string to retype in the right order.
- **The deal's Stage row is gone rather than made editable.** `DealStageBar` in
  the rail below is the control for it and is the richer one — it gates on the
  stage's checklist and asks for a reason on the way to Lost. A second, plainer
  editor in the property list would route around both, and two ways to move a
  deal is how a pipeline stops meaning anything.

## Checks

- `npx tsc --noEmit` clean; eslint clean on every touched file.
- `npx vitest run components/ lib/crm` — 53 files, 687 tests, all pass.
- Verified against a running app rather than by eye: renaming a deal persists
  (`title` comes back changed from the API), and Forecast — one of the twelve —
  moves `PIPELINE → COMMIT` and stays. The spec puts both back afterwards so the
  demo data is unchanged.
- Re-audited all five record pages afterwards: **no attribute is read-only any
  more**, except the deliberate Stage removal above.

## Note on the branch

PR #144 merged while this was in progress, so this branch was restarted from the
merged `main` and force-pushed rather than stacked on finished history. This PR
is a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu

---
_Generated by [Claude Code](https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu)_