### PR TITLE
CRM: a table view for every list, tasks as a split, and an activity feed you can scan

### DIFF
--- a/app/themes/corelith-bridge.css
+++ b/app/themes/corelith-bridge.css
@@ -443,6 +443,14 @@
   --table-row-min-h:  calc(var(--h-control-md) + var(--space-3));    /* 48 */
   --table-head-min-h: calc(var(--h-control-md) + var(--space-1));    /* 40 */
 
+  /* The options row on a record list — the band holding the layout switch, the
+     filters and the search. Named for the same reason the app bar is: it pins
+     to the top of the scrollport, and every sticky table header in the module
+     has to pin *below* it. A literal here and a literal in `RecordTable` is
+     how a header ends up half-hidden behind a toolbar the next time the row
+     gains a control. */
+  --list-toolbar-h:   3.25rem;
+
   /* ══════════════════════════════════════════════════════════════════════
      TYPOGRAPHY
      The package owns `--font-sans` / `--font-mono` / `--font-display` /

--- a/components/crm/leads/leads-table.tsx
+++ b/components/crm/leads/leads-table.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import Link from "next/link";
-import type { ColumnDef } from "@tanstack/react-table";
 import type { CrmLeadStage } from "@prisma/client";
 
 import { Button } from "@/components/ui/button";
-import { DataTable } from "@/components/ui/data-table";
 import { NumericCell } from "@/components/ui/numeric-cell";
 import { StatusChip } from "@/components/ui/status-chip";
 import { ClientDate } from "@/components/ui/client-date";
@@ -18,14 +15,30 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Archive, ChevronDown, Funnel, UserRound } from "@/lib/icons";
+import {
+  Archive,
+  Building2,
+  Checklist,
+  ChevronDown,
+  Clock,
+  Coins,
+  Funnel,
+  Megaphone,
+  UserRound,
+  Users,
+} from "@/lib/icons";
 import type { CrmLeadListRecord } from "@/lib/crm/crm-v2";
-import type { LeadSort } from "@/lib/crm/views";
 import type { ColumnOption } from "@/lib/ui/visible-columns";
 import { cn } from "@/lib/utils";
 
+import { EntityLink } from "@/components/records/entity-link";
 import { RecordMark } from "@/components/records/record-mark";
-import { RecordList } from "@/components/crm/records/record-list";
+import { RecordList, RecordListPager } from "@/components/crm/records/record-list";
+import {
+  RecordTable,
+  RecordTableName,
+  type RecordTableColumn,
+} from "@/components/crm/records/record-table";
 
 import type { LeadFilterOwner } from "./leads-filters";
 import {
@@ -57,60 +70,72 @@ export const LEAD_TABLE_COLUMNS: ColumnOption[] = [
 
 function OwnerCell({ owner }: { owner: CrmLeadListRecord["assignedTo"] }) {
   if (!owner) {
-    return <span className="text-sm text-[var(--text-muted)]">Unassigned</span>;
+    return <span className="text-[var(--text-subtle)]">Unassigned</span>;
   }
   return (
-    <div className="flex items-center gap-2">
+    <span className="flex items-center gap-2">
       <RecordMark kind="rep" name={owner.name} size="sm" />
-      <span className="truncate text-sm">{owner.name ?? "Unnamed"}</span>
-    </div>
+      <span className="min-w-0 truncate">{owner.name ?? "Unnamed"}</span>
+    </span>
   );
 }
 
 function NextTaskCell({ task }: { task: CrmLeadListRecord["nextFollowUp"] }) {
-  if (!task) return <span className="text-sm text-[var(--text-muted)]">—</span>;
+  if (!task) return <span className="text-[var(--text-subtle)]">—</span>;
   const overdue = isOverdue(task.dueAt);
   return (
-    <div className="min-w-0">
-      <div className="truncate text-sm">{task.title}</div>
-      <div
+    <span className="block min-w-0">
+      <span className="block truncate">{task.title}</span>
+      <span
         className={cn(
-          "text-sm",
+          "block truncate text-sm",
           overdue ? "font-medium text-[var(--status-error-text)]" : "text-[var(--text-muted)]",
         )}
       >
         {overdue ? "Overdue · " : ""}
         <ClientDate value={task.dueAt} />
-      </div>
-    </div>
+      </span>
+    </span>
   );
 }
 
+/**
+ * The leads register, as columns.
+ *
+ * On the same `RecordTable` as people, companies, sites and deals rather than
+ * on `DataTable`. Leads was the last CRM list with a table of its own, which
+ * meant the module's busiest screen had a different row height, a different
+ * header and a different empty state from the four beside it — and a fix to
+ * "the CRM table" landed on four of five.
+ *
+ * What was given up in the swap is column-header sorting, and only because it
+ * was already duplicated: the options row above carries a sort button that
+ * writes the same `LeadSort`, and two controls for one setting is the pattern
+ * the toolbar was consolidated to stop.
+ */
 export function LeadsTable({
   leads,
   total,
   page,
   pageSize,
-  sort,
   isLoading,
   owners,
   onPageChange,
-  onSortChange,
   onBulkAssign,
   onBulkStage,
   onBulkArchive,
   showingArchived = false,
   hiddenColumns,
+  selectedIds,
+  onSelectionChange,
 }: {
   leads: CrmLeadListRecord[];
   total: number;
   page: number;
   pageSize: number;
-  sort: LeadSort;
   isLoading: boolean;
   owners: LeadFilterOwner[];
   onPageChange: (page: number) => void;
-  onSortChange: (sort: LeadSort) => void;
   onBulkAssign: (ids: string[], assignedToId: string | null, done: () => void) => void;
   onBulkStage: (ids: string[], stage: CrmLeadStage, done: () => void) => void;
   onBulkArchive: (ids: string[], archived: boolean, done: () => void) => void;
@@ -118,98 +143,104 @@ export function LeadsTable({
   showingArchived?: boolean;
   /** Column ids the reader has switched off. */
   hiddenColumns?: string[];
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
 }) {
-
-  const columns = useMemo<ColumnDef<CrmLeadListRecord>[]>(
+  const columns = useMemo<RecordTableColumn<CrmLeadListRecord>[]>(
     () => [
       {
         id: "leadNo",
-        header: "Lead",
-        size: 220,
-        cell: ({ row }) => (
-          <Link
-            href={`/crm/leads/${row.original.id}`}
-            className="block min-w-0 underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text-muted)]"
-          >
-            <div className="truncate font-medium">
-              {row.original.title ?? row.original.leadNo}
-            </div>
-            <div className="truncate font-mono text-sm text-[var(--text-muted)]">
-              {row.original.leadNo}
-            </div>
-          </Link>
-        ),
-      },
-      {
-        id: "client",
-        header: "Client",
-        size: 200,
-        cell: ({ row }) => (
-          <div className="min-w-0">
-            <div className="truncate text-sm">{row.original.client?.name ?? "—"}</div>
-            {row.original.contactName ? (
-              <div className="truncate text-sm text-[var(--text-muted)]">
-                {row.original.contactName}
-              </div>
-            ) : null}
-          </div>
-        ),
-      },
-      {
-        id: "stage",
-        header: "Stage",
-        size: 140,
-        cell: ({ row }) => (
-          <StatusChip
-            status={CRM_STAGE_STATUS[row.original.stage]}
-            label={CRM_STAGE_LABELS[row.original.stage]}
+        label: "Lead",
+        icon: Funnel,
+        cell: (lead) => (
+          <RecordTableName
+            leading={<RecordMark kind="lead" name={lead.title ?? lead.leadNo} size="sm" />}
+            title={lead.title ?? lead.leadNo}
+            subtitle={<span className="font-mono">{lead.leadNo}</span>}
           />
         ),
       },
       {
+        id: "client",
+        label: "Client",
+        icon: Building2,
+        width: "13rem",
+        cell: (lead) => (
+          <span className="block min-w-0">
+            <span className="block truncate">
+              {lead.client ? (
+                <EntityLink href={`/crm/companies/${lead.client.id}`}>
+                  {lead.client.name}
+                </EntityLink>
+              ) : (
+                <span className="text-[var(--text-subtle)]">—</span>
+              )}
+            </span>
+            {lead.contactName ? (
+              <span className="block truncate text-sm text-[var(--text-muted)]">
+                {lead.contactName}
+              </span>
+            ) : null}
+          </span>
+        ),
+      },
+      {
+        id: "stage",
+        label: "Stage",
+        icon: Funnel,
+        width: "10rem",
+        cell: (lead) => (
+          <StatusChip status={CRM_STAGE_STATUS[lead.stage]} label={CRM_STAGE_LABELS[lead.stage]} />
+        ),
+      },
+      {
         id: "value",
-        header: "Value",
-        size: 130,
-        cell: ({ row }) => (
-          <NumericCell>
-            {formatLeadValue(row.original.estimatedValue, row.original.currency)}
+        label: "Value",
+        icon: Coins,
+        width: "10rem",
+        align: "end",
+        cell: (lead) => (
+          <NumericCell className="whitespace-nowrap">
+            {formatLeadValue(lead.estimatedValue, lead.currency)}
           </NumericCell>
         ),
       },
       {
         id: "owner",
-        header: "Owner",
-        size: 170,
-        cell: ({ row }) => <OwnerCell owner={row.original.assignedTo} />,
+        label: "Owner",
+        icon: Users,
+        width: "11rem",
+        cell: (lead) => <OwnerCell owner={lead.assignedTo} />,
       },
       {
         id: "nextTask",
-        header: "Next task",
-        size: 180,
-        cell: ({ row }) => <NextTaskCell task={row.original.nextFollowUp} />,
+        label: "Next task",
+        icon: Checklist,
+        width: "12rem",
+        cell: (lead) => <NextTaskCell task={lead.nextFollowUp} />,
       },
       {
         id: "source",
-        header: "Source",
-        size: 150,
-        cell: ({ row }) => (
-          <div className="min-w-0">
-            <div className="truncate text-sm">{row.original.source ?? "—"}</div>
-            <div className="truncate text-sm text-[var(--text-muted)]">
-              {CRM_CHANNEL_LABELS[row.original.sourceChannel ?? ""] ??
-                row.original.sourceChannel ??
-                ""}
-            </div>
-          </div>
+        label: "Source",
+        icon: Megaphone,
+        width: "10rem",
+        cell: (lead) => (
+          <span className="block min-w-0">
+            <span className="block truncate">{lead.source ?? "—"}</span>
+            <span className="block truncate text-sm text-[var(--text-muted)]">
+              {CRM_CHANNEL_LABELS[lead.sourceChannel ?? ""] ?? lead.sourceChannel ?? ""}
+            </span>
+          </span>
         ),
       },
       {
         id: "updatedAt",
-        header: "Updated",
-        size: 130,
-        cell: ({ row }) => (
-          <span className="text-sm text-[var(--text-muted)]">
-            <ClientDate value={row.original.updatedAt} />
+        label: "Updated",
+        icon: Clock,
+        width: "9rem",
+        cell: (lead) => (
+          <span className="text-[var(--text-muted)]">
+            <ClientDate value={lead.updatedAt} />
           </span>
         ),
       },
@@ -219,42 +250,22 @@ export function LeadsTable({
 
   const hiddenSet = useMemo(() => new Set(hiddenColumns ?? []), [hiddenColumns]);
   const visibleColumns = useMemo(
-    () => columns.filter((column) => !hiddenSet.has(String(column.id))),
+    () => columns.filter((column) => !hiddenSet.has(column.id)),
     [columns, hiddenSet],
   );
 
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-
   return (
-    <DataTable
-      data={leads}
-      columns={visibleColumns}
-      edgeToEdge
-      stickyHeader
-      queryState={{
-        mode: "paginated",
-        page,
-        pageSize,
-        sortBy: sort.field,
-        sortDirection: sort.direction,
-      }}
-      onQueryStateChange={(next) => {
-        if (next.page && next.page !== page) onPageChange(next.page);
-        if (next.sortBy && next.sortBy !== sort.field) {
-          onSortChange({
-            field: next.sortBy as LeadSort["field"],
-            direction: next.sortDirection ?? "desc",
-          });
-        } else if (next.sortDirection && next.sortDirection !== sort.direction) {
-          onSortChange({ field: sort.field, direction: next.sortDirection });
-        }
-      }}
-      pagination={{ enabled: true, server: true, total, totalPages }}
-      rowSelection={{
-        enabled: true,
-        bulkActions: ({ selectedRows, clearSelection }) => {
-          const ids = selectedRows.map((lead) => lead.id);
-          return (
+    <>
+      <RecordTable
+        rows={leads}
+        columns={visibleColumns}
+        rowHref={(lead) => `/crm/leads/${lead.id}`}
+        isLoading={isLoading}
+        emptyTitle="No leads match these filters"
+        selection={{
+          selectedIds,
+          onChange: onSelectionChange,
+          actions: ({ ids, clear }) => (
             <div className="flex flex-wrap items-center gap-2">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -264,19 +275,21 @@ export function LeadsTable({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
-                  <DropdownMenuLabel>Assign {ids.length} lead{ids.length === 1 ? "" : "s"} to</DropdownMenuLabel>
+                  <DropdownMenuLabel>
+                    Assign {ids.length} lead{ids.length === 1 ? "" : "s"} to
+                  </DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   {owners.map((owner) => (
                     <DropdownMenuItem
                       key={owner.id}
-                      onClick={() => onBulkAssign(ids, owner.id, clearSelection)}
+                      onClick={() => onBulkAssign(ids, owner.id, clear)}
                     >
                       <UserRound />
                       {owner.name ?? "Unnamed"}
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => onBulkAssign(ids, null, clearSelection)}>
+                  <DropdownMenuItem onClick={() => onBulkAssign(ids, null, clear)}>
                     <UserRound />
                     Leave unassigned
                   </DropdownMenuItem>
@@ -297,7 +310,7 @@ export function LeadsTable({
                       // Lost is the one stage move that is a claim about the
                       // business rather than progress along it.
                       variant={stage === "LOST" ? "destructive" : "default"}
-                      onClick={() => onBulkStage(ids, stage, clearSelection)}
+                      onClick={() => onBulkStage(ids, stage, clear)}
                     >
                       <Funnel />
                       {CRM_STAGE_LABELS[stage]}
@@ -314,47 +327,53 @@ export function LeadsTable({
                 size="sm"
                 variant="outline"
                 className="gap-1.5"
-                onClick={() => onBulkArchive(ids, !showingArchived, clearSelection)}
+                onClick={() => onBulkArchive(ids, !showingArchived, clear)}
               >
                 <Archive className="size-4" />
                 {showingArchived ? "Restore" : "Archive"}
               </Button>
             </div>
-          );
-        },
-      }}
-      // On a phone the table becomes the same list every other CRM surface
-      // uses: one row per lead, two lines inside it, rows separated by
-      // whitespace. The owner joins the reference line rather than earning a
-      // third row of its own, and the value sits on the right.
-      mobileListRenderer={({ rows: mobileRows }) => (
-        <RecordList
-          rows={mobileRows.map(({ row }) => ({
-            id: row.id,
-            href: `/crm/leads/${row.id}`,
-            title: row.title ?? row.leadNo,
-            subtitle: `${row.leadNo} · ${row.client?.name ?? "No client"} · ${
-              row.assignedTo?.name ?? "Unassigned"
-            }`,
-            status: (
-              <StatusChip
-                status={CRM_STAGE_STATUS[row.stage]}
-                label={CRM_STAGE_LABELS[row.stage]}
-              />
-            ),
-            facts: [
-              {
-                value: formatLeadValue(row.estimatedValue, row.currency),
-                mono: true,
-                primary: true,
-              },
-            ],
-          }))}
-        />
-      )}
-      emptyState={
-        isLoading ? "Loading leads…" : "No leads match these filters."
-      }
-    />
+          ),
+        }}
+        // On a phone the table becomes the same list every other CRM surface
+        // uses: one row per lead, two lines inside it, rows separated by
+        // whitespace. The owner joins the reference line rather than earning a
+        // third row of its own, and the value sits on the right.
+        mobile={
+          <RecordList
+            isLoading={isLoading}
+            emptyTitle="No leads match these filters"
+            rows={leads.map((lead) => ({
+              id: lead.id,
+              href: `/crm/leads/${lead.id}`,
+              title: lead.title ?? lead.leadNo,
+              subtitle: `${lead.leadNo} · ${lead.client?.name ?? "No client"} · ${
+                lead.assignedTo?.name ?? "Unassigned"
+              }`,
+              status: (
+                <StatusChip
+                  status={CRM_STAGE_STATUS[lead.stage]}
+                  label={CRM_STAGE_LABELS[lead.stage]}
+                />
+              ),
+              facts: [
+                {
+                  value: formatLeadValue(lead.estimatedValue, lead.currency),
+                  mono: true,
+                  primary: true,
+                },
+              ],
+            }))}
+          />
+        }
+      />
+
+      <RecordListPager
+        page={page}
+        pageSize={pageSize}
+        total={total}
+        onPageChange={onPageChange}
+      />
+    </>
   );
 }

--- a/components/crm/leads/leads-workspace.tsx
+++ b/components/crm/leads/leads-workspace.tsx
@@ -10,7 +10,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
 import { Funnel, Plus } from "@/lib/icons";
 import { PageChrome } from "@/components/layout/page-chrome";
-import { SegmentedControl } from "@/components/ui/segmented-control";
+import { LayoutSwitch } from "@/components/crm/records/layout-switch";
 import { PipelineSwitcher } from "@/components/crm/records/pipeline-switcher";
 import { ListSearch } from "@/components/crm/records/list-search";
 import { ViewToolbar } from "@/components/crm/records/view-toolbar";
@@ -79,6 +79,7 @@ export function LeadsWorkspace({
   const debouncedSearch = useDebounced(search, 300);
   const [sort, setSort] = useState<LeadSort>(DEFAULT_LEAD_SORT);
   const [page, setPage] = useState(1);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [activeViewKey, setActiveViewKey] = useState<string>(
     initialViewId ?? BUILT_IN_VIEWS[0].key,
   );
@@ -236,6 +237,17 @@ export function LeadsWorkspace({
           Table/Board switch to contradict it. Stage sits with the filters
           because on a board it decides which columns exist. */}
       <ViewToolbar
+        // The same first control, in the same place, as every other CRM list.
+        // It used to sit on the right of the row beside the column picker, so
+        // leads was the one page in the module where "which arrangement am I
+        // looking at" was answered at the far end of the toolbar.
+        layout={
+          <LayoutSwitch
+            value={viewType}
+            onChange={setViewType}
+            options={["BOARD", "TABLE"]}
+          />
+        }
         start={
           <>
             <ViewPicker
@@ -294,15 +306,6 @@ export function LeadsWorkspace({
         }
         end={
           <>
-            <SegmentedControl
-              value={viewType}
-              onValueChange={(value) => setViewType(value as "TABLE" | "BOARD")}
-              ariaLabel="Board or list"
-              options={[
-                { value: "BOARD", label: "Board" },
-                { value: "TABLE", label: "List" },
-              ]}
-            />
             <ColumnPicker
               columns={viewType === "TABLE" ? LEAD_TABLE_COLUMNS : LEAD_CARD_FIELDS}
               state={viewType === "TABLE" ? tableColumns : boardFields}
@@ -325,19 +328,19 @@ export function LeadsWorkspace({
           total={total}
           page={page}
           pageSize={PAGE_SIZE}
-          sort={sort}
           isLoading={leadsQuery.isLoading}
           owners={owners}
           onPageChange={setPage}
-          onSortChange={(next) => {
-            setSort(next);
-            setPage(1);
-          }}
           onBulkAssign={handleBulkAssign}
           onBulkStage={handleBulkStage}
           onBulkArchive={handleBulkArchive}
           showingArchived={Boolean(activeFilters.archived)}
           hiddenColumns={tableColumns.hidden}
+          // Selection is held by the workspace, not the table: a bulk assign
+          // refetches the list, and a table that owned its own ticked rows
+          // would come back with them cleared halfway through the job.
+          selectedIds={selectedIds}
+          onSelectionChange={setSelectedIds}
         />
       ) : (
         <BoardFieldsProvider hidden={boardFields.hidden}>

--- a/components/crm/records/companies-content.tsx
+++ b/components/crm/records/companies-content.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Badge, Button } from "@corelithzw/react";
-import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Building2, Coins, Funnel, MapPin, Users } from "@/lib/icons";
 import { useToast } from "@/components/ui/use-toast";
 import { StatusChip } from "@/components/ui/status-chip";
 import { fetchCrmCompanies } from "@/lib/crm/crm-v2";
@@ -15,6 +15,8 @@ import { useDebounced } from "@/hooks/use-debounced";
 
 import { CompanyFormSheet } from "./company-form-sheet";
 import { RecordListPager, type RecordListRow } from "./record-list";
+import { RecordTable, RecordTableName, type RecordTableColumn } from "./record-table";
+import { LayoutSwitch, type RecordLayout } from "./layout-switch";
 import { RecordMark } from "@/components/records/record-mark";
 import { RecordBoard } from "./record-board";
 import { ColumnPicker } from "@/components/ui/column-picker";
@@ -65,7 +67,7 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [createOpen, setCreateOpen] = useState(openCreate);
-  const [layout, setLayout] = useState<"LIST" | "BOARD">("LIST");
+  const [layout, setLayout] = useState<RecordLayout>("TABLE");
   const debouncedSearch = useDebounced(search, 300);
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -244,6 +246,134 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
     [companies, fields],
   );
 
+  /**
+   * The same companies, arranged as columns.
+   *
+   * Standing and type are the two questions a directory of accounts gets asked
+   * — "who is on hold", "which of these are suppliers" — and in the row layout
+   * they are two chips crowded against the name, with the second one dropped
+   * entirely on a phone. As columns they line up, which is the whole reason
+   * this arrangement exists.
+   */
+  const columns = useMemo<RecordTableColumn<(typeof companies)[number]>[]>(
+    () => [
+      {
+        id: "name",
+        label: "Company",
+        icon: Building2,
+        cell: (company) => (
+          <RecordTableName
+            leading={
+              <RecordMark
+                kind="company"
+                name={company.name}
+                emoji={company.emoji}
+                avatarUrl={company.avatarUrl}
+                size="sm"
+              />
+            }
+            title={company.name}
+            subtitle={company.clientNo}
+          />
+        ),
+      },
+      ...(fields.isVisible("status")
+        ? [
+            {
+              id: "status",
+              label: "Standing",
+              icon: Funnel,
+              width: "9rem",
+              cell: (company: (typeof companies)[number]) => (
+                <StatusChip
+                  status={ACCOUNT_STATUS_PRESENTATION[company.accountStatus] ?? "pending"}
+                  label={ACCOUNT_STATUS_LABELS[company.accountStatus] ?? company.accountStatus}
+                />
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("type")
+        ? [
+            {
+              id: "type",
+              label: "Type",
+              icon: Funnel,
+              width: "8rem",
+              cell: (company: (typeof companies)[number]) => (
+                <Badge tone="neutral" size="sm">
+                  {COMPANY_TYPE_LABELS[company.companyType] ?? company.companyType}
+                </Badge>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("location")
+        ? [
+            {
+              id: "location",
+              label: "Location",
+              icon: MapPin,
+              width: "11rem",
+              cell: (company: (typeof companies)[number]) => (
+                <span className="block truncate">
+                  {[company.city, company.country].filter(Boolean).join(", ") || (
+                    <span className="text-[var(--text-subtle)]">—</span>
+                  )}
+                </span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("people")
+        ? [
+            {
+              id: "people",
+              label: "People",
+              icon: Users,
+              width: "6rem",
+              align: "end" as const,
+              cell: (company: (typeof companies)[number]) => (
+                <span className="font-mono tabular-nums">{company._count?.people ?? 0}</span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("deals")
+        ? [
+            {
+              id: "deals",
+              label: "Deals",
+              icon: Coins,
+              width: "6rem",
+              align: "end" as const,
+              cell: (company: (typeof companies)[number]) => (
+                <span className="font-mono tabular-nums">{company._count?.deals ?? 0}</span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("owner")
+        ? [
+            {
+              id: "owner",
+              label: "Owner",
+              icon: Users,
+              width: "11rem",
+              cell: (company: (typeof companies)[number]) => (
+                <span className="block truncate">
+                  {company.assignedTo?.name ?? (
+                    <span className="text-[var(--text-subtle)]">Unassigned</span>
+                  )}
+                </span>
+              ),
+            },
+          ]
+        : []),
+    ],
+    [fields],
+  );
+
   // Same reasoning as People: a directory is scanned by name, so it gets a
   // heading per letter and a jump strip once it is long enough to be work to
   // scroll. Search results stay flat — they are ranked, not alphabetical.
@@ -255,6 +385,27 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
         rows: bucket.items,
       })),
     [rows],
+  );
+
+  // The rows arrangement, which is also what the table falls back to on a
+  // phone — so it is written once and used twice rather than diverging.
+  const directory = (
+    <GroupedRecordList
+      sections={debouncedSearch ? [{ id: "results", label: "Results", rows }] : sections}
+      showJumpStrip={!debouncedSearch && rows.length >= 30}
+      isLoading={companiesQuery.isLoading}
+      emptyTitle={debouncedSearch ? "No companies match that search" : "No companies yet"}
+      emptyBody={
+        debouncedSearch ? undefined : "Add one, or convert a lead and its company comes with it."
+      }
+      emptyAction={
+        debouncedSearch ? undefined : (
+          <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+            Add the first company
+          </Button>
+        )
+      }
+    />
   );
 
   return (
@@ -276,18 +427,8 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
           label={layout === "BOARD" ? "Fields" : "Columns"}
         />
       }
-      filters={
-        <>
-          <SegmentedControl
-            value={layout}
-            onValueChange={(value) => setLayout(value as typeof layout)}
-            ariaLabel="List or board"
-            options={[
-              { value: "LIST", label: "List" },
-              { value: "BOARD", label: "Board" },
-            ]}
-          />
-        </>
+      layout={
+        <LayoutSwitch value={layout} onChange={setLayout} options={["TABLE", "LIST", "BOARD"]} />
       }
     >
       {layout === "BOARD" ? (
@@ -300,29 +441,27 @@ export function CompaniesContent({ openCreate = false }: { openCreate?: boolean 
           onMove={(id, accountStatus) => moveAccountStatus.mutate({ id, accountStatus })}
           className="min-h-[24rem]"
         />
+      ) : layout === "TABLE" ? (
+        <RecordTable
+          rows={companies}
+          columns={columns}
+          rowHref={(company) => `/crm/companies/${company.id}`}
+          isLoading={companiesQuery.isLoading}
+          emptyTitle={debouncedSearch ? "No companies match that search" : "No companies yet"}
+          emptyBody={
+            debouncedSearch
+              ? undefined
+              : "Add one, or convert a lead and its company comes with it."
+          }
+          mobile={directory}
+        />
       ) : (
-      <GroupedRecordList
-        sections={debouncedSearch ? [{ id: "results", label: "Results", rows }] : sections}
-        showJumpStrip={!debouncedSearch && rows.length >= 30}
-        isLoading={companiesQuery.isLoading}
-        emptyTitle={debouncedSearch ? "No companies match that search" : "No companies yet"}
-        emptyBody={
-          debouncedSearch ? undefined : "Add one, or convert a lead and its company comes with it."
-        }
-        emptyAction={
-          debouncedSearch ? undefined : (
-            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
-              Add the first company
-            </Button>
-          )
-        }
-      />
-
+        directory
       )}
 
-      {layout === "LIST" ? (
+      {layout === "BOARD" ? null : (
         <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
-      ) : null}
+      )}
 
       <CompanyFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </RecordListShell>

--- a/components/crm/records/deals-content.tsx
+++ b/components/crm/records/deals-content.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
 
-import { DataTable } from "@/components/ui/data-table";
+import { EntityLink } from "@/components/records/entity-link";
+import { RecordMark } from "@/components/records/record-mark";
+import { Building2, Calendar, Checklist, Coins, Funnel, Users } from "@/lib/icons";
 import { NumericCell } from "@/components/ui/numeric-cell";
 import { StatusChip } from "@/components/ui/status-chip";
 import { ClientDate } from "@/components/ui/client-date";
@@ -24,7 +24,9 @@ import { useVisibleColumns, type ColumnOption } from "@/lib/ui/visible-columns";
 import { DealFormSheet } from "./deal-form-sheet";
 import { PipelineSwitcher } from "./pipeline-switcher";
 import { RecordListShell } from "./record-list-shell";
-import { RecordList } from "./record-list";
+import { RecordList, RecordListPager } from "./record-list";
+import { RecordTable, RecordTableName, type RecordTableColumn } from "./record-table";
+import { LayoutSwitch, type RecordLayout } from "./layout-switch";
 
 const PAGE_SIZE = 50;
 
@@ -77,7 +79,7 @@ export function DealsContent({
   const pipelineId = pipelineIdProp ?? ownPipelineId;
   const setPipelineId = (next: string) =>
     onPickPipeline ? onPickPipeline(next) : setOwnPipelineId(next);
-  const [layout, setLayout] = useState<"BOARD" | "LIST">("BOARD");
+  const [layout, setLayout] = useState<RecordLayout>("BOARD");
 
   const pipelinesQuery = useQuery({
     queryKey: ["crm", "pipelines"],
@@ -112,79 +114,87 @@ export function DealsContent({
   const tableColumns = useVisibleColumns("crm.deals.table", DEAL_TABLE_COLUMNS);
   const boardFields = useVisibleColumns("crm.deals.board", DEAL_CARD_FIELDS);
 
-  const columns = useMemo<ColumnDef<CrmDealRecord>[]>(
+  const columns = useMemo<RecordTableColumn<CrmDealRecord>[]>(
     () => [
       {
         id: "deal",
-        header: "Deal",
-        size: 240,
-        cell: ({ row }) => (
-          <Link
-            href={`/crm/deals/${row.original.id}`}
-            className="block min-w-0 underline decoration-[var(--border)] underline-offset-2 hover:decoration-[var(--text-muted)]"
-          >
-            <div className="truncate font-medium">{row.original.title}</div>
-            <div className="truncate font-mono text-sm text-[var(--text-muted)]">
-              {row.original.dealNo}
-            </div>
-          </Link>
+        label: "Deal",
+        icon: Coins,
+        cell: (deal) => (
+          <RecordTableName
+            leading={<RecordMark kind="deal" name={deal.title} size="sm" />}
+            title={deal.title}
+            subtitle={<span className="font-mono">{deal.dealNo}</span>}
+          />
         ),
       },
       {
         id: "company",
-        header: "Company",
-        size: 190,
-        cell: ({ row }) => (
-          <div className="min-w-0">
-            <div className="truncate text-sm">{row.original.client?.name ?? "—"}</div>
-            {row.original.primaryContact ? (
-              <div className="truncate text-sm text-[var(--text-muted)]">
-                {row.original.primaryContact.fullName}
-              </div>
-            ) : null}
-          </div>
+        label: "Company",
+        icon: Building2,
+        width: "13rem",
+        cell: (deal) => (
+          // `block truncate` on the cell, not on the link: a company called
+          // "Chitungwiza Medical Centre" wrapped to two lines and made its row
+          // twice as tall as its neighbours, which is what turns a table back
+          // into a list.
+          <span className="block truncate">
+            {deal.client ? (
+              <EntityLink href={`/crm/companies/${deal.client.id}`}>{deal.client.name}</EntityLink>
+            ) : (
+              <span className="text-[var(--text-subtle)]">—</span>
+            )}
+          </span>
         ),
       },
       {
         id: "stage",
-        header: "Stage",
-        size: 170,
-        cell: ({ row }) => {
+        label: "Stage",
+        icon: Funnel,
+        width: "14rem",
+        cell: (deal) => {
           const stale = isDealStale(
-            { stageEnteredAt: row.original.stageEnteredAt, status: row.original.status },
-            { inactivityDays: row.original.stage.inactivityDays, status: row.original.stage.status },
+            { stageEnteredAt: deal.stageEnteredAt, status: deal.status },
+            { inactivityDays: deal.stage.inactivityDays, status: deal.stage.status },
           );
           return (
-            <div className="flex flex-wrap items-center gap-1.5">
+            <span className="flex flex-wrap items-center gap-1.5">
               <StatusChip
-                status={STATUS_PRESENTATION[row.original.stage.status] ?? "pending"}
-                label={row.original.stage.name}
+                status={STATUS_PRESENTATION[deal.stage.status] ?? "pending"}
+                label={deal.stage.name}
               />
               {stale ? (
                 <Badge variant="outline" className="text-sm text-[var(--status-warning-text)]">
                   Stale
                 </Badge>
               ) : null}
-            </div>
+            </span>
           );
         },
       },
       {
         id: "value",
-        header: "Value",
-        size: 130,
-        cell: ({ row }) => (
-          <NumericCell>{formatMoney(row.original.value, row.original.currency)}</NumericCell>
+        label: "Value",
+        icon: Coins,
+        width: "10rem",
+        align: "end",
+        cell: (deal) => (
+          // Nowrap, or "USD 36,000" breaks after the currency and the column
+          // reads as two stacked half-facts.
+          <NumericCell className="whitespace-nowrap">
+            {formatMoney(deal.value, deal.currency)}
+          </NumericCell>
         ),
       },
       {
         id: "close",
-        header: "Expected close",
-        size: 140,
-        cell: ({ row }) => (
-          <span className="text-sm text-[var(--text-muted)]">
-            {row.original.expectedCloseDate ? (
-              <ClientDate value={row.original.expectedCloseDate} mode="date" />
+        label: "Expected close",
+        icon: Calendar,
+        width: "9rem",
+        cell: (deal) => (
+          <span className="text-[var(--text-muted)]">
+            {deal.expectedCloseDate ? (
+              <ClientDate value={deal.expectedCloseDate} mode="date" />
             ) : (
               "—"
             )}
@@ -193,26 +203,30 @@ export function DealsContent({
       },
       {
         id: "owner",
-        header: "Owner",
-        size: 150,
-        cell: ({ row }) => (
-          <span className="truncate text-sm">{row.original.assignedTo?.name ?? "Unassigned"}</span>
+        label: "Owner",
+        icon: Users,
+        width: "10rem",
+        cell: (deal) => (
+          <span className="block truncate">
+            {deal.assignedTo?.name ?? <span className="text-[var(--text-subtle)]">Unassigned</span>}
+          </span>
         ),
       },
       {
         id: "next",
-        header: "Next task",
-        size: 180,
-        cell: ({ row }) =>
-          row.original.nextFollowUp ? (
-            <div className="min-w-0">
-              <div className="truncate text-sm">{row.original.nextFollowUp.title}</div>
-              <div className="truncate text-sm text-[var(--text-muted)]">
-                <ClientDate value={row.original.nextFollowUp.dueAt} />
-              </div>
-            </div>
+        label: "Next task",
+        icon: Checklist,
+        width: "12rem",
+        cell: (deal) =>
+          deal.nextFollowUp ? (
+            <span className="block min-w-0">
+              <span className="block truncate">{deal.nextFollowUp.title}</span>
+              <span className="block truncate text-sm text-[var(--text-muted)]">
+                <ClientDate value={deal.nextFollowUp.dueAt} />
+              </span>
+            </span>
           ) : (
-            <span className="text-sm text-[var(--text-muted)]">—</span>
+            <span className="text-[var(--text-subtle)]">—</span>
           ),
       },
     ],
@@ -220,7 +234,7 @@ export function DealsContent({
   );
 
   const visibleColumns = useMemo(
-    () => columns.filter((column) => tableColumns.isVisible(String(column.id))),
+    () => columns.filter((column) => tableColumns.isVisible(column.id)),
     [columns, tableColumns],
   );
 
@@ -268,18 +282,9 @@ export function DealsContent({
             onPickPipeline={setPipelineId}
           />
 
-          <SegmentedControl
-            value={layout}
-            onValueChange={(value) => setLayout(value as typeof layout)}
-            ariaLabel="Board or list"
-            options={[
-              { value: "BOARD", label: "Board" },
-              { value: "LIST", label: "List" },
-            ]}
-          />
-
         </>
       }
+      layout={<LayoutSwitch value={layout} onChange={setLayout} options={["BOARD", "TABLE"]} />}
     >
       {layout === "BOARD" ? (
         <BoardFieldsProvider hidden={boardFields.hidden}>
@@ -290,53 +295,48 @@ export function DealsContent({
           />
         </BoardFieldsProvider>
       ) : (
-      <DataTable
-        // The shell above owns search; a second box in the table toolbar is the
-        // duplicate-control failure the cookbook's one-filter-pathway rule exists to stop.
-        features={{ globalFilter: false }}
-        data={rows}
-        columns={visibleColumns}
-        edgeToEdge
-        stickyHeader
-        queryState={{ mode: "paginated", page, pageSize: PAGE_SIZE }}
-        onQueryStateChange={(next) => {
-          if (next.page && next.page !== page) setPage(next.page);
-        }}
-        pagination={{
-          enabled: true,
-          server: true,
-          total,
-          totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-        }}
-        // On a phone the table becomes the same list every other CRM surface
-        // uses: one row per deal, two lines inside it, rows separated by
-        // whitespace. The value moves to the right of the row rather than
-        // taking a third line of its own.
-        mobileListRenderer={({ rows: mobileRows }) => (
-          <RecordList
-            rows={mobileRows.map(({ row }) => ({
-              id: row.id,
-              href: `/crm/deals/${row.id}`,
-              title: row.title,
-              subtitle: `${row.dealNo} · ${row.client?.name ?? "No company"}`,
-              status: (
-                <StatusChip
-                  status={STATUS_PRESENTATION[row.stage.status] ?? "pending"}
-                  label={row.stage.name}
-                />
-              ),
-              facts: [{ value: formatMoney(row.value, row.currency), mono: true, primary: true }],
-            }))}
+        <>
+          <RecordTable
+            rows={rows}
+            columns={visibleColumns}
+            rowHref={(deal) => `/crm/deals/${deal.id}`}
+            isLoading={dealsQuery.isLoading}
+            emptyTitle={
+              statusFilter === "OPEN" ? "No open deals" : "No deals match this filter"
+            }
+            emptyBody={
+              statusFilter === "OPEN" ? "Convert a qualified lead to start one." : undefined
+            }
+            // On a phone the same deals come back as the rows every other CRM
+            // surface uses: two lines, and the value on the right of the title
+            // rather than on a third line of its own.
+            mobile={
+              <RecordList
+                isLoading={dealsQuery.isLoading}
+                rows={rows.map((row) => ({
+                  id: row.id,
+                  href: `/crm/deals/${row.id}`,
+                  title: row.title,
+                  subtitle: `${row.dealNo} · ${row.client?.name ?? "No company"}`,
+                  status: (
+                    <StatusChip
+                      status={STATUS_PRESENTATION[row.stage.status] ?? "pending"}
+                      label={row.stage.name}
+                    />
+                  ),
+                  facts: [
+                    { value: formatMoney(row.value, row.currency), mono: true, primary: true },
+                  ],
+                }))}
+                emptyTitle={
+                  statusFilter === "OPEN" ? "No open deals" : "No deals match this filter"
+                }
+              />
+            }
           />
-        )}
-        emptyState={
-          dealsQuery.isLoading
-            ? "Loading deals…"
-            : statusFilter === "OPEN"
-              ? "No open deals. Convert a qualified lead to start one."
-              : "No deals match this filter."
-        }
-      />
+
+          <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
+        </>
       )}
 
       <DealFormSheet open={createOpen} onOpenChange={setCreateOpen} />

--- a/components/crm/records/layout-switch.tsx
+++ b/components/crm/records/layout-switch.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Kanban, ListBullets, TableRows, type LucideIcon } from "@/lib/icons";
+
+/**
+ * How you are looking at a list: as a table, as rows, or as a board.
+ *
+ * Every CRM list grew its own version of this control, with its own wording and
+ * its own order — "Board / List" on deals, "List / Board" on people, nothing at
+ * all on sites. Which meant the first control on every list page was in a
+ * different place and said a different thing, and switching pages cost a read.
+ *
+ * One control, one order, one vocabulary, and it is always the leftmost thing
+ * in the options row — because "what am I looking at" comes before "how is it
+ * narrowed", which comes before "how do I find one".
+ *
+ * The label is dropped on narrow screens and the mark carries it, which is what
+ * lets three views sit in a row that also has to hold filters and a search box.
+ */
+
+export type RecordLayout = "TABLE" | "LIST" | "BOARD";
+
+const LAYOUT: Record<RecordLayout, { label: string; icon: LucideIcon }> = {
+  TABLE: { label: "Table", icon: TableRows },
+  LIST: { label: "List", icon: ListBullets },
+  BOARD: { label: "Board", icon: Kanban },
+};
+
+export function LayoutSwitch<L extends RecordLayout>({
+  value,
+  onChange,
+  options,
+}: {
+  value: L;
+  onChange: (next: L) => void;
+  /** Which arrangements this list has. A directory with no stages has no board. */
+  options: readonly L[];
+}) {
+  return (
+    <SegmentedControl<L>
+      value={value}
+      onValueChange={onChange}
+      ariaLabel="How the records are arranged"
+      options={options.map((option) => {
+        const Icon = LAYOUT[option].icon;
+        return {
+          value: option,
+          label: (
+            <span className="flex items-center gap-1.5">
+              <Icon className="size-4 shrink-0" aria-hidden="true" />
+              {/* Readable where there is room, and never the reason the row
+                  wraps where there is not. The control keeps its accessible
+                  name either way — the segment's text is still in the DOM at
+                  every width, just not painted. */}
+              <span className="hidden lg:inline">{LAYOUT[option].label}</span>
+              <span className="sr-only lg:hidden">{LAYOUT[option].label}</span>
+            </span>
+          ),
+        };
+      })}
+    />
+  );
+}

--- a/components/crm/records/layout-switch.tsx
+++ b/components/crm/records/layout-switch.tsx
@@ -50,11 +50,20 @@ export function LayoutSwitch<L extends RecordLayout>({
             <span className="flex items-center gap-1.5">
               <Icon className="size-4 shrink-0" aria-hidden="true" />
               {/* Readable where there is room, and never the reason the row
-                  wraps where there is not. The control keeps its accessible
-                  name either way — the segment's text is still in the DOM at
-                  every width, just not painted. */}
-              <span className="hidden lg:inline">{LAYOUT[option].label}</span>
-              <span className="sr-only lg:hidden">{LAYOUT[option].label}</span>
+                  runs out of it where there is not.
+                  ─────────────────────────────────────────────────────────
+                  Visible below `sm` because below `sm` this is not in the
+                  toolbar at all — it is stacked full width inside the view
+                  sheet, where two unlabelled icons are a guess. Hidden from
+                  `sm` to `lg`, which is the narrow-desktop toolbar with six
+                  controls to fit. Back from `lg`, where there is room.
+                  The painted label is decorative and the `sr-only` one is the
+                  accessible name, so the segment is announced the same at
+                  every width and never announced twice. */}
+              <span aria-hidden="true" className="sm:hidden lg:inline">
+                {LAYOUT[option].label}
+              </span>
+              <span className="sr-only">{LAYOUT[option].label}</span>
             </span>
           ),
         };

--- a/components/crm/records/people-content.tsx
+++ b/components/crm/records/people-content.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Badge, Button } from "@corelithzw/react";
-import { SegmentedControl } from "@/components/ui/segmented-control";
+import { EntityLink } from "@/components/records/entity-link";
+import { Building2, Coins, Funnel, Mail, UserRound, Users } from "@/lib/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +20,8 @@ import { useDebounced } from "@/hooks/use-debounced";
 
 import { PersonFormSheet } from "./person-form-sheet";
 import { RecordListPager, type RecordListRow } from "./record-list";
+import { RecordTable, RecordTableName, type RecordTableColumn } from "./record-table";
+import { LayoutSwitch, type RecordLayout } from "./layout-switch";
 import { RecordMark } from "@/components/records/record-mark";
 import { RecordBoard } from "./record-board";
 import { ColumnPicker } from "@/components/ui/column-picker";
@@ -77,7 +80,7 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
   const people = useMemo(() => peopleQuery.data?.data ?? [], [peopleQuery.data]);
   const total = peopleQuery.data?.pagination?.total ?? people.length;
 
-  const [layout, setLayout] = useState<"LIST" | "BOARD">("LIST");
+  const [layout, setLayout] = useState<RecordLayout>("TABLE");
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -253,6 +256,130 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
       }),
   });
 
+  /**
+   * The same people, arranged as columns.
+   *
+   * The picker's fields drive both arrangements, so hiding "Owner" hides it in
+   * the table and in the rows — otherwise the control means one thing on one
+   * view and nothing on the other. The name column is never hidden; a table of
+   * anonymous rows is not a table.
+   */
+  const columns = useMemo<RecordTableColumn<(typeof people)[number]>[]>(
+    () => [
+      {
+        id: "name",
+        label: "Name",
+        icon: UserRound,
+        cell: (person) => (
+          <RecordTableName
+            leading={
+              <RecordMark
+                kind="person"
+                name={person.fullName}
+                emoji={person.emoji}
+                avatarUrl={person.avatarUrl}
+                size="sm"
+              />
+            }
+            title={person.fullName}
+            subtitle={fields.isVisible("role") ? person.jobTitle : null}
+          />
+        ),
+      },
+      ...(fields.isVisible("role")
+        ? [
+            {
+              id: "company",
+              label: "Company",
+              icon: Building2,
+              width: "13rem",
+              cell: (person: (typeof people)[number]) => (
+                // `block truncate` on the cell rather than the link: a long
+                // company name wrapped to two lines and made its row twice as
+                // tall as its neighbours.
+                <span className="block truncate">
+                  {person.client ? (
+                    // A related record, so it peeks rather than navigates: the
+                    // point of a directory is to stay in it while you check who
+                    // somebody works for.
+                    <EntityLink href={`/crm/companies/${person.client.id}`}>
+                      {person.client.name}
+                    </EntityLink>
+                  ) : (
+                    <span className="text-[var(--text-subtle)]">—</span>
+                  )}
+                </span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("contact")
+        ? [
+            {
+              id: "contact",
+              label: "Contact",
+              icon: Mail,
+              width: "14rem",
+              cell: (person: (typeof people)[number]) => (
+                <span className="block truncate text-[var(--text-body)]">
+                  {person.email ?? person.phone ?? "—"}
+                </span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("type")
+        ? [
+            {
+              id: "type",
+              label: "Type",
+              icon: Funnel,
+              width: "10rem",
+              cell: (person: (typeof people)[number]) => (
+                <Badge tone="neutral" size="sm">
+                  {CONTACT_TYPE_LABELS[person.contactType] ?? person.contactType}
+                </Badge>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("deals")
+        ? [
+            {
+              id: "deals",
+              label: "Deals",
+              icon: Coins,
+              width: "6rem",
+              align: "end" as const,
+              cell: (person: (typeof people)[number]) => (
+                <span className="font-mono tabular-nums">
+                  {person._count?.dealContacts ?? 0}
+                </span>
+              ),
+            },
+          ]
+        : []),
+      ...(fields.isVisible("owner")
+        ? [
+            {
+              id: "owner",
+              label: "Owner",
+              icon: Users,
+              width: "11rem",
+              cell: (person: (typeof people)[number]) => (
+                <span className="block truncate">
+                  {person.assignedTo?.name ?? (
+                    <span className="text-[var(--text-subtle)]">Unassigned</span>
+                  )}
+                </span>
+              ),
+            },
+          ]
+        : []),
+    ],
+    [fields],
+  );
+
   const sections = useMemo<RecordListSection[]>(
     () =>
       bucketByLetter(rows, (row) => String(row.title ?? "")).map((bucket) => ({
@@ -261,6 +388,61 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
         rows: bucket.items,
       })),
     [rows],
+  );
+
+  // One selection, whichever way the records are arranged. Written once here
+  // rather than inline in each branch, because two copies of a bulk action are
+  // two chances for the table's version to keep working after the list's has
+  // been changed.
+  const selection = {
+    selectedIds,
+    onChange: setSelectedIds,
+    actions: ({ ids, clear }: { ids: string[]; clear: () => void }) => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" size="sm">
+            Assign owner
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
+          {owners.map((owner) => (
+            <DropdownMenuItem
+              key={owner.id}
+              onClick={() => assign.mutate({ ids, assignedToId: owner.id, clear })}
+            >
+              {owner.name ?? "Unnamed"}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuItem onClick={() => assign.mutate({ ids, assignedToId: null, clear })}>
+            Leave unassigned
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  };
+
+  // The rows arrangement, which is also what the table falls back to on a
+  // phone — so it is written once and used twice rather than diverging.
+  const directory = (
+    <GroupedRecordList
+      selection={selection}
+      sections={debouncedSearch ? [{ id: "results", label: "Results", rows }] : sections}
+      showJumpStrip={!debouncedSearch && rows.length >= 30}
+      isLoading={peopleQuery.isLoading}
+      emptyTitle={debouncedSearch ? "No people match that search" : "No people yet"}
+      emptyBody={
+        debouncedSearch
+          ? undefined
+          : "Add someone, or convert a lead and its contact comes with it."
+      }
+      emptyAction={
+        debouncedSearch ? undefined : (
+          <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+            Add the first person
+          </Button>
+        )
+      }
+    />
   );
 
   return (
@@ -282,18 +464,8 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
           label={layout === "BOARD" ? "Fields" : "Columns"}
         />
       }
-      filters={
-        <>
-          <SegmentedControl
-            value={layout}
-            onValueChange={(value) => setLayout(value as typeof layout)}
-            ariaLabel="List or board"
-            options={[
-              { value: "LIST", label: "List" },
-              { value: "BOARD", label: "Board" },
-            ]}
-          />
-        </>
+      layout={
+        <LayoutSwitch value={layout} onChange={setLayout} options={["TABLE", "LIST", "BOARD"]} />
       }
     >
       {layout === "BOARD" ? (
@@ -306,59 +478,28 @@ export function PeopleContent({ openCreate = false }: { openCreate?: boolean }) 
           onMove={(id, contactType) => moveContactType.mutate({ id, contactType })}
           className="min-h-[24rem]"
         />
+      ) : layout === "TABLE" ? (
+        <RecordTable
+          rows={people}
+          columns={columns}
+          rowHref={(person) => `/crm/people/${person.id}`}
+          isLoading={peopleQuery.isLoading}
+          selection={selection}
+          emptyTitle={debouncedSearch ? "No people match that search" : "No people yet"}
+          emptyBody={
+            debouncedSearch
+              ? undefined
+              : "Add someone, or convert a lead and its contact comes with it."
+          }
+          mobile={directory}
+        />
       ) : (
-      <GroupedRecordList
-        selection={{
-          selectedIds,
-          onChange: setSelectedIds,
-          actions: ({ ids, clear }) => (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="secondary" size="sm">
-                  Assign owner
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
-                {owners.map((owner) => (
-                  <DropdownMenuItem
-                    key={owner.id}
-                    onClick={() => assign.mutate({ ids, assignedToId: owner.id, clear })}
-                  >
-                    {owner.name ?? "Unnamed"}
-                  </DropdownMenuItem>
-                ))}
-                <DropdownMenuItem
-                  onClick={() => assign.mutate({ ids, assignedToId: null, clear })}
-                >
-                  Leave unassigned
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ),
-        }}
-        sections={debouncedSearch ? [{ id: "results", label: "Results", rows }] : sections}
-        showJumpStrip={!debouncedSearch && rows.length >= 30}
-        isLoading={peopleQuery.isLoading}
-        emptyTitle={debouncedSearch ? "No people match that search" : "No people yet"}
-        emptyBody={
-          debouncedSearch
-            ? undefined
-            : "Add someone, or convert a lead and its contact comes with it."
-        }
-        emptyAction={
-          debouncedSearch ? undefined : (
-            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
-              Add the first person
-            </Button>
-          )
-        }
-      />
-
+        directory
       )}
 
-      {layout === "LIST" ? (
+      {layout === "BOARD" ? null : (
         <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
-      ) : null}
+      )}
 
       <PersonFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </RecordListShell>

--- a/components/crm/records/record-list-shell.tsx
+++ b/components/crm/records/record-list-shell.tsx
@@ -28,6 +28,7 @@ export function RecordListShell({
   onSearchChange,
   searchPlaceholder,
   searchNoun,
+  layout,
   filters,
   display,
   createLabel,
@@ -46,6 +47,12 @@ export function RecordListShell({
    * where the title is not what the rows are ("Collections" holding invoices).
    */
   searchNoun?: string;
+  /**
+   * The layout switch — `LayoutSwitch`, on every list that has more than one
+   * arrangement. Separate from `filters` so the toolbar can put the rule in the
+   * right place without a page having to remember to.
+   */
+  layout?: ReactNode;
   filters?: ReactNode;
   /** Display controls — column picker, card fields — right-aligned with search. */
   display?: ReactNode;
@@ -81,6 +88,7 @@ export function RecordListShell({
       <PageChrome title={title}>{actions}</PageChrome>
 
       <ViewToolbar
+        layout={layout}
         start={filters}
         search={
           <ListSearch

--- a/components/crm/records/record-story.tsx
+++ b/components/crm/records/record-story.tsx
@@ -4,9 +4,8 @@ import { useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
 
 import { Avatar } from "@corelithzw/react";
 import { Button } from "@/components/ui/button";
-import { FileText } from "@/lib/icons";
+import { ChevronDown, ChevronRight, FileText } from "@/lib/icons";
 import {
-  EVENT_KIND,
   QUIET_KINDS,
   type EventKind,
   eventKindStyle,
@@ -67,13 +66,40 @@ export type StoryEvent = {
   href?: string;
 };
 
-/** Events that carry a body worth boxing rather than running as one line. */
+/**
+ * Events that carry a body worth boxing rather than running as one line.
+ *
+ * Every kind somebody *writes prose into*, not a hand-picked few. With only
+ * email boxed, a feed alternated between a framed paragraph and an unframed one
+ * for two things that are the same thing — a message — and the frame stopped
+ * meaning "somebody said this" and started meaning "this one happened to be an
+ * email". The accent on the box's leading edge is what tells the kinds apart;
+ * the box itself only says there are words in here.
+ */
 const BOXED: ReadonlySet<EventKind> = new Set([
   "email",
   "note",
   "comment",
   "visit",
+  "call",
+  "whatsapp",
+  "meeting",
 ]);
+
+/**
+ * The kinds that fold away.
+ *
+ * Deliberately narrower than `QUIET_KINDS`. Quiet means "read this second";
+ * this means "you do not have to read it at all unless you ask", and only two
+ * kinds earn that: a stage move and a system line. A raised quotation is quiet
+ * *and* it is the reason somebody opened the record — hiding it behind a
+ * disclosure would answer "what happened here" with a button.
+ *
+ * A run of one is left alone. Replacing a single grey line with a single grey
+ * control that reveals it is not a saving.
+ */
+const FOLDABLE: ReadonlySet<EventKind> = new Set(["stage", "system"]);
+const FOLD_FROM = 2;
 
 function dayKey(iso: string): string {
   return new Date(iso).toISOString().slice(0, 10);
@@ -92,42 +118,110 @@ function dayLabel(iso: string, now: Date): string {
   });
 }
 
+/**
+ * The rail and the mark, which every row in the feed shares.
+ *
+ * `data-accent` is how the design system swaps a hue — it rebinds `--accent-*`
+ * on this element, so the classes stay static and only the attribute changes.
+ *
+ * Solid, not a tint inside a ring. A 24px disc has room for one thing, and a
+ * pale wash behind a pale glyph inside a pale outline spends all three on the
+ * same weak signal — at arm's length the whole rail read as one grey column
+ * again. `.solid-mark` owns the fill-and-glyph pairing for every mark in the
+ * product; see `globals.css` for why three of the thirteen hues are darkened
+ * rather than reversed.
+ */
+function StoryMark({
+  accent,
+  title,
+  children,
+}: {
+  accent: string;
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      data-accent={accent}
+      title={title}
+      className="solid-mark relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
+    >
+      {children}
+    </span>
+  );
+}
+
+/** The vertical line behind the marks, drawn per row so the last one stops. */
+function StoryRail() {
+  return (
+    <span
+      aria-hidden="true"
+      className="absolute bottom-0 left-[11px] top-6 w-px bg-[var(--border-subtle)]"
+    />
+  );
+}
+
 function StoryRow({ event }: { event: StoryEvent }) {
-  const { icon: Icon, accent } = eventKindStyle(event.kind);
+  const { icon: Icon, accent, label } = eventKindStyle(event.kind);
   const quiet = QUIET_KINDS.has(event.kind);
   const boxed = BOXED.has(event.kind) && Boolean(event.body);
 
-  const content = (
-    <>
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+  /**
+   * Who, what and when, on one line above whatever they wrote.
+   *
+   * This used to run inline with the body: avatar, then the sentence, then the
+   * time, then the prose underneath, all in one paragraph-shaped block. Which
+   * meant the two facts a reader scans a feed for — who is talking and when —
+   * were mixed into the same visual run as the thing they said, and finding
+   * "the last time the client emailed" meant reading every row.
+   *
+   * Split out, the header is a fixed shape that repeats down the feed and the
+   * body is free to be any length without moving it.
+   */
+  const header = (
+    <div className="flex items-center gap-2">
+      {event.actorName ? (
+        // Coloured by who wrote it, not by what kind of event it is — that
+        // second channel is the mark on the rail. The design system hashes the
+        // name for us, so two colleagues in one day's worth of rows come out as
+        // two colours rather than two identical discs.
+        <Avatar size="sm" name={event.actorName} solid />
+      ) : null}
+
+      <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
         {event.actorName ? (
-          // Coloured by who wrote it, not by what kind of event it is — that
-          // second channel is the chip on the rail. The design system hashes
-          // the name for us, so two colleagues in one day's worth of rows come
-          // out as two colours rather than two identical discs. Solid, to match
-          // the chip beside it.
-          <Avatar size="sm" name={event.actorName} solid />
+          <span className="text-sm font-medium text-[var(--text-strong)]">{event.actorName}</span>
         ) : null}
+        {/* With an author beside it the title is the *kind* — "Email", "Note" —
+            so it reads as a label rather than repeating the name the avatar
+            already carries. Without one it is the whole sentence. */}
         <span
           className={cn(
-            "text-sm",
-            quiet ? "text-[var(--text-muted)]" : "font-medium text-[var(--text-strong)]",
+            "min-w-0 text-sm",
+            event.actorName || quiet
+              ? "text-[var(--text-muted)]"
+              : "font-medium text-[var(--text-strong)]",
           )}
         >
           {event.title}
         </span>
-        {/* The day is already the section heading, so the row only needs the
-            time of day — a full "8/4/2026, 9:06:53 PM" on every one of a
-            hundred rows repeats the heading and adds a second nobody reads. */}
-        <span className="text-sm tabular-nums text-[var(--text-subtle)]">
-          <ClientTime value={event.occurredAt} />
-        </span>
-      </div>
+      </span>
+
+      {/* The day is already the section heading, so the row only needs the
+          time of day — a full "8/4/2026, 9:06:53 PM" on every one of a hundred
+          rows repeats the heading and adds a second nobody reads. */}
+      <span className="shrink-0 text-sm tabular-nums text-[var(--text-subtle)]">
+        <ClientTime value={event.occurredAt} />
+      </span>
+    </div>
+  );
+
+  const content = (
+    <>
+      {header}
 
       {event.participants && event.participants.length > 0 ? (
-        <p className="mt-0.5 text-sm text-[var(--text-muted)]">
-          {event.participants.join(", ")}
-        </p>
+        <p className="mt-1 text-sm text-[var(--text-muted)]">{event.participants.join(", ")}</p>
       ) : null}
 
       {event.body ? (
@@ -136,7 +230,7 @@ function StoryRow({ event }: { event: StoryEvent }) {
         // it does in the comment thread it might have been written in.
         <RichTextRenderer
           body={event.body}
-          className={cn("mt-1", quiet && "text-[var(--text-muted)]")}
+          className={cn("mt-1.5", quiet && "text-[var(--text-muted)]")}
         />
       ) : null}
 
@@ -165,31 +259,11 @@ function StoryRow({ event }: { event: StoryEvent }) {
   );
 
   return (
-    <li className="relative flex gap-3 pb-4 last:pb-0">
-      {/* The rail. Drawn per row rather than once behind the list so the last
-          row's line stops at its own icon instead of running into the gap. */}
-      <span
-        aria-hidden="true"
-        className="absolute bottom-0 left-[11px] top-6 w-px bg-[var(--border-subtle)] last:hidden"
-      />
-
-      {/* The kind, as a colour and a glyph. `data-accent` is how the design
-          system swaps a hue — it rebinds `--accent-*` on this element, so the
-          classes below stay static and only the attribute changes.
-
-          Solid, not a tint inside a ring. A 24px disc has room for one thing,
-          and a pale wash behind a pale glyph inside a pale outline spends all
-          three on the same weak signal — at arm's length the whole rail read as
-          one grey column again. `.solid-mark` owns the fill-and-glyph pairing
-          for every mark in the product; see `globals.css` for why three of the
-          thirteen hues are darkened rather than reversed. */}
-      <span
-        data-accent={accent}
-        title={EVENT_KIND[event.kind]?.label}
-        className="solid-mark relative z-10 mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
-      >
+    <li className="relative flex gap-3 pb-3 last:pb-0">
+      <StoryRail />
+      <StoryMark accent={accent} title={label}>
         <Icon className="size-3.5" />
-      </span>
+      </StoryMark>
 
       <div className="min-w-0 flex-1">
         {boxed ? (
@@ -199,16 +273,99 @@ function StoryRow({ event }: { event: StoryEvent }) {
           // without reading a word of any of them.
           <div
             data-accent={accent}
-            className="rounded-[var(--card-radius)] border border-[var(--border)] border-l-2 border-l-[var(--accent-solid)] p-3"
+            className="rounded-[var(--card-radius)] border border-[var(--border)] border-l-2 border-l-[var(--accent-solid)] bg-[var(--surface-base)] p-3"
           >
             {content}
           </div>
         ) : (
-          content
+          <div className="py-0.5">{content}</div>
         )}
       </div>
     </li>
   );
+}
+
+/**
+ * A run of mechanical changes, folded into one line.
+ *
+ * A record worked for a year carries hundreds of "Stage changed to Quoted"
+ * rows, and they sit between the things somebody actually said. Each one is
+ * worth having and none of them is worth a row of its own on the way past —
+ * which is exactly what a disclosure is for. Closed it says how many; open it
+ * is the same rows it always was, in the same order, on the same rail.
+ */
+function FoldedRun({ events }: { events: StoryEvent[] }) {
+  const [open, setOpen] = useState(false);
+
+  if (open) {
+    return (
+      <>
+        {events.map((event) => (
+          <StoryRow key={`${event.kind}-${event.id}`} event={event} />
+        ))}
+        <li className="relative flex gap-3 pb-3">
+          <StoryRail />
+          <span className="w-6 shrink-0" aria-hidden="true" />
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="inline-flex items-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--text)]"
+          >
+            <ChevronDown className="size-3.5" aria-hidden="true" />
+            Hide {events.length} changes
+          </button>
+        </li>
+      </>
+    );
+  }
+
+  return (
+    <li className="relative flex gap-3 pb-3 last:pb-0">
+      <StoryRail />
+      {/* The same 24px disc the rows use, so the fold sits on the rail rather
+          than beside it — a gap in the line reads as a gap in the record. */}
+      <StoryMark accent="gray">
+        <ChevronRight className="size-3.5" />
+      </StoryMark>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="min-w-0 flex-1 py-0.5 text-left text-sm text-[var(--text-muted)] hover:text-[var(--text)] hover:underline"
+      >
+        View {events.length} changes
+      </button>
+    </li>
+  );
+}
+
+/**
+ * A day's events, with runs of mechanical ones folded.
+ *
+ * Folding within the day rather than across it, because the day heading is what
+ * gives every row its date — a run that spanned midnight would be one control
+ * hiding two different days.
+ */
+function foldRuns(events: StoryEvent[]): Array<StoryEvent | StoryEvent[]> {
+  const out: Array<StoryEvent | StoryEvent[]> = [];
+  let run: StoryEvent[] = [];
+
+  const flush = () => {
+    if (run.length >= FOLD_FROM) out.push(run);
+    else out.push(...run);
+    run = [];
+  };
+
+  for (const event of events) {
+    if (FOLDABLE.has(event.kind)) {
+      run.push(event);
+      continue;
+    }
+    flush();
+    out.push(event);
+  }
+  flush();
+
+  return out;
 }
 
 /**
@@ -241,7 +398,11 @@ export function RecordStory({
       if (bucket) bucket.push(event);
       else map.set(key, [event]);
     }
-    return [...map.entries()];
+    return [...map.entries()].map(([key, entries]) => ({
+      key,
+      entries,
+      items: foldRuns(entries),
+    }));
   }, [events, visible]);
 
   if (events.length === 0) {
@@ -256,13 +417,24 @@ export function RecordStory({
     <div className="space-y-5">
       {header}
 
-      {groups.map(([key, entries]) => (
-        <section key={key} className="space-y-2">
-          <h4 className="text-sm font-semibold">{dayLabel(entries[0].occurredAt, now)}</h4>
+      {groups.map((group) => (
+        <section key={group.key} className="space-y-2">
+          {/* The date, with the rule running off to the right of it. A bare
+              bold word between two runs of rows reads as another row; a rule
+              says "everything below me is this day" without shouting it. */}
+          <h4 className="flex items-center gap-3 text-sm font-semibold text-[var(--text-strong)]">
+            {dayLabel(group.entries[0].occurredAt, now)}
+            <span className="h-px flex-1 bg-[var(--border-subtle)]" aria-hidden="true" />
+          </h4>
+
           <ul className="relative">
-            {entries.map((event) => (
-              <StoryRow key={`${event.kind}-${event.id}`} event={event} />
-            ))}
+            {group.items.map((item, index) =>
+              Array.isArray(item) ? (
+                <FoldedRun key={`fold-${group.key}-${index}`} events={item} />
+              ) : (
+                <StoryRow key={`${item.kind}-${item.id}`} event={item} />
+              ),
+            )}
           </ul>
         </section>
       ))}

--- a/components/crm/records/record-table.tsx
+++ b/components/crm/records/record-table.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+import { EmptyState, Skeleton } from "@corelithzw/react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DataTableFloatingActions } from "@/components/ui/data-table-floating-actions";
+import type { LucideIcon } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * The CRM's table view.
+ *
+ * A record list has always been rows you open — a title, a supporting line, a
+ * fact or two on the right — and that is the right shape when you are looking
+ * for one thing. It is the wrong shape when you are looking *across* things:
+ * "which of these are unassigned", "who is on hold", "what is closing this
+ * month". Those are column questions, and a stack of two-line rows cannot
+ * answer them because the facts never line up.
+ *
+ * So the same records get a second arrangement rather than a second page. The
+ * grammar is deliberately narrow and shared by every list in the module:
+ *
+ *   - one header row, quiet, with the column's own mark beside its name, so a
+ *     scan down a column knows what it is looking at without reading the head;
+ *   - one line per record, 44px, because a table you can also use with a thumb
+ *     is worth more than one that fits six more rows;
+ *   - the first column is the record, and it is the link. Nothing else in the
+ *     row navigates, so a cell can hold a chip, an avatar or a figure without
+ *     any of them becoming an accidental target.
+ *
+ * `DataTable` is still the right component for a grid you *work* — sorting,
+ * grouping, expandable detail rows, column resizing. This is the presentation
+ * half of that only, over data a parent already has, which is what lets people,
+ * companies, sites and deals share one look for about twelve lines each.
+ */
+
+export type RecordTableColumn<T> = {
+  id: string;
+  label: string;
+  /** The column's mark, beside its name in the header. */
+  icon?: LucideIcon;
+  /**
+   * A fixed width, e.g. `"12rem"`. The first column is normally left to take
+   * whatever is left over — it holds the name, which is the one thing worth
+   * giving the slack to.
+   */
+  width?: string;
+  /** Numbers and money hang off the right edge so their digits line up. */
+  align?: "start" | "end";
+  cell: (row: T) => ReactNode;
+};
+
+export function RecordTable<T extends { id: string }>({
+  rows,
+  columns,
+  rowHref,
+  isLoading,
+  emptyTitle = "Nothing here yet",
+  emptyBody,
+  emptyAction,
+  selection,
+  mobile,
+  className,
+}: {
+  rows: T[];
+  columns: RecordTableColumn<T>[];
+  /** Where the first cell points. The rest of the row is inert on purpose. */
+  rowHref: (row: T) => string;
+  /**
+   * What a phone gets instead.
+   *
+   * Seven columns at 390px is a sideways scroll where every screen shows one
+   * and a half of them, which is not a table — it is a table you have to
+   * operate. So below `md` the same records come back as the rows the rest of
+   * the module uses. Rendered here rather than at each call site because four
+   * lists each remembering to do it is four lists where one of them forgets.
+   */
+  mobile?: ReactNode;
+  isLoading?: boolean;
+  emptyTitle?: string;
+  emptyBody?: string;
+  emptyAction?: ReactNode;
+  className?: string;
+  /** Turns on the leading checkbox column and the floating action bar. */
+  selection?: {
+    selectedIds: string[];
+    onChange: (next: string[]) => void;
+    actions?: (context: { ids: string[]; clear: () => void }) => ReactNode;
+  };
+}) {
+  // Before the loading and empty branches, so a phone gets the row list's own
+  // skeleton and empty state rather than the table's.
+  if (mobile) {
+    return (
+      <>
+        <div className="hidden md:block">
+          <RecordTable
+            rows={rows}
+            columns={columns}
+            rowHref={rowHref}
+            isLoading={isLoading}
+            emptyTitle={emptyTitle}
+            emptyBody={emptyBody}
+            emptyAction={emptyAction}
+            selection={selection}
+            className={className}
+          />
+        </div>
+        <div className="md:hidden">{mobile}</div>
+      </>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-1.5" aria-busy="true" aria-live="polite">
+        <Skeleton height={36} />
+        <Skeleton height={36} />
+        <Skeleton height={36} />
+        <Skeleton height={36} />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return <EmptyState title={emptyTitle} body={emptyBody} action={emptyAction} />;
+  }
+
+  const selectedIds = selection?.selectedIds ?? [];
+  const allSelected = rows.length > 0 && rows.every((row) => selectedIds.includes(row.id));
+
+  const toggleAll = () =>
+    selection?.onChange(
+      allSelected
+        ? selectedIds.filter((id) => !rows.some((row) => row.id === id))
+        : [...new Set([...selectedIds, ...rows.map((row) => row.id)])],
+    );
+
+  const toggle = (id: string) =>
+    selection?.onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((entry) => entry !== id)
+        : [...selectedIds, id],
+    );
+
+  return (
+    <>
+      {/* The table scrolls sideways inside its own box rather than pushing the
+          page wider. Seven columns do not fit a 1280px laptop once the sidebar
+          has had its share, and a page that scrolls horizontally takes the
+          toolbar and the app bar with it.
+          ────────────────────────────────────────────────────────────────────
+          …except where there is room, and then it must not, because of a rule
+          that costs an hour to rediscover: an `overflow-x: auto` box computes
+          `overflow-y` to `auto` as well, which makes it the scrolling ancestor
+          for everything inside it. A `position: sticky` header then sticks to a
+          box that never scrolls vertically — so it silently does nothing, and
+          the header scrolls away with the rows.
+          So the clamp is dropped once this element is wide enough to hold the
+          table (46rem of columns, plus the name column's share), and only then
+          is the header sticky against the page the way it looks like it should
+          be. Narrower than that, the table scrolls and the header goes with it,
+          which is the honest trade. */}
+      <div className={cn("@container", className)}>
+        <div className="overflow-x-auto @5xl:overflow-visible">
+        {/* `border-separate` rather than `border-collapse`: a collapsed border
+            is owned by the table, and a sticky header carries none of it with
+            it — the head detaches and floats over the rows with no seam. */}
+        <table className="w-full min-w-[46rem] border-separate border-spacing-0 text-left">
+          <thead>
+            <tr>
+              {selection ? (
+                <th
+                  scope="col"
+                  className="w-10 border-b border-[var(--border-subtle)] bg-surface-base px-2 py-2 @5xl:sticky @5xl:top-[var(--list-toolbar-h)] @5xl:z-[2]"
+                >
+                  <Checkbox
+                    checked={allSelected}
+                    onCheckedChange={toggleAll}
+                    aria-label={allSelected ? "Clear selection" : "Select every row"}
+                  />
+                </th>
+              ) : null}
+
+              {columns.map((column) => {
+                const Icon = column.icon;
+                return (
+                  <th
+                    key={column.id}
+                    scope="col"
+                    style={column.width ? { width: column.width } : undefined}
+                    className={cn(
+                      // Pinned under the options row, not under the top of the
+                      // scrollport: the toolbar is already sitting there, and a
+                      // header that pins to zero slides underneath it.
+                      //
+                      // Only where the wrapper has dropped its overflow clamp.
+                      // Inside a scroll container that never scrolls
+                      // vertically, `top: 52px` does not pin anything — it just
+                      // pushes the header 52px down the page and leaves a band
+                      // of nothing above it.
+                      "border-b border-[var(--border-subtle)] bg-surface-base px-3 py-2 @5xl:sticky @5xl:top-[var(--list-toolbar-h)] @5xl:z-[2]",
+                      "text-sm font-medium text-[var(--text-subtle)]",
+                      column.align === "end" && "text-right",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "flex items-center gap-1.5",
+                        column.align === "end" && "justify-end",
+                      )}
+                    >
+                      {Icon ? <Icon className="size-3.5 shrink-0" aria-hidden="true" /> : null}
+                      {column.label}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            {rows.map((row) => {
+              const selected = selectedIds.includes(row.id);
+              return (
+                <tr
+                  key={row.id}
+                  className={cn(
+                    "group/row",
+                    selected ? "bg-[var(--surface-subtle)]" : "hover:bg-[var(--surface-muted)]",
+                  )}
+                >
+                  {selection ? (
+                    <td className="border-b border-[var(--border-subtle)] px-2">
+                      <Checkbox
+                        checked={selected}
+                        onCheckedChange={() => toggle(row.id)}
+                        aria-label="Select this row"
+                      />
+                    </td>
+                  ) : null}
+
+                  {columns.map((column, index) => (
+                    <td
+                      key={column.id}
+                      className={cn(
+                        // 44px of row from the padding alone, so a one-line
+                        // cell is still a target a thumb can hit.
+                        "min-h-11 border-b border-[var(--border-subtle)] px-3 py-2.5 align-middle text-sm",
+                        column.align === "end" && "text-right",
+                      )}
+                    >
+                      {index === 0 ? (
+                        // Only the first cell navigates. A row where every cell
+                        // is inside the link is a row where you cannot select
+                        // the text in it, and where a chip in the third column
+                        // is a link that does not look like one.
+                        // The link carries no underline of its own. A text
+                        // decoration is painted by the element that declares
+                        // it and cannot be switched off by a descendant, so an
+                        // underline here struck through the job title and the
+                        // reference under every name — `no-underline` on the
+                        // subtitle does nothing about it. `RecordTableName`
+                        // underlines the title itself instead.
+                        <Link
+                          href={rowHref(row)}
+                          className="-mx-1 block min-w-0 rounded-[var(--radius-sm)] px-1"
+                        >
+                          {column.cell(row)}
+                        </Link>
+                      ) : (
+                        column.cell(row)
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        </div>
+      </div>
+
+      {selection && selectedIds.length > 0 ? (
+        <DataTableFloatingActions
+          count={selectedIds.length}
+          onClear={() => selection.onChange([])}
+        >
+          {selection.actions?.({ ids: selectedIds, clear: () => selection.onChange([]) })}
+        </DataTableFloatingActions>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The name cell every list's first column is built from.
+ *
+ * Two lines: what the record is called, and the one thing that tells two
+ * similarly-named records apart — a reference, a company, a town. Sharing it
+ * is what stops four lists growing four slightly different first columns.
+ */
+export function RecordTableName({
+  leading,
+  title,
+  subtitle,
+}: {
+  leading?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+}) {
+  return (
+    <span className="flex min-w-0 items-center gap-2.5">
+      {leading ? <span className="flex-none">{leading}</span> : null}
+      <span className="min-w-0">
+        {/* The underline is on the title and nowhere else — the same quiet
+            "this opens" cue `EntityLink` draws, and the only part of the cell
+            that actually is the link's subject. */}
+        <span className="block truncate font-medium text-[var(--text-strong)] underline decoration-[var(--border)] underline-offset-2 group-hover/row:decoration-[var(--text-muted)]">
+          {title}
+        </span>
+        {subtitle ? (
+          <span className="block truncate text-sm text-[var(--text-muted)]">{subtitle}</span>
+        ) : null}
+      </span>
+    </span>
+  );
+}

--- a/components/crm/records/sites-content.tsx
+++ b/components/crm/records/sites-content.tsx
@@ -4,11 +4,15 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@corelithzw/react";
+import { EntityLink } from "@/components/records/entity-link";
 import { fetchCrmSites } from "@/lib/crm/crm-v2";
 import { useDebounced } from "@/hooks/use-debounced";
+import { Building2, Calendar, Coins, MapPin, UserRound } from "@/lib/icons";
 
 import { SiteFormSheet } from "./site-form-sheet";
 import { RecordList, RecordListPager, type RecordListRow } from "./record-list";
+import { RecordTable, RecordTableName, type RecordTableColumn } from "./record-table";
+import { LayoutSwitch, type RecordLayout } from "./layout-switch";
 import { RecordMark } from "@/components/records/record-mark";
 import { RecordListShell } from "./record-list-shell";
 
@@ -18,6 +22,7 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [createOpen, setCreateOpen] = useState(openCreate);
+  const [layout, setLayout] = useState<RecordLayout>("TABLE");
   const debouncedSearch = useDebounced(search, 300);
 
   const sitesQuery = useQuery({
@@ -61,6 +66,124 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
     [sites],
   );
 
+  /**
+   * The same sites, arranged as columns.
+   *
+   * A site's row crams its number, its company and its full address onto one
+   * subtitle line, which at any width is a run-on and on a phone is truncated
+   * before the town. Which company owns it and where it is are two different
+   * questions, and here they are two columns.
+   */
+  const columns = useMemo<RecordTableColumn<(typeof sites)[number]>[]>(
+    () => [
+      {
+        id: "name",
+        label: "Site",
+        icon: MapPin,
+        cell: (site) => (
+          <RecordTableName
+            leading={
+              <RecordMark
+                kind="site"
+                name={site.name}
+                emoji={site.emoji}
+                avatarUrl={site.avatarUrl}
+                size="sm"
+              />
+            }
+            title={site.name}
+            subtitle={site.siteNo}
+          />
+        ),
+      },
+      {
+        id: "company",
+        label: "Company",
+        icon: Building2,
+        width: "13rem",
+        // `block truncate` on the cell, not the link: a long name wrapped to
+        // two lines and made its row twice as tall as its neighbours.
+        cell: (site) => (
+          <span className="block truncate">
+            {site.client ? (
+              <EntityLink href={`/crm/companies/${site.client.id}`}>{site.client.name}</EntityLink>
+            ) : (
+              <span className="text-[var(--text-subtle)]">—</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        id: "where",
+        label: "Where",
+        icon: MapPin,
+        width: "14rem",
+        cell: (site) => (
+          <span className="block truncate">
+            {[site.addressLine, site.city, site.country].filter(Boolean).join(", ") || (
+              <span className="text-[var(--text-subtle)]">—</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        id: "contact",
+        label: "Contact",
+        icon: UserRound,
+        width: "12rem",
+        cell: (site) =>
+          site.primaryContact ? (
+            <EntityLink href={`/crm/people/${site.primaryContact.id}`}>
+              {site.primaryContact.fullName}
+            </EntityLink>
+          ) : (
+            <span className="text-[var(--text-subtle)]">—</span>
+          ),
+      },
+      {
+        id: "deals",
+        label: "Deals",
+        icon: Coins,
+        width: "6rem",
+        align: "end",
+        cell: (site) => <span className="font-mono tabular-nums">{site._count?.deals ?? 0}</span>,
+      },
+      {
+        id: "visits",
+        label: "Visits",
+        icon: Calendar,
+        width: "6rem",
+        align: "end",
+        cell: (site) => (
+          <span className="font-mono tabular-nums">{site._count?.appointments ?? 0}</span>
+        ),
+      },
+    ],
+    [],
+  );
+
+  // The rows arrangement, which is also what the table falls back to on a
+  // phone — so it is written once and used twice rather than diverging.
+  const register = (
+    <RecordList
+      rows={rows}
+      isLoading={sitesQuery.isLoading}
+      emptyTitle={debouncedSearch ? "No sites match that search" : "No sites yet"}
+      emptyBody={
+        debouncedSearch
+          ? undefined
+          : "A site is an address you keep going back to — add one and visits and deals can point at it."
+      }
+      emptyAction={
+        debouncedSearch ? undefined : (
+          <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+            Add the first site
+          </Button>
+        )
+      }
+    />
+  );
+
   return (
     <RecordListShell
       title="Sites"
@@ -73,24 +196,32 @@ export function SitesContent({ openCreate = false }: { openCreate?: boolean }) {
       createLabel="New site"
       onCreate={() => setCreateOpen(true)}
       error={sitesQuery.error}
+      layout={<LayoutSwitch value={layout} onChange={setLayout} options={["TABLE", "LIST"]} />}
     >
-      <RecordList
-        rows={rows}
-        isLoading={sitesQuery.isLoading}
-        emptyTitle={debouncedSearch ? "No sites match that search" : "No sites yet"}
-        emptyBody={
-          debouncedSearch
-            ? undefined
-            : "A site is an address you keep going back to — add one and visits and deals can point at it."
-        }
-        emptyAction={
-          debouncedSearch ? undefined : (
-            <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
-              Add the first site
-            </Button>
-          )
-        }
-      />
+      {layout === "TABLE" ? (
+        <RecordTable
+          rows={sites}
+          columns={columns}
+          rowHref={(site) => `/crm/sites/${site.id}`}
+          isLoading={sitesQuery.isLoading}
+          emptyTitle={debouncedSearch ? "No sites match that search" : "No sites yet"}
+          emptyBody={
+            debouncedSearch
+              ? undefined
+              : "A site is an address you keep going back to — add one and visits and deals can point at it."
+          }
+          emptyAction={
+            debouncedSearch ? undefined : (
+              <Button variant="primary" size="sm" onClick={() => setCreateOpen(true)}>
+                Add the first site
+              </Button>
+            )
+          }
+          mobile={register}
+        />
+      ) : (
+        register
+      )}
 
       <RecordListPager page={page} pageSize={PAGE_SIZE} total={total} onPageChange={setPage} />
 

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -14,27 +14,39 @@ import { SlidersHorizontal } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
 /**
- * The one toolbar every list and board sits under.
+ * The options row — the band between the app bar and the records.
  *
  * Leads had its own header row, deals another, and people, companies and
  * sites a third — same intent, three orderings, three control heights. The
  * user's words: "the top bar area and header for kanban and lists should be
- * the same." So there is one row now, with one grammar:
+ * the same." So there is one row now, with one grammar, read left to right:
  *
- *   what you are looking at (view / layout / pipeline) → how it is narrowed
- *   (filters) → …spacer… → how you find one (search) → what is shown
- *   (columns / card fields).
+ *   what you are looking at (the layout) │ how it is narrowed (filters)
+ *   → …spacer… → how you find one (search) → what is shown (columns)
  *
- * Switching between table and board must not move this row — that is the
+ * The rule after the layout switch is doing real work: it splits the row into
+ * "which arrangement" and "which records", which are different questions that
+ * used to sit in one undifferentiated run of six buttons.
+ *
+ * Switching between table, list and board must not move this row — that is the
  * whole point of it. Anything that only makes sense in one layout (a sort
  * button on a board, say) disappears from its slot rather than reshaping the
  * row.
  *
- * On a phone the row is not a row. Six controls at 36px wrap onto three
- * lines and push the records themselves below the fold, and the reader has to
- * read six labels before they can look at anything. So below `sm` the whole
- * lot goes behind one button, and what stays on screen is what somebody came
- * for: the search box, and the records under it.
+ * ## It is a bar, not a gap with controls in it
+ *
+ * A fixed height and a hairline that runs the full width, pinned to the top of
+ * the scrollport. That is what makes the table header below it able to pin too:
+ * `--list-toolbar-h` is the offset every sticky thead in the module measures
+ * from, and it only means anything if this row is actually that tall.
+ *
+ * ## On a phone the row is not a row
+ *
+ * Six controls at 36px wrap onto three lines and push the records themselves
+ * below the fold, and the reader has to read six labels before they can look at
+ * anything. So below `sm` the whole lot goes behind one button, and what stays
+ * on screen is what somebody came for: the search box, and the records under
+ * it.
  *
  * Which means a phone toolbar with no `search` is one outline button on a band
  * of its own — 60px of page spent on a control nobody came for. Every surface
@@ -42,12 +54,18 @@ import { cn } from "@/lib/utils";
  * search gets the button inline with whatever `end` holds rather than a band.
  */
 export function ViewToolbar({
+  layout,
   start,
   search,
   end,
   className,
 }: {
-  /** What you are looking at, and how it is narrowed. */
+  /**
+   * The layout switch. Kept out of `start` so it is always first and always
+   * has the rule after it, whatever else the page passes.
+   */
+  layout?: ReactNode;
+  /** How the records are narrowed: status, pipeline, owner. */
   start?: ReactNode;
   /** The search control, right-aligned with the display controls. */
   search?: ReactNode;
@@ -56,7 +74,7 @@ export function ViewToolbar({
   className?: string;
 }) {
   const [open, setOpen] = useState(false);
-  const hasControls = Boolean(start || end);
+  const hasControls = Boolean(layout || start || end);
 
   return (
     <div
@@ -65,7 +83,26 @@ export function ViewToolbar({
         // content" — the same seam the sidebar draws against the main pane.
         // Sticky: the row is the page's header, and a header that scrolls
         // away takes the filters and the search with it.
-        "sticky top-0 z-10 flex flex-wrap items-center gap-2 border-b border-[var(--border-subtle)] bg-surface-base pb-3 pt-1",
+        //
+        // A sticky element pins to the scrollport's *padding* edge, and `main`
+        // keeps a gutter of top padding — so the bar comes to rest a gutter's
+        // worth below the app bar, and the rows scrolling past show through
+        // the strip between them. The `::before` paints that strip in the
+        // bar's own background, which is the one fix that does not involve
+        // arguing with where sticky decides to stop.
+        //
+        // Not a negative top margin. Tailwind's leading-minus shorthand cannot
+        // negate a bare custom property — it emits a rule containing a literal
+        // ellipsis, which is not CSS, and Turbopack then fails the whole
+        // stylesheet, so *every* page 500s rather than this one looking wrong.
+        // The horizontal bleed below is written as an explicit `calc()` for
+        // the same reason.
+        "sticky top-0 z-10 flex h-[var(--list-toolbar-h)] items-center gap-2 border-b border-[var(--border-subtle)] bg-surface-base",
+        "before:absolute before:inset-x-0 before:bottom-full before:h-[var(--content-gutter-y)] before:bg-surface-base before:content-['']",
+        // The bleed is what makes the hairline a seam across the page rather
+        // than a rule floating inside the gutter — the same edge the app bar
+        // above it draws.
+        "mx-[calc(-1*var(--content-gutter-x))] px-[var(--content-gutter-x)]",
         className,
       )}
     >
@@ -73,7 +110,7 @@ export function ViewToolbar({
       {hasControls ? (
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetTrigger asChild>
-            <Button variant="outline" className="sm:hidden" aria-label="View and filters">
+            <Button variant="outline" size="sm" className="sm:hidden" aria-label="View and filters">
               <SlidersHorizontal className="size-4" aria-hidden="true" />
               View
             </Button>
@@ -99,11 +136,24 @@ export function ViewToolbar({
                 into a row keys off a class this sheet cannot put on controls
                 it was handed. */}
             <div className="stacked-controls flex flex-col items-stretch gap-2">
+              {layout}
               {start}
               {end}
             </div>
           </SheetContent>
         </Sheet>
+      ) : null}
+
+      {layout ? <div className="hidden items-center sm:flex">{layout}</div> : null}
+
+      {/* The seam between "which arrangement" and "which records". Only drawn
+          when there is something on both sides of it — a rule with nothing to
+          separate is a tally mark. */}
+      {layout && start ? (
+        <span
+          aria-hidden="true"
+          className="hidden h-5 w-px shrink-0 bg-[var(--border-subtle)] sm:block"
+        />
       ) : null}
 
       <div className="hidden flex-wrap items-center gap-2 sm:flex">{start}</div>

--- a/components/crm/records/view-toolbar.tsx
+++ b/components/crm/records/view-toolbar.tsx
@@ -144,31 +144,43 @@ export function ViewToolbar({
         </Sheet>
       ) : null}
 
-      {layout ? <div className="hidden items-center sm:flex">{layout}</div> : null}
+      {/* The left half scrolls sideways rather than wrapping.
+          ────────────────────────────────────────────────────────────────────
+          Leads carries seven controls here — saved view, filters, stage,
+          pipeline, sort — and at 1440px with a sidebar they do not fit. Wrapped
+          onto three lines inside a bar with a fixed height they simply drew
+          outside it, over the app bar above and the table header below.
+          The height cannot become a floor instead: `--list-toolbar-h` is the
+          offset every sticky table header in the module pins to, and a bar that
+          is sometimes 52px and sometimes 150px puts those headers in the wrong
+          place on exactly the pages with the most controls.
+          So the controls scroll and the two things somebody came for — search,
+          and what is shown — stay outside the scroller, pinned right. */}
+      {/* The fade is the only cue that there is more to the right — a
+          scrollbar is hidden here, and a control clipped mid-word reads as a
+          bug rather than as an edge. It costs nothing when the row fits, since
+          a short row has nothing at its right edge to fade. */}
+      <div className="hidden min-w-0 flex-1 items-center gap-2 overflow-x-auto pr-1 sm:flex [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [mask-image:linear-gradient(to_right,black_calc(100%-1.25rem),transparent)]">
+        {layout ? <div className="flex shrink-0 items-center">{layout}</div> : null}
 
-      {/* The seam between "which arrangement" and "which records". Only drawn
-          when there is something on both sides of it — a rule with nothing to
-          separate is a tally mark. */}
-      {layout && start ? (
-        <span
-          aria-hidden="true"
-          className="hidden h-5 w-px shrink-0 bg-[var(--border-subtle)] sm:block"
-        />
-      ) : null}
+        {/* The seam between "which arrangement" and "which records". Only drawn
+            when there is something on both sides of it — a rule with nothing to
+            separate is a tally mark. */}
+        {layout && start ? (
+          <span
+            aria-hidden="true"
+            className="h-5 w-px shrink-0 bg-[var(--border-subtle)]"
+          />
+        ) : null}
 
-      <div className="hidden flex-wrap items-center gap-2 sm:flex">{start}</div>
-
-      {/* The spacer pushes search and display controls to the right of a
-          single row. Once the row wraps — which it always does on a phone —
-          a flex-1 spacer becomes a whole blank line between the filters and
-          the search, so it only exists at widths where the row fits. */}
-      <span className="hidden min-w-2 flex-1 sm:block" aria-hidden="true" />
+        <div className="flex shrink-0 items-center gap-2">{start}</div>
+      </div>
 
       {/* Search stays out of the sheet: it is how you find one record, which
           is the most common reason to touch this row at all. */}
-      <div className="min-w-0 flex-1 sm:flex-none">{search}</div>
+      <div className="min-w-0 flex-1 sm:flex-none sm:shrink-0">{search}</div>
 
-      <div className="hidden flex-wrap items-center gap-2 sm:flex">{end}</div>
+      <div className="hidden shrink-0 items-center gap-2 sm:flex">{end}</div>
     </div>
   );
 }

--- a/components/crm/tasks/record-tasks-tab.tsx
+++ b/components/crm/tasks/record-tasks-tab.tsx
@@ -1,18 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
+import { SplitView } from "@/components/records/split-view";
 import { fetchCrmTasks, type CrmTaskRecordRef } from "@/lib/crm/crm-v2";
 import { Plus } from "@/lib/icons";
 
+import { TaskDetail } from "./task-detail";
 import { TaskFormSheet } from "./task-form-sheet";
 import { TaskList } from "./task-list";
+import { useTaskCompletion } from "./use-task-completion";
 
 /**
- * The Tasks tab on a record page. Same list as the queue page, filtered to
- * this record and with the record already filled in on the create form.
+ * The Tasks section on a record page.
+ *
+ * Same tasks as the queue page, filtered to this record — but arranged as a
+ * split rather than a flat register, because the two pages are used for
+ * different things. The queue is a worklist you go down. A record's tasks are a
+ * set you move *between*: you open one to see what the outcome was, decide it
+ * needs a new due date, and then look at the next one. Every one of those used
+ * to cost a form sheet over the top of the list.
+ *
+ * The selected task is held here rather than in the URL. A section of a record
+ * is already a URL-addressable place; a *row inside* one is transient state,
+ * and putting it in the query string would mean the browser's back button walks
+ * back through every task somebody glanced at before it leaves the record.
  */
 export function RecordTasksTab({
   record,
@@ -22,6 +36,7 @@ export function RecordTasksTab({
   currentUserId?: string;
 }) {
   const [creating, setCreating] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const key = ["crm-tasks", "record", record];
 
   const { data, isLoading } = useQuery({
@@ -30,6 +45,17 @@ export function RecordTasksTab({
     // is assigned to is the tab's content, not its filter.
     queryFn: () => fetchCrmTasks({ ...record, queue: "ALL", limit: 100 }),
   });
+
+  const tasks = useMemo(() => data?.data ?? [], [data]);
+  // Looked up by id every render rather than stored: the list is refetched
+  // after every edit, and a held copy of the task would show the old due date
+  // in the panel that just changed it.
+  const selected = tasks.find((task) => task.id === selectedId) ?? null;
+
+  // One instance, shared by the checkbox in the list and the checkbox in the
+  // panel, so a typed task raises exactly one outcome dialog whichever one you
+  // tick.
+  const completion = useTaskCompletion({ currentUserId });
 
   return (
     <div className="space-y-3">
@@ -40,13 +66,36 @@ export function RecordTasksTab({
         </Button>
       </div>
 
-      <TaskList
-        tasks={data?.data ?? []}
-        isLoading={isLoading}
-        showRecord={false}
-        emptyMessage="No tasks on this record yet."
-        currentUserId={currentUserId}
+      <SplitView
+        detailTitle={selected?.title}
+        onClose={() => setSelectedId(null)}
+        placeholder="Pick a task to see and change it here."
+        list={
+          <TaskList
+            tasks={tasks}
+            isLoading={isLoading}
+            showRecord={false}
+            grouped
+            emptyMessage="No tasks on this record yet."
+            currentUserId={currentUserId}
+            onToggle={completion.toggle}
+            selectedId={selectedId}
+            onSelect={(task) => setSelectedId(task.id)}
+          />
+        }
+        detail={
+          selected ? (
+            <TaskDetail
+              task={selected}
+              currentUserId={currentUserId}
+              onToggle={completion.toggle}
+              onDeleted={() => setSelectedId(null)}
+            />
+          ) : null
+        }
       />
+
+      {completion.dialogs}
 
       <TaskFormSheet
         open={creating}

--- a/components/crm/tasks/record-tasks-tab.tsx
+++ b/components/crm/tasks/record-tasks-tab.tsx
@@ -67,7 +67,9 @@ export function RecordTasksTab({
       </div>
 
       <SplitView
-        detailTitle={selected?.title}
+        // No `detailTitle`: the panel opens with the task's name as an editable
+        // heading, and the drilled-in header would have printed it again
+        // directly above it.
         onClose={() => setSelectedId(null)}
         placeholder="Pick a task to see and change it here."
         list={

--- a/components/crm/tasks/task-detail.tsx
+++ b/components/crm/tasks/task-detail.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { Badge } from "@corelithzw/react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Textarea } from "@/components/ui/textarea";
+import { dsConfirm } from "@/components/ui/ds-confirm";
+import { useToast } from "@/components/ui/use-toast";
+import { EntityLink } from "@/components/records/entity-link";
+import { RecordAttributes } from "@/components/records/record-attributes";
+import { useAttributeEditor } from "@/components/records/use-attribute-editor";
+import { fetchJson, getApiErrorMessage } from "@/lib/api-client";
+import { deleteCrmTask, type CrmTaskRecord } from "@/lib/crm/crm-v2";
+import {
+  CRM_TASK_OUTCOME_LABELS,
+  CRM_TASK_PRIORITY_LABELS,
+  CRM_TASK_TYPE_LABELS,
+  isTaskOverdue,
+  taskRecordRef,
+} from "@/lib/crm/tasks";
+import { TASK_PRIORITY_TONE } from "@/lib/crm/tones";
+import { Calendar, Checklist, Repeat, Trash2, UserRound, Zap } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * One task, beside the list it came from.
+ *
+ * Everything here writes through on blur or Enter, the same grammar the record
+ * page's properties use — press the thing you are looking at. That is the whole
+ * reason the panel exists: before it, changing a task's due date meant opening
+ * the form sheet over the list, and the form sheet asks for every field when
+ * you came to change one.
+ *
+ * Two things deliberately do *not* happen here.
+ *
+ * Completing a typed task still goes through the outcome dialog rather than a
+ * checkbox that quietly closes it — the answer is the part worth keeping, and
+ * the server refuses the write without one anyway. So the tick is handed back
+ * to the list, which already owns that flow.
+ *
+ * And the record this task is filed against is a link, not a picker. Moving a
+ * task between records is a real operation with real consequences (it changes
+ * whose timeline it appears on) and it belongs in the form, not in a field you
+ * can brush past.
+ */
+export function TaskDetail({
+  task,
+  currentUserId,
+  onToggle,
+  onDeleted,
+}: {
+  task: CrmTaskRecord;
+  currentUserId?: string;
+  /** Ticking the box — the list owns it, because it may need the outcome dialog. */
+  onToggle: (task: CrmTaskRecord) => void;
+  onDeleted: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const done = task.status === "COMPLETED";
+  const overdue = isTaskOverdue(task);
+  const record = taskRecordRef(task);
+  const recordLabel =
+    task.deal?.title ?? task.lead?.title ?? task.client?.name ?? task.person?.fullName ?? null;
+
+  const editor = useAttributeEditor({
+    path: `/api/v2/crm/tasks/${task.id}`,
+    invalidate: [["crm-tasks"]],
+  });
+
+  const team = useQuery({
+    queryKey: ["crm", "team"],
+    queryFn: () =>
+      fetchJson<{ data: Array<{ id: string; name: string | null }> }>("/api/v2/crm/team"),
+    staleTime: 5 * 60_000,
+  });
+
+  const remove = useMutation({
+    mutationFn: () => deleteCrmTask(task.id),
+    onSuccess: () => {
+      toast({ title: "Task deleted" });
+      onDeleted();
+      queryClient.invalidateQueries({ queryKey: ["crm-tasks"] });
+    },
+    onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
+  });
+
+  const mine = task.assignedToId === currentUserId || !task.assignedToId;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2.5">
+        <Checkbox
+          className="mt-1"
+          checked={done}
+          onCheckedChange={() => onToggle(task)}
+          aria-label={done ? `Reopen ${task.title}` : `Complete ${task.title}`}
+        />
+        <div className="min-w-0 flex-1">
+          <TaskTitle
+            title={task.title}
+            done={done}
+            onCommit={(next) => editor.save.mutate({ title: next })}
+          />
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <Badge tone="neutral" size="sm">
+              {CRM_TASK_TYPE_LABELS[task.type]}
+            </Badge>
+            {task.priority !== "NORMAL" && task.priority !== "LOW" ? (
+              <Badge tone={TASK_PRIORITY_TONE[task.priority] ?? "neutral"} size="sm">
+                {CRM_TASK_PRIORITY_LABELS[task.priority]}
+              </Badge>
+            ) : null}
+            {task.recurrence !== "NONE" ? (
+              <span
+                className="inline-flex items-center gap-1 text-sm text-[var(--text-muted)]"
+                title="Repeating task"
+              >
+                <Repeat className="size-3.5" aria-hidden="true" />
+                {task.recurrence.toLowerCase()}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <RecordAttributes
+        visibleCount={6}
+        attributes={[
+          {
+            id: "due",
+            label: "Due",
+            icon: Calendar,
+            kind: "date",
+            // The server wants a full instant and the field gives a day, so the
+            // day is anchored at 09:00 local — a task due "on Thursday" that
+            // lands at midnight reads as overdue for the whole of Thursday.
+            value: task.dueAt.slice(0, 10),
+            formatted: new Date(task.dueAt).toLocaleDateString(undefined, {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+            }),
+            onCommit: (next) => {
+              if (!next) return;
+              const at = new Date(`${next}T09:00:00`);
+              if (Number.isNaN(at.getTime())) return;
+              editor.save.mutate({ dueAt: at.toISOString(), hasDueTime: false });
+            },
+          },
+          {
+            id: "assignee",
+            label: "Assigned to",
+            icon: UserRound,
+            ...editor.choice(
+              "assignedToId",
+              task.assignedToId,
+              (team.data?.data ?? []).map((member) => ({
+                value: member.id,
+                label: member.name ?? "Unnamed",
+              })),
+              "Leave unassigned",
+            ),
+            placeholder: "Unassigned",
+          },
+          {
+            id: "priority",
+            label: "Priority",
+            icon: Zap,
+            ...editor.choice(
+              "priority",
+              task.priority,
+              Object.entries(CRM_TASK_PRIORITY_LABELS).map(([value, label]) => ({
+                value,
+                label,
+              })),
+            ),
+          },
+          {
+            id: "status",
+            label: "Status",
+            icon: Checklist,
+            display: (
+              <span
+                className={cn(
+                  "block py-2 text-sm leading-5 sm:py-1",
+                  overdue && !done ? "text-[var(--status-danger-fg)]" : "",
+                )}
+              >
+                {done ? "Completed" : overdue ? "Overdue" : "Open"}
+              </span>
+            ),
+          },
+          ...(record && recordLabel
+            ? [
+                {
+                  id: "record",
+                  label: "On",
+                  icon: Checklist,
+                  display: (
+                    <span className="block py-2 text-sm leading-5 sm:py-1">
+                      <EntityLink href={record.href}>{recordLabel}</EntityLink>
+                    </span>
+                  ),
+                },
+              ]
+            : []),
+          ...(task.outcome
+            ? [
+                {
+                  id: "outcome",
+                  label: "Outcome",
+                  icon: Checklist,
+                  display: (
+                    <span className="block py-2 text-sm leading-5 sm:py-1">
+                      {CRM_TASK_OUTCOME_LABELS[task.outcome]}
+                    </span>
+                  ),
+                },
+              ]
+            : []),
+        ]}
+      />
+
+      <TaskNotes
+        label="Description"
+        value={task.description}
+        placeholder="What needs doing, and anything the next person would need to know."
+        onCommit={(next) => editor.save.mutate({ description: next || null })}
+      />
+
+      {done ? (
+        <TaskNotes
+          label="What happened"
+          value={task.outcomeNotes}
+          placeholder="Nothing written down."
+          onCommit={(next) => editor.save.mutate({ outcomeNotes: next || null })}
+        />
+      ) : null}
+
+      {mine ? (
+        <div className="border-t border-[var(--border-subtle)] pt-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-[var(--status-error-text)]"
+            onClick={async () => {
+              const confirmed = await dsConfirm({
+                title: "Delete this task?",
+                description: task.title,
+                confirmLabel: "Delete",
+                variant: "danger",
+              });
+              if (confirmed) remove.mutate();
+            }}
+          >
+            <Trash2 className="mr-1.5 size-4" aria-hidden="true" />
+            Delete task
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** The task's name, edited where it is read — same as a record's own title. */
+function TaskTitle({
+  title,
+  done,
+  onCommit,
+}: {
+  title: string;
+  done: boolean;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  if (draft === null) {
+    return (
+      <button
+        type="button"
+        title="Rename"
+        onClick={() => setDraft(title)}
+        className={cn(
+          "-mx-1.5 block w-full rounded-[var(--radius-sm)] px-1.5 text-left text-base font-semibold leading-snug hover:bg-[var(--surface-subtle)]",
+          done ? "text-[var(--text-muted)] line-through" : "text-[var(--text-strong)]",
+        )}
+      >
+        {title}
+      </button>
+    );
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== title) onCommit(trimmed);
+    setDraft(null);
+  };
+
+  return (
+    <textarea
+      autoFocus
+      rows={Math.min(4, Math.max(1, Math.ceil(draft.length / 30)))}
+      value={draft}
+      aria-label="Task name"
+      className="-mx-1.5 block w-full resize-none rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-base)] px-1.5 py-0.5 text-base font-semibold leading-snug text-[var(--text-strong)] outline-none focus:border-[var(--action-primary-bg)]"
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          commit();
+        }
+        if (event.key === "Escape") setDraft(null);
+      }}
+    />
+  );
+}
+
+/**
+ * A paragraph of a task, edited in place.
+ *
+ * Not a `RecordAttribute`: those are one line in a two-column list, and a
+ * description that runs to a paragraph in a 112px-labelled row is unreadable in
+ * both states. It gets its own heading and the full width under it.
+ */
+function TaskNotes({
+  label,
+  value,
+  placeholder,
+  onCommit,
+}: {
+  label: string;
+  value: string | null;
+  placeholder: string;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  return (
+    <section className="space-y-1.5">
+      <h4 className="text-sm font-semibold uppercase tracking-[0.06em] text-[var(--text-subtle)]">
+        {label}
+      </h4>
+      {draft === null ? (
+        <button
+          type="button"
+          onClick={() => setDraft(value ?? "")}
+          className={cn(
+            "-mx-1.5 block w-full whitespace-pre-wrap rounded-[var(--radius-sm)] px-1.5 py-1 text-left text-sm hover:bg-[var(--surface-subtle)]",
+            value ? "text-[var(--text-body)]" : "text-[var(--text-muted)]",
+          )}
+        >
+          {value || placeholder}
+        </button>
+      ) : (
+        <Textarea
+          autoFocus
+          rows={4}
+          value={draft}
+          aria-label={label}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => {
+            if (draft !== (value ?? "")) onCommit(draft);
+            setDraft(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setDraft(null);
+          }}
+        />
+      )}
+    </section>
+  );
+}

--- a/components/crm/tasks/task-detail.tsx
+++ b/components/crm/tasks/task-detail.tsx
@@ -129,6 +129,7 @@ export function TaskDetail({
 
       <RecordAttributes
         visibleCount={6}
+        columns={1}
         attributes={[
           {
             id: "due",

--- a/components/crm/tasks/task-list.tsx
+++ b/components/crm/tasks/task-list.tsx
@@ -1,35 +1,43 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { Badge, Button, EmptyState, Stack } from "@corelithzw/react";
+import { Badge, Button, EmptyState } from "@corelithzw/react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ClientDate } from "@/components/ui/client-date";
 import { dsConfirm } from "@/components/ui/ds-confirm";
 import { useToast } from "@/components/ui/use-toast";
 import { getApiErrorMessage } from "@/lib/api-client";
-import { deleteCrmTask, updateCrmTask, type CrmTaskRecord } from "@/lib/crm/crm-v2";
+import { deleteCrmTask, type CrmTaskRecord } from "@/lib/crm/crm-v2";
 import {
   CRM_TASK_OUTCOME_LABELS,
   CRM_TASK_TYPE_LABELS,
   isTaskOverdue,
-  requiresOutcome,
   taskRecordRef,
 } from "@/lib/crm/tasks";
 import { TASK_PRIORITY_TONE } from "@/lib/crm/tones";
 import { Clock, Repeat, Trash2 } from "@/lib/icons";
 import { cn } from "@/lib/utils";
 
-import { CompleteTaskDialog } from "./complete-task-dialog";
-import { TaskFormSheet } from "./task-form-sheet";
+import { useTaskCompletion } from "./use-task-completion";
 
 /**
  * The task list, shared by the queue page and every record page's Tasks tab.
  *
  * Ticking a typed task opens the outcome dialog rather than silently closing
- * it, because the answer is the part worth keeping.
+ * it, because the answer is the part worth keeping. That machinery lives in
+ * `useTaskCompletion` now: the split view's detail panel has the same checkbox
+ * and has to behave the same way, and a surface that owns the flow can pass its
+ * own `onToggle` in so the two halves share one dialog rather than racing two.
+ *
+ * ## Rows are selectable when somebody is listening
+ *
+ * Given `onSelect` the row becomes a button that opens the task beside the
+ * list, and the selected one is marked. Without it the list is what it always
+ * was — a register you read, with a checkbox and a delete. The queue page wants
+ * the second; a record's Tasks section wants the first.
  */
 export function TaskList({
   tasks,
@@ -37,63 +45,61 @@ export function TaskList({
   emptyMessage = "Nothing outstanding.",
   showRecord = true,
   currentUserId,
+  onToggle,
+  selectedId,
+  onSelect,
+  grouped = false,
 }: {
   tasks: CrmTaskRecord[];
   isLoading?: boolean;
   emptyMessage?: string;
   showRecord?: boolean;
   currentUserId?: string;
+  /**
+   * Completing a task, when the caller owns that flow. Given one, this list
+   * renders no dialogs of its own — the caller is mounting them.
+   */
+  onToggle?: (task: CrmTaskRecord) => void;
+  selectedId?: string | null;
+  onSelect?: (task: CrmTaskRecord) => void;
+  /**
+   * Split into what needs doing now, what is coming, and what is done. Worth it
+   * on a record, where a year of trading leaves thirty tasks in one undivided
+   * column; not worth it on the queue page, whose tabs have already answered
+   * the same question.
+   */
+  grouped?: boolean;
 }) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const [completing, setCompleting] = useState<CrmTaskRecord | null>(null);
-  const [followUpFor, setFollowUpFor] = useState<CrmTaskRecord | null>(null);
-
-  const refresh = () => queryClient.invalidateQueries({ queryKey: ["crm-tasks"] });
-
-  const update = useMutation({
-    mutationFn: (input: { id: string; body: Record<string, unknown> }) =>
-      updateCrmTask(input.id, input.body),
-    onSuccess: (result) => {
-      refresh();
-      setCompleting(null);
-      if (result.recurredTask) {
-        toast({
-          title: "Task completed",
-          description: "The next one is booked in.",
-        });
-      } else if (result.suggestsFollowUp) {
-        // The outcome says the conversation isn't over, so offer the next step
-        // while the context is still in front of the person.
-        const source = tasks.find((task) => task.id === result.id) ?? null;
-        setFollowUpFor(source);
-      } else {
-        toast({ title: "Task completed" });
-      }
-    },
-    onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
-  });
+  const completion = useTaskCompletion({ currentUserId });
+  const toggle = onToggle ?? completion.toggle;
 
   const remove = useMutation({
     mutationFn: (id: string) => deleteCrmTask(id),
     onSuccess: () => {
       toast({ title: "Task deleted" });
-      refresh();
+      queryClient.invalidateQueries({ queryKey: ["crm-tasks"] });
     },
     onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
   });
 
-  const toggle = (task: CrmTaskRecord) => {
-    if (task.status === "COMPLETED") {
-      update.mutate({ id: task.id, body: { status: "OPEN", outcome: null } });
-      return;
+  const groups = useMemo(() => {
+    if (!grouped) return [{ id: "all", label: null as string | null, tasks }];
+    const overdue: CrmTaskRecord[] = [];
+    const open: CrmTaskRecord[] = [];
+    const done: CrmTaskRecord[] = [];
+    for (const task of tasks) {
+      if (task.status === "COMPLETED") done.push(task);
+      else if (isTaskOverdue(task)) overdue.push(task);
+      else open.push(task);
     }
-    if (requiresOutcome(task.type)) {
-      setCompleting(task);
-      return;
-    }
-    update.mutate({ id: task.id, body: { status: "COMPLETED" } });
-  };
+    return [
+      { id: "overdue", label: "Overdue", tasks: overdue },
+      { id: "open", label: "To do", tasks: open },
+      { id: "done", label: "Done", tasks: done },
+    ].filter((group) => group.tasks.length > 0);
+  }, [grouped, tasks]);
 
   if (isLoading) {
     return <p className="text-sm text-[var(--text-muted)]">Loading tasks…</p>;
@@ -105,138 +111,175 @@ export function TaskList({
 
   return (
     <>
-      <Stack as="ul" gap="xs">
-        {tasks.map((task) => {
-          const overdue = isTaskOverdue(task);
-          const record = showRecord ? taskRecordRef(task) : null;
-          const recordLabel =
-            task.deal?.title ??
-            task.lead?.title ??
-            task.client?.name ??
-            task.person?.fullName ??
-            null;
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <section key={group.id} className="space-y-1">
+            {group.label ? (
+              <h4 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.06em] text-[var(--text-subtle)]">
+                {group.label}
+                <span className="font-mono tabular-nums font-normal">{group.tasks.length}</span>
+              </h4>
+            ) : null}
 
-          return (
-            <li key={task.id} className="flex items-start gap-3 p-3">
-              <Checkbox
-                className="mt-0.5"
-                checked={task.status === "COMPLETED"}
-                onCheckedChange={() => toggle(task)}
-                aria-label={`Complete ${task.title}`}
-              />
+            <ul className="space-y-0.5">
+              {group.tasks.map((task) => {
+                const overdue = isTaskOverdue(task);
+                const record = showRecord ? taskRecordRef(task) : null;
+                const recordLabel =
+                  task.deal?.title ??
+                  task.lead?.title ??
+                  task.client?.name ??
+                  task.person?.fullName ??
+                  null;
+                const selected = selectedId === task.id;
 
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span
-                    className={cn(
-                      "text-sm font-medium",
-                      task.status === "COMPLETED" ? "text-[var(--text-muted)] line-through" : "",
-                    )}
-                  >
-                    {task.title}
-                  </span>
-                  <Badge tone="neutral" size="sm">
-                    {CRM_TASK_TYPE_LABELS[task.type]}
-                  </Badge>
-                  {task.recurrence !== "NONE" ? (
-                    <Repeat
-                      className="size-3.5 text-[var(--text-muted)]"
-                      aria-label="Repeating task"
-                    />
-                  ) : null}
-                </div>
-
-                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--text-muted)]">
-                  <span
-                    className={cn(
-                      "inline-flex items-center gap-1",
-                      overdue ? "text-[var(--status-danger-fg)]" : "",
-                    )}
-                  >
-                    <Clock className="size-3.5" />
-                    <ClientDate value={task.dueAt} mode={task.hasDueTime ? "datetime" : "date"} />
-                  </span>
-                  {task.priority !== "NORMAL" && task.priority !== "LOW" ? (
-                    <Badge tone={TASK_PRIORITY_TONE[task.priority] ?? "neutral"} size="sm">
-                      {task.priority.toLowerCase()}
-                    </Badge>
-                  ) : null}
-                  {task.assignedTo ? <span>{task.assignedTo.name}</span> : <span>Unassigned</span>}
-                  {record && recordLabel ? (
-                    <Link href={record.href} className="hover:underline">
-                      {recordLabel}
-                    </Link>
-                  ) : null}
-                  {task.outcome ? (
-                    <span className="font-medium text-[var(--text-primary)]">
-                      {CRM_TASK_OUTCOME_LABELS[task.outcome]}
+                const facts = (
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--text-muted)]">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1",
+                        overdue ? "text-[var(--status-danger-fg)]" : "",
+                      )}
+                    >
+                      <Clock className="size-3.5" />
+                      <ClientDate
+                        value={task.dueAt}
+                        mode={task.hasDueTime ? "datetime" : "date"}
+                      />
                     </span>
-                  ) : null}
-                </div>
+                    {task.priority !== "NORMAL" && task.priority !== "LOW" ? (
+                      <Badge tone={TASK_PRIORITY_TONE[task.priority] ?? "neutral"} size="sm">
+                        {task.priority.toLowerCase()}
+                      </Badge>
+                    ) : null}
+                    {task.assignedTo ? (
+                      <span>{task.assignedTo.name}</span>
+                    ) : (
+                      <span>Unassigned</span>
+                    )}
+                    {task.outcome ? (
+                      <span className="font-medium text-[var(--text-primary)]">
+                        {CRM_TASK_OUTCOME_LABELS[task.outcome]}
+                      </span>
+                    ) : null}
+                  </div>
+                );
 
-                {task.outcomeNotes ? (
-                  <p className="mt-1 text-sm text-[var(--text-muted)]">{task.outcomeNotes}</p>
-                ) : null}
-              </div>
+                const heading = (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={cn(
+                        "text-sm font-medium",
+                        task.status === "COMPLETED"
+                          ? "text-[var(--text-muted)] line-through"
+                          : "",
+                      )}
+                    >
+                      {task.title}
+                    </span>
+                    <Badge tone="neutral" size="sm">
+                      {CRM_TASK_TYPE_LABELS[task.type]}
+                    </Badge>
+                    {task.recurrence !== "NONE" ? (
+                      <Repeat
+                        className="size-3.5 text-[var(--text-muted)]"
+                        aria-label="Repeating task"
+                      />
+                    ) : null}
+                  </div>
+                );
 
-              {/* Asked first. This is a one-tap delete at the right edge of
-                  every row, which on a phone is exactly where a thumb lands
-                  while scrolling, and a deleted task has no undo. */}
-              {task.assignedToId === currentUserId || !task.assignedToId ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  aria-label={`Delete ${task.title}`}
-                  onClick={async () => {
-                    const confirmed = await dsConfirm({
-                      title: "Delete this task?",
-                      description: task.title,
-                      confirmLabel: "Delete",
-                      variant: "danger",
-                    });
-                    if (confirmed) remove.mutate(task.id);
-                  }}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              ) : null}
-            </li>
-          );
-        })}
-      </Stack>
+                return (
+                  <li
+                    key={task.id}
+                    className={cn(
+                      "flex items-start gap-3 rounded-[var(--radius-md)] p-2.5",
+                      selected
+                        ? "bg-[var(--surface-subtle)]"
+                        : onSelect
+                          ? "hover:bg-[var(--surface-muted)]"
+                          : "",
+                    )}
+                  >
+                    <Checkbox
+                      className="mt-0.5"
+                      checked={task.status === "COMPLETED"}
+                      onCheckedChange={() => toggle(task)}
+                      aria-label={`Complete ${task.title}`}
+                    />
 
-      <CompleteTaskDialog
-        task={completing}
-        isPending={update.isPending}
-        onOpenChange={(open) => !open && setCompleting(null)}
-        onConfirm={(input) =>
-          completing &&
-          update.mutate({
-            id: completing.id,
-            body: { status: "COMPLETED", ...input },
-          })
-        }
-      />
+                    {onSelect ? (
+                      // The row opens the task beside the list. A button rather
+                      // than a link: there is nowhere to navigate to — the task
+                      // has no page of its own, and giving it one would be a
+                      // third place the same six fields are maintained.
+                      <button
+                        type="button"
+                        onClick={() => onSelect(task)}
+                        aria-current={selected ? "true" : undefined}
+                        className="min-w-0 flex-1 text-left"
+                      >
+                        {heading}
+                        {facts}
+                      </button>
+                    ) : (
+                      <div className="min-w-0 flex-1">
+                        {heading}
+                        {facts}
+                        {task.outcomeNotes ? (
+                          <p className="mt-1 text-sm text-[var(--text-muted)]">
+                            {task.outcomeNotes}
+                          </p>
+                        ) : null}
+                        {record && recordLabel ? (
+                          <Link
+                            href={record.href}
+                            className="mt-1 inline-block text-sm text-[var(--text-muted)] hover:underline"
+                          >
+                            {recordLabel}
+                          </Link>
+                        ) : null}
+                      </div>
+                    )}
 
-      <TaskFormSheet
-        open={Boolean(followUpFor)}
-        onOpenChange={(open) => !open && setFollowUpFor(null)}
-        currentUserId={currentUserId}
-        record={
-          followUpFor
-            ? {
-                leadId: followUpFor.leadId ?? undefined,
-                dealId: followUpFor.dealId ?? undefined,
-                clientId: followUpFor.clientId ?? undefined,
-                personId: followUpFor.personId ?? undefined,
-                siteId: followUpFor.siteId ?? undefined,
-              }
-            : undefined
-        }
-        seed={followUpFor ? { title: followUpFor.title, type: followUpFor.type } : undefined}
-        onCreated={() => setFollowUpFor(null)}
-      />
+                    {/* Asked first. This is a one-tap delete at the right edge of
+                        every row, which on a phone is exactly where a thumb lands
+                        while scrolling, and a deleted task has no undo.
+                        The split view drops it — the panel beside the list has
+                        the same button with room for a label, and two deletes for
+                        one task is one too many. */}
+                    {!onSelect &&
+                    (task.assignedToId === currentUserId || !task.assignedToId) ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`Delete ${task.title}`}
+                        onClick={async () => {
+                          const confirmed = await dsConfirm({
+                            title: "Delete this task?",
+                            description: task.title,
+                            confirmLabel: "Delete",
+                            variant: "danger",
+                          });
+                          if (confirmed) remove.mutate(task.id);
+                        }}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      {/* Only when this list owns the flow. Given an `onToggle`, the caller is
+          mounting its own pair and a second set here would open two dialogs for
+          one tick. */}
+      {onToggle ? null : completion.dialogs}
     </>
   );
 }

--- a/components/crm/tasks/use-task-completion.tsx
+++ b/components/crm/tasks/use-task-completion.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useToast } from "@/components/ui/use-toast";
+import { getApiErrorMessage } from "@/lib/api-client";
+import { updateCrmTask, type CrmTaskRecord } from "@/lib/crm/crm-v2";
+import { requiresOutcome } from "@/lib/crm/tasks";
+
+import { CompleteTaskDialog } from "./complete-task-dialog";
+import { TaskFormSheet } from "./task-form-sheet";
+
+/**
+ * Ticking a task off, and everything that has to happen when you do.
+ *
+ * This used to live inside `TaskList`, which was fine while the list was the
+ * only place a task could be completed. The split view added a second: the
+ * detail panel beside the list has the same checkbox, and it has to behave the
+ * same way — a call that closes without an outcome teaches nobody anything, and
+ * the server refuses the write regardless.
+ *
+ * Two copies of that would have been two chances to drift, so it is a hook.
+ * `toggle` is what a checkbox calls; `dialogs` is the JSX that has to be
+ * mounted somewhere for it to work. A surface that renders one without the
+ * other gets a checkbox that silently does nothing on typed tasks, so they are
+ * returned together from one call rather than as two exports.
+ */
+export function useTaskCompletion({ currentUserId }: { currentUserId?: string } = {}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [completing, setCompleting] = useState<CrmTaskRecord | null>(null);
+  const [followUpFor, setFollowUpFor] = useState<CrmTaskRecord | null>(null);
+
+  const update = useMutation({
+    mutationFn: (input: { id: string; body: Record<string, unknown> }) =>
+      updateCrmTask(input.id, input.body),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["crm-tasks"] });
+      const source = completing;
+      setCompleting(null);
+      if (result.recurredTask) {
+        toast({ title: "Task completed", description: "The next one is booked in." });
+      } else if (result.suggestsFollowUp) {
+        // The outcome says the conversation isn't over, so offer the next step
+        // while the context is still in front of the person.
+        setFollowUpFor(source);
+      } else {
+        toast({ title: "Task completed" });
+      }
+    },
+    onError: (error) => toast({ title: getApiErrorMessage(error), variant: "destructive" }),
+  });
+
+  const toggle = (task: CrmTaskRecord) => {
+    if (task.status === "COMPLETED") {
+      update.mutate({ id: task.id, body: { status: "OPEN", outcome: null } });
+      return;
+    }
+    if (requiresOutcome(task.type)) {
+      setCompleting(task);
+      return;
+    }
+    update.mutate({ id: task.id, body: { status: "COMPLETED" } });
+  };
+
+  const dialogs: ReactNode = (
+    <>
+      <CompleteTaskDialog
+        task={completing}
+        isPending={update.isPending}
+        onOpenChange={(open) => !open && setCompleting(null)}
+        onConfirm={(input) =>
+          completing &&
+          update.mutate({ id: completing.id, body: { status: "COMPLETED", ...input } })
+        }
+      />
+
+      <TaskFormSheet
+        open={Boolean(followUpFor)}
+        onOpenChange={(open) => !open && setFollowUpFor(null)}
+        currentUserId={currentUserId}
+        record={
+          followUpFor
+            ? {
+                leadId: followUpFor.leadId ?? undefined,
+                dealId: followUpFor.dealId ?? undefined,
+                clientId: followUpFor.clientId ?? undefined,
+                personId: followUpFor.personId ?? undefined,
+                siteId: followUpFor.siteId ?? undefined,
+              }
+            : undefined
+        }
+        seed={followUpFor ? { title: followUpFor.title, type: followUpFor.type } : undefined}
+        onCreated={() => setFollowUpFor(null)}
+      />
+    </>
+  );
+
+  return { toggle, dialogs, isPending: update.isPending };
+}

--- a/components/records/record-attributes.tsx
+++ b/components/records/record-attributes.tsx
@@ -235,10 +235,21 @@ export function RecordAttributes({
   attributes,
   /** How many to show before the list collapses. */
   visibleCount = 5,
+  columns = "auto",
   className,
 }: {
   attributes: RecordAttribute[];
   visibleCount?: number;
+  /**
+   * `auto` pairs the rows up once there is room for two columns, which is what
+   * a record's standing column and its landing view both want.
+   *
+   * `1` keeps them stacked however wide the container gets. A detail panel
+   * beside a list is the case: it is wide enough to trip the two-column rule
+   * and narrow enough that doing so leaves each value about eight characters,
+   * so "Aug 8, 2026" comes out on two lines beside a label on one.
+   */
+  columns?: 1 | "auto";
   className?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -254,7 +265,12 @@ export function RecordAttributes({
     // column on a desktop; keyed to the viewport, the desktop case put two
     // columns inside 320px and "USD 9,100.00" came out one character per line.
     <div className={cn("@container space-y-0.5", className)}>
-      <dl className="grid gap-x-6 gap-y-0.5 @md:grid-cols-2">
+      <dl
+        className={cn(
+          "grid gap-x-6 gap-y-0.5",
+          columns === "auto" && "@md:grid-cols-2",
+        )}
+      >
         {shown.map((attribute) => {
           const Icon = attribute.icon;
           return (

--- a/components/records/split-view.tsx
+++ b/components/records/split-view.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { IconButton } from "@/components/ui/icon-button";
+import { ArrowLeft } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * A list beside the one thing in it you are looking at.
+ *
+ * The record page's sections are all registers: tasks, documents, visits. You
+ * open one to find something, and then you want to *work* on it — change a due
+ * date, read the outcome, tick it off — and every one of those cost a dialog
+ * that covered the list you were reading. Which meant losing your place in the
+ * list to change one field of one row, and doing it again for the next row.
+ *
+ * The split is the answer the whole industry landed on: the register stays, and
+ * the thing you picked opens beside it. Move to the next row and the panel
+ * follows; nothing is covered and nothing is lost.
+ *
+ * ## Why a container query and not a breakpoint
+ *
+ * This does not know how wide the page is, and must not care. A section renders
+ * in the middle column of a three-column record page on a desktop, full width
+ * on a phone, and inside a 22rem rail if somebody ever puts one there. A
+ * `md:` breakpoint would put two panes into 400px because the *window* is wide,
+ * which is exactly the failure the record page's own columns already avoid.
+ * `@2xl` is 42rem of *this element*, which is the number that actually decides
+ * whether two panes fit.
+ *
+ * Worth knowing what that means in practice on a record page: with the standing
+ * info column open, a 1440px desktop leaves the middle column about 29rem and
+ * this stays a drilldown. Collapse the info column — the chevron at the top of
+ * it — and the same section is a split. That is the correct trade rather than a
+ * bug: a record cannot show its properties, its section list, a register *and*
+ * a detail pane in 1440 pixels, and the one the reader can give up is the one
+ * they choose.
+ *
+ * ## Below that width it is a drilldown, not a sheet
+ *
+ * Same state, no portal: the list gives way to the detail and a back arrow
+ * returns. A sheet would need the width measured in JavaScript, and would put a
+ * second scrolling surface over a page that already scrolls — the thing that
+ * makes a phone's back gesture ambiguous.
+ */
+export function SplitView({
+  list,
+  detail,
+  detailTitle,
+  onClose,
+  placeholder = "Pick one to see it here.",
+  className,
+}: {
+  /** The register. Always rendered; hidden only while a narrow pane drills in. */
+  list: ReactNode;
+  /** The chosen item, or nothing when none is chosen. */
+  detail?: ReactNode;
+  /** What the drilled-in view calls itself, beside the back arrow. */
+  detailTitle?: string;
+  onClose?: () => void;
+  /** What the empty half says while nothing is picked. */
+  placeholder?: string;
+  className?: string;
+}) {
+  const open = Boolean(detail);
+
+  return (
+    <div className={cn("@container", className)}>
+      <div className="@2xl:grid @2xl:grid-cols-[minmax(0,1fr)_18rem] @2xl:items-start">
+        <div className={cn("min-w-0 @2xl:pr-4", open && "hidden @2xl:block")}>{list}</div>
+
+        {open ? (
+          <div className="min-w-0 @2xl:border-l @2xl:border-[var(--border-subtle)] @2xl:pl-4">
+            {/* The header exists only in the drilled-in view: side by side, the
+                panel is obviously the thing you clicked and does not need to
+                introduce itself. */}
+            <div className="mb-3 flex items-center gap-2 @2xl:hidden">
+              <IconButton aria-label="Back to the list" onClick={onClose}>
+                <ArrowLeft />
+              </IconButton>
+              {detailTitle ? (
+                <h4 className="min-w-0 truncate text-sm font-semibold text-[var(--text-strong)]">
+                  {detailTitle}
+                </h4>
+              ) : null}
+            </div>
+            {detail}
+          </div>
+        ) : (
+          // Only wide enough to be worth saying. On a narrow pane the list is
+          // already filling the space and a "pick one" note under it would be
+          // an instruction for a layout the reader cannot see.
+          <div className="hidden @2xl:flex @2xl:min-h-40 @2xl:items-center @2xl:justify-center @2xl:border-l @2xl:border-[var(--border-subtle)] @2xl:pl-4">
+            <p className="text-center text-sm text-[var(--text-subtle)]">{placeholder}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/crm/story.ts
+++ b/lib/crm/story.ts
@@ -186,7 +186,10 @@ export function commentEvents(comments: CommentLike[]): StoryEvent[] {
     id: comment.id,
     kind: "comment" as const,
     // The body carries any @mentions as written; the renderer resolves them.
-    title: `${comment.author?.name ?? "Someone"} commented`,
+    // The kind, not a sentence: the feed's header line already prints the
+    // author beside their avatar, so "Sarah commented" next to "Sarah" was the
+    // name twice and the useful word — which of the five kinds this is — never.
+    title: "Comment",
     body: comment.body,
     occurredAt: comment.createdAt,
     actorName: comment.author?.name ?? null,


### PR DESCRIPTION
Three surfaces, from the Frappe CRM / Helpdesk / Drive references.

## Record list pages — a table view, and one options row above it

A record list has always been rows you open: a title, a supporting line, a fact on the right. That is the right shape for finding one thing and the wrong shape for looking *across* things. "Which of these are unassigned", "who is on hold", "what closes this month" are column questions, and a stack of two-line rows cannot answer them because the facts never line up.

- **`RecordTable`** — the presentation half of a grid over data the parent already has, which is what lets people, companies, sites, deals and leads share one look for about twelve lines each. One header row with each column's own mark, 44px rows, and the first column is the record and the only thing that navigates.
- **Leads moves off `DataTable` with them.** It was the last CRM list with a table of its own, so the module's busiest screen had a different row height, header and empty state from the four beside it. Column-header sorting goes with it — the options row already carries a sort button writing the same `LeadSort`, and two controls for one setting is what the toolbar was consolidated to stop.
- **The options row is a bar**, not a gap with controls in it: fixed height, hairline bled to the page edge, pinned under the app bar. It reads left to right in one grammar on every list — what you are looking at │ how it is narrowed → …→ how you find one → what is shown.
- **`LayoutSwitch`** is always the first control and always says the same three words. Leads had it at the far right of the row; people, companies and sites each had their own wording and order.
- On a phone the table gives way to the rows the rest of the module uses, once, inside `RecordTable` rather than four times at the call sites.

## Record detail — a task opens beside the list it came from

A record's sections are registers you move *between*: open a task to see the outcome, decide it needs a new due date, look at the next one. Every one of those cost a form sheet over the top of the list — and the form asks for every field when you came to change one.

- **`SplitView`** keeps the register and opens what you picked beside it. Sized by a container query rather than a breakpoint, because a section renders in the middle column of a three-column record page on a desktop and full width on a phone; only the width of *that element* decides whether two panes fit. Below the threshold it is a drilldown with a back arrow — same state, no portal, no second scrolling surface over a page that already scrolls.
- **`TaskDetail`** writes through on blur or Enter, the same grammar the record's own properties use. Completing a typed task still goes through the outcome dialog, because the answer is the part worth keeping and the server refuses the write without one.
- That machinery moves into **`useTaskCompletion`**, which returns the toggle and its dialogs together. The list and the panel share one instance, so a typed task raises exactly one dialog whichever checkbox you tick.
- The list groups into Overdue / To do / Done — a record worked for a year leaves thirty tasks in one undivided column.

## Activity — messages, not lines

Every row was one paragraph-shaped block: avatar, sentence, time and prose in the same visual run. The two facts a reader scans a feed for — who is talking, and when — were mixed into the thing they said, so finding "the last time the client emailed" meant reading every row.

- A header line of fixed shape above a body of any length.
- **Every kind somebody writes prose into is boxed**, not a hand-picked few. With only email framed, the feed alternated between a framed paragraph and an unframed one for two things that are both a message. The accent on the leading edge is what tells the kinds apart.
- **Runs of stage moves and system lines fold behind "View N changes".** Deliberately narrower than the quiet set: a raised quotation is quiet *and* it is why somebody opened the record, so hiding it behind a disclosure would answer "what happened here" with a button.

## Two things that cost real time, both now in the source

- An `overflow-x: auto` box computes `overflow-y` to `auto` too, which silently makes it the scrolling ancestor — a `position: sticky` header inside it sticks to a box that never scrolls vertically, so it does nothing and, at scroll 0, pushes itself down by its own `top` and leaves a band of nothing above it. The overflow clamp is now dropped once the container is wide enough to hold the table, and the header is sticky only there.
- Tailwind's leading-minus shorthand cannot negate a bare custom property. `-mt-[var(--content-gutter-y)]` emits a rule containing a literal `…`, which is not CSS, and Turbopack then fails the whole stylesheet — **every page in the app 500s**, not just the one. Written as explicit `calc(-1 * var(…))`.

## Verification

- `tsc --noEmit` clean, `eslint` clean on every touched path, `vitest` 616 passed (the 2 failures in the suite are the DB-backed specs; Postgres is not reachable in this container by default).
- Shot at 1440×900 and 390×844 against the CRM demo tenant: people / companies / sites / deals lists in both arrangements, the phone view-and-filters sheet, a record's activity feed, and the tasks section as both a drilldown and — with the standing column collapsed — a genuine split.
- Worth knowing: with the info column open, a 1440px desktop leaves the middle column about 29rem, so tasks stay a drilldown there and become a split when the column is folded away. That is the intended trade, not a bug — a record cannot show its properties, its section list, a register *and* a detail pane in 1440 pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu

---
_Generated by [Claude Code](https://claude.ai/code/session_014zYNAgfRSVMizkvgc1bwGu)_