### PR TITLE
Rollout program: master plan and seven workstream roadmaps

### DIFF
--- a/docs/platform-pricing-feature-flags-and-modules.md
+++ b/docs/platform-pricing-feature-flags-and-modules.md
@@ -1,5 +1,13 @@
 # Platform Pricing, Feature Bundles, Subscriptions, and Feature Flags
 
+> **Supersession notice (2026-08-18).** The pricing figures in this document (tier prices, the
+> annual-billing multiplier, and the bundle price list) are superseded by the rollout program —
+> see `docs/rollout/master-rollout-plan.md` and `docs/rollout/pricing-packaging-roadmap.md` for
+> the adopted target structure. Until story PR-6.1 rewrites this document, the catalog in
+> `lib/platform/feature-catalog.ts` remains what the platform actually charges, and this
+> document's **mechanism** content — the pricing formula, feature-flag behavior, and the
+> checklist for adding a feature, module, or bundle — remains normative and in force.
+
 ## Scope
 
 This document is the current source of truth for:

--- a/docs/rollout/campus-alignment.md
+++ b/docs/rollout/campus-alignment.md
@@ -1,0 +1,58 @@
+# Campus Vertical — Rollout Alignment Note
+
+This is a framing note, not a roadmap. It carries **no story table and no story IDs** — by the
+rules of `docs/expansion-plan/schools-roadmap.md`, that document is the sole story ledger for the
+Campus (schools) vertical, and this note only records how Campus and the rollout program in
+`docs/rollout/master-rollout-plan.md` touch.
+
+## Ownership
+
+Campus is founder-managed. The rollout program's priorities (fiscalisation, pricing, self-serve,
+scope trim) were adopted from the external plan; Campus is the founder's addition as the third
+vertical alongside Gold and Retail, managed personally against that plan's recommendations. Its
+cadence, scope and stories are decided in the schools roadmap, not here.
+
+## Where Campus stands relative to the rollout
+
+Campus is the platform's most mature vertical. The production-readiness blockers from the
+2026-08-04 audit (`docs/expansion-plan/schools-production-readiness.md`) — academic-year
+creation, provisioning, fees reaching the general ledger — are closed, and the schools roadmap
+shows the overwhelming majority of its stories `done`. **The rollout takes no dependency on
+unshipped schools work, and no rollout story may add one.**
+
+## What the rollout needs from Campus
+
+Nothing on the critical path. Two passive obligations:
+
+1. **The school portals inherit the gate-policy flip.** Before SS-1.1 flips
+   `FEATURE_GATE_POLICY=deny`, the gate audit must cover the portal hosts and
+   `app/api/v2/portal/*` routes exactly as it covers tenant routes — a portal route missing from
+   `lib/platform/gating/route-registry.ts` fails closed for parents and students on flip day.
+2. **The schools fee path is the rollout's canary.** `lib/schools/fiscalisation.ts` and the fee
+   receipts route are the only live fiscalisation consumers today; the FDMS roadmap's standing
+   instructions commit to keeping them green through every iteration.
+
+## What Campus needs from the rollout
+
+1. **Native fiscalisation for fee receipts.** School fee receipts currently fiscalise through the
+   generic connector. After FD-3 lands, they migrate to the native FDGA protocol. That migration
+   is a **schools-roadmap story**, added there under its new-scope rule and cross-referenced to
+   `docs/rollout/fdms-roadmap.md` — it is deliberately not a story here.
+2. **Pricing-band reconciliation.** Schools sell per-term, per-campus
+   (`SCHOOL_PRICING_BANDS` in `lib/marketing/pricing.ts`). PR-4.2 reconciles the bands with the
+   new tier structure; the recommendation is that the bands survive as a vertical pricing model,
+   documented as such, rather than being forced into the monthly tiers.
+3. **Self-serve boundaries.** The public trial (SS-3) covers Fiscal and Start only. School
+   tenants remain operator-provisioned (`scripts/provision-school.ts` and the platform
+   provisioning service SS-2 generalises from it); nothing in this program changes that.
+
+## Standing clause
+
+If a conflict arises between a rollout story and a schools-roadmap rule, the schools roadmap wins
+inside its own domain and the master plan's governance section arbitrates the boundary.
+
+## Changelog
+
+| Date | Commit | Description |
+|---|---|---|
+| 2026-08-18 | — | Note created; ownership, touchpoints and the no-dependency clause recorded. |

--- a/docs/rollout/fdms-roadmap.md
+++ b/docs/rollout/fdms-roadmap.md
@@ -1,0 +1,147 @@
+# Native ZIMRA FDMS v7.2 — Implementation Status
+
+Single source of truth for building native virtual fiscalisation against the ZIMRA Fiscal Device
+Gateway API v7.2. This is the rollout program's critical path: everything else in
+`docs/rollout/master-rollout-plan.md` is downstream of a validated fiscal invoice.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person**, phrased as somebody being able to do something.
+- **The acceptance signal is the test** — and for fiscal stories the test runs against the ZIMRA
+  test environment, never a mock (program DoD item 9).
+- **Story IDs are permanent.** Abandoned stories become `parked` with a reason.
+- **Iterations ship in order.** A later iteration never leaves an earlier one broken.
+
+Sources this roadmap is derived from: `lib/accounting/fiscalisation.ts`,
+`lib/accounting/fdms-connector.ts`, `lib/schools/fiscalisation.ts`, `prisma/schema.prisma`
+(`FiscalisationProviderConfig`, `FiscalReceipt`), `app/api/accounting/fiscalisation/replay/route.ts`
+and its sibling routes, `app/accounting/fiscalisation/page.tsx`,
+`docs/accounting/zimra-fiscalisation.md`, and the ZIMRA Fiscal Device Gateway API v7.2
+specification (external; PN 26 of 2024 governs virtual fiscalisation).
+
+## What exists and what is missing
+
+What exists is a **provider-agnostic skeleton**: durable `FiscalReceipt` rows with retry state,
+a config model with mTLS support, an issue/validate/sync orchestrator, a console page, and two
+live consumers (accounting sales invoices and school fee receipts). What is missing is the actual
+device protocol: device registration (keypair/CSR — no signing code exists in the repo), fiscal
+day open/close and counters, client-side receipt hashing/signing and previous-receipt-hash
+chaining, receipt counters, QR generation and rendering (no QR library is installed;
+`FiscalReceipt.qrCodeData` is stored but never printed), credit/debit-note fiscalisation (the
+`FiscalReceipt` one-source DB CHECK blocks it), POS fiscalisation entirely (`RetailSale` has no
+currency column and no fiscal relation), and a background drainer (`nextRetryAt` is only serviced
+by the manual replay route).
+
+## Standing instructions
+
+- **All fiscal amounts are computed in Decimal, never Float.** Where an upstream document is
+  Float (accounting money today), the conversion boundary is explicit and tested (FD-0.3).
+- **Every FDGA call goes through the connector seam** (`lib/accounting/fdms-connector.ts`) —
+  its idempotency keys, retry state and mTLS handling are the one transport. No route talks to
+  ZIMRA directly.
+- **The receipt hash chain is sacred.** Nothing writes a fiscal document outside the counter and
+  chaining service once FD-3 lands; a gap or fork in the chain is a stop-the-line defect.
+- **The schools fee-receipt path keeps working through every iteration.**
+  `lib/schools/fiscalisation.ts` and `app/api/v2/schools/fees/receipts/route.ts` are the only
+  live fiscalisation consumers today; their tests stay green at every merge. Their migration to
+  the native protocol is a schools-roadmap story (see `docs/rollout/campus-alignment.md`).
+- Certificates and keys are referenced via the existing `env:` indirection
+  (`FiscalisationProviderConfig.certificateRef`), never stored inline; rotation is part of FD-1's
+  runbook.
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: every
+story that touches submission demonstrates idempotency (resubmitting the same operation is
+observably a no-op) and records the ZIMRA sandbox evidence (operation ID or portal screenshot) in
+its changelog row.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 0 — Foundations (schema and money)
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-0.1 | As a bookkeeper, I can transact in ZWG | ZWG seeded in `CurrencyDefinition` platform-wide (today it exists only inside `lib/hr/statutory/zimbabwe-pack.ts`); selectable on an invoice; stored and reported | `todo` |
+| FD-0.2 | As a tax admin, every tax code carries its ZIMRA taxID | New column on `TaxCode` beside `vat7OutputBox`/`vat7InputBox`; surfaced in `components/accounting/tax/tax-setup-workspace.tsx`; issuing a fiscal document with an unmapped code is refused with a named error | `todo` |
+| FD-0.3 | As an accountant, fiscal totals are exact | Decision from master-plan risk #1 recorded here; the chosen boundary implemented; a property test asserts no fiscal total ever differs from its source document total | `todo` |
+| FD-0.4 | As an engineer, a fiscal receipt can attach to a credit note, a debit note, or a POS sale | The `FiscalReceipt` one-source CHECK widened; `RetailSale.currency` added with a backfill rule (master-plan risks #2, #3); migration applies clean on a copy of staging data | `todo` |
+
+## Iteration 1 — Device lifecycle
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-1.1 | As a tenant admin, I register my fiscal device with ZIMRA from the fiscalisation console | Keypair and CSR generated server-side, certificate issued and stored via `certificateRef` indirection, `verifyTaxpayerInformation`/`registerDevice`/`getConfig` round-trip against the ZIMRA test environment from `app/accounting/fiscalisation/page.tsx` | `todo` |
+| FD-1.2 | As an operator, I can see certificate health and renew before expiry | Expiry surfaced on the console and in `lib/notifications.ts` alerts; the rotation runbook written (master-plan risk #6) covering dev/staging/prod registration strategy | `todo` |
+
+## Iteration 2 — Fiscal day
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-2.1 | As a supervisor, I open and close a fiscal day per device | `FiscalDay` model (fiscalDayNo, status, per-taxID counters); open/close endpoints under `app/api/accounting/fiscalisation/`; a full open → receipts → close cycle produces a ZIMRA-accepted Z-report in sandbox | `todo` |
+| FD-2.2 | As a supervisor, a day that cannot close cleanly tells me why | Counter mismatches surfaced with the offending receipts; close-with-discrepancy follows the v7.2 rules and is audited | `todo` |
+
+## Iteration 3 — The core receipt protocol
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-3.1 | As an accountant, an issued sales invoice is fiscalised natively | Client-side canonical hash + signature, previous-receipt-hash chaining, gap-free `receiptCounter`/`receiptGlobalNo` under concurrency (advisory-lock precedent from gold, master-plan risk #7); `submitReceipt` accepted by sandbox; rewires `issueFiscalDocument` in `lib/accounting/fiscalisation.ts` and the auto-issue hook in `app/api/accounting/sales/invoices/route.ts` | `todo` |
+| FD-3.2 | As a customer, the invoice I receive carries a scannable QR that validates on fdms.zimra.co.zw | QR generated (new dependency) and rendered on the invoice PDF templates via `lib/documents/source-registry.ts`; portal shows the invoice as VALID | `todo` |
+| FD-3.3 | As a founder, a fresh sandbox tenant reaches a validated fiscal invoice in under 30 minutes | The activation demo, timed end-to-end: provision → device registration → fiscal day open → invoice → green portal validation. **This is the day-30 exit criterion for the program** | `todo` |
+
+## Iteration 4 — Credit and debit notes
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-4.1 | As an accountant, a credit note fiscalises referencing its original receipt | Depends FD-0.4; the credit note carries the original `receiptGlobalNo` per v7.2; sandbox-validated and visible against the original on the portal | `todo` |
+| FD-4.2 | As an accountant, a sales-side debit note exists and fiscalises | v7.2 debit notes are sales documents; the existing `DebitNote` model is purchase-side, so this story decides reuse-vs-new and implements it; sandbox-validated | `todo` |
+
+## Iteration 5 — POS fiscalisation
+
+The US$19 SKU's core promise, and the highest-volume surface.
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-5.1 | As a till operator, my sale fiscalises without me doing anything | Fiscal relation on `RetailSale`; fiscalise-on-drain in `app/api/v2/retail/pos/sync/route.ts`; receipt print (`lib/retail/offline-receipt.ts`) carries the fiscal number and QR block | `todo` |
+| FD-5.2 | As a till operator, load-shedding does not stop me trading | Kill the network mid-shift, ring 10 sales, reconnect: all 10 fiscalised in order, chain intact, within ZIMRA's permitted offline window (master-plan risk #8). Rides `lib/retail/pos-offline-queue.ts` and the `lib/offline/` outbox/sync-engine | `todo` |
+
+## Iteration 6 — Worker and operations
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-6.1 | As an operator, pending and failed receipts retry without a human | A new fiscal worker script (on the `scripts/pdf-worker.ts` precedent) drains `FiscalReceipt.nextRetryAt`; an induced FDGA outage self-heals with zero uses of the manual replay route | `todo` |
+| FD-6.2 | As an operator, I am told when fiscalisation is failing | Sustained failure emits notifications via `lib/notifications.ts`; the console page shows queue depth and oldest-pending age | `todo` |
+
+## Iteration 7 — Multi-site, multi-till
+
+The differentiator the SKU is priced on.
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-7.1 | As a supervisor, I see and manage fiscal days across every site and till from one screen | A two-site, three-till tenant opens, monitors and closes all fiscal days from one console view | `todo` |
+| FD-7.2 | As an engineer, registers and shifts are referentially sound | The loose `siteId` strings on `RetailRegister`/`RetailShift` become real relations with a backfill; orphan registers surfaced and resolved | `todo` |
+
+## Iteration 8 — Pilot cutover
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| FD-8.1 | As an operator, I can take any tenant live on fiscalisation by runbook | The per-deployment ZIMRA registration runbook (from FD-1.2) executed start-to-finish by someone who did not write it | `todo` |
+| FD-8.2 | As a pilot customer, my real invoices validate on the ZIMRA portal | Each pilot — Huchu Mine, The Gate Shops, Lux Liquor, FloorCode — issuing production fiscal documents; the north-star metric is greater than zero | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created against the fiscalisation-skeleton audit; native-only decision recorded (no Fiscal Harmony bridge). |

--- a/docs/rollout/gold-edition-roadmap.md
+++ b/docs/rollout/gold-edition-roadmap.md
@@ -1,0 +1,93 @@
+# Gold Edition Productisation — Implementation Status
+
+Single source of truth for turning the gold module into a listed, agent-sellable US$299 edition
+and making it campaign-ready for the mining-compliance deadlines. The gold module itself is the
+platform's most hardened vertical (Decimal money, append-only reversal ledger, FIFO advisory
+locks, period close, audit hash chain); this document is about closing its open epics and making
+the commercial wrapper true. Part of the rollout program governed by
+`docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person.** The acceptance signal is the test.
+- **Story IDs are permanent.** Iterations ship in order.
+- Existing epic documents are referenced, never restated — their content stays where it is.
+
+Sources this roadmap is derived from: `docs/gold-team-status-2026-05-10.md`,
+`docs/gold-epic-13-mvp-2026-05-10.md`, `docs/gold-epic-9a-worker-decision-2026-05-10.md`,
+`docs/gold-module-review-2026-05-09.md`, `lib/platform/client-templates.ts`
+(`TEMPLATE_GOLD_MINE`), `lib/commodity-billing.ts`, the `.claude/agents/` gold specialist
+charters.
+
+## Why this edition leads
+
+One Gold deal is worth roughly 26 Start deals in first-year value. Medium-scale gold operations
+are paid 90% USD, face two hard regulatory deadlines (title regularisation, then the 1 January
+2027 re-registration with beneficial-ownership, environmental, labour, tax and marketing
+verification), and the 2024 Responsible Mining Audit suspended 161 mines over exactly the
+payroll and record failures this platform fixes. Huchu Mine is the live reference.
+
+## Standing instructions
+
+- Gold work goes through the module's specialist ownership boundaries (the `.claude/agents/`
+  gold charters): schema work, domain backend, frontend, import workflow, integration and review
+  stay separated as established.
+- The Gold Edition's commercial composition (price, bundle contents, template) is owned by
+  `docs/rollout/pricing-packaging-roadmap.md` PR-5; this document owns whether the product
+  behind it is true.
+- `lib/commodity-billing.ts` is shared infrastructure — treat changes as cross-module
+  (scrap-metal history depends on the documents it created; see ST-2.3).
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: every
+story that touches money or inventory events keeps the reversal-ledger and hash-chain invariants
+under test.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 1 — Close the open epics
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| GE-1.1 | As a gold clerk, price fallback works end-to-end (Epic 5b) | Price-fallback service wired per the epic's remaining scope; role-gate test coverage closed | `todo` |
+| GE-1.2 | As an operator, large ledger imports run in the background (Epic 9a) | The importer background worker per `docs/gold-epic-9a-worker-decision-2026-05-10.md`; the oversized import route decomposed | `todo` |
+| GE-1.3 | As a mine manager, reconciliation reporting is complete (Epic 10) | The in-progress reconciliation reporting finished per the epic's definition | `todo` |
+| GE-1.4 | As an operator, the module is operationally ready (Epic 13) | Runbooks and operational-readiness items per `docs/gold-epic-13-mvp-2026-05-10.md` | `todo` |
+
+## Iteration 2 — The edition is true
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| GE-2.1 | As an agent, I can sell Gold Edition without a founder in the room | A fresh `TEMPLATE_GOLD_MINE` provision (post PR-5) lands on the US$299 tier and every advertised capability works end-to-end on the new tenant — intake, dispatch, settlement, payroll, reconciliation — demonstrated as one scripted walkthrough | `todo` |
+
+## Iteration 3 — Gold fiscalisation
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| GE-3.1 | As a mine, my sales invoices fiscalise | Depends FD-3; gold sales documents (already Decimal — the clean case) issue native fiscal receipts; sandbox-validated | `todo` |
+
+## Iteration 4 — Mining-campaign readiness
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| GE-4.1 | As a prospect mine, Huchu Mine's story convinces me | Written case-study permission; the case study drafted with real numbers (feeds MK-5.1) | `todo` |
+| GE-4.2 | As a mine facing the 1 January 2027 deadline, the compliance pack answers the audit findings | The Mining Compliance Pack collateral — production returns, compliant payslips, registers, royalty calculation — assembled from shipped capabilities only, positioned against the audit findings; input to MK-5.3 | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created; open epics 5b/9a/10/13 carried in as GE-1, edition truth and campaign readiness scoped. |

--- a/docs/rollout/marketing-site-roadmap.md
+++ b/docs/rollout/marketing-site-roadmap.md
@@ -1,0 +1,97 @@
+# Marketing Site Fiscalisation Reposition & Free Tools — Implementation Status
+
+Single source of truth for repositioning corelith.co.zw around ZIMRA fiscalisation and shipping
+the free tools. The site lives in this repo (`app/home/*`, host-switched), so this is code work.
+Part of the rollout program governed by `docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person.** The acceptance signal is the test.
+- **Story IDs are permanent.** Iterations ship in order.
+
+Sources this roadmap is derived from: `app/home/site-data.ts`, `app/home/site-components.tsx`,
+`lib/marketing/pricing.ts`, `lib/marketing/seo.ts`, `app/sitemap.ts`,
+`app/api/marketing/demo-request/route.ts`, `app/home/pricing/page.tsx`.
+
+## Current state being changed
+
+The site mentions ZIMRA, FDMS, fiscalisation and VAT **zero times** — including on the pricing
+page. Every CTA routes to `/home/book-demo`. Demo requests go to a webhook or `console.error`;
+there is no lead table. `buildQuote()` in `lib/marketing/pricing.ts` is exported and tested but
+never rendered.
+
+## Standing instructions
+
+- **Name the regulation, not the benefit.** "Your FDMS invoice validates on the ZIMRA portal"
+  beats "stay compliant effortlessly."
+- **Never claim a compliance capability that has not shipped.** Fiscalisation copy that outruns
+  `docs/rollout/fdms-roadmap.md` status is a defect; comparison and campaign pages state what is
+  live, not what is planned.
+- **Every piece of content ends in a WhatsApp CTA** (`whatsappHref()` in `app/home/site-data.ts`),
+  not an email form. WhatsApp is the primary conversion surface.
+- **Price in public.** The pricing page always renders from the live catalog via
+  `lib/marketing/pricing.ts` — never hand-typed figures.
+- The penalty calculator's formula is tills × days × US$25, **capped at 181 days** (after which
+  liability converts to criminal). An uncapped calculator produces absurd numbers and loses the
+  accountants it exists to win — the cap is a test, not a comment.
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: every
+new public page carries metadata and JSON-LD via `lib/marketing/seo.ts`, is listed in
+`app/sitemap.ts`, and is screenshot-verified at 390×844.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 1 — Reposition
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| MK-1.1 | As a VAT-registered buyer, the homepage tells me this product fiscalises | Homepage rewritten around the compliance-layer claim; ZIMRA/FDMS named above the fold; the fiscal wedge (multi-till, offline, credit notes, fiscal-day management) is the lead story | `todo` |
+| MK-1.2 | As a buyer, the pricing page shows the six new tiers with the fiscal SKU first | Depends PR-1; `app/home/pricing/page.tsx` renders the new structure from `MARKETING_TIERS`; onboarding fees and the 20% annual default stated plainly; payment methods published | `todo` |
+| MK-1.3 | As a buyer comparing options, honest comparison pages exist | Comparison pages positioned at multi-till/multi-site — explicitly not competing with US$3 single-shop products; every capability claim cross-checked against shipped status | `todo` |
+
+## Iteration 2 — Free tools
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| MK-2.1 | As a shop owner, I can compute my fiscalisation penalty exposure | Penalty calculator page: tills × days × US$25 with the 181-day cap under test; WhatsApp CTA; lead capture; indexed in `app/sitemap.ts` | `todo` |
+| MK-2.2 | As a business owner, I can check whether I must register for VAT | VAT threshold checker with current thresholds; same CTA and capture pattern | `todo` |
+
+## Iteration 3 — Leads that persist
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| MK-3.1 | As a founder, a lead is never lost | A lead/demo-request table replaces the webhook-else-`console.error` path in `app/api/marketing/demo-request/route.ts`; tool submissions and demo requests land in it; surfaced in the admin portal or CRM; a submission with the webhook down is still visible in-app | `todo` |
+
+## Iteration 4 — Conversion surface swap
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| MK-4.1 | As a visitor, the primary CTA starts a trial | Depends SS-3; homepage and pricing CTAs move from `/home/book-demo` to trial signup; WhatsApp remains the assisted path; book-demo survives for Grow/Scale/Gold | `todo` |
+
+## Iteration 5 — Campaign and proof
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| MK-5.1 | As a prospect, I can read real case studies with real numbers | Depends FD-8; written permission from the four pilots; four short case studies published | `todo` |
+| MK-5.2 | As a customer, referring a peer is worth something | Referral offer page (one month free for the referrer, 20% off first three months for the referred), linked from the activation moment (pairs with PC-4) | `todo` |
+| MK-5.3 | As a mine owner facing the 1 January 2027 re-registration deadline, there is a page that speaks to my deadline | Mining-compliance campaign landing page, positioned against the audit findings; distribution-ready before day 90; pairs with GE-4 collateral | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created; zero-ZIMRA-mentions baseline and webhook-only lead path recorded. |

--- a/docs/rollout/master-rollout-plan.md
+++ b/docs/rollout/master-rollout-plan.md
@@ -1,0 +1,182 @@
+# Rollout Master Plan — 90-Day Program Contract
+
+This document is the program contract for the platform rollout adopted in August 2026. It fixes
+the decisions, the workstreams, the dependencies between them, and the order in which they ship.
+Workstream detail lives in the roadmap documents this plan indexes; this document never carries
+story tables of its own.
+
+## Normative references
+
+- **The Corelith marketing, sales and revenue plan (17 August 2026, external).** Its adopted bets
+  are restated in this document so the repo does not depend on an external file.
+- `docs/platform-pricing-feature-flags-and-modules.md` — the commercial mechanism reference. Its
+  **pricing figures are superseded** by the Pricing & Packaging workstream (`PR-`); its mechanism
+  documentation (pricing formula, feature-flag behaviour, and the 13-step checklist for adding a
+  feature, module, or bundle) remains normative and is used by every catalog-touching story.
+- `docs/expansion-plan/schools-roadmap.md` — the sole story ledger for the Campus vertical, and
+  the house-style exemplar every rollout roadmap mirrors.
+- `lib/platform/feature-catalog.ts` — the code source of truth for tiers, bundles and features.
+  Pricing changes land there first; documents follow.
+
+## Program intent
+
+**North-star metric: the number of businesses issuing ZIMRA-validated fiscal invoices through the
+platform.** It is the activation event, the retention hook and the expansion trigger in one number,
+and it cannot be gamed by signups.
+
+**Activation target:** first validated fiscal invoice — green "Invoice is Valid" on the FDMS
+portal — in under 30 minutes from signup.
+
+**90-day outcome:** native FDMS live and validating; the four pilot tenants (Huchu Mine, The Gate
+Shops, Lux Liquor, FloorCode) converted to paid contracts on the new pricing; self-serve trial
+open to the public; the mining-compliance campaign for the 1 January 2027 re-registration
+deadline live on the marketing site.
+
+## Founder decisions (locked)
+
+1. **FDMS is built natively** against the ZIMRA Fiscal Device Gateway API v7.2. No Fiscal Harmony
+   bridge, no interim provider dependency. The existing provider-agnostic connector
+   (`lib/accounting/fdms-connector.ts`) is the transport seam the native protocol is built into.
+2. **Pricing adopts the new structure fully:** Fiscal US$19/mo (free onboarding) · Start US$39/mo
+   (free onboarding, self-serve only) · Grow US$99/mo (+US$250 onboarding) · Scale US$199/mo
+   (+US$250) · Gold Edition US$299/mo (+US$500) · Enterprise custom. The annual discount rises to
+   20% and becomes the default ask.
+3. **Full self-serve trial signup:** public signup, 14-day no-card trial on Fiscal and Start, the
+   WhatsApp number as the identifier, sample data on first login.
+4. **Campus continues as the third vertical,** founder-managed, governed entirely by
+   `docs/expansion-plan/schools-roadmap.md`. See `docs/rollout/campus-alignment.md`.
+5. **The platform narrows.** We are not an accounting software company. Accounting is trimmed to
+   the posting engine, the AR/AP document core, and the tax/VAT module; fixed assets and budgets
+   are deleted; CCTV, Autos/car-sales and Scrap metal are dropped entirely; Maintenance is frozen.
+   Detail and evidence in `docs/rollout/scope-trim-roadmap.md`.
+
+## Strategic frame (restated from the adopted plan)
+
+- Lead with ZIMRA fiscalisation. The product claim is the compliance layer — "fiscal invoicing
+  that ZIMRA accepts, on top of the POS, stock, books and payroll that produce the numbers" — not
+  "business operating system".
+- Beachhead on medium-scale gold operations and multi-till / multi-site formal retail. Cede the
+  single-till shop: MiniPOS sells at US$3/mo with free FDMS and cannot be beaten there.
+- The US$19 Fiscal SKU wins on the genuinely hard part of the FDMS API: offline queuing and
+  resubmission through a load-shedding day, credit and debit notes, certificate lifecycle, and
+  fiscal-day open/close correctness across multiple sites and tills.
+- Never claim a compliance capability that has not shipped. One ZIMRA rejection at a customer
+  site ends the referral network.
+
+## Workstream index
+
+| Doc | Prefix | Scope |
+|---|---|---|
+| `docs/rollout/scope-trim-roadmap.md` | `ST-` | Module drops (CCTV, Autos, Scrap metal), accounting trim, freeze register |
+| `docs/rollout/fdms-roadmap.md` | `FD-` | Native FDGA v7.2: device lifecycle, fiscal days, receipts, credit notes, POS, worker, multi-site console, pilot cutover |
+| `docs/rollout/pricing-packaging-roadmap.md` | `PR-` | New tier catalog, 20% annual, tenant migration, marketing derivation, Gold Edition packaging |
+| `docs/rollout/self-serve-billing-roadmap.md` | `SS-` | Gate hardening, provisioning automation, public trial, payment rails, lifecycle messaging, activation instrumentation |
+| `docs/rollout/marketing-site-roadmap.md` | `MK-` | Fiscalisation reposition, free tools, lead persistence, CTA swap, campaign pages |
+| `docs/rollout/partner-channel-roadmap.md` | `PC-` | Multi-org membership, practice dashboard, rev-share, referral thin slice |
+| `docs/rollout/gold-edition-roadmap.md` | `GE-` | Open gold epics, US$299 tier end-to-end, gold fiscalisation, mining-campaign readiness |
+| `docs/rollout/campus-alignment.md` | — | Framing note only; no stories |
+
+## Cross-workstream dependencies
+
+An edge means the left item must be `done` before the right item starts.
+
+| Before | After | Why |
+|---|---|---|
+| ST-1/ST-2 catalog-and-flag phase | SS-1 deny flip | Smaller route surface to audit before gating fails closed |
+| ST-1/ST-2 catalog-and-flag phase | PR-1 | The tier/bundle rewrite lands after dropped SKUs leave the catalog — one migration story, not two |
+| FD-0 foundations | FD-3, FD-4, FD-5 | CHECK widening, Decimal totals, ZWG, taxID mapping |
+| FD-2 fiscal day | FD-3, FD-5 | Receipts submit into an open fiscal day |
+| FD-3 core protocol | FD-4, FD-5, GE-3, Campus fee migration | Hash chain and counters are shared by every document type |
+| PR-1 catalog | MK-1, PR-3, PR-5, SS-3 | Prices and tiers must exist before anything sells or signs up onto them |
+| SS-1 + SS-2 | SS-3 public signup | Fail-open gating and unenforced expiry are unsafe for strangers |
+| SS-4 payment rails | SS-5 dunning enforcement, PC-3 | Cannot dun or pay rev-share without a way to collect |
+| FD-3 + SS-3 | SS-6, MK-4 | The activation funnel and the CTA swap need the real flow |
+| FD-8 pilots live | MK-5 case studies, GE-4 | Proof requires production usage |
+
+The graph is acyclic; keep it that way when adding stories.
+
+## 90-day critical path
+
+**Days 0–30 — Unblock.**
+ST catalog/template/navigation/marketing removals plus the tenant-usage audit (cheap, and it
+shrinks everything downstream). FD-0 through FD-3 — the day-30 exit criterion is a
+sandbox-validated fiscal invoice with a rendered QR. PR-1/PR-2 on the post-trim catalog. SS-1
+gate audit begins (it needs a long soak). MK-1 copy drafting. The payment-gateway evaluation memo
+(SS-4's first story).
+
+**Days 30–60 — Convert.**
+ST code and schema deletions (after export). FD-4, FD-6, and FD-2/FD-7 hardening; FD-8 pilot
+cutover begins with Huchu Mine and Lux Liquor. PR-3 converts the pilots to paid on the new
+pricing — the program's revenue moment. SS-2 provisioning automation; SS-4 gateway integration.
+MK-1, MK-2 and MK-3 go live.
+
+**Days 60–90 — Open.**
+FD-5 POS fiscalisation on the multi-till retail pilots. SS-3 public trial plus SS-6
+instrumentation. SS-5 lifecycle messaging and dunning. MK-4 CTA swap and MK-5 mining-deadline
+campaign. PC-4 referral thin slice.
+
+**Explicitly waits (post-90):** PC-1/PC-2/PC-3 (the partner platform proper), GE deep work beyond
+GE-4, the web-push send path, broader SEO/comparison-page buildout beyond the first pages, Campus
+expansion (founder cadence), and anything on the freeze register.
+
+## Risk register and open technical decisions
+
+Each row names an owner (F = technical founder, C = co-founder) and the stories it blocks. A
+decision row is closed by recording the decision in the owning roadmap's changelog.
+
+| # | Risk / decision | Owner | Blocks |
+|---|---|---|---|
+| 1 | Float→Decimal for accounting money feeding fiscal totals: full migration (gold precedent — the `scripts/backfill-gold-accounting-usd.ts` family and the gold Decimal migrations) vs Decimal-at-the-boundary | F | FD-3 |
+| 2 | `FiscalReceipt` one-source CHECK widening — DB constraint migration on a live table | F | FD-4, FD-5 |
+| 3 | `RetailSale` has no currency column; backfill rule for historical rows | F | FD-5 |
+| 4 | Fail-open → deny flip: `FEATURE_GATE_POLICY=deny` can black-hole ungated routes; audit-first, staged flip | F | SS-3 |
+| 5 | Existing-tenant repricing without entitlement loss; alias strategy for legacy tier codes in data | C | PR-3 |
+| 6 | ZIMRA test-environment registration is per-taxpayer/per-device; dev/staging/prod strategy and cert storage/rotation runbook | F | FD-1 |
+| 7 | `receiptGlobalNo` must be gap-free under concurrent issue; advisory-lock pattern from gold | F | FD-3 |
+| 8 | ZIMRA's permitted offline window bounds the POS queue design | F | FD-5 |
+| 9 | WhatsApp Business API provider (Meta Cloud API direct vs BSP); template approval lead time | C | SS-5, MK funnel |
+| 10 | Payment gateway choice — criteria fixed: recurring-billing support and settlement time, not headline rate | C | SS-4 |
+| 11 | Fiscal SKU shape: standalone minimal tier vs `ADDON_ZIMRA_FISCAL` (which today depends on `ADDON_ACCOUNTING_CORE`) | F + C | PR-1 |
+| 12 | 20%-annual mechanism: the `ANNUAL_BILLING_MONTHS` multiplier cannot express 20% cleanly | F | PR-2 |
+| 13 | Dual commercial implementations (`lib/platform/entitlements.ts` vs `scripts/platform/domain/commercial-service.ts`) drift under heavy catalog change | F | standing, PR-* |
+| 14 | WhatsApp number as identifier: E.164 normalisation, uniqueness, account recovery | F | SS-3 |
+| 15 | Two pricing truths exist between this doc set landing and PR-6; the supersession banner is the mitigation | C | PR-6 |
+| 16 | Destructive schema drops lose tenant data. Pre-drop usage audit and export are mandatory; the pilots' templates hold none of CCTV/Autos/Scrap, but other tenants might | F | ST-1 |
+| 17 | The scrap-metal drop severs FKs (`ScrapMetalSale`/`ScrapMetalPurchase` → `SalesInvoice`/`PurchaseBill`/`Vendor`); the migration drops from the dependent side and preserves the accounting documents | F | ST-1.3 |
+| 18 | Freeze discipline: frozen modules (Maintenance) still ship in pilot bundles, so regressions there remain release-blocking even though no new work lands | F + C | standing |
+
+## Governance
+
+- **Pricing changes land in `lib/platform/feature-catalog.ts` first.**
+  `docs/platform-pricing-feature-flags-and-modules.md` is updated in the same PR, following its
+  own 13-step checklist. No document states a price the catalog does not.
+- **Schools stories live only in `docs/expansion-plan/schools-roadmap.md`.** Rollout work that
+  needs something from Campus adds a story there, under that document's new-scope rule, and links
+  it — it never opens a parallel ledger.
+- **Roadmap documents follow the house rules** stated in each document's preamble: fixed
+  structure, permanent story IDs, status-cell updates and appended changelog rows only,
+  iterations shipped in order.
+- **The freeze register is binding.** A module on it accepts bug fixes only; a new-feature PR
+  against a frozen module is a regression of this plan.
+
+## Program Definition of Done
+
+Every story in every rollout roadmap, no exceptions:
+
+1. `npx tsc --noEmit` clean
+2. `npx eslint <changed files>` clean
+3. `npx vitest run` green, with tests covering the story's invariants
+4. `npx next build` succeeds
+5. Screenshot-verified at 390×844 and 768×1024 if it renders anything
+6. No new hard-coded colours, sizes or fonts — design-system tokens only
+7. Every privileged action writes a `PlatformAuditEvent`; every query is scoped by `companyId`
+8. Any story that moves money ships with a reversal/void test
+9. Any fiscal story demonstrates its acceptance signal against the ZIMRA test environment, not a mock
+
+## Changelog
+
+Newest first. One entry per commit that changes this document.
+
+| Date | Commit | Description |
+|---|---|---|
+| 2026-08-18 | — | Document created: program contract for the adopted rollout, workstream index, dependencies, critical path, risk register, governance. |

--- a/docs/rollout/partner-channel-roadmap.md
+++ b/docs/rollout/partner-channel-roadmap.md
@@ -1,0 +1,88 @@
+# Accountant Partner Channel & Referrals — Implementation Status
+
+Single source of truth for the accountant practice channel and referral mechanics. Deliberately
+mostly **post-90-day**: the load-bearing schema change (multi-organisation membership) does not
+belong in the same quarter as the FDMS build. One thin referral slice ships inside the 90 days.
+Part of the rollout program governed by `docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person.** The acceptance signal is the test.
+- **Story IDs are permanent.** Iterations ship in order — except PC-4, which is explicitly
+  ordered first despite its number, because the marketing plan needs a referral offer inside the
+  90 days and it does not depend on the membership work.
+
+Sources this roadmap is derived from: `prisma/schema.prisma` (`User.companyId` — a single
+required FK today), `components/admin-portal/` (the staff multi-client console whose patterns
+this borrows), `lib/platform/gating/portal-isolation.ts`, the `SupportAccessRequest`
+approval-gated impersonation model, `lib/platform/client-templates.ts`
+(`TEMPLATE_PAYROLL_BUREAU` — a bureau is anticipated as a client type but still gets one tenant).
+
+## Why this channel
+
+Zimbabwe's dominant software distribution pattern is tax-and-audit consultancies that resell
+software; no local vendor offers an accountant-facing practice layer — no multi-client dashboard,
+no bulk submissions, no revenue share. The commercial terms adopted: **20% recurring revenue
+share for the life of the account**. The claim that accountants gatekeep SME software choice is
+inference, not evidence — it is tested with the first ten partner conversations before the year
+is bet on it.
+
+## Standing instructions
+
+- **PC-1 is the load-bearing change; nothing else in this document starts before it** (except
+  PC-4). Membership must compose with tenant isolation in `proxy.ts`, portal isolation, and
+  feature gating — the enumeration of those implications is part of PC-1, not an afterthought.
+- Cross-tenant access is always explicit, audited (`PlatformAuditEvent`), and revocable by the
+  client — the `SupportAccessRequest` model is the consent-and-audit precedent.
+- Rev-share is computed from collected revenue, not invoiced revenue (depends SS-4).
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: every
+cross-tenant read path ships a test proving a partner sees nothing from a company that has not
+granted them membership.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 4 — Referral thin slice (in the 90 days, ships first)
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PC-4.1 | As a customer, referring a peer is recorded and rewarded | A referral code exists at signup (SS-3) and attribution is stored against both accounts; the reward terms from MK-5.2 applied manually by an operator from a report — no membership model required | `todo` |
+
+## Iteration 1 — Multi-organisation membership (post-90)
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PC-1.1 | As a person, I can belong to more than one company | A membership model replaces the single `User.companyId` assumption where it matters; session carries an active company; switching is explicit; tenant isolation, portal isolation and feature gating all keyed off the active membership; the isolation test suite passes for a two-company user | `todo` |
+
+## Iteration 2 — Practice dashboard (post-90)
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PC-2.1 | As an accountant, I see all my client organisations in one list | A tenant-side practice console borrowing the `components/admin-portal/` patterns: client list with subscription and compliance signals; entering a client is an audited membership action | `todo` |
+| PC-2.2 | As a client, I control what my accountant sees | Grant and revoke per-company; scoped roles for partner members; revocation takes effect on next request | `todo` |
+
+## Iteration 3 — Revenue share (post-90)
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PC-3.1 | As a partner, my 20% recurring share is computed from what my referrals actually paid | Attribution from PC-4 plus payments from SS-4 produce a per-partner statement; a refunded or failed payment never counts | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created; single-company `User.companyId` constraint and the deliberate post-90 sequencing recorded. |

--- a/docs/rollout/pricing-packaging-roadmap.md
+++ b/docs/rollout/pricing-packaging-roadmap.md
@@ -1,0 +1,100 @@
+# Pricing & Packaging Restructure — Implementation Status
+
+Single source of truth for moving the commercial catalog to the adopted structure. Part of the
+rollout program governed by `docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person.** The acceptance signal is the test.
+- **Story IDs are permanent.** Iterations ship in order.
+
+Sources this roadmap is derived from: `lib/platform/feature-catalog.ts`,
+`lib/platform/entitlements.ts` and `lib/platform/entitlements.test.ts`,
+`scripts/platform/domain/commercial-service.ts`, `lib/platform/client-templates.ts`,
+`lib/marketing/pricing.ts` and `lib/marketing/pricing.test.ts`,
+`docs/platform-pricing-feature-flags-and-modules.md`.
+
+## Target structure (the founder-locked decision)
+
+| SKU | Price / month | Onboarding | Target |
+|---|---:|---:|---|
+| Fiscal | US$19 | Free | Multi-till and multi-site businesses needing FDMS — the wedge |
+| Start | US$39 | Free | Single-site retail, self-serve only |
+| Grow | US$99 | US$250 | Multi-site retail, 3+ tills |
+| Scale | US$199 | US$250 | Chains, unlimited sites |
+| Gold Edition | US$299 | US$500 | Small/medium gold operations |
+| Enterprise | Custom | Scoped | Groups, bespoke configuration |
+
+Annual billing: **20% discount, and the default ask** (today `ANNUAL_BILLING_MONTHS = 10` ≈
+16.7%). Current live tiers being replaced: BASIC/"Launch" US$29, STANDARD/"Grow" US$79,
+MEDIUM/"Scale" US$189, ENTERPRISE US$449. Gold today is sold as `ADDON_GOLD_CORE` (US$69) +
+`ADDON_GOLD_ADVANCED` (US$79) on an ENTERPRISE tenant — not a listed edition.
+
+## Standing instructions
+
+- **Every catalog change follows the 13-step checklist** in
+  `docs/platform-pricing-feature-flags-and-modules.md`, and that document is updated in the same
+  PR. Prices land in `lib/platform/feature-catalog.ts` first; no document states a price the
+  catalog does not.
+- **TUI parity is part of every story's signal.** `scripts/platform/domain/commercial-service.ts`
+  implements pricing in parallel with `lib/platform/entitlements.ts`; a story is not `done` while
+  the two disagree (master-plan risk #13).
+- After every change: `syncEntitlementCatalog`, `pnpm platform:audit-feature-gates`, and the
+  entitlement + marketing pricing test suites.
+- Runs on the **post-trim** catalog: `ST-1.1` removes the dropped SKUs before PR-1 rewrites the
+  tiers (one migration story, not two).
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: any
+story that changes what an existing tenant is entitled to ships a per-tenant before/after diff
+report, and zero pilots lose a feature they had.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 1 — The new catalog
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PR-1.1 | As a founder, the fiscal SKU's shape is decided and recorded | Master-plan risk #11 closed in this changelog: standalone minimal tier (just-enough invoicing + `accounting.zimra.fiscalisation`) vs `ADDON_ZIMRA_FISCAL` (which today depends on `ADDON_ACCOUNTING_CORE`). The dependency audit showed fiscalisation itself needs no journals and no tax module — only customer, invoice, supplier identity — so a minimal tier is viable | `todo` |
+| PR-1.2 | As a founder, I can quote the adopted structure from the live catalog | `TIERS` rewritten to Fiscal/Start/Grow/Scale/Gold Edition/Enterprise with the prices above; onboarding fees carried as catalog metadata; `TIER_CODE_ALIASES` extended so every legacy code (BASIC, STANDARD, MEDIUM, ENTERPRISE and their aliases) resolves to a new tier; `computeCompanyPricing` tests green across all six tiers | `todo` |
+| PR-2.1 | As a buyer, annual prepay is 20% off and the default ask | The discount mechanism decided (master-plan risk #12 — the months multiplier cannot express 20% cleanly; a rate field is the likely answer) and recorded here; an annual quote equals 12 × monthly × 0.8 in the pricing tests; annual presented first wherever a price is shown | `todo` |
+
+## Iteration 2 — Existing tenants
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PR-3.1 | As an operator, I can see what the new pricing does to every existing tenant before it happens | Dry-run migration report: current tier/bundles/price vs proposed, feature-by-feature diff per tenant; zero lost features for the four pilots | `todo` |
+| PR-3.2 | As a pilot customer, I land on my new tier with nothing taken away | Migration script using `grantBundleToCompany` + tier assignment; grandfathering decisions recorded per tenant in the changelog; billing preferences page shows the new plan | `todo` |
+
+## Iteration 3 — Derived surfaces
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PR-4.1 | As a visitor, the marketing site quotes the new structure from the same source | `MARKETING_TIERS` in `lib/marketing/pricing.ts` re-derives from the new `TIERS`; `buildQuote()` output matches `computeCompanyPricing` for the same inputs; `lib/marketing/pricing.test.ts` updated and green | `todo` |
+| PR-4.2 | As a school buyer, per-term per-campus pricing still makes sense next to the new tiers | The schools bands (`SCHOOL_PRICING_BANDS`) reconciled with the tier structure — the recommendation is they survive as a vertical pricing model and this story documents them as such (see `docs/rollout/campus-alignment.md`) | `todo` |
+| PR-5.1 | As a mine, Gold Edition is a listed product an agent can sell without a founder | `TEMPLATE_GOLD_MINE` provisions onto the US$299 Gold Edition tier (composition: base platform + the former `ADDON_GOLD_CORE` and `ADDON_GOLD_ADVANCED` content); provisioning from the template yields the US$299 subscription; product readiness is `docs/rollout/gold-edition-roadmap.md`'s job | `todo` |
+
+## Iteration 4 — Truth restored
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| PR-6.1 | As an engineer, there is exactly one pricing truth again | `docs/platform-pricing-feature-flags-and-modules.md` rewritten to the new structure and its supersession banner removed; a grep for the old prices across `docs/` and `lib/` finds only historical changelog rows | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created; target structure and legacy-tier mapping recorded. |

--- a/docs/rollout/scope-trim-roadmap.md
+++ b/docs/rollout/scope-trim-roadmap.md
@@ -1,0 +1,157 @@
+# Scope Trim — Implementation Status
+
+Single source of truth for narrowing the platform: what is dropped, what is parked, what is
+frozen, and the order it happens in. Part of the rollout program governed by
+`docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell of an existing row and appends to the changelog — nothing else.
+- **A story is a promise to a person.** Here that person is usually an engineer or an operator;
+  the promise is that something is verifiably gone, flagged off, or safely retained.
+- **The acceptance signal is the test.** A story is `done` when the signal can be demonstrated.
+- **Story IDs are permanent.** An abandoned story becomes `parked` with a reason; it is never
+  deleted or renumbered.
+- **Iterations ship in order.** Catalog-and-flag removals come before code deletion, which comes
+  before schema deletion. Nothing destructive runs before its export story is `done`.
+
+Sources this roadmap is derived from: the accounting and module dependency audit of 2026-08-18
+(recorded in this document's scope notes), `lib/platform/feature-catalog.ts`,
+`lib/platform/client-templates.ts`, `lib/platform/gating/route-registry.ts`,
+`lib/accounting/posting.ts`, `lib/accounting/integration.ts`, `lib/commodity-billing.ts`,
+`prisma/schema.prisma`.
+
+## Why this trim, and where the line is
+
+The founder decision: we are not an accounting software company; the platform keeps only what it
+needs to keep working. The line was drawn from a dependency audit, not taste:
+
+**Kept — pilot-critical, verified consumers outside accounting:**
+
+- **The posting engine** — `ChartOfAccount`, `JournalEntry`/`JournalLine`, `AccountingPeriod` and
+  period locks, `PostingRule*`, `AccountingSettings`, tender mappings, and the services in
+  `lib/accounting/posting.ts`, `lib/accounting/defaults.ts`, `lib/accounting/bootstrap.ts`,
+  `lib/accounting/integration.ts`. Retail (`app/api/v2/retail/_helpers.ts`), schools fees
+  (`app/api/v2/schools/fees/_helpers.ts`), gold (`app/api/gold/purchases/route.ts` and the
+  capture-with-PENDING call sites), payroll (`lib/hr/payroll/posting.ts`), disbursements and
+  stores all post through it — gold and schools tenants run it headlessly with no accounting UI
+  entitlement.
+- **The AR/AP document core** — `Customer`, `Vendor`, `SalesInvoice`, `SalesReceipt`,
+  `SalesQuotation`, `PurchaseBill`. Gold buys and sells through `lib/commodity-billing.ts`; CRM
+  creates and reads these documents directly (`lib/crm/accounting-bridge.ts`); document PDFs
+  render from `lib/documents/source-registry.ts`.
+- **The tax/VAT module in full** — tax codes, categories, templates, rules, and the VAT-return
+  workflow (`lib/accounting/vat-return.ts`, `components/accounting/tax/tax-setup-workspace.tsx`).
+  Founder decision: keep it all; native FDMS needs a ZIMRA taxID per rate regardless, and VAT
+  returns are part of the compliance-layer claim.
+- **Currency data** — `CurrencyRate` and `AccountingSettings.baseCurrency` are read by
+  `lib/money.ts` (23 importers). The models stay even though the UI is parked.
+- **The trial-balance function** in `lib/accounting/ledger.ts` — input to any future statement
+  work and cheap to keep.
+
+**Deleted — zero consumers anywhere, verified:** fixed assets (a register; nothing computes or
+posts depreciation, no `DEPRECIATION` source type exists) and budgets (no variance report or
+actual-vs-budget query exists anywhere).
+
+**Parked (flagged off, models retained):** banking-reconciliation UI (the executive dashboard
+reads `BankAccount`/`BankTransaction` in `lib/dashboard/executive-aggregations.ts`, and retail
+setup checks `defaultBankAccountId`), financial-statement pages, cost-center UI (the
+`costCenterId` columns on journal and posting-rule lines stay — the posting engine touches them),
+currency-rate UI.
+
+**Dropped modules (code and SKU removed):** CCTV, Autos/car-sales, Scrap metal. None are in the
+four pilots' templates. CCTV and Autos are leaf modules with no cross-domain FKs; Scrap metal is
+substantial but sits outside the gold/retail/campus focus — its FKs into accounting documents
+make its migration the careful one.
+
+**Frozen, not dropped:** Maintenance — it posts `MAINTENANCE_COMPLETION` to the ledger and ships
+in the gold and retail pilot bundles. **Kept outright:** Compliance (gold pilot bundle; the
+mining-campaign collateral is built on it) and CRM (the largest actively developed module and the
+deepest AR consumer).
+
+## Standing instructions
+
+- **Nothing is dropped while any tenant has the feature enabled, until its export story is
+  `done`.** The usage audit decides; the export is the undo.
+- Every removal story runs `pnpm platform:audit-feature-gates`, the entitlement tests
+  (`lib/platform/entitlements.test.ts`), and the marketing pricing tests
+  (`lib/marketing/pricing.test.ts`) before merge.
+- `lib/commodity-billing.ts` is **not** scrap-metal code. Gold depends on it. It stays.
+- Catalog rows, templates, navigation, route-registry entries, workspace products, permission
+  catalog entries, and marketing copy for a dropped module are removed **together** in one story —
+  a half-removed SKU that still renders on the pricing page is a regression.
+- Parked features are removed from navigation, templates and sellable bundles but keep their
+  route-registry entries mapped to a feature key no bundle grants; the code stays compiling.
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md` applies to every story. For this
+document additionally: any story that deletes a Prisma model ships its migration with a
+`prisma migrate diff` check against `prisma/schema.prisma` in both directions, and names in its
+changelog row where the exported data landed.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 0 — Truth before deletion
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| ST-0.1 | As an operator, I know exactly which tenants use each feature slated for removal | A usage report per dropped/parked feature: tenants with the bundle or flag enabled, and row counts in the module's tables per tenant. Produced by script, committed as an artifact of the changelog row | `todo` |
+| ST-0.2 | As an operator, any tenant's data in a dropped module is exported before the drop | Per-tenant export (CSV or JSON per table) for CCTV, Autos and Scrap metal tables, generated and stored; re-runnable; empty tenants produce empty exports, not errors | `todo` |
+
+## Iteration 1 — Catalog and flag removals (non-destructive)
+
+Everything in this iteration is reversible: no code or schema is deleted yet.
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| ST-1.1 | As a buyer, dropped modules no longer appear anywhere they could be bought or navigated to | `ADDON_CCTV_SUITE`, `ADDON_AUTOS_SUITE`, `ADDON_SCRAP_METAL_SUITE` removed from `FEATURE_BUNDLES`; `TEMPLATE_CAR_SALES`, `TEMPLATE_SCRAP_METAL`, `TEMPLATE_SMALL_BUSINESS_SECURITY_STOCK` removed or re-pointed in `lib/platform/client-templates.ts`; navigation groups gone from `lib/navigation.ts`; vertical bundles gone from `lib/workspace-products.ts`; marketing rows gone from `lib/marketing/pricing.ts` and `app/home/site-data.ts`; catalog sync reports the expected reduced bundle count | `todo` |
+| ST-1.2 | As a tenant admin on a parked accounting feature, the page is gone but my data is not | Banking-reconciliation, financial-statements, cost-center and currency pages removed from `lib/accounting/tab-config.ts` navigation and from every sellable bundle; models untouched; executive dashboard cash tiles still render | `todo` |
+| ST-1.3 | As an engineer, no tenant can reach a dropped module's routes | Route-registry entries for `/cctv`, `/car-sales`, `/scrap-metal` and their API prefixes resolve to feature keys no bundle grants; `pnpm platform:audit-feature-gates` clean; a request to each returns the feature-disabled response | `todo` |
+
+## Iteration 2 — Code deletion
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| ST-2.1 | As an engineer, the CCTV module and its server are gone | `app/cctv`, `app/api/cctv`, `components/cctv`, `lib/cctv-playback.ts` and related lib files, `cctv-server/`, and `app/reports/cctv-events` deleted; `hls.js` dependency removed if nothing else uses it; build green | `todo` |
+| ST-2.2 | As an engineer, Autos/car-sales is gone | `app/car-sales`, `app/api/v2/autos`, `app/api/v2/car-sales` (re-export shims), `lib/autos`, `components/car-sales`, `app/portal/autos` and the `portal.autos` feature deleted; build green | `todo` |
+| ST-2.3 | As an engineer, Scrap metal is gone but gold still bills | `app/scrap-metal`, `app/api/scrap-metal`, `lib/scrap-metal.ts`, `lib/scrap-metal/`, `components/scrap-metal` deleted; `lib/commodity-billing.ts` untouched and gold purchase/receipt posting tests green | `todo` |
+| ST-2.4 | As an engineer, dead accounting features are gone | `app/accounting/assets`, `app/accounting/budgets`, `app/api/accounting/assets`, `app/api/accounting/budgets` deleted; the thrift redirect stub `app/thrift/page.tsx` removed alongside its route-registry entry | `todo` |
+| ST-2.5 | As an engineer, the workspace and persona registries no longer know the dropped verticals | `SCRAP_METAL` and `AUTOS` handling removed from `lib/platform/vertical-defaults.ts`, `lib/platform/vertical-role-registry.ts` and workspace profile resolution, with a documented mapping for any existing tenant on those profiles (re-point to `GENERAL`); tests updated | `todo` |
+
+## Iteration 3 — Schema deletion
+
+Blocked until ST-0.2 is `done` for the affected tables.
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| ST-3.1 | As an operator, dropped-module tables no longer exist and nothing misses them | Migrations drop `NVR`/`Camera`/`CCTVEvent`/`CameraAccessLog`, `CarSales*`, and `ScrapMetal*` models. The scrap migration drops from the dependent side, preserving every `SalesInvoice`, `PurchaseBill` and `Vendor` row it pointed at. `prisma migrate diff` empty both directions; migration replay per `scripts/verify-migration-replay.sh` | `todo` |
+| ST-3.2 | As an engineer, `FixedAsset` and `Budget`/`BudgetLine` are gone; `JournalLine.costCenterId` and the `CostCenter` model remain | Migration applies clean on a copy of production data; posting-engine tests green | `todo` |
+| ST-3.3 | As an engineer, dead `AccountingSourceType` values are pruned | `SCRAP_METAL_PURCHASE`, `SCRAP_METAL_BATCH`, `SCRAP_METAL_SALE` and other breadcrumb-only values with no seeded posting rule removed from the enum and from `lib/accounting/source-types.ts`; existing `AccountingIntegrationEvent` rows for removed types handled by the migration (retained with a string column or archived per ST-0.2) | `todo` |
+| ST-3.4 | As a buyer, `ADDON_ACCOUNTING_ADVANCED` sells what still exists | Bundle contents pruned to the surviving features (AR/AP, multi-currency data); fixed-assets/budgets/cost-center/banking feature keys removed from `FEATURE_CATALOG`; `docs/platform-pricing-feature-flags-and-modules.md` updated in the same PR | `todo` |
+
+## Iteration 4 — Freeze register
+
+The register itself is the deliverable; it lives here and the master plan's governance section
+makes it binding.
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| ST-4.1 | As a maintainer, the freeze register exists and is enforced in review | This table row is the register: **Maintenance (`app/maintenance`, `app/api/work-orders`, `app/api/equipment`) is frozen** — bug fixes only, no new stories; it stays in the gold and retail bundles and its `MAINTENANCE_COMPLETION` posting keeps working. A CONTRIBUTING note points here | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created with the dependency-audit evidence and the keep/park/drop/freeze line. |

--- a/docs/rollout/self-serve-billing-roadmap.md
+++ b/docs/rollout/self-serve-billing-roadmap.md
@@ -1,0 +1,116 @@
+# Self-Serve Trial, Payments & Lifecycle Messaging — Implementation Status
+
+Single source of truth for opening the platform to strangers: hardening the gates, automating
+provisioning, the public 14-day trial, payment rails, the WhatsApp lifecycle sequences, and
+activation instrumentation. One document because these share one state machine
+(`CompanySubscription`) and one messaging layer — splitting them invites two owners for one
+lifecycle. Part of the rollout program governed by `docs/rollout/master-rollout-plan.md`.
+
+## How this document works
+
+- **The structure never changes.** Iterations, stories and their IDs are fixed. Work updates the
+  `Status` cell and appends to the changelog — nothing else.
+- **A story is a promise to a person.** The acceptance signal is the test.
+- **Story IDs are permanent.** Iterations ship in order — the gates harden before the doors open.
+
+Sources this roadmap is derived from: `lib/platform/gating/policy.ts`,
+`lib/platform/gating/route-registry.ts`, `proxy.ts`, `lib/platform/subscription.ts`,
+`prisma/schema.prisma` (`CompanySubscription`), `scripts/provision-school.ts`,
+`lib/schools/provision.ts`, `scripts/seed-staging-tenant.ts`, `components/onboarding/`,
+`components/preferences/organization/billing-preferences.tsx`, `lib/audit/platform.ts`,
+`lib/notifications.ts`, `scripts/platform/audit-feature-gates.ts`.
+
+## Current state being changed
+
+- Feature gating is **fail-open**: `isAllowByDefaultFeaturePolicy()` allows unless
+  `FEATURE_GATE_POLICY=deny` is set.
+- Subscription health (`getSubscriptionHealth`/`shouldBlock`) is computed but **never enforced**
+  in `proxy.ts` — an expired tenant is not restricted.
+- There is **no public signup**: tenants are provisioned by operators; `TRIALING` is a manual
+  dropdown with no length, expiry job, or conversion prompt.
+- There are **no payment integrations** and no upgrade path; the tenant billing page is
+  read-only; `CompanySubscription.externalSubscriptionId` is the prepared, unused seam.
+- There is **no outbound messaging** of any kind (no email, SMS, or WhatsApp provider), and no
+  product analytics beyond pageviews; the hash-chained `PlatformAuditEvent` ledger is the best
+  activation substrate.
+
+## Standing instructions
+
+- **Degradation, never hard cutoff.** A tenant that stops paying goes read-only with a banner —
+  writes blocked, reads allowed. A locked-out merchant on a market day becomes an angry referral.
+- The trial identifier is the WhatsApp number, normalised to E.164, unique per user
+  (master-plan risk #14). Signup never requires a card.
+- Every lifecycle transition (trial start, expiry, payment, past-due, degradation) writes a
+  `PlatformAuditEvent` and is idempotent — a replayed webhook must not double-transition.
+- WhatsApp templates go through provider approval; the sequences in SS-5 are drafted and
+  submitted the week the provider is chosen (master-plan risk #9), not when the code is ready.
+
+## Definition of Done
+
+The program DoD in `docs/rollout/master-rollout-plan.md`. For this document additionally: every
+externally-triggered transition (webhook, scheduled job) has a test for the replayed and the
+out-of-order case.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| `done` | Acceptance signal demonstrated, DoD met |
+| `wip` | In progress on the current branch |
+| `todo` | Accepted into the roadmap, not started |
+| `blocked` | Cannot start; blocker named in the row |
+| `parked` | Deliberately not being built; reason named in the row |
+
+## Iteration 1 — Gate hardening
+
+Prerequisite for letting strangers in. Runs on the post-trim route surface (ST-1.3).
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-1.1 | As a platform operator, the platform denies by default | `pnpm platform:audit-feature-gates` clean; uncovered routes fixed in `lib/platform/gating/route-registry.ts`; `FEATURE_GATE_POLICY=deny` flipped in staging, soaked, then production; a tenant without a feature gets the feature-disabled response while entitled tenants are unaffected | `todo` |
+| SS-1.2 | As a platform operator, an expired tenant is actually restricted | `getSubscriptionHealth().shouldBlock` wired into `proxy.ts` as read-only degradation: mutating requests blocked with a named error, reads allowed, banner shown; an `EXPIRED_BLOCKED` tenant can view but not create an invoice | `todo` |
+
+## Iteration 2 — Provisioning automation
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-2.1 | As an engineer, one function call yields a working tenant | `lib/schools/provision.ts` generalised into a platform provisioning service (template + tier + host + admin user), callable from an API route as well as the TUI; provisioning a Start and a Fiscal tenant lands each on a working workspace on its own subdomain | `todo` |
+| SS-2.2 | As a new trial user, my workspace is not empty | Sample data seeded on first login per template (the `scripts/seed-staging-tenant.ts` precedent, production-safe subset); an empty-POS first impression is gone; sample data clearly marked and one-click removable | `todo` |
+
+## Iteration 3 — Public trial signup
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-3.1 | As a visitor, I can start a 14-day trial on Fiscal or Start without talking to anyone and without a card | Public signup flow; WhatsApp number as identifier (E.164, unique, recovery path decided per master-plan risk #14); `TRIALING` subscription with `trialEndsAt` +14 days; lands in the workspace with sample data. Incognito-browser test: signup → first sandbox fiscal invoice with zero staff involvement | `todo` |
+| SS-3.2 | As a platform operator, trials end by themselves | A scheduled job (worker precedent) transitions expired trials; conversion prompt in-app before expiry; post-expiry the SS-1.2 degradation applies | `todo` |
+
+## Iteration 4 — Payment rails
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-4.1 | As a founder, the gateway choice is made on evidence | Written evaluation memo — Paynow vs Pesepay vs ContiPay — against the fixed criteria: recurring-billing support and settlement time first, headline rate last (master-plan risk #10). The memo is the artifact; the decision lands in this changelog | `todo` |
+| SS-4.2 | As a tenant admin, I can pay for my subscription myself | Gateway integrated behind `CompanySubscription.externalSubscriptionId`; webhook route with replay-safe transitions; checkout/upgrade actions on the currently read-only `components/preferences/organization/billing-preferences.tsx`; a sandbox payment flips `TRIALING` → `ACTIVE`; TUI reflects it | `todo` |
+| SS-4.3 | As a buyer, annual prepay is the path of least resistance | Annual (20% off, per PR-2.1) presented first at checkout; quarterly as the middle option; monthly the fallback | `todo` |
+
+## Iteration 5 — Lifecycle messaging
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-5.1 | As a founder, the platform can send WhatsApp messages | Provider chosen (master-plan risk #9) and integrated as a messaging service; templates approved; a test message delivers; failure falls back to in-app notification via `lib/notifications.ts` | `todo` |
+| SS-5.2 | As a new trial user, I am walked to my first validated invoice | Onboarding sequence on WhatsApp — Day 0 setup confirmation, Day 1 fiscalisation walkthrough, Day 3 validated-invoice check with human follow-up if not, Day 7 second-module nudge, Day 12 trial-end with the annual offer. Clock-advanced test tenant receives the full sequence | `todo` |
+| SS-5.3 | As a paying customer, I am reminded before I lapse, and degraded gently after | Payment reminders at T-7, T-3, T-0, T+3; `PAST_DUE` applies the SS-1.2 read-only degradation after grace, never a hard cutoff; recovery on payment is immediate | `todo` |
+
+## Iteration 6 — Activation instrumentation
+
+| ID | Story | Acceptance signal | Status |
+|---|---|---|---|
+| SS-6.1 | As a founder, I can see the activation funnel | Signup → first login → device registered → first validated fiscal invoice, each written via `writePlatformAuditEvent` (`lib/audit/platform.ts`); a funnel report in the admin control plane (`components/admin-portal/`) shows a real trial's timestamps and whether it beat 30 minutes | `todo` |
+| SS-6.2 | As a founder, the leading indicators are on one screen | Trials/month, trial→paid rate, time-to-first-validated-invoice, annual-prepay mix, monthly logo churn — computed from subscription and audit data, matching the program's 90-day targets | `todo` |
+
+## Changelog
+
+Newest first. One entry per commit that changes implementation status.
+
+| Date | Commit | Stories | Description |
+|---|---|---|---|
+| 2026-08-18 | — | — | Document created; fail-open gating, unenforced expiry, and the absent signup/payments/messaging surfaces recorded as the starting state. |


### PR DESCRIPTION
Turns the adopted priorities (the Corelith plan plus the Campus vertical) into an executable program under `docs/rollout/`, grounded in a codebase dependency audit. Docs only — no code changes beyond a banner.

## What's in here

- **`master-rollout-plan.md`** — the 90-day program contract: north-star metric (businesses issuing ZIMRA-validated fiscal invoices), the locked decisions (native FDMS v7.2 only; full new pricing structure Fiscal $19 → Gold Edition $299 with 20% annual; full self-serve 14-day no-card trial; scope trim), the cross-workstream dependency table, the critical path, an 18-item risk register, governance, and the program Definition of Done.
- **`scope-trim-roadmap.md` (ST-)** — narrows the platform: drop CCTV, Autos/car-sales, and Scrap metal (usage audit + export before any destructive step); delete fixed assets and budgets (zero consumers, verified); park banking-recon/financial-statements/cost-center/currency UIs with models retained; keep the posting engine, AR/AP document core, and the full tax/VAT module; freeze Maintenance.
- **`fdms-roadmap.md` (FD-)** — native ZIMRA FDGA v7.2 on the existing connector seam: foundations (ZWG, taxID mapping, Decimal, CHECK widening), device lifecycle, fiscal days, the core signed/chained receipt protocol with rendered QR (day-30 exit criterion), credit/debit notes, offline POS fiscalisation, background worker, multi-site fiscal-day console, pilot cutover.
- **`pricing-packaging-roadmap.md` (PR-)** — catalog rewrite to the new tiers, 20% annual mechanics, zero-entitlement-loss tenant migration, marketing derivation, Gold Edition packaging, and restoring the pricing doc as single truth.
- **`self-serve-billing-roadmap.md` (SS-)** — gate hardening (deny-by-default flip, enforce subscription expiry as read-only degradation), provisioning automation, public trial, payment rails behind `externalSubscriptionId`, WhatsApp lifecycle sequences, activation-funnel instrumentation on the audit ledger.
- **`marketing-site-roadmap.md` (MK-)** — fiscalisation reposition, penalty calculator (181-day cap under test) and VAT checker, persistent leads, CTA swap, campaign/proof pages.
- **`partner-channel-roadmap.md` (PC-)** — deliberately post-90-day except the referral thin slice; multi-org membership named as the load-bearing change.
- **`gold-edition-roadmap.md` (GE-)** — closes open gold epics, proves the $299 edition end-to-end, gold fiscalisation, mining-campaign readiness.
- **`campus-alignment.md`** — framing note only; the schools roadmap stays the sole story ledger for Campus.
- **`docs/platform-pricing-feature-flags-and-modules.md`** — supersession banner: pricing figures yield to the program until PR-6.1; mechanism content stays normative.

## Verification

- Every backtick file path in the new docs exists in the repo (scripted check, zero missing).
- Story IDs unique; prefixes don't collide with the schools roadmap's `S-`.
- All seven roadmaps carry the house structure (preamble, sources, standing instructions, DoD, status legend, iteration tables, seeded changelog) mirroring `docs/expansion-plan/schools-roadmap.md`.
- Dependency table is acyclic; campus note defines zero story IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkkYUShqFVWZjvnePJfY24

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkYUShqFVWZjvnePJfY24)_